### PR TITLE
Set node selector when sending job to executor

### DIFF
--- a/config/scheduler/config.yaml
+++ b/config/scheduler/config.yaml
@@ -37,6 +37,7 @@ grpc:
     permitWithoutStream: true
 scheduling:
   executorTimeout: 10m
+  nodeIdLabel: kubernetes.io/hostname
   preemption:
     enabled: true
     priorityClasses:

--- a/internal/common/ingest/testfixtures/event.go
+++ b/internal/common/ingest/testfixtures/event.go
@@ -136,6 +136,7 @@ var Leased = &armadaevents.EventSequence_Event{
 			RunId:      RunIdProto,
 			JobId:      JobIdProto,
 			ExecutorId: ExecutorId,
+			NodeId:     NodeName,
 		},
 	},
 }

--- a/internal/scheduler/api_test.go
+++ b/internal/scheduler/api_test.go
@@ -262,7 +262,6 @@ func TestAddNodeSelector(t *testing.T) {
 			addNodeSelector(tc.input, tc.key, tc.value)
 			assert.Equal(t, tc.expected, tc.input)
 		})
-
 	}
 }
 

--- a/internal/scheduler/publisher.go
+++ b/internal/scheduler/publisher.go
@@ -18,8 +18,8 @@ import (
 	"github.com/armadaproject/armada/pkg/armadaevents"
 )
 
-// This is half the default pulsar BatchingMaxSize
 const (
+	// This is half the default pulsar BatchingMaxSize
 	defaultMaxMessageBatchSize = 64 * 1024
 	explicitPartitionKey       = "armada_pulsar_partition"
 )

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -336,6 +336,7 @@ func (s *Scheduler) generateLeaseMessages(scheduledJobs []*jobdb.Job) ([]*armada
 							RunId:      armadaevents.ProtoUuidFromUuid(job.LatestRun().Id()),
 							JobId:      jobId,
 							ExecutorId: job.LatestRun().Executor(),
+							NodeId:     job.LatestRun().Node(),
 						},
 					},
 				},

--- a/internal/scheduler/schedulerapp.go
+++ b/internal/scheduler/schedulerapp.go
@@ -117,7 +117,8 @@ func Run(config Configuration) error {
 		executorRepository,
 		legacyExecutorRepository,
 		allowedPcs,
-		config.Scheduling.MaximumJobsToSchedule)
+		config.Scheduling.MaximumJobsToSchedule,
+		config.Scheduling.Preemption.NodeIdLabel)
 	if err != nil {
 		return errors.WithMessage(err, "error creating executorApi")
 	}

--- a/internal/scheduleringester/instructions.go
+++ b/internal/scheduleringester/instructions.go
@@ -172,6 +172,7 @@ func (c *InstructionConverter) handleJobRunLeased(jobRunLeased *armadaevents.Job
 		JobID:    jobId,
 		JobSet:   meta.jobset,
 		Executor: jobRunLeased.GetExecutorId(),
+		Node:     jobRunLeased.GetNodeId(),
 	}}}, nil
 }
 

--- a/internal/scheduleringester/instructions_test.go
+++ b/internal/scheduleringester/instructions_test.go
@@ -76,6 +76,7 @@ func TestConvertSequence(t *testing.T) {
 				JobID:    f.JobIdString,
 				JobSet:   f.JobSetName,
 				Executor: f.ExecutorId,
+				Node:     f.NodeName,
 			}}},
 		},
 		"job run running": {


### PR DESCRIPTION
The scheduler assigns pods to nodes

We now remember this value and set a node selector on jobs we send to the executor - to enforce the schedulers decision