### PR TITLE
Exclude armada resource usage from NodeInfo.allocated_resources

### DIFF
--- a/internal/executor/utilisation/cluster_utilisation.go
+++ b/internal/executor/utilisation/cluster_utilisation.go
@@ -151,7 +151,7 @@ func (clusterUtilisationService *ClusterUtilisationService) GetAvailableClusterC
 		available.Sub(clusterUtilisationService.nodeReservedResources)
 
 		runningNodePods := runningPodsByNode[n.Name]
-		allocated := getAllocatedResourcesByPriority(runningNodePods)
+		allocated := getAllocatedResourceForNonArmadaPodsByPriority(runningNodePods)
 
 		nodes = append(nodes, api.NodeInfo{
 			Name:                 n.Name,
@@ -252,8 +252,11 @@ func groupPodsByNodes(pods []*v1.Pod) map[string][]*v1.Pod {
 	return podsByNodes
 }
 
-func getAllocatedResourcesByPriority(pods []*v1.Pod) map[int32]api.ComputeResource {
+func getAllocatedResourceForNonArmadaPodsByPriority(pods []*v1.Pod) map[int32]api.ComputeResource {
 	resourceUsageByPriority := make(map[int32]api.ComputeResource)
+
+	// Exclude managed pods - as this should only include non armada pods
+	pods = util.FilterPods(pods, IsManagedPod)
 
 	podsByPriority := groupPodsByPriority(pods)
 

--- a/pkg/api/queue.proto
+++ b/pkg/api/queue.proto
@@ -79,6 +79,7 @@ message NodeInfo {
     // Total node resources.
     // Resources available for allocation is given by the difference between this and allocated_resources.
     map<string, k8s.io.apimachinery.pkg.api.resource.Quantity> total_resources = 6 [(gogoproto.nullable) = false];
+    // The resources allocated to non armada pods by priority
     // Each pod is created with a priority class. Each priority class has an integer priority associated with it.
     // This is a map from priority to the total amount of resources allocated to pods with that priority.
     // It is used by the scheduler to decide whether more jobs should be sent to an executor.


### PR DESCRIPTION
The server is now aware of which pods are allocated to which node, so we no longer need to report this back to the server

This also allows the server to know how much resource is used on each node by non-armada pods



