### PR TITLE
[armada-scheduler] Set default maxAllowedMessageSize to 4Mi

### DIFF
--- a/config/scheduler/config.yaml
+++ b/config/scheduler/config.yaml
@@ -9,6 +9,7 @@ pulsar:
   maxConnectionsPerBroker: 1
   compressionType: zlib
   compressionLevel: faster
+  maxAllowedMessageSize: 4194304 #4Mi
 redis:
   addrs:
     - redis:6379

--- a/internal/scheduler/publisher.go
+++ b/internal/scheduler/publisher.go
@@ -19,8 +19,10 @@ import (
 )
 
 // This is half the default pulsar BatchingMaxSize
-const defaultMaxMessageBatchSize = 64 * 1024
-const explicitPartitionKey = "armada_pulsar_partition"
+const (
+	defaultMaxMessageBatchSize = 64 * 1024
+	explicitPartitionKey       = "armada_pulsar_partition"
+)
 
 // Publisher is an interface to be implemented by structs that handle publishing messages to pulsar
 type Publisher interface {

--- a/internal/scheduler/publisher.go
+++ b/internal/scheduler/publisher.go
@@ -18,6 +18,8 @@ import (
 	"github.com/armadaproject/armada/pkg/armadaevents"
 )
 
+// This is half the default pulsar BatchingMaxSize
+const defaultMaxMessageBatchSize = 64 * 1024
 const explicitPartitionKey = "armada_pulsar_partition"
 
 // Publisher is an interface to be implemented by structs that handle publishing messages to pulsar
@@ -59,10 +61,14 @@ func NewPulsarPublisher(
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	maxMessageBatchSize := producerOptions.BatchingMaxSize / 2
+	if maxMessageBatchSize <= 0 {
+		maxMessageBatchSize = defaultMaxMessageBatchSize
+	}
 	return &PulsarPublisher{
 		producer:            producer,
 		pulsarSendTimeout:   pulsarSendTimeout,
-		maxMessageBatchSize: 2 * 1024 * 1024, // max pulsar message size is 4MB, so we use 2MB here to be safe
+		maxMessageBatchSize: maxMessageBatchSize,
 		numPartitions:       len(partitions),
 	}, nil
 }


### PR DESCRIPTION
This should be set, otherwise we fail to send message to pulsar due to them being too large

We now also set `maxMessageBatchSize` off this value - as that value should always be half of `maxAllowedMessageSize`
 - In the case it isn't set, we default to half of the pulsar default for `BatchingMaxSize` (which is the value we're setting with maxAllowedMessageSize)


