### PR TITLE
Updating CI/CD for executors to include all clusters 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ commands:
             echo $KUBECONFIG_WORKER_<< parameters.worker-id >> | base64 -d > kubeconfig_worker_<< parameters.worker-id >>_decoded.yaml
             export KUBECONFIG=./kubeconfig_worker_<< parameters.worker-id >>_decoded.yaml
             if timeout 15 helm list; then
-              helm upgrade --install armada-executor --namespace=armada ./deployment/executor/ -f ./executor_config.yaml -f ./executor_api_credentials.yaml --set applicationConfig.application.clusterId="worker-pool-<< parameters.worker-id >>" --set image.tag="0c030681780a44cf13e94f29b7181ea3e7568d1e"
+              helm upgrade --install armada-executor --namespace=armada ./deployment/executor/ -f ./executor_config.yaml -f ./executor_api_credentials.yaml --set applicationConfig.application.clusterId="worker-pool-<< parameters.worker-id >>" --set image.tag="${CIRCLE_SHA1}"
             else
               echo Unable to connect to worker << parameters.worker-id >>
             fi
@@ -41,56 +41,56 @@ jobs:
     working_directory: /go/src/github.com/G-Research/k8s-batch
     steps:
       - checkout
-#      - setup_remote_docker
-#
-#      - restore_cache:
-#          keys:
-#            - go-mod-v1-{{ checksum "go.sum" }}
-#
-#      - run:
-#          name: Test
-#          command: |
-#            go get -v -d ./...
-#            go test -v ./...
-#
-#      - save_cache:
-#          key: go-mod-v1-{{ checksum "go.sum" }}
-#          paths:
-#            - "/go/pkg/mod"
-#
-#      - run:
-#          name: Check formatting
-#          command: exit $(gofmt -l . | wc -l)
-#
-#      - run:
-#          name: Build
-#          command: make build
-#
-#      - store_artifacts:
-#          path: armadactl
-#          destination: armadactl
-#
-#      - aws-cli/install
-#      - aws-cli/configure
-#      - run:
-#          name: Push Image
-#          command: |
-#
-#            TAG=${CIRCLE_SHA1}
-#
-#            if [ ${CIRCLE_BRANCH} != master ]
-#              then
-#                TAG=branch-${CIRCLE_BRANCH}-${CIRCLE_SHA1}
-#            fi
-#
-#            source scripts/assume-role.sh
-#            $(aws ecr get-login --region eu-west-1 --no-include-email)
-#
-#            docker tag armada ${ECR_REPOSITORY}/armada:${TAG}
-#            docker push ${ECR_REPOSITORY}/armada:${TAG}
-#
-#            docker tag armada-executor ${ECR_REPOSITORY}/armada-executor:${TAG}
-#            docker push ${ECR_REPOSITORY}/armada-executor:${TAG}
+      - setup_remote_docker
+
+      - restore_cache:
+          keys:
+            - go-mod-v1-{{ checksum "go.sum" }}
+
+      - run:
+          name: Test
+          command: |
+            go get -v -d ./...
+            go test -v ./...
+
+      - save_cache:
+          key: go-mod-v1-{{ checksum "go.sum" }}
+          paths:
+            - "/go/pkg/mod"
+
+      - run:
+          name: Check formatting
+          command: exit $(gofmt -l . | wc -l)
+
+      - run:
+          name: Build
+          command: make build
+
+      - store_artifacts:
+          path: armadactl
+          destination: armadactl
+
+      - aws-cli/install
+      - aws-cli/configure
+      - run:
+          name: Push Image
+          command: |
+
+            TAG=${CIRCLE_SHA1}
+
+            if [ ${CIRCLE_BRANCH} != master ]
+              then
+                TAG=branch-${CIRCLE_BRANCH}-${CIRCLE_SHA1}
+            fi
+
+            source scripts/assume-role.sh
+            $(aws ecr get-login --region eu-west-1 --no-include-email)
+
+            docker tag armada ${ECR_REPOSITORY}/armada:${TAG}
+            docker push ${ECR_REPOSITORY}/armada:${TAG}
+
+            docker tag armada-executor ${ECR_REPOSITORY}/armada-executor:${TAG}
+            docker push ${ECR_REPOSITORY}/armada-executor:${TAG}
   deploy:
     docker:
       - image: alpine/helm:2.13.1
@@ -110,7 +110,7 @@ jobs:
             echo $KUBECONFIG_SERVICES | base64 -d > kubeconfig_services_decoded.yaml
             export KUBECONFIG=./kubeconfig_services_decoded.yaml
             if timeout 15 helm list; then
-              helm upgrade --install armada --namespace=armada ./deployment/armada/ -f ./armada_config.yaml -f ./armada_users.yaml --set image.tag="0c030681780a44cf13e94f29b7181ea3e7568d1e"
+              helm upgrade --install armada --namespace=armada ./deployment/armada/ -f ./armada_config.yaml -f ./armada_users.yaml --set image.tag="${CIRCLE_SHA1}"
             else
               echo Unable to connect to services cluster
             fi
@@ -134,4 +134,4 @@ workflows:
             - build
           filters:
             branches:
-              only: all-clusters-CI
+              only: master


### PR DESCRIPTION
Now deploying to worker pool clusters 1-5
Not breaking the build if deployment fails to a cluster because it is down (i.e if cluster 1 is down, we will skip it and continue deployment to cluster 2-5)
Using helm upgrade --install so if armada isn't present on a cluster it is installed, otherwise it is upgraded