### PR TITLE
Update CircleCI Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src="./logo.svg" width="200"/>
 
-[![CircleCI](https://circleci.com/gh/helm/helm.svg?style=shield)](https://circleci.com/gh/armadaproject/armada)
+[![CircleCI](https://circleci.com/gh/armadaproject/armada.svg?style=shield)](https://circleci.com/gh/armadaproject/armada)
 [![Go Report Card](https://goreportcard.com/badge/github.com/armadaproject/armada)](https://goreportcard.com/report/github.com/armadaproject/armada)
 
 # Armada


### PR DESCRIPTION
Previously, this pointed to another organization's CircleCI badge.