### PR TITLE
Significantly increase kubernetes client rate limits

### DIFF
--- a/internal/executor/kubernetes_client.go
+++ b/internal/executor/kubernetes_client.go
@@ -15,6 +15,9 @@ func CreateKubernetesClient(kubernetesConfig *configuration.KubernetesConfigurat
 		return nil, err
 	}
 
+	config.Burst = 10000
+	config.QPS = 10000
+
 	return kubernetes.NewForConfig(config)
 }
 


### PR DESCRIPTION
Currently we are using the default kubernetes client rate limits which are very low

This is causing significant issues managing the cluster, as we can't request actions fast enough
 - Can't submit pods fast enough so the cluster is never full
 - Can't update pods fast enough, so we can't keep track of which states are reported
 - Can't delete pods fast enough, so the cluster is full of completed pods

This change makes the limit much higher so we make as many changes in the cluster as we need