### PR TITLE
Executor: Retry on flexvolume mount failure

### DIFF
--- a/internal/executor/util/pod_status.go
+++ b/internal/executor/util/pod_status.go
@@ -17,9 +17,6 @@ var expectedWarningsEventReasons = util.StringListToSet([]string{
 var imagePullBackOffStatesSet = util.StringListToSet([]string{"ImagePullBackOff", "ErrImagePull"})
 var invalidImageNameStatesSet = util.StringListToSet([]string{"InvalidImageName"})
 
-const failedMountReason = "FailedMount"
-const failedFlexVolumeMountPrefix = "MountVolume.SetUp failed for volume"
-
 const failedPullPrefix = "Failed to pull image"
 const failedPullAndUnpack = "desc = failed to pull and unpack image"
 const failedPullErrorResponse = "code = Unknown desc = Error response from daemon"
@@ -181,9 +178,6 @@ func hasUnrecoverableEvent(podEvents []*v1.Event) (bool, *v1.Event) {
 		return true, event
 	}
 
-	if isMountFailure, event := hasFailedMountEvent(podEvents); isMountFailure {
-		return true, event
-	}
 	return false, nil
 }
 
@@ -208,15 +202,6 @@ func hasUnpullableImageEvent(podEvents []*v1.Event) (bool, *v1.Event) {
 			if strings.Contains(event.Message, failedPullErrorResponse) {
 				return true, event
 			}
-		}
-	}
-	return false, nil
-}
-
-func hasFailedMountEvent(podEvents []*v1.Event) (bool, *v1.Event) {
-	for _, event := range podEvents {
-		if event.Type == v1.EventTypeWarning && event.Reason == failedMountReason && strings.HasPrefix(event.Message, failedFlexVolumeMountPrefix) {
-			return true, event
 		}
 	}
 	return false, nil

--- a/internal/executor/util/pod_status_test.go
+++ b/internal/executor/util/pod_status_test.go
@@ -127,15 +127,6 @@ func TestDiagnoseStuckPod_ShouldReportUnrecoverable_WhenImageUnpullable(t *testi
 	assert.Equal(t, startupState, Unrecoverable)
 }
 
-func TestDiagnoseStuckPod_ShouldReportUnrecoverable_WhenInvalidMount(t *testing.T) {
-	waitingContainer := v1.ContainerState{Waiting: &v1.ContainerStateWaiting{}}
-	pod := makePodWithContainerStatuses([]v1.ContainerState{waitingContainer}, []v1.ContainerState{})
-	events := []*v1.Event{&v1.Event{Reason: "FailedMount", Type: v1.EventTypeWarning, Message: "MountVolume.SetUp failed for volume /some/volume because reason"}}
-
-	startupState, _ := DiagnoseStuckPod(pod, events)
-	assert.Equal(t, startupState, Unrecoverable)
-}
-
 func makePodWithContainerStatuses(containerStates []v1.ContainerState, initContainerStates []v1.ContainerState) *v1.Pod {
 	containers := make([]v1.ContainerStatus, len(containerStates))
 	for i, state := range containerStates {


### PR DESCRIPTION
In practice this error sometimes occurs due to node-specific issues, so it is worth retrying.