### PR TITLE
disable codecov build checks

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,3 +2,8 @@ ignore:
   - "**/*.pb.go"
   - "**/*.sql.go"
   - "**/*_moq.go"
+coverage:
+  status:
+    project:
+      default:
+        informational: true


### PR DESCRIPTION
Disable codecov github checks.  This PR should only annotate codecov in PRs and it will not test builds as failed.  

