### PR TITLE
Fixes to scheduler logger + leader election

### DIFF
--- a/internal/scheduler/config.go
+++ b/internal/scheduler/config.go
@@ -57,7 +57,7 @@ type Configuration struct {
 }
 
 type LeaderConfig struct {
-	// Valid modes are "standalone" or "cluster"
+	// Valid modes are "standalone" or "kubernetes"
 	Mode string `validate:"required"`
 	// Name of the K8s Lock Object
 	LeaseLockName string

--- a/internal/scheduler/leader.go
+++ b/internal/scheduler/leader.go
@@ -92,11 +92,13 @@ type KubernetesLeaderController struct {
 }
 
 func NewKubernetesLeaderController(config LeaderConfig, client coordinationv1client.LeasesGetter) *KubernetesLeaderController {
-	return &KubernetesLeaderController{
+	controller := &KubernetesLeaderController{
 		client: client,
 		token:  atomic.Value{},
 		config: config,
 	}
+	controller.token.Store(InvalidLeaderToken())
+	return controller
 }
 
 func (lc *KubernetesLeaderController) GetToken() LeaderToken {

--- a/internal/scheduler/schedulerapp.go
+++ b/internal/scheduler/schedulerapp.go
@@ -194,7 +194,7 @@ func createLeaderController(config LeaderConfig) (LeaderController, error) {
 		return NewStandaloneLeaderController(), nil
 	case "kubernetes":
 		log.Infof("Scheduler will run kubernetes mode")
-		clusterConfig, err := loadConfig()
+		clusterConfig, err := loadClusterConfig()
 		if err != nil {
 			return nil, errors.Wrapf(err, "Error creating kubernetes client")
 		}
@@ -208,7 +208,7 @@ func createLeaderController(config LeaderConfig) (LeaderController, error) {
 	}
 }
 
-func loadConfig() (*rest.Config, error) {
+func loadClusterConfig() (*rest.Config, error) {
 	config, err := rest.InClusterConfig()
 	if err == rest.ErrNotInCluster {
 		log.Info("Running with default client configuration")

--- a/internal/scheduler/schedulerapp.go
+++ b/internal/scheduler/schedulerapp.go
@@ -6,7 +6,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus/ctxlogrus"
 	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/armadaproject/armada/internal/common"
 
@@ -32,6 +34,8 @@ import (
 // Run sets up a Scheduler application and runs it until a SIGTERM is received
 func Run(config Configuration) error {
 	g, ctx := errgroup.WithContext(app.CreateContextWithShutdown())
+	logrusLogger := log.NewEntry(log.New())
+	ctx = ctxlogrus.ToContext(ctx, logrusLogger)
 
 	// List of services to run concurrently.
 	// Because we want to start services only once all input validation has been completed,
@@ -188,9 +192,9 @@ func createLeaderController(config LeaderConfig) (LeaderController, error) {
 	case "standalone":
 		log.Infof("Scheduler will run in standalone mode")
 		return NewStandaloneLeaderController(), nil
-	case "cluster":
-		log.Infof("Scheduler will run cluster mode")
-		clusterConfig, err := rest.InClusterConfig()
+	case "kubernetes":
+		log.Infof("Scheduler will run kubernetes mode")
+		clusterConfig, err := loadConfig()
 		if err != nil {
 			return nil, errors.Wrapf(err, "Error creating kubernetes client")
 		}
@@ -202,4 +206,16 @@ func createLeaderController(config LeaderConfig) (LeaderController, error) {
 	default:
 		return nil, errors.Errorf("%s is not a value leader mode", config.Mode)
 	}
+}
+
+func loadConfig() (*rest.Config, error) {
+	config, err := rest.InClusterConfig()
+	if err == rest.ErrNotInCluster {
+		log.Info("Running with default client configuration")
+		rules := clientcmd.NewDefaultClientConfigLoadingRules()
+		overrides := &clientcmd.ConfigOverrides{}
+		return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, overrides).ClientConfig()
+	}
+	log.Info("Running with in cluster client configuration")
+	return config, err
 }


### PR DESCRIPTION
 - Set the token to Invalid in the constructor
   - to avoid nil token
 - Set logger on context
   - This was not being set and causing many places using the logger in the context to log nothing
 - Swap "cluster" leader election mode to "kubernetes"
   - This now tries to use in cluster config and if not, falls back to looking for a kubeconfig. This makes it easy to test the leader election locally

