### PR TITLE
Make subscription type user settable in ingesters

### DIFF
--- a/internal/common/ingest/ingestion_pipeline.go
+++ b/internal/common/ingest/ingestion_pipeline.go
@@ -59,6 +59,7 @@ type IngestionPipeline[T HasPulsarMessageIds] struct {
 	pulsarSubscriptionName string
 	pulsarBatchSize        int
 	pulsarBatchDuration    time.Duration
+	pulsarSubscriptionType pulsar.SubscriptionType
 	msgFilter              func(msg pulsar.Message) bool
 	converter              InstructionConverter[T]
 	sink                   Sink[T]
@@ -71,6 +72,7 @@ func NewIngestionPipeline[T HasPulsarMessageIds](
 	pulsarSubscriptionName string,
 	pulsarBatchSize int,
 	pulsarBatchDuration time.Duration,
+	pulsarSubscriptionType pulsar.SubscriptionType,
 	converter InstructionConverter[T],
 	sink Sink[T],
 	metricsConfig configuration.MetricsConfig,
@@ -81,6 +83,7 @@ func NewIngestionPipeline[T HasPulsarMessageIds](
 		pulsarSubscriptionName,
 		pulsarBatchSize,
 		pulsarBatchDuration,
+		pulsarSubscriptionType,
 		func(_ pulsar.Message) bool { return true },
 		converter,
 		sink,
@@ -96,6 +99,7 @@ func NewFilteredMsgIngestionPipeline[T HasPulsarMessageIds](
 	pulsarSubscriptionName string,
 	pulsarBatchSize int,
 	pulsarBatchDuration time.Duration,
+	pulsarSubscriptionType pulsar.SubscriptionType,
 	msgFilter func(msg pulsar.Message) bool,
 	converter InstructionConverter[T],
 	sink Sink[T],
@@ -109,6 +113,7 @@ func NewFilteredMsgIngestionPipeline[T HasPulsarMessageIds](
 		pulsarSubscriptionName: pulsarSubscriptionName,
 		pulsarBatchSize:        pulsarBatchSize,
 		pulsarBatchDuration:    pulsarBatchDuration,
+		pulsarSubscriptionType: pulsarSubscriptionType,
 		msgFilter:              msgFilter,
 		converter:              converter,
 		sink:                   sink,
@@ -223,7 +228,7 @@ func (ingester *IngestionPipeline[T]) subscribe() (pulsar.Consumer, func(), erro
 	consumer, err := pulsarClient.Subscribe(pulsar.ConsumerOptions{
 		Topic:                       ingester.pulsarConfig.JobsetEventsTopic,
 		SubscriptionName:            ingester.pulsarSubscriptionName,
-		Type:                        pulsar.KeyShared,
+		Type:                        ingester.pulsarSubscriptionType,
 		SubscriptionInitialPosition: pulsar.SubscriptionPositionEarliest,
 	})
 	if err != nil {

--- a/internal/eventingester/ingester.go
+++ b/internal/eventingester/ingester.go
@@ -1,6 +1,7 @@
 package eventingester
 
 import (
+	"github.com/apache/pulsar-client-go/pulsar"
 	"regexp"
 	"time"
 
@@ -53,7 +54,16 @@ func Run(config *configuration.EventIngesterConfiguration) {
 	converter := convert.NewEventConverter(compressor, uint(config.BatchSize), metrics)
 
 	ingester := ingest.
-		NewIngestionPipeline(config.Pulsar, config.SubscriptionName, config.BatchSize, config.BatchDuration, converter, eventDb, config.Metrics, metrics)
+		NewIngestionPipeline(
+			config.Pulsar,
+			config.SubscriptionName,
+			config.BatchSize,
+			config.BatchDuration,
+			pulsar.KeyShared,
+			converter,
+			eventDb,
+			config.Metrics,
+			metrics)
 	err = ingester.Run(app.CreateContextWithShutdown())
 
 	if err != nil {

--- a/internal/eventingester/ingester.go
+++ b/internal/eventingester/ingester.go
@@ -1,17 +1,15 @@
 package eventingester
 
 import (
-	"github.com/apache/pulsar-client-go/pulsar"
 	"regexp"
 	"time"
 
-	"github.com/pkg/errors"
-
-	"github.com/armadaproject/armada/internal/common/app"
-
+	"github.com/apache/pulsar-client-go/pulsar"
 	"github.com/go-redis/redis"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
+	"github.com/armadaproject/armada/internal/common/app"
 	"github.com/armadaproject/armada/internal/common/compress"
 	"github.com/armadaproject/armada/internal/common/ingest"
 	"github.com/armadaproject/armada/internal/eventingester/configuration"

--- a/internal/lookoutingester/ingester.go
+++ b/internal/lookoutingester/ingester.go
@@ -1,6 +1,7 @@
 package lookoutingester
 
 import (
+	"github.com/apache/pulsar-client-go/pulsar"
 	"os"
 
 	"github.com/pkg/errors"
@@ -59,6 +60,7 @@ func Run(config *configuration.LookoutIngesterConfiguration) {
 		config.SubscriptionName,
 		config.BatchSize,
 		config.BatchDuration,
+		pulsar.KeyShared,
 		converter,
 		lookoutDb,
 		config.Metrics,

--- a/internal/lookoutingester/ingester.go
+++ b/internal/lookoutingester/ingester.go
@@ -1,9 +1,9 @@
 package lookoutingester
 
 import (
-	"github.com/apache/pulsar-client-go/pulsar"
 	"os"
 
+	"github.com/apache/pulsar-client-go/pulsar"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"

--- a/internal/lookoutingesterv2/ingester.go
+++ b/internal/lookoutingesterv2/ingester.go
@@ -1,6 +1,7 @@
 package lookoutingesterv2
 
 import (
+	"github.com/apache/pulsar-client-go/pulsar"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
@@ -38,6 +39,7 @@ func Run(config *configuration.LookoutIngesterV2Configuration) {
 		config.SubscriptionName,
 		config.BatchSize,
 		config.BatchDuration,
+		pulsar.KeyShared,
 		converter,
 		lookoutDb,
 		config.Metrics,

--- a/internal/scheduleringester/ingester.go
+++ b/internal/scheduleringester/ingester.go
@@ -1,6 +1,7 @@
 package scheduleringester
 
 import (
+	"github.com/apache/pulsar-client-go/pulsar"
 	"time"
 
 	"github.com/armadaproject/armada/internal/common/schedulers"
@@ -38,6 +39,7 @@ func Run(config Configuration) {
 		config.SubscriptionName,
 		config.BatchSize,
 		config.BatchDuration,
+		pulsar.Failover,
 		schedulers.ForPulsarScheduler,
 		converter,
 		schedulerDb,

--- a/internal/scheduleringester/ingester.go
+++ b/internal/scheduleringester/ingester.go
@@ -1,11 +1,9 @@
 package scheduleringester
 
 import (
-	"github.com/apache/pulsar-client-go/pulsar"
 	"time"
 
-	"github.com/armadaproject/armada/internal/common/schedulers"
-
+	"github.com/apache/pulsar-client-go/pulsar"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
@@ -14,6 +12,7 @@ import (
 	"github.com/armadaproject/armada/internal/common/database"
 	"github.com/armadaproject/armada/internal/common/ingest"
 	"github.com/armadaproject/armada/internal/common/ingest/metrics"
+	"github.com/armadaproject/armada/internal/common/schedulers"
 )
 
 // Run will create a pipeline that will take Armada event messages from Pulsar and update the


### PR DESCRIPTION
- Make subscription type user settable in ingesters
- All ingesters apart from scheduler ingester use `keyShared`
- scheduler ingester uses `failover`