### PR TITLE
WIP: Fix integration

### DIFF
--- a/magefiles/ci.go
+++ b/magefiles/ci.go
@@ -17,7 +17,13 @@ func ciRunTests() error {
 
 	// TODO: Necessary to avoid connection error on Armada server startup.
 	time.Sleep(10 * time.Second)
-	err = dockerComposeRun("up", "-d", "server", "executor")
+	err = dockerComposeRun("up", "-d", "server")
+	if err != nil {
+		return err
+	}
+
+	time.Sleep(5 * time.Second)
+	err = dockerComposeRun("up", "-d", "executor")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I noticed some weirdness with running server and executor in same docker-compose.  Moving server to after executor seems to allow the queue creation to work.  

Our tests were failing to create queues which means that the server wasn't actually up.  