### PR TITLE
Lookout v2 cronjob - replace old if new one gets scheduled

### DIFF
--- a/deployment/lookout-v2/templates/cronjob.yaml
+++ b/deployment/lookout-v2/templates/cronjob.yaml
@@ -7,13 +7,14 @@ metadata:
     {{- include "lookout_v2.labels.all" . | nindent 4 }}
 spec:
   schedule: {{ .Values.dbPruneSchedule | default "@hourly" | quote }}
+  concurrencyPolicy: Forbid
   jobTemplate:
     metadata:
       name: lookout-v2-db-pruner
       labels:
         {{- include "lookout_v2.labels.all" . | nindent 8 }}
     spec:
-      concurrencyPolicy: Replace
+      backoffLimit: 6
       template:
         metadata:
           name: lookout-v2-db-pruner

--- a/deployment/lookout-v2/templates/cronjob.yaml
+++ b/deployment/lookout-v2/templates/cronjob.yaml
@@ -13,6 +13,7 @@ spec:
       labels:
         {{- include "lookout_v2.labels.all" . | nindent 8 }}
     spec:
+      concurrencyPolicy: Replace
       template:
         metadata:
           name: lookout-v2-db-pruner


### PR DESCRIPTION
This is to prevent multiple copies of the pruning job to run at the same time