### PR TITLE
Fix gang preemption

### DIFF
--- a/config/armada/config.yaml
+++ b/config/armada/config.yaml
@@ -30,6 +30,7 @@ eventsApiRedis:
   db: 1
   poolSize: 1000
 scheduling:
+  enableAssertions: true
   preemption:
     enabled: true
     preemptToFairShare: true
@@ -55,9 +56,6 @@ scheduling:
     priorityClassNameOverride: armada-default
   queueLeaseBatchSize: 1000
   maxExtraNodesToConsider: 1
-  minimumResourceToSchedule:
-    memory: 1000000 # 1Mb
-    cpu: 0.1
   maximalResourceFractionToSchedulePerQueue:
     memory: 1.0
     cpu: 1.0

--- a/internal/armada/configuration/types.go
+++ b/internal/armada/configuration/types.go
@@ -82,12 +82,11 @@ type PulsarConfig struct {
 }
 
 type SchedulingConfig struct {
-	Preemption PreemptionConfig
+	// Set to true to enable scheduler assertions. This results in some performance loss.
+	EnableAssertions bool
+	Preemption       PreemptionConfig
 	// Number of jobs to load from the database at a time.
 	QueueLeaseBatchSize uint
-	// Minimum resources to schedule per request from an executor.
-	// Applies to the old scheduler.
-	MinimumResourceToSchedule armadaresource.ComputeResourcesFloat
 	// Maximum total size in bytes of all jobs returned in a single lease jobs call.
 	// Applies to the old scheduler. But is not necessary since we now stream job leases.
 	MaximumLeasePayloadSizeBytes int

--- a/internal/armada/server.go
+++ b/internal/armada/server.go
@@ -41,11 +41,10 @@ import (
 func Serve(ctx context.Context, config *configuration.ArmadaConfig, healthChecks *health.MultiChecker) error {
 	log.Info("Armada server starting")
 	defer log.Info("Armada server shutting down")
-
 	if config.Scheduling.Preemption.Enabled {
 		log.Info("Armada Job preemption is enabled")
-		log.Infof("Supported priority classes are: %v", config.Scheduling.Preemption.PriorityClasses)
-		log.Infof("Default priority class is: %s", config.Scheduling.Preemption.DefaultPriorityClass)
+		log.Infof("Armada priority classes: %v", config.Scheduling.Preemption.PriorityClasses)
+		log.Infof("Default priority class: %s", config.Scheduling.Preemption.DefaultPriorityClass)
 	} else {
 		log.Info("Armada Job preemption is disabled")
 	}

--- a/internal/common/validation/podspec.go
+++ b/internal/common/validation/podspec.go
@@ -10,15 +10,12 @@ import (
 )
 
 func ValidatePodSpec(spec *v1.PodSpec, schedulingConfig *configuration.SchedulingConfig) error {
-	maxAllowedSize := schedulingConfig.MaxPodSpecSizeBytes
-	minJobResources := schedulingConfig.MinJobResources
-
 	if spec == nil {
 		return errors.Errorf("empty pod spec")
 	}
 
-	if uint(spec.Size()) > maxAllowedSize {
-		return errors.Errorf("pod spec has a size of %v bytes which is greater than the maximum allowed size of %v", spec.Size(), maxAllowedSize)
+	if uint(spec.Size()) > schedulingConfig.MaxPodSpecSizeBytes {
+		return errors.Errorf("pod spec has a size of %v bytes which is greater than the maximum allowed size of %v", spec.Size(), schedulingConfig.MaxPodSpecSizeBytes)
 	}
 
 	if len(spec.Containers) == 0 {
@@ -42,11 +39,11 @@ func ValidatePodSpec(spec *v1.PodSpec, schedulingConfig *configuration.Schedulin
 		if len(container.Resources.Requests) == 0 {
 			return errors.Errorf("container %v has no resource requests specified", container.Name)
 		}
-		err = validateContainerResource(container.Resources.Limits, minJobResources, container.Name, "limit")
+		err = validateContainerResource(container.Resources.Limits, schedulingConfig.MinJobResources, container.Name, "limit")
 		if err != nil {
 			return err
 		}
-		err = validateContainerResource(container.Resources.Requests, minJobResources, container.Name, "request")
+		err = validateContainerResource(container.Resources.Requests, schedulingConfig.MinJobResources, container.Name, "request")
 		if err != nil {
 			return err
 		}

--- a/internal/scheduler/legacyscheduler_test.go
+++ b/internal/scheduler/legacyscheduler_test.go
@@ -1115,6 +1115,9 @@ func TestReschedule(t *testing.T) {
 		// For each queue, indices of jobs expected to be preempted.
 		// E.g., ExpectedPreemptedIndices["A"][0] is the indices of jobs declared for queue A in round 0.
 		ExpectedPreemptedIndices map[string]map[int][]int
+		// For each queue, indices of jobs to unbind before scheduling, to, simulate jobs terminating.
+		// E.g., IndicesToUnbind["A"][0] is the indices of jobs declared for queue A in round 0.
+		IndicesToUnbind map[string]map[int][]int
 	}
 	tests := map[string]struct {
 		SchedulingConfig configuration.SchedulingConfig
@@ -1524,6 +1527,33 @@ func TestReschedule(t *testing.T) {
 				"A": 1,
 				"B": 1,
 				"C": 1,
+			},
+		},
+		"gang preemption with partial gang": {
+			SchedulingConfig: testSchedulingConfig(),
+			Nodes:            testNCpuNode(2, testPriorities),
+			Rounds: []ReschedulingRound{
+				{
+					// Schedule a gang across two nodes.
+					ReqsByQueue: map[string][]*schedulerobjects.PodRequirements{
+						"A": withGangAnnotationsPodReqs(testNLargeCpuJob("A", 0, 2)),
+					},
+					ExpectedScheduledIndices: map[string][]int{
+						"A": intRange(0, 1),
+					},
+				},
+				{
+					// Unbind one of the jobs in the gang (simulating that job terminating)
+					// and test that the remaining job isn't preempted.
+					IndicesToUnbind: map[string]map[int][]int{
+						"A": {
+							0: intRange(0, 0),
+						},
+					},
+				},
+			},
+			PriorityFactorByQueue: map[string]float64{
+				"A": 1,
 			},
 		},
 		"gang preemption with NodeEvictionProbability 0": {
@@ -2011,6 +2041,9 @@ func TestReschedule(t *testing.T) {
 			var gangIdByJobId map[string]string
 			log := logrus.NewEntry(logrus.New())
 			for i, round := range tc.Rounds {
+				log = log.WithField("round", i)
+				log.Infof("starting scheduling round %d", i)
+
 				jobs := make([]LegacySchedulerJob, 0)
 				for queue, reqs := range round.ReqsByQueue {
 					// TODO: Remove PC name argument. Since we now infer it.
@@ -2024,6 +2057,28 @@ func TestReschedule(t *testing.T) {
 						require.NoError(t, err)
 						roundByJobId[jobId] = i
 						indexByJobId[jobId] = j
+					}
+				}
+
+				// Unbind jobs from nodes, to simulate those jobs terminating between rounds.
+				for queue, reqIndicesByRoundIndex := range round.IndicesToUnbind {
+					for roundIndex, reqIndices := range reqIndicesByRoundIndex {
+						for _, reqIndex := range reqIndices {
+							req := tc.Rounds[roundIndex].ReqsByQueue[queue][reqIndex]
+							jobId, err := JobIdFromPodRequirements(req)
+							require.NoError(t, err)
+							nodeId := nodeIdByJobId[jobId]
+							node, err := nodeDb.GetNode(nodeId)
+							require.NoError(t, err)
+							node, err = UnbindPodFromNode(req, node)
+							require.NoError(t, err)
+							err = nodeDb.Upsert(node)
+							require.NoError(t, err)
+							if gangId, ok := gangIdByJobId[jobId]; ok {
+								delete(gangIdByJobId, jobId)
+								delete(jobIdsByGangId[gangId], jobId)
+							}
+						}
 					}
 				}
 
@@ -2051,13 +2106,13 @@ func TestReschedule(t *testing.T) {
 					gangIdByJobId,
 					nil,
 				)
-				rescheduler.enableAssertions = true
+				rescheduler.EnableAssertions()
 				result, err := rescheduler.Schedule(ctxlogrus.ToContext(context.Background(), log))
 				require.NoError(t, err)
-				gangIdByJobId = rescheduler.gangIdByJobId
 				jobIdsByGangId = rescheduler.jobIdsByGangId
+				gangIdByJobId = rescheduler.gangIdByJobId
 
-				// Update initialUsage.
+				// Test resource accounting.
 				for _, job := range result.PreemptedJobs {
 					req := PodRequirementFromLegacySchedulerJob(job, tc.SchedulingConfig.Preemption.PriorityClasses)
 					requests := schedulerobjects.ResourceListFromV1ResourceList(req.ResourceRequirements.Requests)

--- a/internal/scheduler/scheduling_algo.go
+++ b/internal/scheduler/scheduling_algo.go
@@ -205,6 +205,9 @@ func (l *LegacySchedulingAlgo) scheduleOnExecutor(
 		nil,
 		nil, // TODO: Add a repo to enable querying for scheduler reports.
 	)
+	if l.config.EnableAssertions {
+		scheduler.EnableAssertions()
+	}
 	result, err := scheduler.Schedule(ctx)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Specifically:
- Make sure `nodeIdByJobId` is populated in `lease.go`, so that when evicting we can figure out which node each gang job is on.
- If some jobs in a gang have terminated, ensure that the cardinality of the gang is updated before rescheduling, so that the remaining jobs can be re-scheduled.

In addition, the eviction logic has been made more robust, by adding checks where it makes sense, and better tested.