### PR TITLE
Fix partition marker flow when pulsar topics have many partitions

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -595,7 +595,7 @@ func (s *Scheduler) initialise(ctx context.Context) error {
 // function was called. This is achieved firstly by publishing messages to Pulsar and then polling the
 // database until all messages have been written.
 func (s *Scheduler) ensureDbUpToDate(ctx context.Context, pollInterval time.Duration) error {
-	var groupId uuid.UUID
+	groupId := uuid.New()
 	var numSent uint32
 	var err error
 

--- a/internal/scheduleringester/dbops.go
+++ b/internal/scheduleringester/dbops.go
@@ -172,9 +172,9 @@ func (a InsertJobRunErrors) Merge(b DbOperation) bool {
 	return mergeInMap(a, b)
 }
 
-func (a InsertPartitionMarker) Merge(b DbOperation) bool {
+func (a *InsertPartitionMarker) Merge(b DbOperation) bool {
 	switch op := b.(type) {
-	case InsertPartitionMarker:
+	case *InsertPartitionMarker:
 		a.markers = append(a.markers, op.markers...)
 		return true
 	}
@@ -271,7 +271,7 @@ func (a MarkRunsRunning) CanBeAppliedBefore(b DbOperation) bool {
 	return !definesRun(a, b)
 }
 
-func (a InsertPartitionMarker) CanBeAppliedBefore(b DbOperation) bool {
+func (a *InsertPartitionMarker) CanBeAppliedBefore(b DbOperation) bool {
 	// Partition markers can never be brought forward
 	return false
 }

--- a/internal/scheduleringester/dbops_test.go
+++ b/internal/scheduleringester/dbops_test.go
@@ -29,6 +29,31 @@ func TestMerge(t *testing.T) {
 	assert.Equal(t, MarkJobsCancelRequested{jobId1: false, jobId2: true, jobId3: true}, markJobsCancelled1)
 }
 
+func TestMerge_InsertPartitionMarker(t *testing.T) {
+	marker1 := &InsertPartitionMarker{markers: []*schedulerdb.Marker{
+		{
+			PartitionID: int32(1),
+		},
+	}}
+	marker2 := &InsertPartitionMarker{markers: []*schedulerdb.Marker{
+		{
+			PartitionID: int32(2),
+		},
+	}}
+	expectedOutput := &InsertPartitionMarker{markers: []*schedulerdb.Marker{
+		{
+			PartitionID: int32(1),
+		},
+		{
+			PartitionID: int32(2),
+		},
+	}}
+
+	marker1.Merge(marker2)
+
+	assert.Equal(t, expectedOutput, marker1)
+}
+
 // Test that db op optimisation
 // 1. produces the expected number of ops after optimisations and
 // 2. results in the same end state as if no optimisation had been applied.
@@ -142,7 +167,7 @@ func TestDbOperationOptimisation(t *testing.T) {
 		}},
 		"InsertPartitionMarker": {N: 2, Ops: []DbOperation{
 			InsertJobs{jobIds[0]: &schedulerdb.Job{JobID: jobIds[0]}}, // 1
-			InsertPartitionMarker{markers: []*schedulerdb.Marker{}},   // 2
+			&InsertPartitionMarker{markers: []*schedulerdb.Marker{}},  // 2
 			InsertJobs{jobIds[1]: &schedulerdb.Job{JobID: jobIds[1]}}, // 1
 			InsertJobs{jobIds[2]: &schedulerdb.Job{JobID: jobIds[2]}}, // 1
 		}},

--- a/internal/scheduleringester/instructions.go
+++ b/internal/scheduleringester/instructions.go
@@ -281,7 +281,7 @@ func (c *InstructionConverter) handleCancelledJob(cancelledJob *armadaevents.Can
 }
 
 func (c *InstructionConverter) handlePartitionMarker(pm *armadaevents.PartitionMarker, created time.Time) ([]DbOperation, error) {
-	return []DbOperation{InsertPartitionMarker{
+	return []DbOperation{&InsertPartitionMarker{
 		markers: []*schedulerdb.Marker{
 			{
 				GroupID:     armadaevents.UuidFromProtoUuid(pm.GroupId),

--- a/internal/scheduleringester/instructions_test.go
+++ b/internal/scheduleringester/instructions_test.go
@@ -153,7 +153,7 @@ func TestConvertSequence(t *testing.T) {
 		"PositionMarker": {
 			events: []*armadaevents.EventSequence_Event{f.PartitionMarker},
 			expected: []DbOperation{
-				InsertPartitionMarker{markers: []*schedulerdb.Marker{
+				&InsertPartitionMarker{markers: []*schedulerdb.Marker{
 					{
 						GroupID:     f.PartitionMarkerGroupIdUuid,
 						PartitionID: f.PartitionMarkerPartitionId,

--- a/internal/scheduleringester/schedulerdb.go
+++ b/internal/scheduleringester/schedulerdb.go
@@ -159,7 +159,7 @@ func (s *SchedulerDb) WriteDbOp(ctx context.Context, op DbOperation) error {
 			i++
 		}
 		return database.Upsert(ctx, s.db, "job_run_errors", records)
-	case InsertPartitionMarker:
+	case *InsertPartitionMarker:
 		for _, marker := range o.markers {
 			err := queries.InsertMarker(ctx, schedulerdb.InsertMarkerParams{
 				GroupID:     marker.GroupID,

--- a/internal/scheduleringester/schedulerdb_test.go
+++ b/internal/scheduleringester/schedulerdb_test.go
@@ -202,7 +202,7 @@ func TestWriteOps(t *testing.T) {
 			},
 		}},
 		"Insert PositionMarkers": {Ops: []DbOperation{
-			InsertPartitionMarker{
+			&InsertPartitionMarker{
 				markers: []*schedulerdb.Marker{
 					{
 						GroupID:     uuid.New(),
@@ -509,7 +509,7 @@ func assertOpSuccess(t *testing.T, schedulerDb *SchedulerDb, serials map[string]
 			}
 		}
 		assert.Equal(t, expected, actual)
-	case InsertPartitionMarker:
+	case *InsertPartitionMarker:
 		actual, err := queries.SelectAllMarkers(ctx)
 		require.NoError(t, err)
 		require.Equal(t, len(expected.markers), len(actual))


### PR DESCRIPTION
 - Initialise groupId correctly on partition markers - currently all getting the id of 0
 - Merging InsertPartitionMarker is not working as expected - as it doesn't mutate the InsertPartitionMarker at all (it mutates a copy)
    - Fixed by enforcing it is used as a pointer
 
Now all the PartitionMarkers should get populated in the scheduler db with a non-zero group id 
