### PR TITLE
Fix resource accounting in lease.go

### DIFF
--- a/internal/armada/server/lease.go
+++ b/internal/armada/server/lease.go
@@ -389,11 +389,6 @@ func (q *AggregatedQueueServer) getJobs(ctx context.Context, req *api.StreamingL
 			continue
 		}
 		nodes = append(nodes, node)
-
-		log.Info(
-			"[node] id: %s, AllocatableByPriorityAndResource: %s, JobRunsByState: %s",
-			node.Id, node.AllocatableByPriorityAndResource, node.JobRunsByState,
-		)
 	}
 	indexedResources := q.schedulingConfig.IndexedResources
 	if len(indexedResources) == 0 {

--- a/internal/armada/server/lease.go
+++ b/internal/armada/server/lease.go
@@ -123,7 +123,7 @@ func (q *AggregatedQueueServer) StreamingLeaseJobs(stream api.AggregatedQueue_St
 		return errors.WithStack(err)
 	}
 
-	// Old scheduler resource accounting logic. Should be called on all requests.
+	// Old scheduler resource accounting logic.
 	err = q.usageRepository.UpdateClusterLeased(&req.ClusterLeasedReport)
 	if err != nil {
 		return err
@@ -155,7 +155,12 @@ func (q *AggregatedQueueServer) StreamingLeaseJobs(stream api.AggregatedQueue_St
 		}
 		usageByQueue[r.Name] = report
 	}
-	clusterUsageReport := q.createClusterUsageReport(usageByQueue, req.Pool)
+
+	clusterUsageReport := &schedulerobjects.ClusterResourceUsageReport{
+		Pool:             req.Pool,
+		Created:          q.clock.Now(),
+		ResourcesByQueue: usageByQueue,
+	}
 	err = q.usageRepository.UpdateClusterQueueResourceUsage(req.ClusterId, clusterUsageReport)
 	if err != nil {
 		return err
@@ -305,7 +310,7 @@ func (q *AggregatedQueueServer) getJobs(ctx context.Context, req *api.StreamingL
 	}
 	aggregatedUsageByQueue := q.aggregateUsage(reportsByExecutor, req.Pool)
 
-	// Collect all allowed allowedPriorities.
+	// Collect all allowed priorities.
 	allowedPriorities := q.schedulingConfig.Preemption.AllowedPriorities()
 	if len(allowedPriorities) == 0 {
 		return nil, errors.WithStack(&armadaerrors.ErrInvalidArgument{
@@ -361,12 +366,16 @@ func (q *AggregatedQueueServer) getJobs(ctx context.Context, req *api.StreamingL
 			continue
 		}
 
+		// Bind pods to nodes, thus ensuring resources are marked allocated on the node.
 		skipNode := false
 		for _, job := range jobs {
-			podReq := scheduler.PodRequirementFromLegacySchedulerJob(job, q.schedulingConfig.Preemption.PriorityClasses)
-
-			// Bind pod to node, thus ensuring resources are marked allocated on the node.
-			node, err = scheduler.BindPodToNode(podReq, node)
+			node, err = scheduler.BindPodToNode(
+				scheduler.PodRequirementFromLegacySchedulerJob(
+					job,
+					q.schedulingConfig.Preemption.PriorityClasses,
+				),
+				node,
+			)
 			if err != nil {
 				logging.WithStacktrace(log, err).Warnf(
 					"skipping node %s from executor %s: failed to bind job %s to node",
@@ -380,6 +389,11 @@ func (q *AggregatedQueueServer) getJobs(ctx context.Context, req *api.StreamingL
 			continue
 		}
 		nodes = append(nodes, node)
+
+		log.Info(
+			"[node] id: %s, AllocatableByPriorityAndResource: %s, JobRunsByState: %s",
+			node.Id, node.AllocatableByPriorityAndResource, node.JobRunsByState,
+		)
 	}
 	indexedResources := q.schedulingConfig.IndexedResources
 	if len(indexedResources) == 0 {
@@ -448,7 +462,6 @@ func (q *AggregatedQueueServer) getJobs(ctx context.Context, req *api.StreamingL
 		schedulerobjects.ResourceList{Resources: totalCapacity},
 	)
 
-	// var schedulingRoundReport *scheduler.SchedulingRoundReport
 	var preemptedJobs []scheduler.LegacySchedulerJob
 	var scheduledJobs []scheduler.LegacySchedulerJob
 	var nodesByJobId map[string]*schedulerobjects.Node
@@ -531,6 +544,7 @@ func (q *AggregatedQueueServer) getJobs(ctx context.Context, req *api.StreamingL
 					Created: &created,
 					Event: &armadaevents.EventSequence_Event_JobRunPreempted{
 						JobRunPreempted: &armadaevents.JobRunPreempted{
+							// Until the executor supports runs properly, JobId and RunId are the same.
 							PreemptedJobId: jobId,
 							PreemptedRunId: jobId,
 						},
@@ -656,20 +670,8 @@ func (q *AggregatedQueueServer) getJobs(ctx context.Context, req *api.StreamingL
 	// 	q.SchedulingReportsRepository.AddSchedulingRoundReport(sched.SchedulingRoundReport)
 	// }
 
-	// Update the usage report in-place to account for any leased jobs and write it back into Redis.
-	// This ensures resources of leased jobs are accounted for without needing to wait for feedback from the executor.
-	aggregatedUsageByQueue = scheduler.UpdateUsage(
-		aggregatedUsageByQueue,
-		preemptedJobs,
-		q.schedulingConfig.Preemption.PriorityClasses,
-		scheduler.Subtract,
-	)
-	aggregatedUsageByQueue = scheduler.UpdateUsage(
-		aggregatedUsageByQueue,
-		successfullyLeasedApiJobs,
-		q.schedulingConfig.Preemption.PriorityClasses,
-		scheduler.Add,
-	)
+	// Update the usage report for this executor in-place to account for preempted/leased jobs and write it back into Redis.
+	// This ensures rpeempted/leased jobs are accounted for without needing to wait for feedback from the executor.
 	executorReport, ok := reportsByExecutor[req.ClusterId]
 	if !ok || executorReport.ResourcesByQueue == nil {
 		executorReport = &schedulerobjects.ClusterResourceUsageReport{
@@ -679,7 +681,26 @@ func (q *AggregatedQueueServer) getJobs(ctx context.Context, req *api.StreamingL
 		}
 		reportsByExecutor[req.ClusterId] = executorReport
 	}
-	for queue, usage := range aggregatedUsageByQueue {
+	aggregatedUsageByQueueForCluster := q.aggregateUsage(
+		// We only want resources for this cluster.
+		map[string]*schedulerobjects.ClusterResourceUsageReport{
+			req.ClusterId: executorReport,
+		},
+		req.Pool,
+	)
+	aggregatedUsageByQueueForCluster = scheduler.UpdateUsage(
+		aggregatedUsageByQueueForCluster,
+		preemptedJobs,
+		q.schedulingConfig.Preemption.PriorityClasses,
+		scheduler.Subtract,
+	)
+	aggregatedUsageByQueueForCluster = scheduler.UpdateUsage(
+		aggregatedUsageByQueueForCluster,
+		successfullyLeasedApiJobs,
+		q.schedulingConfig.Preemption.PriorityClasses,
+		scheduler.Add,
+	)
+	for queue, usage := range aggregatedUsageByQueueForCluster {
 		executorReport.ResourcesByQueue[queue] = &schedulerobjects.QueueClusterResourceUsage{
 			Created:             q.clock.Now(),
 			Queue:               queue,
@@ -694,37 +715,31 @@ func (q *AggregatedQueueServer) getJobs(ctx context.Context, req *api.StreamingL
 	return successfullyLeasedApiJobs, nil
 }
 
-// aggregateUsage Creates a map of usage first by cluster and then by queue
-// Note that the desired cluster is excluded as this will be filled in later as are clusters that are not in the
-// same pool as the desired cluster
+// aggregateUsage Creates a map of resource usage first by cluster and then by queue.
+// Clusters in pools other than pool are excluded.
 func (q *AggregatedQueueServer) aggregateUsage(reportsByCluster map[string]*schedulerobjects.ClusterResourceUsageReport, pool string) map[string]schedulerobjects.QuantityByPriorityAndResourceType {
 	const activeClusterExpiry = 10 * time.Minute
 	now := q.clock.Now()
-
-	// Aggregate resource usage across clusters.
 	aggregatedUsageByQueue := make(map[string]schedulerobjects.QuantityByPriorityAndResourceType)
 	for _, clusterReport := range reportsByCluster {
-		if clusterReport.Pool == pool && clusterReport.Created.Add(activeClusterExpiry).After(now) {
-			for queue, report := range clusterReport.ResourcesByQueue {
-				quantityByPriorityAndResourceType, ok := aggregatedUsageByQueue[queue]
-				if !ok {
-					quantityByPriorityAndResourceType = make(schedulerobjects.QuantityByPriorityAndResourceType)
-					aggregatedUsageByQueue[queue] = quantityByPriorityAndResourceType
-				}
-				quantityByPriorityAndResourceType.Add(report.ResourcesByPriority)
+		if clusterReport.Pool != pool {
+			// Separate resource accounting per pool.
+			continue
+		}
+		if !clusterReport.Created.Add(activeClusterExpiry).After(now) {
+			// Stale report; omit.
+			continue
+		}
+		for queue, report := range clusterReport.ResourcesByQueue {
+			quantityByPriorityAndResourceType, ok := aggregatedUsageByQueue[queue]
+			if !ok {
+				quantityByPriorityAndResourceType = make(schedulerobjects.QuantityByPriorityAndResourceType)
+				aggregatedUsageByQueue[queue] = quantityByPriorityAndResourceType
 			}
+			quantityByPriorityAndResourceType.Add(report.ResourcesByPriority)
 		}
 	}
 	return aggregatedUsageByQueue
-}
-
-// createClusterUsageReport creates a schedulerobjects.ClusterResourceUsageReport suitable for storing in redis
-func (q *AggregatedQueueServer) createClusterUsageReport(resourceByQueue map[string]*schedulerobjects.QueueClusterResourceUsage, pool string) *schedulerobjects.ClusterResourceUsageReport {
-	return &schedulerobjects.ClusterResourceUsageReport{
-		Pool:             pool,
-		Created:          q.clock.Now(),
-		ResourcesByQueue: resourceByQueue,
-	}
 }
 
 func (q *AggregatedQueueServer) decompressJobOwnershipGroups(jobs []*api.Job) error {

--- a/internal/scheduler/legacyscheduler.go
+++ b/internal/scheduler/legacyscheduler.go
@@ -1289,8 +1289,14 @@ func UpdateUsage[S ~[]E, E LegacySchedulerJob](
 	priorityClasses map[string]configuration.PriorityClass,
 	addOrSubtract AddOrSubtract,
 ) map[string]schedulerobjects.QuantityByPriorityAndResourceType {
+	if usage == nil {
+		usage = make(map[string]schedulerobjects.QuantityByPriorityAndResourceType)
+	}
 	for _, job := range jobs {
 		req := PodRequirementFromLegacySchedulerJob(job, priorityClasses)
+		if req == nil {
+			continue
+		}
 		requests := schedulerobjects.ResourceListFromV1ResourceList(req.ResourceRequirements.Requests)
 		queue := job.GetQueue()
 		m := usage[queue]

--- a/pkg/api/util.go
+++ b/pkg/api/util.go
@@ -44,19 +44,19 @@ func NewNodeFromNodeInfo(nodeInfo *NodeInfo, executor string, allowedPriorities 
 			Message: "nodeInfo.Name is empty",
 		})
 	}
+
 	allocatableByPriorityAndResource := schedulerobjects.NewAllocatableByPriorityAndResourceType(
 		allowedPriorities,
 		schedulerobjects.ResourceList{
 			Resources: nodeInfo.TotalResources,
 		},
 	)
-	for p, rs := range nodeInfo.NonArmadaAllocatedResources {
-		allocatableByPriorityAndResource.MarkAllocated(p, schedulerobjects.ResourceList{Resources: rs.Resources})
+	for p, rl := range nodeInfo.NonArmadaAllocatedResources {
+		allocatableByPriorityAndResource.MarkAllocated(p, schedulerobjects.ResourceList{Resources: rl.Resources})
 	}
-
 	nonArmadaAllocatedResources := make(map[int32]schedulerobjects.ResourceList)
-	for k, v := range nodeInfo.NonArmadaAllocatedResources {
-		nonArmadaAllocatedResources[k] = schedulerobjects.ResourceList{Resources: v.Resources}
+	for p, rl := range nodeInfo.NonArmadaAllocatedResources {
+		nonArmadaAllocatedResources[p] = schedulerobjects.ResourceList{Resources: rl.Resources}
 	}
 
 	jobRunsByState := make(map[string]schedulerobjects.JobRunState)


### PR DESCRIPTION
Previously, we'd write the aggregate resource usage across all clusters to the usage report of each cluster. I.e., the scheduler would think each queue had been allocated n times as much resources as the correct allocation, where n is the number of clusters. This PR fixes the problem.