### PR TITLE
Make scheduler exit code non-zero on error

### DIFF
--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/armadaproject/armada/cmd/scheduler/cmd"
 	"github.com/armadaproject/armada/internal/common"
 )
@@ -8,5 +10,8 @@ import (
 func main() {
 	common.ConfigureLogging()
 	common.BindCommandlineArguments()
-	_ = cmd.RootCmd().Execute()
+	err := cmd.RootCmd().Execute()
+	if err != nil {
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
We want to exit with a non-zero exit code on error

This makes it clear when there was an error and also means kubernetes doesn't mark the execution as successful

