### PR TITLE
Adding config to allow connecting to redis HA

### DIFF
--- a/internal/armada/configuration/types.go
+++ b/internal/armada/configuration/types.go
@@ -11,9 +11,11 @@ type ArmadaConfig struct {
 }
 
 type RedisConfig struct {
-	Addr     string
-	Password string
-	Db       int
+	Addr              string
+	MasterName        string
+	SentinelAddresses []string
+	Password          string
+	Db                int
 }
 
 type AuthenticationConfig struct {


### PR DESCRIPTION
Now if MasterName and SentinelAddresses is populated in the config, armada will attempt to connect to redis HA rather than as standard redis