### PR TITLE
Remove option to cancel  multiple jobns without supplying a queue and jobset

### DIFF
--- a/internal/armada/server/submit_to_log.go
+++ b/internal/armada/server/submit_to_log.go
@@ -214,7 +214,6 @@ func selectJobsForLegacyScheduler(jobs []*armadaevents.SubmitJob) []*armadaevent
 }
 
 func (srv *PulsarSubmitServer) CancelJobs(ctx context.Context, req *api.JobCancelRequest) (*api.CancellationResult, error) {
-
 	if len(req.JobIds) > 0 {
 		return srv.cancelJobsByIdsQueueJobset(ctx, req.JobIds, req.Queue, req.JobSetId)
 	}

--- a/internal/armada/server/submit_to_log.go
+++ b/internal/armada/server/submit_to_log.go
@@ -22,7 +22,6 @@ import (
 	"github.com/armadaproject/armada/internal/common/eventutil"
 	"github.com/armadaproject/armada/internal/common/pgkeyvalue"
 	"github.com/armadaproject/armada/internal/common/pulsarutils"
-	"github.com/armadaproject/armada/internal/common/util"
 	commonvalidation "github.com/armadaproject/armada/internal/common/validation"
 	"github.com/armadaproject/armada/internal/executor/configuration"
 	"github.com/armadaproject/armada/internal/scheduler"
@@ -215,12 +214,11 @@ func selectJobsForLegacyScheduler(jobs []*armadaevents.SubmitJob) []*armadaevent
 }
 
 func (srv *PulsarSubmitServer) CancelJobs(ctx context.Context, req *api.JobCancelRequest) (*api.CancellationResult, error) {
+
 	if len(req.JobIds) > 0 {
-		if req.Queue == "" || req.JobSetId == "" {
-			return srv.cancelJobsByIds(ctx, req.JobIds)
-		}
 		return srv.cancelJobsByIdsQueueJobset(ctx, req.JobIds, req.Queue, req.JobSetId)
 	}
+
 	// If either queue or jobSetId is missing, we need to get those from Redis.
 	// This must be done before checking auth, since the auth check expects a queue.
 	// If both queue and jobSetId are provided, we assume that those are correct
@@ -335,58 +333,22 @@ func (srv *PulsarSubmitServer) CancelJobs(ctx context.Context, req *api.JobCance
 	}, nil
 }
 
-func (srv *PulsarSubmitServer) cancelJobsByIds(ctx context.Context, jobIds []string) (*api.CancellationResult, error) {
-	batchSize := srv.SubmitServer.cancelJobsBatchSize
-	batches := util.Batch(jobIds, batchSize)
-	idQueueJobSetMap := make(map[string]map[string][]string)
-
-	for _, batch := range batches {
-		jobs, err := srv.SubmitServer.jobRepository.GetJobsByIds(batch)
-		if err != nil {
-			return nil, status.Error(codes.Internal, "failed to get jobs from redis")
-		}
-		for _, job := range jobs {
-			q := job.Job.GetQueue()
-			jobSet := job.Job.GetJobSetId()
-			_, ok := idQueueJobSetMap[q]
-			if !ok {
-				idQueueJobSetMap[q] = make(map[string][]string)
-			}
-			_, ok = idQueueJobSetMap[q][jobSet]
-			if !ok {
-				idQueueJobSetMap[q][jobSet] = []string{}
-			}
-			idQueueJobSetMap[q][jobSet] = append(idQueueJobSetMap[q][jobSet], job.Job.Id)
-		}
-	}
-
-	var cancelledIds []string
-	var eventSequences []*armadaevents.EventSequence
-	for q, jobSets := range idQueueJobSetMap {
-		userId, groups, err := srv.Authorize(ctx, q, permissions.CancelAnyJobs, queue.PermissionVerbCancel)
-		if err != nil {
-			return nil, err
-		}
-
-		for jobSet, jobIds := range jobSets {
-			sequence, validIds := eventSequenceForJobIds(jobIds, q, jobSet, userId, groups)
-			eventSequences = append(eventSequences, sequence)
-			cancelledIds = append(cancelledIds, validIds...)
-		}
-	}
-
-	err := srv.publishToPulsar(ctx, eventSequences)
-	if err != nil {
-		log.WithError(err).Error("failed send to Pulsar")
-		return nil, status.Error(codes.Internal, "Failed to send message")
-	}
-	return &api.CancellationResult{
-		CancelledIds: cancelledIds,
-	}, nil
-}
-
 // Assumes all Job IDs are in the queue and job set provided
 func (srv *PulsarSubmitServer) cancelJobsByIdsQueueJobset(ctx context.Context, jobIds []string, q, jobSet string) (*api.CancellationResult, error) {
+	if q == "" {
+		return nil, &armadaerrors.ErrInvalidArgument{
+			Name:    "Queue",
+			Value:   "",
+			Message: "Queue cannot be empty when cancelling multiple jobs",
+		}
+	}
+	if jobSet == "" {
+		return nil, &armadaerrors.ErrInvalidArgument{
+			Name:    "Jobset",
+			Value:   "",
+			Message: "Jobset cannot be empty when cancelling multiple jobs",
+		}
+	}
 	userId, groups, err := srv.Authorize(ctx, q, permissions.CancelAnyJobs, queue.PermissionVerbCancel)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Before Christmas we added a bulk cancel API for use by Lookout.  This supported two code paths for bulk cancelling jobs:

* User provides just a list of job ids but not a queue and jobset
* User provides a list of job ids and queue/jobset

The first of these is not very performant as all jobs have to be fetched in order to validate the user has perms to cancel them.  Lookout has now been migrated to use only the second api so we can delete the non performant code paths.

Although this is a public api- it was only added recently and lookout is (was) the only user so this should be safe to remove.