### PR TITLE
Set executor timeout in a single place

### DIFF
--- a/config/scheduler/config.yaml
+++ b/config/scheduler/config.yaml
@@ -1,5 +1,4 @@
 cyclePeriod: 10s
-executorTimeout: 1h
 databaseFetchSize: 1000
 pulsarSendTimeout: 5s
 internedStringsCacheSize: 100000
@@ -35,6 +34,7 @@ grpc:
     minTime: 10s
     permitWithoutStream: true
 scheduling:
+  executorTimeout: 1h
   preemption:
     enabled: true
     priorityClasses:

--- a/internal/scheduler/config.go
+++ b/internal/scheduler/config.go
@@ -39,8 +39,6 @@ type Configuration struct {
 	InternedStringsCacheSize uint32 `validate:"required"`
 	// How often the scheduling cycle should run
 	CyclePeriod time.Duration `validate:"required"`
-	// How long after a heartbeat an executor will be considered lost
-	ExecutorTimeout time.Duration `validate:"required"`
 	// Maximum number of rows to fetch in a given query
 	DatabaseFetchSize int `validate:"required"`
 	// Timeout to use when sending messages to pulsar

--- a/internal/scheduler/schedulerapp.go
+++ b/internal/scheduler/schedulerapp.go
@@ -144,7 +144,7 @@ func Run(config Configuration) error {
 		pulsarPublisher,
 		stringInterner,
 		config.CyclePeriod,
-		config.ExecutorTimeout,
+		config.Scheduling.ExecutorTimeout,
 		config.Scheduling.MaxRetries)
 	if err != nil {
 		return errors.WithMessage(err, "error creating scheduler")


### PR DESCRIPTION
We currently have executor timeout configured in 2 places. Only one of which get set in config - making places that use the other location always consider every executor as timed out

Reducing this to a single place and making all places use this location


