### PR TITLE
Make helm chart version helm3 compatible

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ commands:
         command: |
           RELEASE_TAG=${CIRCLE_TAG}
           echo release version is $RELEASE_TAG
-          find . \( -name "Chart.yaml" -o -name "values.yaml" \) -exec sed -i s/LATEST/$RELEASE_TAG/ {} +
+          find . \( -name "Chart.yaml" -o -name "values.yaml" \) -exec sed -i s/0.0.0-latest/$RELEASE_TAG/ {} +
 
     - run:
         name: Build new packages and index.yaml

--- a/deployment/armada-bundle/Chart.yaml
+++ b/deployment/armada-bundle/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: A helm chart which bundles Armada components
 name: armada-bundle
 version: 0.0.1
-appVersion: LATEST
+appVersion: 0.0.0-latest
 dependencies:
   - name: redis-ha
     version: 4.15.0

--- a/deployment/armada-bundle/README.md
+++ b/deployment/armada-bundle/README.md
@@ -1,6 +1,6 @@
 # armada-bundle
 
-![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![AppVersion: LATEST](https://img.shields.io/badge/AppVersion-LATEST-informational?style=flat-square)
+![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![AppVersion: 0.0.0-latest](https://img.shields.io/badge/AppVersion-0.0.0--latest-informational?style=flat-square)
 
 A helm chart which bundles Armada components
 

--- a/deployment/armada/Chart.yaml
+++ b/deployment/armada/Chart.yaml
@@ -5,8 +5,8 @@ home: https://armadaproject.io
 sources:
   - https://github.com/armadaproject/armada
 icon: https://armadaproject.io/assets/img/Armada-favicon.png
-version: LATEST
-appVersion: LATEST
+version: 0.0.0-latest
+appVersion: 0.0.0-latest
 keywords:
   - multi-cluster
   - batch-scheduler

--- a/deployment/armada/README.md
+++ b/deployment/armada/README.md
@@ -1,6 +1,6 @@
 # armada
 
-![Version: LATEST](https://img.shields.io/badge/Version-LATEST-informational?style=flat-square)
+![Version: 0.0.0-latest](https://img.shields.io/badge/Version-0.0.0--latest-informational?style=flat-square)
 
 Armada Server is the centralized Control Plane for Armada, the multi-cluster batch scheduler.
 
@@ -56,7 +56,7 @@ helm uninstall armada-server
 | fullnameOverride | string | `""` |  |
 | hostnames | list | `[]` | Hostnames for which to create gRPC and REST Ingress rules |
 | image.repository | string | `"gresearchdev/armada-server"` |  |
-| image.tag | string | `"LATEST"` |  |
+| image.tag | string | `"0.0.0-latest"` |  |
 | ingress.annotations | object | `{}` | Additional annotations for Ingress resource |
 | ingress.enabled | bool | `true` | Toggle whether to create gRPC and HTTP Ingress for Armada Server |
 | ingress.labels | object | `{}` | Additional labels for Ingress resource |

--- a/deployment/armada/values.yaml
+++ b/deployment/armada/values.yaml
@@ -3,7 +3,7 @@ fullnameOverride: ""
 
 image:
   repository: gresearchdev/armada-server
-  tag: LATEST
+  tag: 0.0.0-latest
 
 resources:
   limits:

--- a/deployment/binoculars/Chart.yaml
+++ b/deployment/binoculars/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: A helm chart for Armada Binoculars component
 name: armada-binoculars
-version: LATEST
-appVersion: LATEST
+version: 0.0.0-latest
+appVersion: 0.0.0-latest

--- a/deployment/binoculars/README.md
+++ b/deployment/binoculars/README.md
@@ -1,6 +1,6 @@
 # armada-binoculars
 
-![Version: LATEST](https://img.shields.io/badge/Version-LATEST-informational?style=flat-square) ![AppVersion: LATEST](https://img.shields.io/badge/AppVersion-LATEST-informational?style=flat-square)
+![Version: 0.0.0-latest](https://img.shields.io/badge/Version-0.0.0--latest-informational?style=flat-square) ![AppVersion: 0.0.0-latest](https://img.shields.io/badge/AppVersion-0.0.0--latest-informational?style=flat-square)
 
 A helm chart for Armada Binoculars component
 
@@ -14,7 +14,7 @@ A helm chart for Armada Binoculars component
 | applicationConfig.metricsPort | int | `9000` |  |
 | customServiceAccount | string | `nil` |  |
 | image.repository | string | `"gresearchdev/armada-binoculars"` |  |
-| image.tag | string | `"LATEST"` |  |
+| image.tag | string | `"0.0.0-latest"` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.labels | object | `{}` |  |
 | prometheus.enabled | bool | `false` |  |

--- a/deployment/binoculars/values.yaml
+++ b/deployment/binoculars/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: gresearchdev/armada-binoculars
-  tag: LATEST
+  tag: 0.0.0-latest
 resources:
   limits:
     memory: 1Gi

--- a/deployment/event-ingester/Chart.yaml
+++ b/deployment/event-ingester/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: A helm chart for Armada Event Ingester component
 name: armada-event-ingester
-version: LATEST
-appVersion: LATEST
+version: 0.0.0-latest
+appVersion: 0.0.0-latest

--- a/deployment/event-ingester/README.md
+++ b/deployment/event-ingester/README.md
@@ -1,6 +1,6 @@
 # armada-event-ingester
 
-![Version: LATEST](https://img.shields.io/badge/Version-LATEST-informational?style=flat-square) ![AppVersion: LATEST](https://img.shields.io/badge/AppVersion-LATEST-informational?style=flat-square)
+![Version: 0.0.0-latest](https://img.shields.io/badge/Version-0.0.0--latest-informational?style=flat-square) ![AppVersion: 0.0.0-latest](https://img.shields.io/badge/AppVersion-0.0.0--latest-informational?style=flat-square)
 
 A helm chart for Armada Event Ingester component
 
@@ -14,7 +14,7 @@ A helm chart for Armada Event Ingester component
 | applicationConfig.pulsar.authenticationEnabled | bool | `false` |  |
 | customServiceAccount | string | `nil` |  |
 | image.repository | string | `"gresearchdev/event-ingester-ingester"` |  |
-| image.tag | string | `"LATEST"` |  |
+| image.tag | string | `"0.0.0-latest"` |  |
 | replicas | int | `1` |  |
 | resources.limits.cpu | string | `"300m"` |  |
 | resources.limits.memory | string | `"1Gi"` |  |

--- a/deployment/event-ingester/values.yaml
+++ b/deployment/event-ingester/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: gresearchdev/event-ingester-ingester
-  tag: LATEST
+  tag: 0.0.0-latest
 resources:
   limits:
     memory: 1Gi

--- a/deployment/executor-cluster-monitoring/Chart.yaml
+++ b/deployment/executor-cluster-monitoring/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description:  A helm chart for monitoring metrics of a cluster managed by a armada-executor component
 name: armada-executor-cluster-monitoring
-version: LATEST
-appVerison: LATEST
+version: 0.0.0-latest
+appVerison: 0.0.0-latest

--- a/deployment/executor-cluster-monitoring/README.md
+++ b/deployment/executor-cluster-monitoring/README.md
@@ -1,6 +1,6 @@
 # armada-executor-cluster-monitoring
 
-![Version: LATEST](https://img.shields.io/badge/Version-LATEST-informational?style=flat-square)
+![Version: 0.0.0-latest](https://img.shields.io/badge/Version-0.0.0--latest-informational?style=flat-square)
 
 A helm chart for monitoring metrics of a cluster managed by a armada-executor component
 

--- a/deployment/executor/Chart.yaml
+++ b/deployment/executor/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: A helm chart for armada-executor component
 name: armada-executor
-version: LATEST
-appVersion: LATEST
+version: 0.0.0-latest
+appVersion: 0.0.0-latest

--- a/deployment/executor/README.md
+++ b/deployment/executor/README.md
@@ -1,6 +1,6 @@
 # armada-executor
 
-![Version: LATEST](https://img.shields.io/badge/Version-LATEST-informational?style=flat-square) ![AppVersion: LATEST](https://img.shields.io/badge/AppVersion-LATEST-informational?style=flat-square)
+![Version: 0.0.0-latest](https://img.shields.io/badge/Version-0.0.0--latest-informational?style=flat-square) ![AppVersion: 0.0.0-latest](https://img.shields.io/badge/AppVersion-0.0.0--latest-informational?style=flat-square)
 
 A helm chart for armada-executor component
 
@@ -12,7 +12,7 @@ A helm chart for armada-executor component
 | applicationConfig.apiConnection.armadaUrl | string | `""` |  |
 | customServiceAccount | string | `nil` |  |
 | image.repository | string | `"gresearchdev/armada-executor"` |  |
-| image.tag | string | `"LATEST"` |  |
+| image.tag | string | `"0.0.0-latest"` |  |
 | nodeSelector | object | `{}` |  |
 | prometheus.enabled | bool | `false` |  |
 | prometheus.labels | object | `{}` |  |

--- a/deployment/executor/values.yaml
+++ b/deployment/executor/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: gresearchdev/armada-executor
-  tag: LATEST
+  tag: 0.0.0-latest
 resources:
   limits:
     memory: 1Gi

--- a/deployment/jobservice/Chart.yaml
+++ b/deployment/jobservice/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: A helm chart for armada-jobservice component
 name: armada-jobservice
-version: LATEST
-appVersion: LATEST
+version: 0.0.0-latest
+appVersion: 0.0.0-latest

--- a/deployment/jobservice/README.md
+++ b/deployment/jobservice/README.md
@@ -1,6 +1,6 @@
 # armada-jobservice
 
-![Version: LATEST](https://img.shields.io/badge/Version-LATEST-informational?style=flat-square) ![AppVersion: LATEST](https://img.shields.io/badge/AppVersion-LATEST-informational?style=flat-square)
+![Version: 0.0.0-latest](https://img.shields.io/badge/Version-0.0.0--latest-informational?style=flat-square) ![AppVersion: 0.0.0-latest](https://img.shields.io/badge/AppVersion-0.0.0--latest-informational?style=flat-square)
 
 A helm chart for armada-jobservice component
 
@@ -12,7 +12,7 @@ A helm chart for armada-jobservice component
 | applicationConfig.grpcPort | int | `60063` |  |
 | customServiceAccount | string | `nil` |  |
 | image.repository | string | `"gresearchdev/armada-server"` |  |
-| image.tag | string | `"LATEST"` |  |
+| image.tag | string | `"0.0.0-latest"` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.labels | object | `{}` |  |
 | ingress.nameOverride | string | `""` |  |

--- a/deployment/jobservice/values.yaml
+++ b/deployment/jobservice/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: gresearchdev/armada-server
-  tag: LATEST
+  tag: 0.0.0-latest
 resources:
   limits:
     memory: 1Gi

--- a/deployment/lookout-ingester-v2/Chart.yaml
+++ b/deployment/lookout-ingester-v2/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: A helm chart for Armada Lookout Ingester v2 component
 name: armada-lookout-ingester-v2
-version: LATEST
-appVersion: LATEST
+version: 0.0.0-latest
+appVersion: 0.0.0-latest

--- a/deployment/lookout-ingester-v2/README.md
+++ b/deployment/lookout-ingester-v2/README.md
@@ -1,6 +1,6 @@
 # armada-lookout-ingester-v2
 
-![Version: LATEST](https://img.shields.io/badge/Version-LATEST-informational?style=flat-square) ![AppVersion: LATEST](https://img.shields.io/badge/AppVersion-LATEST-informational?style=flat-square)
+![Version: 0.0.0-latest](https://img.shields.io/badge/Version-0.0.0--latest-informational?style=flat-square) ![AppVersion: 0.0.0-latest](https://img.shields.io/badge/AppVersion-0.0.0--latest-informational?style=flat-square)
 
 A helm chart for Armada Lookout Ingester v2 component
 
@@ -12,7 +12,7 @@ A helm chart for Armada Lookout Ingester v2 component
 | applicationConfig.pulsar.authenticationEnabled | bool | `false` |  |
 | customServiceAccount | string | `nil` |  |
 | image.repository | string | `"gresearchdev/armada-lookout-ingester"` |  |
-| image.tag | string | `"LATEST"` |  |
+| image.tag | string | `"0.0.0-latest"` |  |
 | replicas | int | `1` |  |
 | resources.limits.cpu | string | `"300m"` |  |
 | resources.limits.memory | string | `"1Gi"` |  |

--- a/deployment/lookout-ingester-v2/values.yaml
+++ b/deployment/lookout-ingester-v2/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: gresearchdev/armada-lookout-ingester-v2
-  tag: LATEST
+  tag: 0.0.0-latest
 resources:
   limits:
     memory: 1Gi

--- a/deployment/lookout-ingester/Chart.yaml
+++ b/deployment/lookout-ingester/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: A helm chart for Armada Lookout Ingester component
 name: armada-lookout-ingester
-version: LATEST
-appVersion: LATEST
+version: 0.0.0-latest
+appVersion: 0.0.0-latest

--- a/deployment/lookout-ingester/README.md
+++ b/deployment/lookout-ingester/README.md
@@ -1,6 +1,6 @@
 # armada-lookout-ingester
 
-![Version: LATEST](https://img.shields.io/badge/Version-LATEST-informational?style=flat-square) ![AppVersion: LATEST](https://img.shields.io/badge/AppVersion-LATEST-informational?style=flat-square)
+![Version: 0.0.0-latest](https://img.shields.io/badge/Version-0.0.0--latest-informational?style=flat-square) ![AppVersion: 0.0.0-latest](https://img.shields.io/badge/AppVersion-0.0.0--latest-informational?style=flat-square)
 
 A helm chart for Armada Lookout Ingester component
 
@@ -12,7 +12,7 @@ A helm chart for Armada Lookout Ingester component
 | applicationConfig.pulsar.authenticationEnabled | bool | `false` |  |
 | customServiceAccount | string | `nil` |  |
 | image.repository | string | `"gresearchdev/armada-lookout-ingester"` |  |
-| image.tag | string | `"LATEST"` |  |
+| image.tag | string | `"0.0.0-latest"` |  |
 | replicas | int | `1` |  |
 | resources.limits.cpu | string | `"300m"` |  |
 | resources.limits.memory | string | `"1Gi"` |  |

--- a/deployment/lookout-ingester/values.yaml
+++ b/deployment/lookout-ingester/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: gresearchdev/armada-lookout-ingester
-  tag: LATEST
+  tag: 0.0.0-latest
 resources:
   limits:
     memory: 1Gi

--- a/deployment/lookout-migration-v2/Chart.yaml
+++ b/deployment/lookout-migration-v2/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: A Helm chart for the Armada Lookout v2 database migration
 name: armada-lookout-migration-v2
-version: LATEST
-appVersion: LATEST
+version: 0.0.0-latest
+appVersion: 0.0.0-latest

--- a/deployment/lookout-migration-v2/README.md
+++ b/deployment/lookout-migration-v2/README.md
@@ -1,6 +1,6 @@
 # armada-lookout-migration-v2
 
-![Version: LATEST](https://img.shields.io/badge/Version-LATEST-informational?style=flat-square) ![AppVersion: LATEST](https://img.shields.io/badge/AppVersion-LATEST-informational?style=flat-square)
+![Version: 0.0.0-latest](https://img.shields.io/badge/Version-0.0.0--latest-informational?style=flat-square) ![AppVersion: 0.0.0-latest](https://img.shields.io/badge/AppVersion-0.0.0--latest-informational?style=flat-square)
 
 A Helm chart for the Armada Lookout database migration
 
@@ -12,7 +12,7 @@ A Helm chart for the Armada Lookout database migration
 | applicationConfig | object | `{}` |  |
 | customServiceAccount | string | `nil` |  |
 | image.repository | string | `"gresearchdev/armada-lookout"` |  |
-| image.tag | string | `"LATEST"` |  |
+| image.tag | string | `"0.0.0-latest"` |  |
 | resources.limits.cpu | string | `"200m"` |  |
 | resources.limits.memory | string | `"256Mi"` |  |
 | resources.requests.cpu | string | `"100m"` |  |

--- a/deployment/lookout-migration-v2/values.yaml
+++ b/deployment/lookout-migration-v2/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: gresearchdev/armada-lookout-v2
-  tag: LATEST
+  tag: 0.0.0-latest
 resources:
   limits:
     memory: 256Mi

--- a/deployment/lookout-migration/Chart.yaml
+++ b/deployment/lookout-migration/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: A Helm chart for the Armada Lookout database migration
 name: armada-lookout-migration
-version: LATEST
-appVersion: LATEST
+version: 0.0.0-latest
+appVersion: 0.0.0-latest

--- a/deployment/lookout-migration/README.md
+++ b/deployment/lookout-migration/README.md
@@ -1,6 +1,6 @@
 # armada-lookout-migration
 
-![Version: LATEST](https://img.shields.io/badge/Version-LATEST-informational?style=flat-square) ![AppVersion: LATEST](https://img.shields.io/badge/AppVersion-LATEST-informational?style=flat-square)
+![Version: 0.0.0-latest](https://img.shields.io/badge/Version-0.0.0--latest-informational?style=flat-square) ![AppVersion: 0.0.0-latest](https://img.shields.io/badge/AppVersion-0.0.0--latest-informational?style=flat-square)
 
 A Helm chart for the Armada Lookout database migration
 
@@ -12,7 +12,7 @@ A Helm chart for the Armada Lookout database migration
 | applicationConfig | object | `{}` |  |
 | customServiceAccount | string | `nil` |  |
 | image.repository | string | `"gresearchdev/armada-lookout"` |  |
-| image.tag | string | `"LATEST"` |  |
+| image.tag | string | `"0.0.0-latest"` |  |
 | resources.limits.cpu | string | `"200m"` |  |
 | resources.limits.memory | string | `"256Mi"` |  |
 | resources.requests.cpu | string | `"100m"` |  |

--- a/deployment/lookout-migration/values.yaml
+++ b/deployment/lookout-migration/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: gresearchdev/armada-lookout
-  tag: LATEST
+  tag: 0.0.0-latest
 resources:
   limits:
     memory: 256Mi

--- a/deployment/lookout-v2/Chart.yaml
+++ b/deployment/lookout-v2/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: A helm chart for Armada Lookout v2 component
 name: armada-lookout-v2
-version: LATEST
-appVersion: LATEST
+version: 0.0.0-latest
+appVersion: 0.0.0-latest

--- a/deployment/lookout-v2/README.md
+++ b/deployment/lookout-v2/README.md
@@ -1,6 +1,6 @@
 # armada-lookout-v2
 
-![Version: LATEST](https://img.shields.io/badge/Version-LATEST-informational?style=flat-square) ![AppVersion: LATEST](https://img.shields.io/badge/AppVersion-LATEST-informational?style=flat-square)
+![Version: 0.0.0-latest](https://img.shields.io/badge/Version-0.0.0--latest-informational?style=flat-square) ![AppVersion: 0.0.0-latest](https://img.shields.io/badge/AppVersion-0.0.0--latest-informational?style=flat-square)
 
 A helm chart for Armada Lookout component
 
@@ -14,7 +14,7 @@ A helm chart for Armada Lookout component
 | applicationConfig.metricsPort | int | `9000` |  |
 | customServiceAccount | string | `nil` |  |
 | image.repository | string | `"gresearchdev/armada-lookout"` |  |
-| image.tag | string | `"LATEST"` |  |
+| image.tag | string | `"0.0.0-latest"` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.labels | object | `{}` |  |
 | prometheus.enabled | bool | `false` |  |

--- a/deployment/lookout-v2/values.yaml
+++ b/deployment/lookout-v2/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: gresearchdev/armada-lookout-v2-dev
-  tag: LATEST
+  tag: 0.0.0-latest
 resources:
   limits:
     memory: 1Gi

--- a/deployment/lookout/Chart.yaml
+++ b/deployment/lookout/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: A helm chart for Armada Lookout component
 name: armada-lookout
-version: LATEST
-appVersion: LATEST
+version: 0.0.0-latest
+appVersion: 0.0.0-latest

--- a/deployment/lookout/README.md
+++ b/deployment/lookout/README.md
@@ -1,6 +1,6 @@
 # armada-lookout
 
-![Version: LATEST](https://img.shields.io/badge/Version-LATEST-informational?style=flat-square) ![AppVersion: LATEST](https://img.shields.io/badge/AppVersion-LATEST-informational?style=flat-square)
+![Version: 0.0.0-latest](https://img.shields.io/badge/Version-0.0.0--latest-informational?style=flat-square) ![AppVersion: 0.0.0-latest](https://img.shields.io/badge/AppVersion-0.0.0--latest-informational?style=flat-square)
 
 A helm chart for Armada Lookout component
 
@@ -14,7 +14,7 @@ A helm chart for Armada Lookout component
 | applicationConfig.metricsPort | int | `9000` |  |
 | customServiceAccount | string | `nil` |  |
 | image.repository | string | `"gresearchdev/armada-lookout"` |  |
-| image.tag | string | `"LATEST"` |  |
+| image.tag | string | `"0.0.0-latest"` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.labels | object | `{}` |  |
 | prometheus.enabled | bool | `false` |  |

--- a/deployment/lookout/values.yaml
+++ b/deployment/lookout/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: gresearchdev/armada-lookout
-  tag: LATEST
+  tag: 0.0.0-latest
 resources:
   limits:
     memory: 1Gi

--- a/deployment/scheduler-migration/Chart.yaml
+++ b/deployment/scheduler-migration/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: A Helm chart for the Armada Scheduler database migration
 name: armada-scheduler-migration
-version: LATEST
-appVersion: LATEST
+version: 0.0.0-latest
+appVersion: 0.0.0-latest

--- a/deployment/scheduler-migration/README.md
+++ b/deployment/scheduler-migration/README.md
@@ -1,6 +1,6 @@
 # armada-scheduler-migration
 
-![Version: LATEST](https://img.shields.io/badge/Version-LATEST-informational?style=flat-square) ![AppVersion: LATEST](https://img.shields.io/badge/AppVersion-LATEST-informational?style=flat-square)
+![Version: 0.0.0-latest](https://img.shields.io/badge/Version-0.0.0--latest-informational?style=flat-square) ![AppVersion: 0.0.0-latest](https://img.shields.io/badge/AppVersion-0.0.0--latest-informational?style=flat-square)
 
 A Helm chart for the Armada Scheduler database migration
 
@@ -15,7 +15,7 @@ A Helm chart for the Armada Scheduler database migration
 | args.timeout | string | `"5m"` |  |
 | customServiceAccount | string | `nil` |  |
 | image.repository | string | `"gresearchdev/armada-scheduler"` |  |
-| image.tag | string | `"LATEST"` |  |
+| image.tag | string | `"0.0.0-latest"` |  |
 | resources.limits.cpu | string | `"200m"` |  |
 | resources.limits.memory | string | `"256Mi"` |  |
 | resources.requests.cpu | string | `"100m"` |  |

--- a/deployment/scheduler-migration/values.yaml
+++ b/deployment/scheduler-migration/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: gresearchdev/armada-scheduler
-  tag: LATEST
+  tag: 0.0.0-latest
 resources:
   limits:
     memory: 256Mi

--- a/deployment/scheduler/Chart.yaml
+++ b/deployment/scheduler/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: A helm chart for Armada Scheduler component
 name: armada-scheduler
-version: LATEST
-appVersion: LATEST
+version: 0.0.0-latest
+appVersion: 0.0.0-latest

--- a/deployment/scheduler/README.md
+++ b/deployment/scheduler/README.md
@@ -15,7 +15,7 @@ A helm chart for Armada Scheduler component
 | ingester.applicationConfig.pulsar | object | `{}` |  |
 | ingester.customServiceAccount | string | `nil` |  |
 | ingester.image.repository | string | `"gresearchdev/armada-scheduler-ingester"` |  |
-| ingester.image.tag | string | `"LATEST"` |  |
+| ingester.image.tag | string | `"0.0.0-latest"` |  |
 | ingester.replicas | int | `1` |  |
 | ingester.resources.limits.cpu | string | `"300m"` |  |
 | ingester.resources.limits.memory | string | `"1Gi"` |  |
@@ -42,7 +42,7 @@ A helm chart for Armada Scheduler component
 | scheduler.customServiceAccount | string | `nil` |  |
 | scheduler.hostnames[0] | string | `"test"` |  |
 | scheduler.image.repository | string | `"gresearchdev/armada-scheduler"` |  |
-| scheduler.image.tag | string | `"LATEST"` |  |
+| scheduler.image.tag | string | `"0.0.0-latest"` |  |
 | scheduler.ingress.annotations | object | `{}` |  |
 | scheduler.ingress.labels | object | `{}` |  |
 | scheduler.ingress.nameOverride | string | `""` |  |

--- a/deployment/scheduler/values.yaml
+++ b/deployment/scheduler/values.yaml
@@ -4,7 +4,7 @@ scheduler:
   replicas: 1
   image:
     repository: gresearchdev/armada-scheduler
-    tag: LATEST
+    tag: 0.0.0-latest
   resources:
     limits:
       memory: 1Gi
@@ -40,7 +40,7 @@ ingester:
   replicas: 1
   image:
     repository: gresearchdev/armada-scheduler-ingester
-    tag: LATEST
+    tag: 0.0.0-latest
   resources:
     limits:
       memory: 1Gi


### PR DESCRIPTION
helm3 expects Chart version + appVersion to be a semver

So swapping from `LATEST` to `0.0.0-latest` so it works with helm3

Swapped the sed command used when publishing the charts

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-198) by [Unito](https://www.unito.io)
