### PR TITLE
Setting wait for ready to true

### DIFF
--- a/internal/executor/application.go
+++ b/internal/executor/application.go
@@ -109,6 +109,7 @@ func StartUp(config configuration.ExecutorConfiguration) (func(), *sync.WaitGrou
 }
 
 func createConnectionToApi(config configuration.ExecutorConfiguration) (*grpc.ClientConn, error) {
+	dialOptions := grpc.WithDefaultCallOptions(grpc.WaitForReady(true))
 	if config.Authentication.EnableAuthentication {
 		return grpc.Dial(
 			config.Armada.Url,
@@ -118,13 +119,15 @@ func createConnectionToApi(config configuration.ExecutorConfiguration) (*grpc.Cl
 				Password: config.Authentication.Password,
 			}),
 			grpc.WithUnaryInterceptor(grpc_prometheus.UnaryClientInterceptor),
-			grpc.WithStreamInterceptor(grpc_prometheus.StreamClientInterceptor))
+			grpc.WithStreamInterceptor(grpc_prometheus.StreamClientInterceptor),
+			dialOptions)
 	} else {
 		return grpc.Dial(
 			config.Armada.Url,
 			grpc.WithInsecure(),
 			grpc.WithUnaryInterceptor(grpc_prometheus.UnaryClientInterceptor),
-			grpc.WithStreamInterceptor(grpc_prometheus.StreamClientInterceptor))
+			grpc.WithStreamInterceptor(grpc_prometheus.StreamClientInterceptor),
+			dialOptions)
 	}
 }
 


### PR DESCRIPTION
NGINX has a max requests limit

When we hit it, it rejects requests temporarily to not breach its max request limit

WaitForReady should in theory handle these rejections gracefully and prevent requests from failing

NOTE: We will likely turn up NGINX max request limit too, but we want to better handle when we hit the limit