### PR TITLE
Add cache to submitchecks

### DIFF
--- a/config/armada/config.yaml
+++ b/config/armada/config.yaml
@@ -107,8 +107,6 @@ scheduling:
     - memory
   minTerminationGracePeriod: 1s
   maxTerminationGracePeriod: 300s
-  gangIdAnnotation: armadaproject.io/gangId
-  gangCardinalityAnnotation: armadaproject.io/gangCardinality
 queueManagement:
   defaultPriorityFactor: 1000
   defaultQueuedJobsLimit: 0  # No Limit

--- a/go.mod
+++ b/go.mod
@@ -272,6 +272,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
+	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/mitchellh/iochan v1.0.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/go.mod
+++ b/go.mod
@@ -94,6 +94,7 @@ require (
 	github.com/kyleconroy/sqlc v1.16.0
 	github.com/magefile/mage v1.14.0
 	github.com/matryer/moq v0.3.0
+	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/openconfig/goyang v1.2.0
 	github.com/pingcap/log v0.0.0-20210906054005-afc726e70354
 	github.com/prometheus/common v0.37.0
@@ -272,7 +273,6 @@ require (
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
-	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/mitchellh/iochan v1.0.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/go.sum
+++ b/go.sum
@@ -998,6 +998,8 @@ github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eI
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
 github.com/mitchellh/gox v1.0.1 h1:x0jD3dcHk9a9xPSDN6YEL4xL6Qz0dvNYm8yZqui5chI=
 github.com/mitchellh/gox v1.0.1/go.mod h1:ED6BioOGXMswlXa2zxfh/xdd5QhwYliBFn9V18Ap4z4=
+github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4NcD46KavDd4=
+github.com/mitchellh/hashstructure/v2 v2.0.2/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/zz4kQkprJgF2EVszyDE=
 github.com/mitchellh/iochan v1.0.0 h1:C+X3KsSTLFVBr/tK1eYN/vs4rJcvsiLU338UhYPJWeY=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=

--- a/internal/armada/configuration/constants.go
+++ b/internal/armada/configuration/constants.go
@@ -1,0 +1,14 @@
+package configuration
+
+// GangIdAnnotation Jobs with equal value for this annotation make up a gang.
+// All jobs in a gang are guaranteed to be scheduled onto the same cluster at the same time.
+const GangIdAnnotation = "armadaproject.io/gangId"
+
+// GangCardinalityAnnotation All jobs in a gang must specify the total number of jobs in the gang via this annotation.
+// The cardinality should be expressed as an integer, e.g., "3".
+const GangCardinalityAnnotation = "armadaproject.io/gangCardinality"
+
+var ArmadaManagedAnnotations = []string {
+	GangIdAnnotation,
+	GangCardinalityAnnotation,
+}

--- a/internal/armada/configuration/constants.go
+++ b/internal/armada/configuration/constants.go
@@ -8,7 +8,7 @@ const GangIdAnnotation = "armadaproject.io/gangId"
 // The cardinality should be expressed as an integer, e.g., "3".
 const GangCardinalityAnnotation = "armadaproject.io/gangCardinality"
 
-var ArmadaManagedAnnotations = []string {
+var ArmadaManagedAnnotations = []string{
 	GangIdAnnotation,
 	GangCardinalityAnnotation,
 }

--- a/internal/armada/configuration/types.go
+++ b/internal/armada/configuration/types.go
@@ -170,12 +170,6 @@ type SchedulingConfig struct {
 	// Should normally not be set greater than single-digit minutes,
 	// since cancellation and preemption may need to wait for this amount of time.
 	MaxTerminationGracePeriod time.Duration
-	// Jobs with equal value for this annotation make up a gang.
-	// All jobs in a gang are guaranteed to be scheduled onto the same cluster at the same time.
-	GangIdAnnotation string
-	// All jobs in a gang must specify the total number of jobs in the gang via this annotation.
-	// The cardinality should be expressed as an integer, e.g., "3".
-	GangCardinalityAnnotation string
 	// If an executor hasn't heartbeated in this time period, it will be considered stale
 	ExecutorTimeout time.Duration
 }

--- a/internal/armada/server.go
+++ b/internal/armada/server.go
@@ -201,7 +201,7 @@ func Serve(ctx context.Context, config *configuration.ArmadaConfig, healthChecks
 		PulsarSchedulerEnabled:             config.PulsarSchedulerEnabled,
 		ProbabilityOdfUsingPulsarScheduler: config.ProbabilityOfUsingPulsarScheduler,
 		Rand:                               util.NewThreadsafeRand(time.Now().UnixNano()),
-		GangIdAnnotation:                   config.Scheduling.GangIdAnnotation,
+		GangIdAnnotation:                   configuration.GangIdAnnotation,
 		IgnoreJobSubmitChecks:              config.IgnoreJobSubmitChecks,
 	}
 	submitServerToRegister := pulsarSubmitServer

--- a/internal/common/util/hash.go
+++ b/internal/common/util/hash.go
@@ -79,29 +79,28 @@ const (
 //
 // Notes on the value:
 //
-//   * Unexported fields on structs are ignored and do not affect the
+//   - Unexported fields on structs are ignored and do not affect the
 //     hash value.
 //
-//   * Adding an exported field to a struct with the zero value will change
+//   - Adding an exported field to a struct with the zero value will change
 //     the hash value.
 //
 // For structs, the hashing can be controlled using tags. For example:
 //
-//    struct {
-//        Name string
-//        UUID string `hash:"ignore"`
-//    }
+//	struct {
+//	    Name string
+//	    UUID string `hash:"ignore"`
+//	}
 //
 // The available tag values are:
 //
-//   * "ignore" or "-" - The field will be ignored and not affect the hash code.
+//   - "ignore" or "-" - The field will be ignored and not affect the hash code.
 //
-//   * "set" - The field will be treated as a set, where ordering doesn't
-//             affect the hash code. This only works for slices.
+//   - "set" - The field will be treated as a set, where ordering doesn't
+//     affect the hash code. This only works for slices.
 //
-//   * "string" - The field will be hashed as a string, only works when the
-//                field implements fmt.Stringer
-//
+//   - "string" - The field will be hashed as a string, only works when the
+//     field implements fmt.Stringer
 func Hash(v interface{}, format Format, opts *HashOptions) (uint64, error) {
 	// Validate our format
 	if format <= formatInvalid || format >= formatMax {
@@ -474,11 +473,11 @@ func hashUpdateUnordered(a, b uint64) uint64 {
 // hashUpdateUnordered can effectively cancel out a previous change to the hash
 // result if the same hash value appears later on. For example, consider:
 //
-//   hashUpdateUnordered(hashUpdateUnordered("A", "B"), hashUpdateUnordered("A", "C")) =
-//   H("A") ^ H("B")) ^ (H("A") ^ H("C")) =
-//   (H("A") ^ H("A")) ^ (H("B") ^ H(C)) =
-//   H(B) ^ H(C) =
-//   hashUpdateUnordered(hashUpdateUnordered("Z", "B"), hashUpdateUnordered("Z", "C"))
+//	hashUpdateUnordered(hashUpdateUnordered("A", "B"), hashUpdateUnordered("A", "C")) =
+//	H("A") ^ H("B")) ^ (H("A") ^ H("C")) =
+//	(H("A") ^ H("A")) ^ (H("B") ^ H(C)) =
+//	H(B) ^ H(C) =
+//	hashUpdateUnordered(hashUpdateUnordered("Z", "B"), hashUpdateUnordered("Z", "C"))
 //
 // hashFinishUnordered "hardens" the result, so that encountering partially
 // overlapping input data later on in a different context won't cancel out.

--- a/internal/common/util/hash.go
+++ b/internal/common/util/hash.go
@@ -1,0 +1,502 @@
+// This code is largely a copy from https://github.com/mitchellh/hashstructure/blob/master/hashstructure.go
+// It contains a small change to also be able to properly hash resource.Quantity
+
+package util
+
+import (
+	"encoding/binary"
+	"fmt"
+	"hash"
+	"hash/fnv"
+	"reflect"
+	"time"
+
+	"github.com/mitchellh/hashstructure/v2"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// HashOptions are options that are available for hashing.
+type HashOptions struct {
+	// Hasher is the hash function to use. If this isn't set, it will
+	// default to FNV.
+	Hasher hash.Hash64
+
+	// TagName is the struct tag to look at when hashing the structure.
+	// By default this is "hash".
+	TagName string
+
+	// ZeroNil is flag determining if nil pointer should be treated equal
+	// to a zero value of pointed type. By default this is false.
+	ZeroNil bool
+
+	// IgnoreZeroValue is determining if zero value fields should be
+	// ignored for hash calculation.
+	IgnoreZeroValue bool
+
+	// SlicesAsSets assumes that a `set` tag is always present for slices.
+	// Default is false (in which case the tag is used instead)
+	SlicesAsSets bool
+
+	// UseStringer will attempt to use fmt.Stringer always. If the struct
+	// doesn't implement fmt.Stringer, it'll fall back to trying usual tricks.
+	// If this is true, and the "string" tag is also set, the tag takes
+	// precedence (meaning that if the type doesn't implement fmt.Stringer, we
+	// panic)
+	UseStringer bool
+}
+
+// Format specifies the hashing process used. Different formats typically
+// generate different hashes for the same value and have different properties.
+type Format uint
+
+const (
+	// To disallow the zero value
+	formatInvalid Format = iota
+
+	// FormatV1 is the format used in v1.x of this library. This has the
+	// downsides noted in issue #18 but allows simultaneous v1/v2 usage.
+	FormatV1
+
+	// FormatV2 is the current recommended format and fixes the issues
+	// noted in FormatV1.
+	FormatV2
+
+	formatMax // so we can easily find the end
+)
+
+// Hash returns the hash value of an arbitrary value.
+//
+// If opts is nil, then default options will be used. See HashOptions
+// for the default values. The same *HashOptions value cannot be used
+// concurrently. None of the values within a *HashOptions struct are
+// safe to read/write while hashing is being done.
+//
+// The "format" is required and must be one of the format values defined
+// by this library. You should probably just use "FormatV2". This allows
+// generated hashes uses alternate logic to maintain compatibility with
+// older versions.
+//
+// Notes on the value:
+//
+//   * Unexported fields on structs are ignored and do not affect the
+//     hash value.
+//
+//   * Adding an exported field to a struct with the zero value will change
+//     the hash value.
+//
+// For structs, the hashing can be controlled using tags. For example:
+//
+//    struct {
+//        Name string
+//        UUID string `hash:"ignore"`
+//    }
+//
+// The available tag values are:
+//
+//   * "ignore" or "-" - The field will be ignored and not affect the hash code.
+//
+//   * "set" - The field will be treated as a set, where ordering doesn't
+//             affect the hash code. This only works for slices.
+//
+//   * "string" - The field will be hashed as a string, only works when the
+//                field implements fmt.Stringer
+//
+func Hash(v interface{}, format Format, opts *HashOptions) (uint64, error) {
+	// Validate our format
+	if format <= formatInvalid || format >= formatMax {
+		return 0, &hashstructure.ErrFormat{}
+	}
+
+	// Create default options
+	if opts == nil {
+		opts = &HashOptions{}
+	}
+	if opts.Hasher == nil {
+		opts.Hasher = fnv.New64()
+	}
+	if opts.TagName == "" {
+		opts.TagName = "hash"
+	}
+
+	// Reset the hash
+	opts.Hasher.Reset()
+
+	// Create our walker and walk the structure
+	w := &walker{
+		format:          format,
+		h:               opts.Hasher,
+		tag:             opts.TagName,
+		zeronil:         opts.ZeroNil,
+		ignorezerovalue: opts.IgnoreZeroValue,
+		sets:            opts.SlicesAsSets,
+		stringer:        opts.UseStringer,
+	}
+	return w.visit(reflect.ValueOf(v), nil)
+}
+
+type walker struct {
+	format          Format
+	h               hash.Hash64
+	tag             string
+	zeronil         bool
+	ignorezerovalue bool
+	sets            bool
+	stringer        bool
+}
+
+type visitOpts struct {
+	// Flags are a bitmask of flags to affect behavior of this visit
+	Flags visitFlag
+
+	// Information about the struct containing this field
+	Struct      interface{}
+	StructField string
+}
+
+var timeType = reflect.TypeOf(time.Time{})
+var quantityType = reflect.TypeOf(resource.Quantity{})
+
+func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
+	t := reflect.TypeOf(0)
+
+	// Loop since these can be wrapped in multiple layers of pointers
+	// and interfaces.
+	for {
+		// If we have an interface, dereference it. We have to do this up
+		// here because it might be a nil in there and the check below must
+		// catch that.
+		if v.Kind() == reflect.Interface {
+			v = v.Elem()
+			continue
+		}
+
+		if v.Kind() == reflect.Ptr {
+			if w.zeronil {
+				t = v.Type().Elem()
+			}
+			v = reflect.Indirect(v)
+			continue
+		}
+
+		break
+	}
+
+	// If it is nil, treat it like a zero.
+	if !v.IsValid() {
+		v = reflect.Zero(t)
+	}
+
+	// Binary writing can use raw ints, we have to convert to
+	// a sized-int, we'll choose the largest...
+	switch v.Kind() {
+	case reflect.Int:
+		v = reflect.ValueOf(int64(v.Int()))
+	case reflect.Uint:
+		v = reflect.ValueOf(uint64(v.Uint()))
+	case reflect.Bool:
+		var tmp int8
+		if v.Bool() {
+			tmp = 1
+		}
+		v = reflect.ValueOf(tmp)
+	}
+
+	k := v.Kind()
+
+	// We can shortcut numeric values by directly binary writing them
+	if k >= reflect.Int && k <= reflect.Complex64 {
+		// A direct hash calculation
+		w.h.Reset()
+		err := binary.Write(w.h, binary.LittleEndian, v.Interface())
+		return w.h.Sum64(), err
+	}
+
+	switch v.Type() {
+	case timeType:
+		w.h.Reset()
+		b, err := v.Interface().(time.Time).MarshalBinary()
+		if err != nil {
+			return 0, err
+		}
+
+		err = binary.Write(w.h, binary.LittleEndian, b)
+		return w.h.Sum64(), err
+	}
+
+	switch v.Type() {
+	case quantityType:
+		w.h.Reset()
+		b, ok := v.Interface().(resource.Quantity)
+		if !ok {
+			return 0, errors.Errorf("unexpected type found when hashing, expected resource.Quantity got %s", v.Type().String())
+		}
+
+		_, err := w.h.Write([]byte(b.String()))
+		return w.h.Sum64(), err
+	}
+
+	switch k {
+	case reflect.Array:
+		var h uint64
+		l := v.Len()
+		for i := 0; i < l; i++ {
+			current, err := w.visit(v.Index(i), nil)
+			if err != nil {
+				return 0, err
+			}
+
+			h = hashUpdateOrdered(w.h, h, current)
+		}
+
+		return h, nil
+
+	case reflect.Map:
+		var includeMap hashstructure.IncludableMap
+		if opts != nil && opts.Struct != nil {
+			if v, ok := opts.Struct.(hashstructure.IncludableMap); ok {
+				includeMap = v
+			}
+		}
+
+		// Build the hash for the map. We do this by XOR-ing all the key
+		// and value hashes. This makes it deterministic despite ordering.
+		var h uint64
+		for _, k := range v.MapKeys() {
+			v := v.MapIndex(k)
+			if includeMap != nil {
+				incl, err := includeMap.HashIncludeMap(
+					opts.StructField, k.Interface(), v.Interface())
+				if err != nil {
+					return 0, err
+				}
+				if !incl {
+					continue
+				}
+			}
+
+			kh, err := w.visit(k, nil)
+			if err != nil {
+				return 0, err
+			}
+			vh, err := w.visit(v, nil)
+			if err != nil {
+				return 0, err
+			}
+
+			fieldHash := hashUpdateOrdered(w.h, kh, vh)
+			h = hashUpdateUnordered(h, fieldHash)
+		}
+
+		if w.format != FormatV1 {
+			// Important: read the docs for hashFinishUnordered
+			h = hashFinishUnordered(w.h, h)
+		}
+
+		return h, nil
+
+	case reflect.Struct:
+		parent := v.Interface()
+		var include hashstructure.Includable
+		if impl, ok := parent.(hashstructure.Includable); ok {
+			include = impl
+		}
+
+		if impl, ok := parent.(hashstructure.Hashable); ok {
+			return impl.Hash()
+		}
+
+		// If we can address this value, check if the pointer value
+		// implements our interfaces and use that if so.
+		if v.CanAddr() {
+			vptr := v.Addr()
+			parentptr := vptr.Interface()
+			if impl, ok := parentptr.(hashstructure.Includable); ok {
+				include = impl
+			}
+
+			if impl, ok := parentptr.(hashstructure.Hashable); ok {
+				return impl.Hash()
+			}
+		}
+
+		t := v.Type()
+		h, err := w.visit(reflect.ValueOf(t.Name()), nil)
+		if err != nil {
+			return 0, err
+		}
+
+		l := v.NumField()
+		for i := 0; i < l; i++ {
+			if innerV := v.Field(i); v.CanSet() || t.Field(i).Name != "_" {
+				var f visitFlag
+				fieldType := t.Field(i)
+				if fieldType.PkgPath != "" {
+					// Unexported
+					continue
+				}
+
+				tag := fieldType.Tag.Get(w.tag)
+				if tag == "ignore" || tag == "-" {
+					// Ignore this field
+					continue
+				}
+
+				if w.ignorezerovalue {
+					if innerV.IsZero() {
+						continue
+					}
+				}
+
+				// if string is set, use the string value
+				if tag == "string" || w.stringer {
+					if impl, ok := innerV.Interface().(fmt.Stringer); ok {
+						innerV = reflect.ValueOf(impl.String())
+					} else if tag == "string" {
+						// We only show this error if the tag explicitly
+						// requests a stringer.
+						return 0, &hashstructure.ErrNotStringer{
+							Field: v.Type().Field(i).Name,
+						}
+					}
+				}
+
+				// Check if we implement includable and check it
+				if include != nil {
+					incl, err := include.HashInclude(fieldType.Name, innerV)
+					if err != nil {
+						return 0, err
+					}
+					if !incl {
+						continue
+					}
+				}
+
+				switch tag {
+				case "set":
+					f |= visitFlagSet
+				}
+
+				kh, err := w.visit(reflect.ValueOf(fieldType.Name), nil)
+				if err != nil {
+					return 0, err
+				}
+
+				vh, err := w.visit(innerV, &visitOpts{
+					Flags:       f,
+					Struct:      parent,
+					StructField: fieldType.Name,
+				})
+				if err != nil {
+					return 0, err
+				}
+
+				fieldHash := hashUpdateOrdered(w.h, kh, vh)
+				h = hashUpdateUnordered(h, fieldHash)
+			}
+
+			if w.format != FormatV1 {
+				// Important: read the docs for hashFinishUnordered
+				h = hashFinishUnordered(w.h, h)
+			}
+		}
+
+		return h, nil
+
+	case reflect.Slice:
+		// We have two behaviors here. If it isn't a set, then we just
+		// visit all the elements. If it is a set, then we do a deterministic
+		// hash code.
+		var h uint64
+		var set bool
+		if opts != nil {
+			set = (opts.Flags & visitFlagSet) != 0
+		}
+		l := v.Len()
+		for i := 0; i < l; i++ {
+			current, err := w.visit(v.Index(i), nil)
+			if err != nil {
+				return 0, err
+			}
+
+			if set || w.sets {
+				h = hashUpdateUnordered(h, current)
+			} else {
+				h = hashUpdateOrdered(w.h, h, current)
+			}
+		}
+
+		if set && w.format != FormatV1 {
+			// Important: read the docs for hashFinishUnordered
+			h = hashFinishUnordered(w.h, h)
+		}
+
+		return h, nil
+
+	case reflect.String:
+		// Directly hash
+		w.h.Reset()
+		_, err := w.h.Write([]byte(v.String()))
+		return w.h.Sum64(), err
+
+	default:
+		return 0, fmt.Errorf("unknown kind to hash: %s", k)
+	}
+
+}
+
+func hashUpdateOrdered(h hash.Hash64, a, b uint64) uint64 {
+	// For ordered updates, use a real hash function
+	h.Reset()
+
+	// We just panic if the binary writes fail because we are writing
+	// an int64 which should never be fail-able.
+	e1 := binary.Write(h, binary.LittleEndian, a)
+	e2 := binary.Write(h, binary.LittleEndian, b)
+	if e1 != nil {
+		panic(e1)
+	}
+	if e2 != nil {
+		panic(e2)
+	}
+
+	return h.Sum64()
+}
+
+func hashUpdateUnordered(a, b uint64) uint64 {
+	return a ^ b
+}
+
+// After mixing a group of unique hashes with hashUpdateUnordered, it's always
+// necessary to call hashFinishUnordered. Why? Because hashUpdateUnordered
+// is a simple XOR, and calling hashUpdateUnordered on hashes produced by
+// hashUpdateUnordered can effectively cancel out a previous change to the hash
+// result if the same hash value appears later on. For example, consider:
+//
+//   hashUpdateUnordered(hashUpdateUnordered("A", "B"), hashUpdateUnordered("A", "C")) =
+//   H("A") ^ H("B")) ^ (H("A") ^ H("C")) =
+//   (H("A") ^ H("A")) ^ (H("B") ^ H(C)) =
+//   H(B) ^ H(C) =
+//   hashUpdateUnordered(hashUpdateUnordered("Z", "B"), hashUpdateUnordered("Z", "C"))
+//
+// hashFinishUnordered "hardens" the result, so that encountering partially
+// overlapping input data later on in a different context won't cancel out.
+func hashFinishUnordered(h hash.Hash64, a uint64) uint64 {
+	h.Reset()
+
+	// We just panic if the writes fail
+	e1 := binary.Write(h, binary.LittleEndian, a)
+	if e1 != nil {
+		panic(e1)
+	}
+
+	return h.Sum64()
+}
+
+// visitFlag is used as a bitmask for affecting visit behavior
+type visitFlag uint
+
+const (
+	visitFlagInvalid visitFlag = iota
+	visitFlagSet               = iota << 1
+)

--- a/internal/common/util/hash.go
+++ b/internal/common/util/hash.go
@@ -154,8 +154,10 @@ type visitOpts struct {
 	StructField string
 }
 
-var timeType = reflect.TypeOf(time.Time{})
-var quantityType = reflect.TypeOf(resource.Quantity{})
+var (
+	timeType     = reflect.TypeOf(time.Time{})
+	quantityType = reflect.TypeOf(resource.Quantity{})
+)
 
 func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
 	t := reflect.TypeOf(0)
@@ -442,7 +444,6 @@ func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
 	default:
 		return 0, fmt.Errorf("unknown kind to hash: %s", k)
 	}
-
 }
 
 func hashUpdateOrdered(h hash.Hash64, a, b uint64) uint64 {

--- a/internal/common/validation/job.go
+++ b/internal/common/validation/job.go
@@ -12,7 +12,7 @@ import (
 )
 
 func ValidateApiJobs(jobs []*api.Job, config configuration.SchedulingConfig) error {
-	err := validateGangs(jobs, config.GangIdAnnotation, config.GangCardinalityAnnotation)
+	err := validateGangs(jobs, configuration.GangIdAnnotation, configuration.GangCardinalityAnnotation)
 	if err != nil {
 		return err
 	}

--- a/internal/scheduler/legacyscheduler.go
+++ b/internal/scheduler/legacyscheduler.go
@@ -1481,9 +1481,7 @@ func PodRequirementsFromLegacySchedulerJobs[S ~[]E, E LegacySchedulerJob](jobs S
 func PodRequirementFromLegacySchedulerJob[E LegacySchedulerJob](job E, priorityClasses map[string]configuration.PriorityClass) *schedulerobjects.PodRequirements {
 	info := job.GetRequirements(priorityClasses)
 	req := PodRequirementFromJobSchedulingInfo(info)
-	if req.Annotations == nil {
-		req.Annotations = make(map[string]string)
-	}
+	req.Annotations = make(map[string]string)
 	for _, key := range configuration.ArmadaManagedAnnotations {
 		if value, present := job.GetAnnotations()[key]; present {
 			req.GetAnnotations()[key] = value

--- a/internal/scheduler/legacyscheduler.go
+++ b/internal/scheduler/legacyscheduler.go
@@ -952,8 +952,8 @@ func NewLegacyScheduler(
 			ctx,
 			queue.jobIterator,
 			config.QueueLeaseBatchSize,
-			config.GangIdAnnotation,
-			config.GangCardinalityAnnotation,
+			configuration.GangIdAnnotation,
+			configuration.GangCardinalityAnnotation,
 		)
 
 		// Enforce per-queue constraints.
@@ -1484,7 +1484,11 @@ func PodRequirementFromLegacySchedulerJob[E LegacySchedulerJob](job E, priorityC
 	if req.Annotations == nil {
 		req.Annotations = make(map[string]string)
 	}
-	maps.Copy(req.Annotations, job.GetAnnotations())
+	for _, key := range configuration.ArmadaManagedAnnotations {
+		if value, present := job.GetAnnotations()[key]; present {
+			req.GetAnnotations()[key] = value
+		}
+	}
 	req.Annotations[JobIdAnnotation] = job.GetId()
 	req.Annotations[QueueAnnotation] = job.GetQueue()
 	return req

--- a/internal/scheduler/submitcheck.go
+++ b/internal/scheduler/submitcheck.go
@@ -72,7 +72,15 @@ func NewSubmitChecker(
 
 func (srv *SubmitChecker) Run(ctx context.Context) error {
 	srv.updateExecutors(ctx)
-	return nil
+	ticker := time.NewTicker(1 * time.Minute)
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			srv.updateExecutors(ctx)
+		}
+	}
 }
 
 func (srv *SubmitChecker) updateExecutors(ctx context.Context) {

--- a/internal/scheduler/submitcheck.go
+++ b/internal/scheduler/submitcheck.go
@@ -52,7 +52,7 @@ func NewSubmitChecker(
 	schedulingConfig configuration.SchedulingConfig,
 	executorRepository database.ExecutorRepository,
 ) *SubmitChecker {
-	jobRequirementSchedulingResults, err := lru.New(maxJobSchedulingResults)
+	jobSchedulingResultsCache, err := lru.New(maxJobSchedulingResults)
 	if err != nil {
 		panic(errors.WithStack(err))
 	}
@@ -67,7 +67,7 @@ func NewSubmitChecker(
 		indexedNodeLabels:         schedulingConfig.IndexedNodeLabels,
 		executorRepository:        executorRepository,
 		clock:                     clock.RealClock{},
-		jobSchedulingResultsCache: jobRequirementSchedulingResults,
+		jobSchedulingResultsCache: jobSchedulingResultsCache,
 	}
 }
 

--- a/internal/scheduler/submitcheck.go
+++ b/internal/scheduler/submitcheck.go
@@ -8,13 +8,13 @@ import (
 	"time"
 
 	lru "github.com/hashicorp/golang-lru"
-	"github.com/mitchellh/hashstructure/v2"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/exp/maps"
 	"k8s.io/apimachinery/pkg/util/clock"
 
 	"github.com/armadaproject/armada/internal/armada/configuration"
+	"github.com/armadaproject/armada/internal/common/util"
 	"github.com/armadaproject/armada/internal/scheduler/database"
 	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
 	"github.com/armadaproject/armada/pkg/api"
@@ -150,7 +150,7 @@ func GroupJobsByAnnotation(annotation string, jobs []*api.Job) map[string][]*api
 
 func (srv *SubmitChecker) getSchedulingResult(reqs []*schedulerobjects.PodRequirements) schedulingResult {
 	overwriteAnnotations(reqs)
-	reqsHash, err := hashstructure.Hash(reqs, hashstructure.FormatV2, nil)
+	reqsHash, err := util.Hash(reqs, util.FormatV2, nil)
 	if err != nil {
 		return schedulingResult{isSchedulable: false, reason: err.Error()}
 	}

--- a/internal/scheduler/submitcheck.go
+++ b/internal/scheduler/submitcheck.go
@@ -9,6 +9,7 @@ import (
 
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/mitchellh/hashstructure/v2"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/exp/maps"
 	"k8s.io/apimachinery/pkg/util/clock"
@@ -53,7 +54,7 @@ func NewSubmitChecker(
 ) *SubmitChecker {
 	jobRequirementSchedulingResults, err := lru.New(maxJobSchedulingResults)
 	if err != nil {
-		panic(err)
+		panic(errors.WithStack(err))
 	}
 	return &SubmitChecker{
 		executorTimeout:           executorTimeout,

--- a/internal/scheduler/submitcheck.go
+++ b/internal/scheduler/submitcheck.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 	"time"
 
+	lru "github.com/hashicorp/golang-lru"
+	"github.com/mitchellh/hashstructure/v2"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/exp/maps"
 	"k8s.io/apimachinery/pkg/util/clock"
@@ -22,18 +24,26 @@ type minimalExecutor struct {
 	updateTime time.Time
 }
 
+type schedulingResult struct {
+	isSchedulable bool
+	reason        string
+}
+
+const maxJobSchedulingResults = 10000
+
 type SubmitChecker struct {
-	executorTimeout    time.Duration
-	priorityClasses    map[string]configuration.PriorityClass
-	gangIdAnnotation   string
-	executorById       map[string]minimalExecutor
-	priorities         []int32
-	indexedResources   []string
-	indexedTaints      []string
-	indexedNodeLabels  []string
-	executorRepository database.ExecutorRepository
-	clock              clock.Clock
-	mu                 sync.Mutex
+	executorTimeout           time.Duration
+	priorityClasses           map[string]configuration.PriorityClass
+	gangIdAnnotation          string
+	executorById              map[string]minimalExecutor
+	priorities                []int32
+	indexedResources          []string
+	indexedTaints             []string
+	indexedNodeLabels         []string
+	executorRepository        database.ExecutorRepository
+	clock                     clock.Clock
+	mu                        sync.Mutex
+	jobSchedulingResultsCache *lru.Cache
 }
 
 func NewSubmitChecker(
@@ -41,31 +51,28 @@ func NewSubmitChecker(
 	schedulingConfig configuration.SchedulingConfig,
 	executorRepository database.ExecutorRepository,
 ) *SubmitChecker {
+	jobRequirementSchedulingResults, err := lru.New(maxJobSchedulingResults)
+	if err != nil {
+		panic(err)
+	}
 	return &SubmitChecker{
-		executorTimeout:    executorTimeout,
-		priorityClasses:    schedulingConfig.Preemption.PriorityClasses,
-		gangIdAnnotation:   schedulingConfig.GangIdAnnotation,
-		executorById:       map[string]minimalExecutor{},
-		priorities:         schedulingConfig.Preemption.AllowedPriorities(),
-		indexedResources:   schedulingConfig.IndexedResources,
-		indexedTaints:      schedulingConfig.IndexedTaints,
-		indexedNodeLabels:  schedulingConfig.IndexedNodeLabels,
-		executorRepository: executorRepository,
-		clock:              clock.RealClock{},
+		executorTimeout:           executorTimeout,
+		priorityClasses:           schedulingConfig.Preemption.PriorityClasses,
+		gangIdAnnotation:          configuration.GangIdAnnotation,
+		executorById:              map[string]minimalExecutor{},
+		priorities:                schedulingConfig.Preemption.AllowedPriorities(),
+		indexedResources:          schedulingConfig.IndexedResources,
+		indexedTaints:             schedulingConfig.IndexedTaints,
+		indexedNodeLabels:         schedulingConfig.IndexedNodeLabels,
+		executorRepository:        executorRepository,
+		clock:                     clock.RealClock{},
+		jobSchedulingResultsCache: jobRequirementSchedulingResults,
 	}
 }
 
 func (srv *SubmitChecker) Run(ctx context.Context) error {
 	srv.updateExecutors(ctx)
-	ticker := time.NewTicker(1 * time.Minute)
-	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		case <-ticker.C:
-			srv.updateExecutors(ctx)
-		}
-	}
+	return nil
 }
 
 func (srv *SubmitChecker) updateExecutors(ctx context.Context) {
@@ -91,15 +98,18 @@ func (srv *SubmitChecker) updateExecutors(ctx context.Context) {
 		}
 
 	}
+
+	// Reset cache as the executors may have updated - changing what can be scheduled
+	srv.jobSchedulingResultsCache.Purge()
 }
 
 func (srv *SubmitChecker) CheckApiJobs(jobs []*api.Job) (bool, string) {
 	// First, check if all jobs can be scheduled individually.
 	for i, job := range jobs {
 		reqs := PodRequirementFromLegacySchedulerJob(job, srv.priorityClasses)
-		canSchedule, reason := srv.check([]*schedulerobjects.PodRequirements{reqs})
-		if !canSchedule {
-			return canSchedule, fmt.Sprintf("%d-th job unschedulable:\n%s", i, reason)
+		schedulingResult := srv.getSchedulingResult([]*schedulerobjects.PodRequirements{reqs})
+		if !schedulingResult.isSchedulable {
+			return schedulingResult.isSchedulable, fmt.Sprintf("%d-th job unschedulable:\n%s", i, schedulingResult.reason)
 		}
 	}
 	// Then, check if all gangs can be scheduled.
@@ -108,9 +118,9 @@ func (srv *SubmitChecker) CheckApiJobs(jobs []*api.Job) (bool, string) {
 			continue
 		}
 		reqs := PodRequirementsFromLegacySchedulerJobs(jobs, srv.priorityClasses)
-		canSchedule, reason := srv.check(reqs)
-		if !canSchedule {
-			return canSchedule, fmt.Sprintf("gang %s is unschedulable:\n%s", gangId, reason)
+		schedulingResult := srv.getSchedulingResult(reqs)
+		if !schedulingResult.isSchedulable {
+			return schedulingResult.isSchedulable, fmt.Sprintf("gang %s is unschedulable:\n%s", gangId, schedulingResult.reason)
 		}
 	}
 	return true, ""
@@ -129,10 +139,26 @@ func GroupJobsByAnnotation(annotation string, jobs []*api.Job) map[string][]*api
 	return rv
 }
 
+func (srv *SubmitChecker) getSchedulingResult(reqs []*schedulerobjects.PodRequirements) schedulingResult {
+	reqsHash, err := hashstructure.Hash(reqs, hashstructure.FormatV2, nil)
+	if err != nil {
+		return schedulingResult{isSchedulable: false, reason: err.Error()}
+	}
+	cachedResult, cacheExists := srv.jobSchedulingResultsCache.Get(reqsHash)
+	result, castSuccess := cachedResult.(schedulingResult)
+
+	if !cacheExists || !castSuccess {
+		result = srv.check(reqs)
+		srv.jobSchedulingResultsCache.Add(reqsHash, result)
+	}
+
+	return result
+}
+
 // Check if a set of pods can be scheduled onto some cluster.
-func (srv *SubmitChecker) check(reqs []*schedulerobjects.PodRequirements) (bool, string) {
+func (srv *SubmitChecker) check(reqs []*schedulerobjects.PodRequirements) schedulingResult {
 	if len(reqs) == 0 {
-		return true, ""
+		return schedulingResult{isSchedulable: true, reason: ""}
 	}
 
 	// Make a shallow copy to avoid holding the lock and
@@ -142,7 +168,7 @@ func (srv *SubmitChecker) check(reqs []*schedulerobjects.PodRequirements) (bool,
 	srv.mu.Unlock()
 	executorById = srv.filterStaleNodeDbs(executorById)
 	if len(executorById) == 0 {
-		return false, "no executor clusters available"
+		return schedulingResult{isSchedulable: false, reason: "no executor clusters available"}
 	}
 
 	canSchedule := false
@@ -181,7 +207,7 @@ func (srv *SubmitChecker) check(reqs []*schedulerobjects.PodRequirements) (bool,
 			sb.WriteString(fmt.Sprintf(" %d out of %d pods schedulable\n", numSuccessfullyScheduled, len(reqs)))
 		}
 	}
-	return canSchedule, sb.String()
+	return schedulingResult{isSchedulable: canSchedule, reason: sb.String()}
 }
 
 func (srv *SubmitChecker) filterStaleNodeDbs(executorsById map[string]minimalExecutor) map[string]minimalExecutor {

--- a/internal/scheduler/submitcheck_test.go
+++ b/internal/scheduler/submitcheck_test.go
@@ -146,7 +146,7 @@ func testNJobGang(n int) []*api.Job {
 	gang := make([]*api.Job, n)
 	for i := 0; i < n; i++ {
 		job := test1CoreCpuJob()
-		job.Annotations = map[string]string{testGangIdAnnotation: gangId}
+		job.Annotations = map[string]string{configuration.GangIdAnnotation: gangId}
 		gang[i] = job
 	}
 	return gang

--- a/internal/scheduler/testfixtures_test.go
+++ b/internal/scheduler/testfixtures_test.go
@@ -16,9 +16,7 @@ import (
 )
 
 const (
-	testGangIdAnnotation          = "armada.io/gangId"
-	testGangCardinalityAnnotation = "armada.io/gangCardinality"
-	testHostnameLabel             = "kubernetes.io/hostname"
+	testHostnameLabel = "kubernetes.io/hostname"
 )
 
 var (
@@ -58,10 +56,8 @@ func testSchedulingConfig() configuration.SchedulingConfig {
 			PriorityClasses:      maps.Clone(testPriorityClasses),
 			DefaultPriorityClass: testDefaultPriorityClass,
 		},
-		IndexedResources:          []string{"cpu", "memory"},
-		GangIdAnnotation:          testGangIdAnnotation,
-		GangCardinalityAnnotation: testGangCardinalityAnnotation,
-		ExecutorTimeout:           15 * time.Minute,
+		IndexedResources: []string{"cpu", "memory"},
+		ExecutorTimeout:  15 * time.Minute,
 	}
 }
 
@@ -177,7 +173,7 @@ func withGangAnnotationsPodReqs(reqs []*schedulerobjects.PodRequirements) []*sch
 	gangId := uuid.NewString()
 	gangCardinality := fmt.Sprintf("%d", len(reqs))
 	return withAnnotationsPodReqs(
-		map[string]string{testGangIdAnnotation: gangId, testGangCardinalityAnnotation: gangCardinality},
+		map[string]string{configuration.GangIdAnnotation: gangId, configuration.GangCardinalityAnnotation: gangCardinality},
 		reqs,
 	)
 }

--- a/magefiles/ci.go
+++ b/magefiles/ci.go
@@ -28,7 +28,7 @@ func ciRunTests() error {
 		return err
 	}
 
-	time.Sleep(5 * time.Second)
+	time.Sleep(10 * time.Second)
 	err = goRun("run", "cmd/armadactl/main.go", "create", "queue", "e2e-test-queue")
 	if err != nil {
 		return err


### PR DESCRIPTION
On submission we check if jobs are schedulable on any known node
 - If they are not, submission is rejected

Often submissions contain many (100-500) jobs with the same scheduling requirements

So now instead of checking if each are schedulable individually we:
 - Hash the job scheduling requirements
 - Cache the result for scheduling a scheduling requirement
 - Use the cache value when it is present

I have also made it so GangIdAnnotation and GangCardinalityAnnotation are no longer configurable and defined as constants
 - These likely should never be changed after initial installation - so being constant makes more sense
 - It means we don't need to pass the config around everywhere - and helps us filter just those annotations in PodRequirementFromLegacySchedulerJob
 - I have done the minimal change for now - and some structs still take these constants as arguments
