### PR TITLE
Add codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+ignore:
+  - "**/*.pb.go"
+  - "**/*.sql.go"
+  - "**/*_moq.go"


### PR DESCRIPTION
Add codecov.yml to ignore file types that shouldn't be included in Codecov's coverage report. 

Fixes #2211 