### PR TITLE
Make cancel job integration tests more reliable

### DIFF
--- a/e2e/pulsar_test/pulsar_test.go
+++ b/e2e/pulsar_test/pulsar_test.go
@@ -243,6 +243,8 @@ func TestSubmitCancelJobs(t *testing.T) {
 			return nil
 		}
 
+		// Workaround to let jobs get through pulsar into redis before cancelling - otherwise cancel does nothing
+		time.Sleep(2 * time.Second)
 		// Cancel the jobs
 		for _, r := range res.JobResponseItems {
 			ctxWithTimeout, _ = context.WithTimeout(context.Background(), time.Second)
@@ -313,6 +315,9 @@ func TestSubmitCancelJobSet(t *testing.T) {
 		if ok := assert.Equal(t, numJobs, len(res.JobResponseItems)); !ok {
 			return nil
 		}
+
+		// Workaround to let jobs get through pulsar into redis before cancelling - otherwise cancel does nothing
+		time.Sleep(time.Second * 2)
 
 		ctxWithTimeout, _ = context.WithTimeout(context.Background(), time.Second)
 		_, err = client.CancelJobs(ctxWithTimeout, &api.JobCancelRequest{

--- a/e2e/pulsar_test/pulsar_test.go
+++ b/e2e/pulsar_test/pulsar_test.go
@@ -862,6 +862,7 @@ func countObjectTypes(objects []*armadaevents.KubernetesObject) map[string]int {
 	}
 	return result
 }
+
 func receiveJobSetSequences(
 	ctx context.Context,
 	consumer pulsar.Consumer,


### PR DESCRIPTION
Motivation for this is that these integration tests regularly fail - wasting a lot of our time + preventing images getting pushed

Adding a sleep to allow time for the submitted job to get through pulsar into redis before we cancel
 - If the job isn't in redis when the cancel is called, the job doesn't get cancelled. This leads to it running and the test failing

Adding filtering - as if the job gets Leased before the cancel - it breaks the expected events
 - Now we just ensure we get the expected cancel events in the expected order - but ignore intermediate events

This is a workaround
 - Long term we need to make it so the cancel happens async - so the cancel gets put onto pulsar after the job submission
   - This will mean it should always work

