### PR TITLE
Scheduler String Interning

### DIFF
--- a/config/scheduler/config.yaml
+++ b/config/scheduler/config.yaml
@@ -2,6 +2,7 @@ cyclePeriod: 10s
 executorTimeout: 1h
 databaseFetchSize: 1000
 pulsarSendTimeout: 5s
+internedStringsCacheSize: 100000
 pulsar:
   URL: "pulsar://pulsar:6650"
   jobsetEventsTopic: "events"
@@ -19,7 +20,7 @@ postgres:
 leader:
   mode: standalone
 grpc:
-  #port: 50052
+  port: 50052
   keepaliveParams:
     maxConnectionIdle: 5m
     time: 120s

--- a/go.mod
+++ b/go.mod
@@ -83,7 +83,6 @@ require (
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
-	github.com/disgoorg/log v1.2.0
 	github.com/go-openapi/errors v0.20.3
 	github.com/go-openapi/strfmt v0.21.3
 	github.com/go-openapi/swag v0.22.3
@@ -183,6 +182,7 @@ require (
 	github.com/dghubble/sling v1.4.0 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/disgoorg/disgo v0.13.20 // indirect
+	github.com/disgoorg/log v1.2.0 // indirect
 	github.com/disgoorg/snowflake/v2 v2.0.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/dvsekhvalnov/jose2go v1.5.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -83,6 +83,7 @@ require (
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
+	github.com/disgoorg/log v1.2.0
 	github.com/go-openapi/errors v0.20.3
 	github.com/go-openapi/strfmt v0.21.3
 	github.com/go-openapi/swag v0.22.3
@@ -182,7 +183,6 @@ require (
 	github.com/dghubble/sling v1.4.0 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/disgoorg/disgo v0.13.20 // indirect
-	github.com/disgoorg/log v1.2.0 // indirect
 	github.com/disgoorg/snowflake/v2 v2.0.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/dvsekhvalnov/jose2go v1.5.0 // indirect

--- a/internal/common/util/stringintern.go
+++ b/internal/common/util/stringintern.go
@@ -1,0 +1,36 @@
+package util
+
+import (
+	lru "github.com/hashicorp/golang-lru"
+	"github.com/pkg/errors"
+)
+
+// StringInterner allows strings with equal values but different backing arrays to be deduplicated
+// This is useful in Armada where common strings are often used across jobs (e.g. jobset, queue)
+// and so deduplication can help save memory.
+// The Interner is backed by an LRU so that only the most recently interned strings are kept.
+// Note that this probably isn't the most efficient implementation (eg see https://github.com/josharian/intern
+// which abuses sync.pool) but this should be reliable and performance more than good enough for Armada use cases
+type StringInterner struct {
+	cache *lru.Cache
+}
+
+// NewStringInterner will allocate an Interner backed by an LRU limited to the provided size
+func NewStringInterner(cacheSize uint32) (*StringInterner, error) {
+	cache, err := lru.New(int(cacheSize))
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return &StringInterner{cache: cache}, nil
+}
+
+// Intern ensures the string is cached and returns the cached string
+func (i *StringInterner) Intern(s string) string {
+	interned, present := i.cache.Get(s)
+	if !present {
+		interned = s
+		i.cache.Add(s, s)
+
+	}
+	return interned.(string)
+}

--- a/internal/common/util/stringintern_test.go
+++ b/internal/common/util/stringintern_test.go
@@ -19,7 +19,6 @@ var (
 
 // Test that repeated calls to intern for strings with identical values but different backing arrays result in deduplication
 func TestStringInterner_TestIntern(t *testing.T) {
-
 	interner, err := NewStringInterner(defaultCapacity)
 	require.NoError(t, err)
 
@@ -43,7 +42,6 @@ func TestStringInterner_TestIntern(t *testing.T) {
 
 // Test that we don't store more strings than capacity
 func TestStringInterner_TestCapacity(t *testing.T) {
-
 	interner, err := NewStringInterner(defaultCapacity)
 	require.NoError(t, err)
 
@@ -65,7 +63,6 @@ func TestStringInterner_TestCapacity(t *testing.T) {
 	assert.NotEqual(t, retrievedPtr, retrieved2Ptr)
 
 	assert.Equal(t, 3, interner.cache.Len()) // confirm that our cache hasn't gone over capacity
-
 }
 
 // This horrible thing allows us to check the pointer to the data backing the string

--- a/internal/common/util/stringintern_test.go
+++ b/internal/common/util/stringintern_test.go
@@ -1,0 +1,85 @@
+package util
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	testStrings     = []string{"foo", "bar", "baz", "alice", "bob"}
+	cloned1         = cloneStrings(testStrings)
+	cloned2         = cloneStrings(testStrings)
+	defaultCapacity = uint32(3)
+)
+
+// Test that repeated calls to intern for strings with identical values but different backing arrays result in deduplication
+func TestStringInterner_TestIntern(t *testing.T) {
+
+	interner, err := NewStringInterner(defaultCapacity)
+	require.NoError(t, err)
+
+	for i := 0; i < len(cloned1); i++ {
+		s1 := cloned1[i]
+		s2 := cloned2[i]
+
+		// intern the string and confirm that we can retrieve it
+		retrieved1 := interner.Intern(s1)
+		assert.Equal(t, retrieved1, s1)
+		retrieved1Ptr := addr(retrieved1)
+
+		// assert that retrieving it using the same string results in both value and pointer being unchanged
+		retrieved2 := interner.Intern(s2)
+		retrieved2Ptr := addr(retrieved2)
+		assert.Equal(t, s1, retrieved2)
+		assert.Equal(t, retrieved1Ptr, retrieved2Ptr)
+		assert.NotEqual(t, retrieved2Ptr, addr(s2))
+	}
+}
+
+// Test that we don't store more strings than capacity
+func TestStringInterner_TestCapacity(t *testing.T) {
+
+	interner, err := NewStringInterner(defaultCapacity)
+	require.NoError(t, err)
+
+	// intern a string and assert we return the same string
+	retrieved1 := interner.Intern(cloned1[0])
+	retrievedPtr := addr(retrieved1)
+	assert.Equal(t, addr(cloned1[0]), retrievedPtr)
+
+	// intern a some more strings so tha the first interning is evicted
+	for i := 0; i < len(cloned1); i++ {
+		interner.Intern(cloned1[i])
+	}
+
+	// intern the first string again and see we have a reference to the new pointer
+	retrieved2 := interner.Intern(cloned2[0])
+	retrieved2Ptr := addr(retrieved2)
+
+	assert.Equal(t, addr(cloned2[0]), retrieved2Ptr)
+	assert.NotEqual(t, retrievedPtr, retrieved2Ptr)
+
+	assert.Equal(t, 3, interner.cache.Len()) // confirm that our cache hasn't gone over capacity
+
+}
+
+// This horrible thing allows us to check the pointer to the data backing the string
+// We need it to determine if two strings have different data even if their values are equal
+func addr(s string) uintptr {
+	return (*reflect.StringHeader)(unsafe.Pointer(&s)).Data
+}
+
+// Clone an array of strings such that the new array has strings with the same value
+// but different backing data
+func cloneStrings(orig []string) []string {
+	cloned := make([]string, len(orig))
+	for i, s := range orig {
+		cloned[i] = strings.Clone(s)
+	}
+	return cloned
+}

--- a/internal/scheduler/config.go
+++ b/internal/scheduler/config.go
@@ -10,10 +10,10 @@ import (
 )
 
 const (
-	// If set on a pod, the value of this annotation is interpreted as the id of a node
+	// TargetNodeIdAnnotation if set on a pod, the value of this annotation is interpreted as the id of a node
 	// and only the node with that id will be considered for scheduling the pod.
 	TargetNodeIdAnnotation = "armadaproject.io/targetNodeId"
-	// If set on a pod, indicates which job this pod is part of.
+	// JobIdAnnotation if set on a pod, indicates which job this pod is part of.
 	JobIdAnnotation = "armadaproject.io/jobId"
 )
 
@@ -30,6 +30,8 @@ type Configuration struct {
 	Scheduling configuration.SchedulingConfig
 	Auth       authconfig.AuthConfig
 	Grpc       grpcconfig.GrpcConfig
+	// Maximum number of strings that should be cached at any one time
+	InternedStringsCacheSize uint32 `validate:"required"`
 	// How often the scheduling cycle should run
 	CyclePeriod time.Duration `validate:"required"`
 	// How long after a heartbeat an executor will be considered lost

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -2,7 +2,6 @@ package scheduler
 
 import (
 	"context"
-
 	"time"
 
 	"github.com/gogo/protobuf/proto"

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"context"
+
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -12,6 +13,7 @@ import (
 	"golang.org/x/exp/maps"
 	"k8s.io/apimachinery/pkg/util/clock"
 
+	"github.com/armadaproject/armada/internal/common/util"
 	"github.com/armadaproject/armada/internal/scheduler/database"
 	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
 	"github.com/armadaproject/armada/pkg/armadaevents"
@@ -35,6 +37,8 @@ type Scheduler struct {
 	schedulingAlgo SchedulingAlgo
 	// Tells us if we are leader. Only the leader may schedule jobs
 	leaderController LeaderController
+	// We intern strings to save memory
+	stringInterner *util.StringInterner
 	// Responsible for publishing messages to Pulsar.  Only the leader publishes.
 	publisher Publisher
 	// Minimum duration between scheduling cycles.
@@ -61,6 +65,7 @@ func NewScheduler(
 	schedulingAlgo SchedulingAlgo,
 	leaderController LeaderController,
 	publisher Publisher,
+	stringInterner *util.StringInterner,
 	cyclePeriod time.Duration,
 	executorTimeout time.Duration,
 	maxLeaseReturns uint,
@@ -75,6 +80,7 @@ func NewScheduler(
 		schedulingAlgo:     schedulingAlgo,
 		leaderController:   leaderController,
 		publisher:          publisher,
+		stringInterner:     stringInterner,
 		jobDb:              jobDb,
 		clock:              clock.RealClock{},
 		cyclePeriod:        cyclePeriod,
@@ -237,7 +243,7 @@ func (s *Scheduler) syncState(ctx context.Context) ([]*SchedulerJob, error) {
 		}
 		job = job.DeepCopy()
 		if job == nil {
-			job, err = createSchedulerJob(&dbJob)
+			job, err = s.createSchedulerJob(&dbJob)
 			if err != nil {
 				return nil, err
 			}
@@ -272,7 +278,7 @@ func (s *Scheduler) syncState(ctx context.Context) ([]*SchedulerJob, error) {
 		returnProcessed := false
 		run := job.RunById(dbRun.RunID)
 		if run == nil {
-			run = createSchedulerRun(&dbRun)
+			run = s.createSchedulerRun(&dbRun)
 			job.Runs = append(job.Runs, run)
 		} else {
 			returnProcessed = run.Returned
@@ -610,17 +616,18 @@ func (s *Scheduler) ensureDbUpToDate(ctx context.Context, pollInterval time.Dura
 }
 
 // createSchedulerJob creates a new scheduler job from a database job
-func createSchedulerJob(dbJob *database.Job) (*SchedulerJob, error) {
+func (s *Scheduler) createSchedulerJob(dbJob *database.Job) (*SchedulerJob, error) {
 	schedulingInfo := &schedulerobjects.JobSchedulingInfo{}
 	err := proto.Unmarshal(dbJob.SchedulingInfo, schedulingInfo)
 	if err != nil {
 		return nil, errors.Wrapf(
 			errors.WithStack(err), "error unmarshalling scheduling info for job %s", dbJob.JobID)
 	}
+	s.internJobSchedulingInfoStrings(schedulingInfo)
 	return &SchedulerJob{
 		JobId:             dbJob.JobID,
-		Jobset:            dbJob.JobSet,
-		Queue:             dbJob.Queue,
+		Jobset:            s.stringInterner.Intern(dbJob.JobSet),
+		Queue:             s.stringInterner.Intern(dbJob.Queue),
 		Queued:            true,
 		Priority:          uint32(dbJob.Priority),
 		jobSchedulingInfo: schedulingInfo,
@@ -631,15 +638,30 @@ func createSchedulerJob(dbJob *database.Job) (*SchedulerJob, error) {
 }
 
 // createSchedulerRun creates a new scheduler job run from a database job run
-func createSchedulerRun(dbRun *database.Run) *JobRun {
+func (s *Scheduler) createSchedulerRun(dbRun *database.Run) *JobRun {
 	return &JobRun{
 		RunID:     dbRun.RunID,
-		Executor:  dbRun.Executor,
+		Executor:  s.stringInterner.Intern(dbRun.Executor),
 		Running:   dbRun.Running,
 		Succeeded: dbRun.Succeeded,
 		Failed:    dbRun.Failed,
 		Cancelled: dbRun.Cancelled,
 		Returned:  dbRun.Returned,
+	}
+}
+
+func (s *Scheduler) internJobSchedulingInfoStrings(info *schedulerobjects.JobSchedulingInfo) {
+	for _, requirement := range info.ObjectRequirements {
+		if podRequirement := requirement.GetPodRequirements(); podRequirement != nil {
+			for k, v := range podRequirement.Annotations {
+				podRequirement.Annotations[s.stringInterner.Intern(k)] = s.stringInterner.Intern(v)
+			}
+
+			for k, v := range podRequirement.NodeSelector {
+				podRequirement.NodeSelector[s.stringInterner.Intern(k)] = s.stringInterner.Intern(v)
+			}
+			podRequirement.PreemptionPolicy = s.stringInterner.Intern(podRequirement.PreemptionPolicy)
+		}
 	}
 }
 

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -202,6 +202,9 @@ func TestCycle(t *testing.T) {
 			testClock := clock.NewFakeClock(time.Now())
 			schedulingAlgo := &testSchedulingAlgo{jobsToSchedule: tc.expectedJobRunLeased, shouldError: tc.scheduleError}
 			publisher := &testPublisher{shouldError: tc.publishError}
+			stringInterner, err := util.NewStringInterner(100)
+			require.NoError(t, err)
+
 			heartbeatTime := testClock.Now()
 			if tc.staleExecutor {
 				heartbeatTime = heartbeatTime.Add(-2 * clusterTimeout)
@@ -215,6 +218,7 @@ func TestCycle(t *testing.T) {
 				schedulingAlgo,
 				NewStandaloneLeaderController(),
 				publisher,
+				stringInterner,
 				1*time.Second,
 				clusterTimeout,
 				maxLeaseReturns)
@@ -336,6 +340,8 @@ func TestRun(t *testing.T) {
 	publisher := &testPublisher{}
 	clusterRepo := &testExecutorRepository{}
 	leaderController := NewStandaloneLeaderController()
+	stringInterner, err := util.NewStringInterner(100)
+	require.NoError(t, err)
 
 	sched, err := NewScheduler(
 		&jobRepo,
@@ -343,6 +349,7 @@ func TestRun(t *testing.T) {
 		schedulingAlgo,
 		leaderController,
 		publisher,
+		stringInterner,
 		1*time.Second,
 		1*time.Hour,
 		maxLeaseReturns)

--- a/internal/scheduler/schedulerapp.go
+++ b/internal/scheduler/schedulerapp.go
@@ -20,6 +20,7 @@ import (
 	dbcommon "github.com/armadaproject/armada/internal/common/database"
 	grpcCommon "github.com/armadaproject/armada/internal/common/grpc"
 	"github.com/armadaproject/armada/internal/common/pulsarutils"
+	"github.com/armadaproject/armada/internal/common/util"
 	"github.com/armadaproject/armada/internal/scheduler/database"
 	"github.com/armadaproject/armada/pkg/executorapi"
 )
@@ -107,12 +108,14 @@ func Run(config Configuration) error {
 	// Scheduling
 	//////////////////////////////////////////////////////////////////////////
 	log.Infof("Starting up scheduling loop")
+	stringInterner, err := util.NewStringInterner(config.InternedStringsCacheSize)
 	schedulingAlgo := NewLegacySchedulingAlgo(config.Scheduling, executorRepository, queueRepository)
 	scheduler, err := NewScheduler(jobRepository,
 		executorRepository,
 		schedulingAlgo,
 		leaderController,
 		pulsarPublisher,
+		stringInterner,
 		config.CyclePeriod,
 		config.ExecutorTimeout,
 		config.Scheduling.MaxRetries)

--- a/internal/scheduler/schedulerapp.go
+++ b/internal/scheduler/schedulerapp.go
@@ -109,6 +109,9 @@ func Run(config Configuration) error {
 	//////////////////////////////////////////////////////////////////////////
 	log.Infof("Starting up scheduling loop")
 	stringInterner, err := util.NewStringInterner(config.InternedStringsCacheSize)
+	if err != nil {
+		return errors.WithMessage(err, "error creating string interner")
+	}
 	schedulingAlgo := NewLegacySchedulingAlgo(config.Scheduling, executorRepository, queueRepository)
 	scheduler, err := NewScheduler(jobRepository,
 		executorRepository,


### PR DESCRIPTION
The scheduler needs to hold all queued jobs in memory.  By observation we can see that the common case is for the queued jobs to have many common strings (queue, jobset, annotations, etc).  We can thus intern these strings to save memory at a (hopefully small) cost to performance when creating job objects.

This PR introduces a string interner backed by a LRU (we already use this LRU elsewhere in armada so no big changes here).  The scheduler than interns certain key strings when creating both jobs and job runs