### PR TITLE
Double defaultPulsarTimeout

### DIFF
--- a/e2e/pulsar_test/pulsar_test.go
+++ b/e2e/pulsar_test/pulsar_test.go
@@ -543,7 +543,7 @@ func TestService(t *testing.T) {
 		}
 
 		_, ok := sequence.Events[numEventsExpected-1].GetEvent().(*armadaevents.EventSequence_Event_JobSucceeded)
-		assert.True(t, ok) // FIXME(Clif) Failure here
+		assert.True(t, ok)
 
 		// Cancel the original job (i.e., the nginx job).
 		ctxWithTimeout, _ = context.WithTimeout(context.Background(), time.Second)


### PR DESCRIPTION
As a minimum-effort way to avoid flaky pulsar test failures.