### PR TITLE
Using dockerhub instead of AWS ECR 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,8 +97,6 @@ jobs:
       - run:
           name: Load relevant docker images
           command: |
-            source scripts/assume-role.sh
-            $(aws ecr get-login --region eu-west-1 --no-include-email)
             docker pull alpine:3.10
             docker pull gresearchdev/armada-server-dev:branch-${CIRCLE_BRANCH}-${CIRCLE_SHA1}
             docker pull gresearchdev/armada-executor-dev:branch-${CIRCLE_BRANCH}-${CIRCLE_SHA1}

--- a/scripts/assume-role.sh
+++ b/scripts/assume-role.sh
@@ -1,9 +1,0 @@
-unset  AWS_SESSION_TOKEN
-
-temp_role=$(aws sts assume-role \
-                    --role-arn "${ROLE_ARN}" \
-                    --role-session-name "circle-ci")
-
-export AWS_ACCESS_KEY_ID=$(echo $temp_role | jq .Credentials.AccessKeyId | xargs)
-export AWS_SECRET_ACCESS_KEY=$(echo $temp_role | jq .Credentials.SecretAccessKey | xargs)
-export AWS_SESSION_TOKEN=$(echo $temp_role | jq .Credentials.SessionToken | xargs)


### PR DESCRIPTION
For now this just publishes to dev repository

The idea is to have dev repository which just has dev builds on and a "prod" repository which just has release builds on.

So users can clearly see all available release version in the "prod" repository, while people developing can use images built by CI, found in the dev repository.

Maybe this will change in the future, but that is the current thinking.