### PR TITLE
Remove remaining traces of G-Research/armada

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,4 +22,4 @@ linters-settings:
   lll:
     line-length: 261
   goimports:
-    local-prefixes: github.com/G-Research/armada
+    local-prefixes: github.com/armadaproject/armada

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -158,7 +158,7 @@ dockers:
       - --label=org.opencontainers.image.title=armada
       - --label=org.opencontainers.image.description="Armada Bundle"
       - --label=org.opencontainers.image.url=https://hub.docker.com/r/gresearchdev/armada
-      - --label=org.opencontainers.image.source=https://github.com/G-Research/armada
+      - --label=org.opencontainers.image.source=https://github.com/armadaproject/armada
       - --label=org.opencontainers.image.version={{ .Version }}
       - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
       - --label=org.opencontainers.image.revision={{ .FullCommit }}
@@ -194,7 +194,7 @@ dockers:
       - --label=org.opencontainers.image.title=armada-server
       - --label=org.opencontainers.image.description="Armada Server"
       - --label=org.opencontainers.image.url=https://hub.docker.com/r/gresearchdev/armada-server
-      - --label=org.opencontainers.image.source=https://github.com/G-Research/armada
+      - --label=org.opencontainers.image.source=https://github.com/armadaproject/armada
       - --label=org.opencontainers.image.version={{ .Version }}
       - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
       - --label=org.opencontainers.image.revision={{ .FullCommit }}
@@ -222,7 +222,7 @@ dockers:
       - --label=org.opencontainers.image.title=armada-executor
       - --label=org.opencontainers.image.description="Armada Executor"
       - --label=org.opencontainers.image.url=https://hub.docker.com/r/gresearchdev/armada-executor
-      - --label=org.opencontainers.image.source=https://github.com/G-Research/armada
+      - --label=org.opencontainers.image.source=https://github.com/armadaproject/armada
       - --label=org.opencontainers.image.version={{ .Version }}
       - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
       - --label=org.opencontainers.image.revision={{ .FullCommit }}
@@ -250,7 +250,7 @@ dockers:
       - --label=org.opencontainers.image.title=armada-lookoutingester
       - --label=org.opencontainers.image.description="Armada Lookout Ingester"
       - --label=org.opencontainers.image.url=https://hub.docker.com/r/gresearchdev/armada-lookoutingester
-      - --label=org.opencontainers.image.source=https://github.com/G-Research/armada
+      - --label=org.opencontainers.image.source=https://github.com/armadaproject/armada
       - --label=org.opencontainers.image.version={{ .Version }}
       - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
       - --label=org.opencontainers.image.revision={{ .FullCommit }}
@@ -278,7 +278,7 @@ dockers:
       - --label=org.opencontainers.image.title=armada-lookoutingesterv2
       - --label=org.opencontainers.image.description="Armada Lookout Ingester v2"
       - --label=org.opencontainers.image.url=https://hub.docker.com/r/gresearchdev/armada-lookoutingesterv2
-      - --label=org.opencontainers.image.source=https://github.com/G-Research/armada
+      - --label=org.opencontainers.image.source=https://github.com/armadaproject/armada
       - --label=org.opencontainers.image.version={{ .Version }}
       - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
       - --label=org.opencontainers.image.revision={{ .FullCommit }}
@@ -306,7 +306,7 @@ dockers:
       - --label=org.opencontainers.image.title=armada-lookout
       - --label=org.opencontainers.image.description="Armada Lookout
       - --label=org.opencontainers.image.url=https://hub.docker.com/r/gresearchdev/armada-lookout
-      - --label=org.opencontainers.image.source=https://github.com/G-Research/armada
+      - --label=org.opencontainers.image.source=https://github.com/armadaproject/armada
       - --label=org.opencontainers.image.version={{ .Version }}
       - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
       - --label=org.opencontainers.image.revision={{ .FullCommit }}
@@ -340,7 +340,7 @@ dockers:
       - --label=org.opencontainers.image.title=armada-lookoutv2
       - --label=org.opencontainers.image.description="Armada Lookout v2"
       - --label=org.opencontainers.image.url=https://hub.docker.com/r/gresearchdev/armada-lookoutv2
-      - --label=org.opencontainers.image.source=https://github.com/G-Research/armada
+      - --label=org.opencontainers.image.source=https://github.com/armadaproject/armada
       - --label=org.opencontainers.image.version={{ .Version }}
       - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
       - --label=org.opencontainers.image.revision={{ .FullCommit }}
@@ -370,7 +370,7 @@ dockers:
       - --label=org.opencontainers.image.title=armada-eventingester
       - --label=org.opencontainers.image.description="Armada Event Ingester"
       - --label=org.opencontainers.image.url=https://hub.docker.com/r/gresearchdev/armada-eventingester
-      - --label=org.opencontainers.image.source=https://github.com/G-Research/armada
+      - --label=org.opencontainers.image.source=https://github.com/armadaproject/armada
       - --label=org.opencontainers.image.version={{ .Version }}
       - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
       - --label=org.opencontainers.image.revision={{ .FullCommit }}
@@ -398,7 +398,7 @@ dockers:
       - --label=org.opencontainers.image.title=armada-binoculars
       - --label=org.opencontainers.image.description="Armada Binoculars"
       - --label=org.opencontainers.image.url=https://hub.docker.com/r/gresearchdev/armada-binoculars
-      - --label=org.opencontainers.image.source=https://github.com/G-Research/armada
+      - --label=org.opencontainers.image.source=https://github.com/armadaproject/armada
       - --label=org.opencontainers.image.version={{ .Version }}
       - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
       - --label=org.opencontainers.image.revision={{ .FullCommit }}
@@ -426,7 +426,7 @@ dockers:
       - --label=org.opencontainers.image.title=armada-jobservice
       - --label=org.opencontainers.image.description="Armada Job Service"
       - --label=org.opencontainers.image.url=https://hub.docker.com/r/gresearchdev/armada-jobservice
-      - --label=org.opencontainers.image.source=https://github.com/G-Research/armada
+      - --label=org.opencontainers.image.source=https://github.com/armadaproject/armada
       - --label=org.opencontainers.image.version={{ .Version }}
       - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
       - --label=org.opencontainers.image.revision={{ .FullCommit }}
@@ -454,7 +454,7 @@ dockers:
       - --label=org.opencontainers.image.title=armadactl
       - --label=org.opencontainers.image.description="Armada CLI"
       - --label=org.opencontainers.image.url=https://hub.docker.com/r/gresearchdev/armadactl
-      - --label=org.opencontainers.image.source=https://github.com/G-Research/armada
+      - --label=org.opencontainers.image.source=https://github.com/armadaproject/armada
       - --label=org.opencontainers.image.version={{ .Version }}
       - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
       - --label=org.opencontainers.image.revision={{ .FullCommit }}
@@ -476,7 +476,7 @@ release:
   draft: false
   header: |
     ## Armada {{ .Version }} - ({{ .Date }})
-    See https://github.com/G-Research/armada for more info and documentation.
+    See https://github.com/armadaproject/armada for more info and documentation.
     ## Docker images
     ### Armada Bundle
     - `docker pull {{ .Env.DOCKER_REPO }}armada:{{ .Major }}.{{ .Minor }}.{{ .Patch }}`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src="./logo.svg" width="200"/>
 
-[![CircleCI](https://circleci.com/gh/helm/helm.svg?style=shield)](https://circleci.com/gh/G-Research/armada)
+[![CircleCI](https://circleci.com/gh/helm/helm.svg?style=shield)](https://circleci.com/gh/armadaproject/armada)
 [![Go Report Card](https://goreportcard.com/badge/github.com/armadaproject/armada)](https://goreportcard.com/report/github.com/armadaproject/armada)
 
 # Armada

--- a/internal/scheduler/scheduling_algo_test.go
+++ b/internal/scheduler/scheduling_algo_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/armadaproject/armada/internal/common/util"
 	"k8s.io/apimachinery/pkg/util/clock"
+
+	"github.com/armadaproject/armada/internal/common/util"
 
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"

--- a/scripts/add-checksum-summary.sh
+++ b/scripts/add-checksum-summary.sh
@@ -1,7 +1,7 @@
 API_TOKEN=$1
 RELEASE_TAG=$2
 
-RELEASE_INFO_REPLY=$(curl --fail -H "Authorization: token $API_TOKEN" https://api.github.com/repos/G-Research/armada/releases/tags/$RELEASE_TAG)
+RELEASE_INFO_REPLY=$(curl --fail -H "Authorization: token $API_TOKEN" https://api.github.com/repos/armadaproject/armada/releases/tags/$RELEASE_TAG)
 
 if [ $? -ne 0 ]; then
     echo "Failed to get release information from Github"
@@ -39,4 +39,4 @@ JSON_STRING="{\"body\" : \"$DETAILS\"}"
 echo "$JSON_STRING"
 
 
-curl -H "Authorization: token $API_TOKEN" -X PATCH https://api.github.com/repos/G-Research/armada/releases/$RELEASE_ID --data "$JSON_STRING"
+curl -H "Authorization: token $API_TOKEN" -X PATCH https://api.github.com/repos/armadaproject/armada/releases/$RELEASE_ID --data "$JSON_STRING"

--- a/scripts/upload-github-release-asset.sh
+++ b/scripts/upload-github-release-asset.sh
@@ -7,7 +7,7 @@ if [ ! -f $FILE ]; then
     exit -1
 fi
 
-RELEASE_INFO_REPLY=$(curl --fail -H "Authorization: token $API_TOKEN" https://api.github.com/repos/G-Research/armada/releases/tags/$RELEASE_TAG)
+RELEASE_INFO_REPLY=$(curl --fail -H "Authorization: token $API_TOKEN" https://api.github.com/repos/armadaproject/armada/releases/tags/$RELEASE_TAG)
 
 if [ $? -ne 0 ]; then
     echo "Failed to get release information from Github"
@@ -21,7 +21,7 @@ if [ $RELEASE_ID = null ]; then
     exit -1
 fi
 
-curl --fail -H "Authorization: token $API_TOKEN" -H "Content-Type: application/octet-stream" --data-binary @$FILE "https://uploads.github.com/repos/G-Research/armada/releases/$RELEASE_ID/assets?name=$(basename $FILE)"
+curl --fail -H "Authorization: token $API_TOKEN" -H "Content-Type: application/octet-stream" --data-binary @$FILE "https://uploads.github.com/repos/armadaproject/armada/releases/$RELEASE_ID/assets?name=$(basename $FILE)"
 
 if [ $? -ne 0 ]; then
     echo "Failed to upload file to Github"


### PR DESCRIPTION
Removes remaining mentions of `G-Research/armada` by replacing them with `armadaproject/armada`.

