### PR TITLE
Exit out of metric calculation early on issue

### DIFF
--- a/internal/scheduler/metrics.go
+++ b/internal/scheduler/metrics.go
@@ -176,6 +176,7 @@ func (c *MetricsCollector) refresh(ctx context.Context) error {
 			recorder = qs.runningJobRecorder
 		} else {
 			log.Warnf("Job %s is marked as leased but has no runs", job.Id())
+			break
 		}
 		recorder.RecordJobRuntime(pool, priorityClass, timeInState)
 		recorder.RecordResources(pool, priorityClass, jobResources)


### PR DESCRIPTION
Without this it causes a panic as the recorders are not initialised

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-226) by [Unito](https://www.unito.io)
