### PR TITLE
Populate RunIds on NodeInfo during lease call

### DIFF
--- a/internal/executor/service/cluster_allocation.go
+++ b/internal/executor/service/cluster_allocation.go
@@ -57,7 +57,7 @@ func (allocationService *ClusterAllocationService) AllocateSpareClusterCapacity(
 		return
 	}
 
-	capacityReport, err := allocationService.utilisationService.GetAvailableClusterCapacity()
+	capacityReport, err := allocationService.utilisationService.GetAvailableClusterCapacity(false)
 	if err != nil {
 		log.Errorf("Failed to allocate spare cluster capacity because %s", err)
 		return
@@ -192,7 +192,7 @@ func (allocationService *LegacyClusterAllocationService) AllocateSpareClusterCap
 		return
 	}
 
-	capacityReport, err := allocationService.utilisationService.GetAvailableClusterCapacity()
+	capacityReport, err := allocationService.utilisationService.GetAvailableClusterCapacity(true)
 	if err != nil {
 		log.Errorf("Failed to allocate spare cluster capacity because %s", err)
 		return

--- a/internal/executor/util/pod_util.go
+++ b/internal/executor/util/pod_util.go
@@ -108,6 +108,18 @@ func ExtractJobId(pod *v1.Pod) string {
 	return pod.Labels[domain.JobId]
 }
 
+func ExtractJobRunIds(pods []*v1.Pod) []string {
+	runIds := make([]string, 0, len(pods))
+
+	for _, pod := range pods {
+		if runId := ExtractJobRunId(pod); runId != "" {
+			runIds = append(runIds, runId)
+		}
+	}
+
+	return runIds
+}
+
 func ExtractJobRunId(pod *v1.Pod) string {
 	return pod.Labels[domain.JobRunId]
 }

--- a/internal/executor/util/pod_util_test.go
+++ b/internal/executor/util/pod_util_test.go
@@ -308,6 +308,60 @@ func makePodsWithJobIds(jobIds []string) []*v1.Pod {
 	return pods
 }
 
+func TestExtractJobRunIds(t *testing.T) {
+	runIds := []string{"1", "2", "3", "4"}
+	pods := makePodsWithJobRunIds(runIds)
+
+	result := ExtractJobRunIds(pods)
+	assert.Equal(t, result, runIds)
+}
+
+func TestExtractJobRunIds_HandlesEmptyList(t *testing.T) {
+	expected := []string{}
+	pods := []*v1.Pod{}
+
+	result := ExtractJobRunIds(pods)
+	assert.Equal(t, result, expected)
+}
+
+func TestExtractJobRunIds_SkipsWhenJobIdNotPresent(t *testing.T) {
+	expected := []string{}
+	podWithNoJobRunId := v1.Pod{}
+	pods := []*v1.Pod{&podWithNoJobRunId}
+
+	result := ExtractJobRunIds(pods)
+	assert.Equal(t, result, expected)
+}
+
+func TestExtractJobRunId(t *testing.T) {
+	pod := makePodsWithJobRunIds([]string{"1"})[0]
+
+	result := ExtractJobRunId(pod)
+	assert.Equal(t, result, "1")
+}
+
+func TestExtractRunJobId_ReturnsEmpty_WhenJobIdNotPresent(t *testing.T) {
+	pod := v1.Pod{}
+
+	result := ExtractJobRunId(&pod)
+	assert.Equal(t, result, "")
+}
+
+func makePodsWithJobRunIds(runIds []string) []*v1.Pod {
+	pods := make([]*v1.Pod, 0, len(runIds))
+
+	for _, runId := range runIds {
+		pod := v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{domain.JobRunId: runId},
+			},
+		}
+		pods = append(pods, &pod)
+	}
+
+	return pods
+}
+
 func TestIsReportingPhaseRequired(t *testing.T) {
 	assert.Equal(t, true, IsReportingPhaseRequired(v1.PodRunning))
 	assert.Equal(t, true, IsReportingPhaseRequired(v1.PodSucceeded))


### PR DESCRIPTION
RunIds need to be populated so that the scheduler knows what pod is running on which node
