### PR TITLE
WIP: events and news page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,9 @@ collections:
   pages:
     output: true
     permalink: /:name
+  news:
+    output: true
+    permalink: /news/:name
 
 defaults:
   -
@@ -20,12 +23,11 @@ defaults:
       type: "pages"
     values:
       layout: "default"
-  -
-    scope:
+  - scope:
       path: ""
       type: "posts"
     values:
-      layout: "post" 
+      layout: "post"
 
 sass:
   sass_dir: assets/styles
@@ -37,5 +39,5 @@ plugins:
   - jekyll-sitemap
 
 paginate: 6
-paginate_path: "/blog/page:num/"
+paginate_path: "/news/page:num/"
   

--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -31,6 +31,8 @@ blog_settings:
   # 3. Add a color of the icon - text-primary, text-success, text-info, text-danger, text-warning and text-default all work! 
 menu_settings:
   menu_items:
+    - title: 'News & Events'
+      url: '/news'
     - title: 'Design'
       url: '/design'    
     - title: 'Documentation'

--- a/_news/test1.md
+++ b/_news/test1.md
@@ -1,0 +1,9 @@
+---
+title: "Test Post 1"
+categories: news
+excerpt_separator: <!--more-->
+---
+
+This is a test post <!--more-->
+
+With more information here

--- a/_news/test2.md
+++ b/_news/test2.md
@@ -1,0 +1,9 @@
+---
+title: "Test Post 2"
+categories: news
+excerpt_separator: <!--more-->
+---
+
+This is another test post <!--more-->
+
+With more information here, a second time

--- a/_news/test3.md
+++ b/_news/test3.md
@@ -1,0 +1,9 @@
+---
+title: "Test Post 3"
+categories: news
+excerpt_separator: <!--more-->
+---
+
+This a third test post <!--more-->
+
+With more information here, a second time

--- a/_news/test4.md
+++ b/_news/test4.md
@@ -1,0 +1,9 @@
+---
+title: "Test Post 4"
+categories: news
+excerpt_separator: <!--more-->
+---
+
+This a fourth test post <!--more-->
+
+With more information here, a second time

--- a/news.html
+++ b/news.html
@@ -1,0 +1,38 @@
+---
+title: News and Events
+layout: default
+description: Armada news and Events
+featured_image: /assets/img/social.jpg
+---
+<section id="news" class="section-content">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-12">
+                <h1 class="text-center">News</h1>
+                <div class="row">
+                    {% for article in site.news %}
+                    <div class="col-lg-4 col-md-6 col-sm-6 col-xs-12 article">
+                        {%if article.image %}
+                        <a href="{{ article.url }}">
+                            <div class="article-image article-image-container" style="background: center no-repeat url(/media/news/title/{{ article.image }});"></div>
+                        </a>
+                        {% endif %}
+                        <a href="{{ article.url }}"><h3><b>{{ article.title }}</b></h3></a>
+                        <p>{{ article.excerpt }}</p>
+                        <a href="{{ article.url }}"><span>Read More</span></a>
+                    </div>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-lg-12">
+                <br><br>
+                <h1 class="text-center">Event Calendar</h1>
+                <div class="row">
+                    <iframe src="https://calendar.google.com/calendar/embed?src=c_duoua9l58o305bsa39udvk3ihk%40group.calendar.google.com&ctz=America%2FLos_Angeles" style="border: 0" width="980" height="600" frameborder="0" scrolling="no"></iframe>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>


### PR DESCRIPTION
Needs:


* Events/news items populated from previous events (including creating images for them ala siembol's page). Some topics to cover would include:
  * Armada's recent admission as a CNCF Sandbox project
  * Any recent talks about Armada
* The google calendar embed needs to be replaced with one from a shared calendar accessible to everyone, and prepopulated with some events. Armada folks in the UK offered to run a weekly "office hours" or similar in order to give us a recurring event.



┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-69) by [Unito](https://www.unito.io)
