### PR TITLE
Fix release steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,7 +247,7 @@ jobs:
   release-armadactl:
     machine:
       docker_layer_caching: true
-      image: ubuntu-2204:2022.07.1
+      image: ubuntu-2204:2023.02.1
       resource_class: large
       # resource_class: xlarge
     environment:
@@ -384,7 +384,7 @@ jobs:
   release-dotnet-client:
     machine:
       docker_layer_caching: true
-      image: ubuntu-2204:2022.07.1
+      image: ubuntu-2204:2023.02.1
       resource_class: large
       # resource_class: xlarge
     environment:


### PR DESCRIPTION
The release steps are broken as the project now uses go 1.20 but the machine images we were using (`ubuntu-2204:2022.07.1`) only had go 1.18

Swapping to machine image `ubuntu-2204:2023.02.1` which has go 1.20 and can successfully install the dependencies required to build the project

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-189) by [Unito](https://www.unito.io)
