### PR TITLE
Restore a valid 'runs-on' GH Actions specifier.

### DIFF
--- a/.github/workflows/build-release-images.yml
+++ b/.github/workflows/build-release-images.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   test-and-build-images:
     if: github.repository_owner == 'armadaproject'
+    runs-on: ubuntu-22.04
     # runs-on: buildjet-4vcpu-ubuntu-2204
     strategy:
       fail-fast: true


### PR DESCRIPTION
A prior commit commented-out the BuildJet 'runs-on' specifier, but GH Actions requires a `runs-on`, so just specify a generic Ubuntu 22.04 runner.