### PR TITLE
use PartitionToMaxLen in PostgeresJobRepositiory.FetchJobRunErrors

### DIFF
--- a/internal/scheduler/database/job_repository.go
+++ b/internal/scheduler/database/job_repository.go
@@ -73,7 +73,11 @@ func NewPostgresJobRepository(db *pgxpool.Pool, batchSize int32) *PostgresJobRep
 // FetchJobRunErrors returns all armadaevents.JobRunErrors for the provided job run ids.  The returned map is
 // keyed by job run id.  Any dbRuns which don't have errors wil be absent from the map.
 func (r *PostgresJobRepository) FetchJobRunErrors(ctx context.Context, runIds []uuid.UUID) (map[uuid.UUID]*armadaevents.Error, error) {
-	chunks := armadaslices.Partition(runIds, int(r.batchSize))
+	if len(runIds) == 0 {
+		return map[uuid.UUID]*armadaevents.Error{}, nil
+	}
+
+	chunks := armadaslices.PartitionToMaxLen(runIds, int(r.batchSize))
 
 	errorsByRunId := make(map[uuid.UUID]*armadaevents.Error, len(runIds))
 	decompressor := compress.NewZlibDecompressor()


### PR DESCRIPTION
PostgeresJobRepositiory.FetchJobRunErrors was using `armadaslices.Partition` which meant it was making 1000 partitions regardless of the input dataset.  What I meant to use here was `armadaslices.PartitionToMaxLen` which would split the input into partitions of length 1000 (doh!).

I've also added a check of that if the input dataset is empty, we just return straight away