### PR TITLE
Mark runs as cancelled when job is cancelled

### DIFF
--- a/internal/scheduler/database/query.sql.go
+++ b/internal/scheduler/database/query.sql.go
@@ -162,6 +162,15 @@ func (q *Queries) MarkJobsSucceededById(ctx context.Context, jobIds []string) er
 	return err
 }
 
+const markRunsCancelledByJobId = `-- name: MarkRunsCancelledByJobId :exec
+UPDATE runs SET cancelled = true WHERE job_id = ANY($1::text[])
+`
+
+func (q *Queries) MarkRunsCancelledByJobId(ctx context.Context, jobIds []string) error {
+	_, err := q.db.Exec(ctx, markRunsCancelledByJobId, jobIds)
+	return err
+}
+
 const selectAllExecutors = `-- name: SelectAllExecutors :many
 SELECT executor_id, last_request, last_updated FROM executors
 `

--- a/internal/scheduler/database/query/query.sql
+++ b/internal/scheduler/database/query/query.sql
@@ -58,6 +58,9 @@ UPDATE runs SET run_attempted = true WHERE run_id = ANY(sqlc.arg(run_ids)::UUID[
 -- name: MarkJobRunsRunningById :exec
 UPDATE runs SET running = true WHERE run_id = ANY(sqlc.arg(run_ids)::UUID[]);
 
+-- name: MarkRunsCancelledByJobId :exec
+UPDATE runs SET cancelled = true WHERE job_id = ANY(sqlc.arg(job_ids)::text[]);
+
 -- name: SelectJobsForExecutor :many
 SELECT jr.run_id, j.queue, j.job_set, j.user_id, j.groups, j.submit_message
 FROM runs jr

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -289,19 +289,19 @@ func TestScheduler_TestCycle(t *testing.T) {
 			expectedQueuedVersion: leasedJob.QueuedVersion(),
 		},
 		"Job cancelled": {
-			initialJobs: []*jobdb.Job{queuedJob},
+			initialJobs: []*jobdb.Job{leasedJob},
 			jobUpdates: []database.Job{
 				{
-					JobID:           queuedJob.Id(),
+					JobID:           leasedJob.Id(),
 					JobSet:          "testJobSet",
 					Queue:           "testQueue",
 					CancelRequested: true,
 					Serial:          1,
 				},
 			},
-			expectedJobCancelled:  []string{queuedJob.Id()},
-			expectedTerminal:      []string{queuedJob.Id()},
-			expectedQueuedVersion: queuedJob.QueuedVersion(),
+			expectedJobCancelled:  []string{leasedJob.Id()},
+			expectedTerminal:      []string{leasedJob.Id()},
+			expectedQueuedVersion: leasedJob.QueuedVersion(),
 		},
 		"Job reprioritised": {
 			initialJobs: []*jobdb.Job{queuedJob},
@@ -484,6 +484,13 @@ func TestScheduler_TestCycle(t *testing.T) {
 				if job.InTerminalState() {
 					_, ok := remainingTerminal[job.Id()]
 					assert.True(t, ok)
+					allRunsTerminal := true
+					for _, run := range job.AllRuns() {
+						if !run.InTerminalState() {
+							allRunsTerminal = false
+						}
+					}
+					assert.True(t, allRunsTerminal)
 					delete(remainingTerminal, job.Id())
 				} else if job.Queued() {
 					_, ok := remainingQueued[job.Id()]

--- a/internal/scheduleringester/schedulerdb.go
+++ b/internal/scheduleringester/schedulerdb.go
@@ -165,6 +165,10 @@ func (s *SchedulerDb) WriteDbOp(ctx context.Context, tx pgx.Tx, op DbOperation) 
 		if err != nil {
 			return errors.WithStack(err)
 		}
+		err = queries.MarkRunsCancelledByJobId(ctx, jobIds)
+		if err != nil {
+			return errors.WithStack(err)
+		}
 	case MarkJobsSucceeded:
 		jobIds := maps.Keys(o)
 		err := queries.MarkJobsSucceededById(ctx, jobIds)


### PR DESCRIPTION
This PR marks all runs associated run a cancelled job as also cancelled

Without this, we continue to lease out these active runs associated with the cancelled job


