### PR TITLE
Return error on failing to publish preempted messages in lease call

### DIFF
--- a/internal/armada/server/lease.go
+++ b/internal/armada/server/lease.go
@@ -554,7 +554,7 @@ func (q *AggregatedQueueServer) getJobs(ctx context.Context, req *api.StreamingL
 		}
 	}
 
-	// Prepare preempted + failed messages.
+	// Publish preempted + failed messages.
 	sequences := make([]*armadaevents.EventSequence, len(preemptedJobs))
 	for i, job := range preemptedJobs {
 		jobId, err := armadaevents.ProtoUuidFromUlidString(job.GetId())
@@ -595,6 +595,10 @@ func (q *AggregatedQueueServer) getJobs(ctx context.Context, req *api.StreamingL
 			},
 		}
 	}
+	err = pulsarutils.CompactAndPublishSequences(ctx, sequences, q.pulsarProducer, q.maxPulsarMessageSize, schedulers.All)
+	if err != nil {
+		return nil, errors.WithMessage(err, "failed to publish preempted messages")
+	}
 
 	preemptedApiJobsById := make(map[string]*api.Job)
 	for _, job := range preemptedJobs {
@@ -610,6 +614,27 @@ func (q *AggregatedQueueServer) getJobs(ctx context.Context, req *api.StreamingL
 			scheduledApiJobsById[job.GetId()] = apiJob
 		} else {
 			log.Errorf("failed to convert job %s to api job", job.GetId())
+		}
+	}
+
+	// Delete preempted jobs from Redis.
+	// This ensures preempted jobs don't count towards allocated resources in the next scheduling round.
+	// As a fallback, a log processor asynchronously deletes any jobs for which there's a job failed message.
+	if len(preemptedApiJobsById) > 0 {
+		jobsToDelete := maps.Values(preemptedApiJobsById)
+		jobIdsToDelete := util.Map(jobsToDelete, func(job *api.Job) string { return job.Id })
+		log.Infof("deleting preempted jobs: %v", jobIdsToDelete)
+		if deletionResult, err := q.jobRepository.DeleteJobs(jobsToDelete); err != nil {
+			logging.WithStacktrace(log, err).Error("failed to delete preempted jobs from Redis")
+		} else {
+			deleteErrorByJobId := armadamaps.MapKeys(deletionResult, func(job *api.Job) string { return job.Id })
+			for jobId := range preemptedApiJobsById {
+				if err, ok := deleteErrorByJobId[jobId]; !ok {
+					log.Errorf("deletion result missing for preempted job %s", jobId)
+				} else if err != nil {
+					log.Errorf("failed to delete preempted job %s: %s", jobId, err.Error())
+				}
+			}
 		}
 	}
 
@@ -632,37 +657,6 @@ func (q *AggregatedQueueServer) getJobs(ctx context.Context, req *api.StreamingL
 				successfullyLeasedApiJobs = append(successfullyLeasedApiJobs, apiJob)
 			} else {
 				log.Errorf("didn't expect job %s to be leased", jobId)
-			}
-		}
-	}
-
-	// Publish preempted messages.
-	if q.pulsarProducer != nil {
-		err = pulsarutils.CompactAndPublishSequences(ctx, sequences, q.pulsarProducer, q.maxPulsarMessageSize, schedulers.All)
-		if err != nil {
-			logging.WithStacktrace(log, err).Error("failed to publish preempted messages")
-		}
-	} else {
-		log.Error("no Pulsar producer provided; omitting publishing preempted messages")
-	}
-
-	// Delete preempted jobs from Redis.
-	// This ensures preempted jobs don't count towards allocated resources in the next scheduling round.
-	// As a fallback, a log processor asynchronously deletes any jobs for which there's a job failed message.
-	if len(preemptedApiJobsById) > 0 {
-		jobsToDelete := maps.Values(preemptedApiJobsById)
-		jobIdsToDelete := util.Map(jobsToDelete, func(job *api.Job) string { return job.Id })
-		log.Infof("deleting preempted jobs: %v", jobIdsToDelete)
-		if deletionResult, err := q.jobRepository.DeleteJobs(jobsToDelete); err != nil {
-			logging.WithStacktrace(log, err).Error("failed to delete preempted jobs from Redis")
-		} else {
-			deleteErrorByJobId := armadamaps.MapKeys(deletionResult, func(job *api.Job) string { return job.Id })
-			for jobId := range preemptedApiJobsById {
-				if err, ok := deleteErrorByJobId[jobId]; !ok {
-					log.Errorf("deletion result missing for preempted job %s", jobId)
-				} else if err != nil {
-					log.Errorf("failed to delete preempted job %s: %s", jobId, err.Error())
-				}
 			}
 		}
 	}


### PR DESCRIPTION
To avoid jobs being deleted without a reason first being published.