### PR TITLE
integration test fix

### DIFF
--- a/client/python/tests/integration/test_no_auth.py
+++ b/client/python/tests/integration/test_no_auth.py
@@ -155,22 +155,6 @@ def test_submit_job_and_cancel_by_id(client: ArmadaClient, queue_name):
     assert cancelled_message.cancelled_ids[0] == jobs.job_response_items[0].job_id
 
 
-def test_submit_job_and_cancel_by_queue_job_set(client: ArmadaClient, queue_name):
-    job_set_name = f"set-{uuid.uuid1()}"
-    client.submit_jobs(
-        queue=queue_name,
-        job_set_id=job_set_name,
-        job_request_items=submit_sleep_job(client),
-    )
-
-    wait_for(client, queue=queue_name, job_set_id=job_set_name)
-
-    cancelled_message = client.cancel_jobs(queue=queue_name, job_set_id=job_set_name)
-
-    expected = f"all jobs in job set {job_set_name}"
-    assert expected == cancelled_message.cancelled_ids[0]
-
-
 def test_submit_job_and_cancel_by_job_id(client: ArmadaClient, queue_name):
     job_set_name = f"set-{uuid.uuid1()}"
     jobs = client.submit_jobs(

--- a/makefile
+++ b/makefile
@@ -473,6 +473,9 @@ tests-e2e-setup: setup-cluster
 	$(GO_CMD) go run cmd/armadactl/main.go create queue queue-a || true
 	$(GO_CMD) go run cmd/armadactl/main.go create queue queue-b || true
 
+	# Logs to diagonose problems
+	docker logs executor
+	docker logs server
 .ONESHELL:
 tests-e2e-no-setup: gotestsum
 	function printApplicationLogs {

--- a/makefile
+++ b/makefile
@@ -473,8 +473,6 @@ tests-e2e-setup: setup-cluster
 	$(GO_CMD) go run cmd/armadactl/main.go create queue queue-a || true
 	$(GO_CMD) go run cmd/armadactl/main.go create queue queue-b || true
 
-	docker logs executor
-
 .ONESHELL:
 tests-e2e-no-setup: gotestsum
 	function printApplicationLogs {

--- a/makefile
+++ b/makefile
@@ -473,6 +473,8 @@ tests-e2e-setup: setup-cluster
 	$(GO_CMD) go run cmd/armadactl/main.go create queue queue-a || true
 	$(GO_CMD) go run cmd/armadactl/main.go create queue queue-b || true
 
+	docker logs executor
+
 .ONESHELL:
 tests-e2e-no-setup: gotestsum
 	function printApplicationLogs {


### PR DESCRIPTION
I don't think this endpoint is supported anymore.  We can use `cancel_jobset` and that seems to work.  