### PR TITLE
Remainder scheduling

### DIFF
--- a/internal/armada/server/lease.go
+++ b/internal/armada/server/lease.go
@@ -40,9 +40,14 @@ func NewAggregatedQueueServer(
 const minPriority = 0.5
 const batchSize = 100
 
-var minimalResource = common.ComputeResourcesFloat{"cpu": 0.5, "memory": 200.0 * 1024 * 1024}
+var minimalResource = common.ComputeResourcesFloat{"cpu": 0.25, "memory": 100.0 * 1024 * 1024}
 
 func (q AggregatedQueueServer) LeaseJobs(ctx context.Context, request *api.LeaseRequest) (*api.JobLease, error) {
+
+	var res common.ComputeResources = request.Resources
+	if res.AsFloat().IsLessThan(minimalResource) {
+		return &api.JobLease{}, nil
+	}
 
 	queuePriority, e := q.calculatePriorities()
 	if e != nil {
@@ -129,7 +134,7 @@ func (q AggregatedQueueServer) distributeRemainder(clusterId string, priorities 
 		}
 		jobs = append(jobs, leased...)
 		remainder = remaining
-		if remainder.IsLessThen(minimalResource) {
+		if remainder.IsLessThan(minimalResource) {
 			break
 		}
 	}

--- a/internal/common/resource.go
+++ b/internal/common/resource.go
@@ -131,7 +131,7 @@ func (a ComputeResourcesFloat) DeepCopy() ComputeResourcesFloat {
 	return targetComputeResource
 }
 
-func (a ComputeResourcesFloat) IsLessThen(b ComputeResourcesFloat) bool {
+func (a ComputeResourcesFloat) IsLessThan(b ComputeResourcesFloat) bool {
 	reduced := a.DeepCopy()
 	reduced.Sub(b)
 	return !reduced.IsValid()


### PR DESCRIPTION
After initial round of scheduling there might be significant amount of resources remaining when there are many queues.
This change introduce additional scheduling round where we go through queues in priority order and try to schedule 1 job from each. 