### PR TITLE
Fixes from testing armada-scheduler

### DIFF
--- a/config/executor/config.yaml
+++ b/config/executor/config.yaml
@@ -18,7 +18,7 @@ task:
   queueUsageDataRefreshInterval: 5s
   utilisationEventProcessingInterval: 1s
   utilisationEventReportingInterval: 5m
-  stateProcessorInterval: 5s
+  stateProcessorInterval: 1s
 # The executor api section should only be needed until we migrate to it fully - then we go back to just using apiConnection
 executorApiConnection:
   armadaUrl: "server:50052"

--- a/config/scheduler/config.yaml
+++ b/config/scheduler/config.yaml
@@ -46,9 +46,9 @@ grpc:
     permitWithoutStream: true
 scheduling:
   executorTimeout: 10m
-  nodeIdLabel: kubernetes.io/hostname
   preemption:
     enabled: true
+    nodeIdLabel: kubernetes.io/hostname
     priorityClasses:
       armada-default:
         priority: 1000

--- a/internal/armada/configuration/types.go
+++ b/internal/armada/configuration/types.go
@@ -210,7 +210,7 @@ type PreemptionConfig struct {
 	// If true, NodeIdLabel must be non-empty.
 	SetNodeIdSelector bool
 	// Label used with SetNodeIdSelector. Must be non-empty if SetNodeIdSelector is true.
-	NodeIdLabel string
+	NodeIdLabel string `validate:"required"`
 	// If true, the Armada scheduler will set the node name of the selected node directly on scheduled pods,
 	// thus bypassing kube-scheduler entirely.
 	SetNodeName bool

--- a/internal/executor/fake/application.go
+++ b/internal/executor/fake/application.go
@@ -15,7 +15,7 @@ func StartUp(config configuration.ExecutorConfiguration, nodes []*context.NodeSp
 	wg.Add(1)
 	return executor.StartUpWithContext(
 		config,
-		context.NewFakeClusterContext(config.Application, nodes),
+		context.NewFakeClusterContext(config.Application, config.Kubernetes.NodeIdLabel, nodes),
 		nil,
 		task.NewBackgroundTaskManager(metrics.ArmadaExecutorMetricsPrefix),
 		wg,

--- a/internal/executor/fake/context/context.go
+++ b/internal/executor/fake/context/context.go
@@ -353,7 +353,7 @@ func (c *FakeClusterContext) trySchedule(pod *v1.Pod) (scheduled bool, removed b
 		if node, ok := c.nodesByNodeId[selectedNode]; ok {
 			nodes = []*v1.Node{node}
 		} else {
-			log.Warnf("pod %s is targetting node (%s) that does not exist.", pod.Name, selectedNode)
+			log.Warnf("pod %s is targeting node (%s) that does not exist.", pod.Name, selectedNode)
 			return false, true
 		}
 	}

--- a/internal/executor/fake/context/context.go
+++ b/internal/executor/fake/context/context.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/armadaproject/armada/internal/common/util"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -25,6 +24,7 @@ import (
 	"k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 
 	armadaresource "github.com/armadaproject/armada/internal/common/resource"
+	"github.com/armadaproject/armada/internal/common/util"
 	"github.com/armadaproject/armada/internal/executor/configuration"
 	cluster_context "github.com/armadaproject/armada/internal/executor/context"
 )

--- a/internal/executor/fake/context/context.go
+++ b/internal/executor/fake/context/context.go
@@ -317,6 +317,9 @@ func (c *FakeClusterContext) addNodes(specs []*NodeSpec) {
 		for i := 0; i < s.Count; i++ {
 			name := c.clusterId + "-" + s.Name + "-" + strconv.Itoa(i)
 			labels := util.DeepCopy(s.Labels)
+			if labels == nil {
+				labels = map[string]string{}
+			}
 			labels[c.nodeIdLabel] = name
 			node := &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{

--- a/internal/executor/fake/context/context.go
+++ b/internal/executor/fake/context/context.go
@@ -346,7 +346,7 @@ func (c *FakeClusterContext) trySchedule(pod *v1.Pod) (scheduled bool, removed b
 		return false, true
 	}
 
-	// Use node index if node is targeting a node based on nodeIdLabe
+	// Use node index if job is targeting a node based on nodeIdLabe
 	// This will likely account for all pods, as the armada scheduler now sets the selector
 	nodes := c.nodes
 	if selectedNode, exists := pod.Spec.NodeSelector[c.nodeIdLabel]; exists {

--- a/internal/executor/job/submit_test.go
+++ b/internal/executor/job/submit_test.go
@@ -22,7 +22,7 @@ const (
 var testAppConfig = configuration.ApplicationConfiguration{ClusterId: "test", Pool: "pool"}
 
 func TestIsRecoverable_ArbitraryErrorIsNotRecoverable(t *testing.T) {
-	clusterContext := context.NewFakeClusterContext(testAppConfig, []*context.NodeSpec{})
+	clusterContext := context.NewFakeClusterContext(testAppConfig, "kubernetes.io/hostname", []*context.NodeSpec{})
 	submitter := NewSubmitter(clusterContext, &configuration.PodDefaults{}, 1, []string{
 		AdmissionWebhookRegex,
 		HelloRegex,
@@ -34,7 +34,7 @@ func TestIsRecoverable_ArbitraryErrorIsNotRecoverable(t *testing.T) {
 }
 
 func TestIsRecoverable_KubernetesStatusInvalidIsUnrecoverable(t *testing.T) {
-	clusterContext := context.NewFakeClusterContext(testAppConfig, []*context.NodeSpec{})
+	clusterContext := context.NewFakeClusterContext(testAppConfig, "kubernetes.io/hostname", []*context.NodeSpec{})
 	submitter := NewSubmitter(clusterContext, &configuration.PodDefaults{}, 1, []string{})
 
 	recoverable := submitter.isRecoverable(newK8sApiError("", metav1.StatusReasonInvalid))
@@ -42,7 +42,7 @@ func TestIsRecoverable_KubernetesStatusInvalidIsUnrecoverable(t *testing.T) {
 }
 
 func TestIsRecoverable_KubernetesStatusForbiddenIsUnrecoverable(t *testing.T) {
-	clusterContext := context.NewFakeClusterContext(testAppConfig, []*context.NodeSpec{})
+	clusterContext := context.NewFakeClusterContext(testAppConfig, "kubernetes.io/hostname", []*context.NodeSpec{})
 	submitter := NewSubmitter(clusterContext, &configuration.PodDefaults{}, 1, []string{})
 
 	recoverable := submitter.isRecoverable(newK8sApiError("", metav1.StatusReasonForbidden))
@@ -50,7 +50,7 @@ func TestIsRecoverable_KubernetesStatusForbiddenIsUnrecoverable(t *testing.T) {
 }
 
 func TestIsRecoverable_K8sApiMatchingRegexIsUnrecoverable(t *testing.T) {
-	clusterContext := context.NewFakeClusterContext(testAppConfig, []*context.NodeSpec{})
+	clusterContext := context.NewFakeClusterContext(testAppConfig, "kubernetes.io/hostname", []*context.NodeSpec{})
 	submitter := NewSubmitter(clusterContext, &configuration.PodDefaults{}, 1, []string{
 		AdmissionWebhookRegex,
 		HelloRegex,
@@ -71,7 +71,7 @@ func TestIsRecoverable_K8sApiMatchingRegexIsUnrecoverable(t *testing.T) {
 }
 
 func TestIsRecoverable_ArmadaErrCreateResourceIsRecoverable(t *testing.T) {
-	clusterContext := context.NewFakeClusterContext(testAppConfig, []*context.NodeSpec{})
+	clusterContext := context.NewFakeClusterContext(testAppConfig, "kubernetes.io/hostname", []*context.NodeSpec{})
 	submitter := NewSubmitter(clusterContext, &configuration.PodDefaults{}, 1, []string{})
 
 	recoverable := submitter.isRecoverable(newArmadaErrCreateResource())

--- a/internal/executor/node/node_group_test.go
+++ b/internal/executor/node/node_group_test.go
@@ -14,7 +14,7 @@ import (
 var testAppConfig = configuration.ApplicationConfiguration{ClusterId: "test", Pool: "pool"}
 
 func TestGetType_WhenNodeHasNoTaint(t *testing.T) {
-	context := fakeContext.NewFakeClusterContext(testAppConfig, nil)
+	context := fakeContext.NewFakeClusterContext(testAppConfig, "kubernetes.io/hostname", nil)
 	nodeInfoService := NewKubernetesNodeInfoService(context, []string{"tolerated1", "tolerated2"})
 	node := createNodeWithTaints("node1")
 
@@ -24,7 +24,7 @@ func TestGetType_WhenNodeHasNoTaint(t *testing.T) {
 }
 
 func TestGetType_WhenNodeHasUntoleratedTaint(t *testing.T) {
-	context := fakeContext.NewFakeClusterContext(testAppConfig, nil)
+	context := fakeContext.NewFakeClusterContext(testAppConfig, "kubernetes.io/hostname", nil)
 	nodeInfoService := NewKubernetesNodeInfoService(context, []string{"tolerated1", "tolerated2"})
 	node := createNodeWithTaints("node1", "untolerated")
 
@@ -34,7 +34,7 @@ func TestGetType_WhenNodeHasUntoleratedTaint(t *testing.T) {
 }
 
 func TestGetType_WhenNodeHasToleratedTaint(t *testing.T) {
-	context := fakeContext.NewFakeClusterContext(testAppConfig, nil)
+	context := fakeContext.NewFakeClusterContext(testAppConfig, "kubernetes.io/hostname", nil)
 	nodeInfoService := NewKubernetesNodeInfoService(context, []string{"tolerated1", "tolerated2"})
 
 	node := createNodeWithTaints("node1", "tolerated1")
@@ -51,7 +51,7 @@ func TestGetType_WhenNodeHasToleratedTaint(t *testing.T) {
 }
 
 func TestGetType_WhenSomeNodeTaintsTolerated(t *testing.T) {
-	context := fakeContext.NewFakeClusterContext(testAppConfig, nil)
+	context := fakeContext.NewFakeClusterContext(testAppConfig, "kubernetes.io/hostname", nil)
 	nodeInfoService := NewKubernetesNodeInfoService(context, []string{"tolerated1", "tolerated2"})
 
 	node := createNodeWithTaints("node1", "tolerated1", "untolerated")
@@ -62,7 +62,7 @@ func TestGetType_WhenSomeNodeTaintsTolerated(t *testing.T) {
 }
 
 func TestGroupNodesByType(t *testing.T) {
-	context := fakeContext.NewFakeClusterContext(testAppConfig, nil)
+	context := fakeContext.NewFakeClusterContext(testAppConfig, "kubernetes.io/hostname", nil)
 	nodeInfoService := NewKubernetesNodeInfoService(context, []string{"tolerated1", "tolerated2"})
 
 	node1 := createNodeWithTaints("node1")
@@ -88,7 +88,7 @@ func TestGroupNodesByType(t *testing.T) {
 }
 
 func TestFilterAvailableProcessingNodes(t *testing.T) {
-	context := fakeContext.NewFakeClusterContext(testAppConfig, nil)
+	context := fakeContext.NewFakeClusterContext(testAppConfig, "kubernetes.io/hostname", nil)
 	nodeInfoService := NewKubernetesNodeInfoService(context, []string{})
 
 	node := v1.Node{
@@ -103,7 +103,7 @@ func TestFilterAvailableProcessingNodes(t *testing.T) {
 }
 
 func TestIsAvailableProcessingNode_IsFalse_UnschedulableNode(t *testing.T) {
-	context := fakeContext.NewFakeClusterContext(testAppConfig, nil)
+	context := fakeContext.NewFakeClusterContext(testAppConfig, "kubernetes.io/hostname", nil)
 	nodeInfoService := NewKubernetesNodeInfoService(context, []string{})
 
 	node := v1.Node{
@@ -118,7 +118,7 @@ func TestIsAvailableProcessingNode_IsFalse_UnschedulableNode(t *testing.T) {
 }
 
 func TestFilterAvailableProcessingNodes_IsFalse_NodeWithNoScheduleTaint(t *testing.T) {
-	context := fakeContext.NewFakeClusterContext(testAppConfig, nil)
+	context := fakeContext.NewFakeClusterContext(testAppConfig, "kubernetes.io/hostname", nil)
 	nodeInfoService := NewKubernetesNodeInfoService(context, []string{})
 
 	taint := v1.Taint{
@@ -137,7 +137,7 @@ func TestFilterAvailableProcessingNodes_IsFalse_NodeWithNoScheduleTaint(t *testi
 }
 
 func TestFilterAvailableProcessingNodes_IsTrue_NodeWithToleratedTaint(t *testing.T) {
-	context := fakeContext.NewFakeClusterContext(testAppConfig, nil)
+	context := fakeContext.NewFakeClusterContext(testAppConfig, "kubernetes.io/hostname", nil)
 	nodeInfoService := NewKubernetesNodeInfoService(context, []string{"taint"})
 
 	taint := v1.Taint{

--- a/internal/executor/service/job_lease_test.go
+++ b/internal/executor/service/job_lease_test.go
@@ -20,7 +20,7 @@ func TestJobLease_GetAvoidNodeLabels_EverythingSetUpCorrectly_ReturnsLabels(t *t
 
 	node := &fakeContext.NodeSpec{Name: "node1", Count: 1}
 	node.Labels = map[string]string{"a": "aa", "b": "bb", "c": "cc"}
-	fakeCc := fakeContext.NewFakeClusterContext(testAppConfig, []*fakeContext.NodeSpec{node})
+	fakeCc := fakeContext.NewFakeClusterContext(testAppConfig, "kubernetes.io/hostname", []*fakeContext.NodeSpec{node})
 
 	labels, err := getAvoidNodeLabels(pod, avoidNodeLabels, fakeCc)
 
@@ -37,7 +37,7 @@ func TestJobLease_GetAvoidNodeLabels_NodeNameNotSet_ReturnsEmptyMap(t *testing.T
 
 	node := &fakeContext.NodeSpec{Name: "node1", Count: 1}
 	node.Labels = map[string]string{"a": "aa"}
-	fakeCc := fakeContext.NewFakeClusterContext(testAppConfig, []*fakeContext.NodeSpec{node})
+	fakeCc := fakeContext.NewFakeClusterContext(testAppConfig, "kubernetes.io/hostname", []*fakeContext.NodeSpec{node})
 
 	labels, err := getAvoidNodeLabels(pod, avoidNodeLabels, fakeCc)
 
@@ -54,7 +54,7 @@ func TestJobLease_GetAvoidNodeLabels_NoMatchingLabels_ReturnsError(t *testing.T)
 
 	node := &fakeContext.NodeSpec{Name: "node1", Count: 1}
 	node.Labels = map[string]string{"b": "bb"}
-	fakeCc := fakeContext.NewFakeClusterContext(testAppConfig, []*fakeContext.NodeSpec{node})
+	fakeCc := fakeContext.NewFakeClusterContext(testAppConfig, "kubernetes.io/hostname", []*fakeContext.NodeSpec{node})
 
 	labels, err := getAvoidNodeLabels(pod, avoidNodeLabels, fakeCc)
 

--- a/internal/executor/utilisation/job_utilisation_reporter_test.go
+++ b/internal/executor/utilisation/job_utilisation_reporter_test.go
@@ -31,7 +31,7 @@ var testPodResources = domain.UtilisationData{
 
 func TestUtilisationEventReporter_ReportUtilisationEvents(t *testing.T) {
 	reportingPeriod := 100 * time.Millisecond
-	clusterContext := fakeContext.NewFakeClusterContext(configuration.ApplicationConfiguration{ClusterId: "test", Pool: "pool"}, nil)
+	clusterContext := fakeContext.NewFakeClusterContext(configuration.ApplicationConfiguration{ClusterId: "test", Pool: "pool"}, "kubernetes.io/hostname", nil)
 	fakeEventReporter := &mocks.FakeEventReporter{}
 	fakeUtilisationService := &fakePodUtilisationService{data: &testPodResources}
 
@@ -64,7 +64,7 @@ func TestUtilisationEventReporter_ReportUtilisationEvents(t *testing.T) {
 
 func TestUtilisationEventReporter_ReportUtilisationEvents_WhenNoUtilisationData(t *testing.T) {
 	reportingPeriod := 100 * time.Millisecond
-	clusterContext := fakeContext.NewFakeClusterContext(configuration.ApplicationConfiguration{ClusterId: "test", Pool: "pool"}, nil)
+	clusterContext := fakeContext.NewFakeClusterContext(configuration.ApplicationConfiguration{ClusterId: "test", Pool: "pool"}, "kubernetes.io/hostname", nil)
 	fakeEventReporter := &mocks.FakeEventReporter{}
 	fakeUtilisationService := &fakePodUtilisationService{data: domain.EmptyUtilisationData()}
 


### PR DESCRIPTION
 - Setting `nodeIdLabel` in the correct place in the armada schedule config + making it required
   - Without this the nodeSelector doesn't get set on jobs
   - Without this retrying jobs doesn't work - as we need to set an anti affinity based on this nodeIdLabel - which fails when the nodeIdLabel config is missing
 - Fixing fake executor to handle jobs having nodeSelectors targeting nodes by nodeIdLabel
   - The scheduler now sets this on all jobs. However the fake executor wasn't setting this label and it meant it could never schedule any jobs
   - Added an index to make the scheduling much faster on executor side
 - Set `stateProcessorInterval` to 1s - so the executor is more responsive 
┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-209) by [Unito](https://www.unito.io)
