### PR TITLE
Use inline cache for DOCKER_BUILDX_CACHE_FROM by default

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -139,7 +139,7 @@ env:
   # Setup to enable Docker to use, e.g., the Github actions cache; see
   # https://docs.docker.com/build/building/cache/backends/
   # https://github.com/moby/buildkit#export-cache
-  - DOCKER_BUILDX_CACHE_FROM={{ if index .Env "DOCKER_BUILDX_CACHE_FROM"  }}{{ .Env.DOCKER_BUILDX_CACHE_FROM }}{{ else }}type=registry{{ end }}
+  - DOCKER_BUILDX_CACHE_FROM={{ if index .Env "DOCKER_BUILDX_CACHE_FROM"  }}{{ .Env.DOCKER_BUILDX_CACHE_FROM }}{{ else }}type=inline{{ end }}
   - DOCKER_BUILDX_CACHE_TO={{ if index .Env "DOCKER_BUILDX_CACHE_TO"  }}{{ .Env.DOCKER_BUILDX_CACHE_TO }}{{ else }}type=inline{{ end }}
 
 dockers:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you: -->

#### What type of PR is this?

Build Fix

#### What this PR does / why we need it:

Goreleaser build is broken for some because `registry` is used as the default for `DOCKER_BUILDX_CACHE_FROM` but no registry is specified by default. Change this to `inline` so whatever is built locally is used by default.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-176) by [Unito](https://www.unito.io)
