### PR TITLE
Add a mechanism to detect other platforms to build

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,4 +1,35 @@
-gobuild = GOOS=linux GARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w"
+# Ruthlessly copied from containerd's Makefile:
+# https://github.com/containerd/containerd/blob/57b51b94815aa2e592264eb69c2f98e3a6616adc/Makefile
+
+ifneq "$(strip $(shell command -v go 2>/dev/null))" ""
+	GOOS ?= $(shell go env GOOS)
+	GOARCH ?= $(shell go env GOARCH)
+else
+	ifeq ($(GOOS),)
+		# approximate GOOS for the platform if we don't have Go and GOOS isn't
+		# set. We leave GOARCH unset, so that may need to be fixed.
+		ifeq ($(OS),Windows_NT)
+			GOOS = windows
+		else
+			UNAME_S := $(shell uname -s)
+			ifeq ($(UNAME_S),Linux)
+				GOOS = linux
+			endif
+			ifeq ($(UNAME_S),Darwin)
+				GOOS = darwin
+			endif
+			ifeq ($(UNAME_S),FreeBSD)
+				GOOS = freebsd
+			endif
+		endif
+	else
+		GOOS ?= $$GOOS
+		GOARCH ?= $$GOARCH
+	endif
+endif
+
+
+gobuild = GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build -ldflags="-s -w"
 
 build-server:
 	$(gobuild) -o armada cmd/armada/main.go


### PR DESCRIPTION
I wanted to build `armadactl` on my Mac laptop, so I added a section of containerd's `Makefile` to set `GOOS` and `GOARCH` parameters. I could add in support for even more ornate flavors of platforms if we think it's useful or slim this down if we think it's too verbose.

I also fixed a tiny typo in the gobuild line. GARCH should have been GOARCH.