### PR TITLE
Better scheduler.initialise

### DIFF
--- a/internal/scheduler/schedulerapp.go
+++ b/internal/scheduler/schedulerapp.go
@@ -39,10 +39,10 @@ func Run(config Configuration) error {
 	//////////////////////////////////////////////////////////////////////////
 	log.Infof("Setting up database connections")
 	db, err := dbcommon.OpenPgxPool(config.Postgres)
-	defer db.Close()
 	if err != nil {
 		return errors.WithMessage(err, "Error opening connection to postgres")
 	}
+	defer db.Close()
 	jobRepository := database.NewPostgresJobRepository(db, int32(config.DatabaseFetchSize))
 	executorRepository := database.NewPostgresExecutorRepository(db)
 


### PR DESCRIPTION
- If there's an error on the init don't try again straight away but back off for 1 second
- Respect the context that is passed in.
- In `schedulerapp.go` move the deferred database close to after we've checked for an error, else we'll atttmept to clise a non existent connection.