### PR TITLE
Defaulting last statusChange for pending pods to CreationTimestamp

### DIFF
--- a/internal/executor/reporter/job_event_reporter.go
+++ b/internal/executor/reporter/job_event_reporter.go
@@ -166,6 +166,9 @@ func lastStatusChange(pod *v1.Pod) (time.Time, error) {
 	conditions := pod.Status.Conditions
 
 	if len(conditions) <= 0 {
+		if pod.Status.Phase == v1.PodPending && !pod.CreationTimestamp.IsZero() {
+			return pod.CreationTimestamp.Time, nil
+		}
 		return *new(time.Time), errors.New("no state changes found, cannot determine last status change")
 	}
 


### PR DESCRIPTION
We know as the pod is in pending, that if no conditions have changed, the last thing that happened must have been creation.

This change is mostly to allow identification of pods that have got stuck in pending but with no events.
 - If a pod gets stuck in pending and never gets an event, currently we'll never delete it

This change just means if it gets truly stuck in pending, we'll clean it up based on being a long time since it was created.