### PR TITLE
Set scheduling.executorTimeout in scheduler config

### DIFF
--- a/config/scheduler/config.yaml
+++ b/config/scheduler/config.yaml
@@ -35,6 +35,7 @@ grpc:
     minTime: 10s
     permitWithoutStream: true
 scheduling:
+  executorTimeout: 10m
   preemption:
     enabled: true
     priorityClasses:


### PR DESCRIPTION
Currently this isn't set and causes the scheduler to always consider executors stale - and never schedule anything


