### PR TITLE
fix hashing function

### DIFF
--- a/internal/common/proto/protoutil.go
+++ b/internal/common/proto/protoutil.go
@@ -83,14 +83,17 @@ func Hash(msg proto.Message) ([]byte, error) {
 
 // HashMany produces a 160 bit hash of the supplied proto objects
 func HashMany[T proto.Message](msgs []T) ([]byte, error) {
-	var hash []byte = nil
 	h := sha1.New()
+	sha1.Sum(nil)
 	for _, msg := range msgs {
 		b, err := json.Marshal(msg)
 		if err != nil {
 			return nil, err
 		}
-		hash = h.Sum(b)
+		_, err = h.Write(b)
+		if err != nil {
+			return nil, err
+		}
 	}
-	return hash, nil
+	return h.Sum(nil), nil
 }

--- a/internal/common/proto/protoutil.go
+++ b/internal/common/proto/protoutil.go
@@ -84,7 +84,6 @@ func Hash(msg proto.Message) ([]byte, error) {
 // HashMany produces a 160 bit hash of the supplied proto objects
 func HashMany[T proto.Message](msgs []T) ([]byte, error) {
 	h := sha1.New()
-	sha1.Sum(nil)
 	for _, msg := range msgs {
 		b, err := json.Marshal(msg)
 		if err != nil {

--- a/internal/common/proto/protoutil_test.go
+++ b/internal/common/proto/protoutil_test.go
@@ -89,7 +89,7 @@ func TestHashMany(t *testing.T) {
 
 func TestHash_NoCollisions(t *testing.T) {
 	hashes := make(map[string]bool)
-	for i := 0; i < 1000000; i++ {
+	for i := 0; i < 100000; i++ {
 		intialHash, err := Hash(&schedulerobjects.JobSchedulingInfo{Lifetime: uint32(i)})
 		require.NoError(t, err)
 		hashStr := string(intialHash)

--- a/internal/common/proto/protoutil_test.go
+++ b/internal/common/proto/protoutil_test.go
@@ -70,6 +70,35 @@ func TestMustMarshallAndCompress(t *testing.T) {
 	assert.Equal(t, compressedMsg, bytes)
 }
 
+func TestHashMany(t *testing.T) {
+	input1 := &schedulerobjects.JobSchedulingInfo{Lifetime: 1}
+	input2 := &schedulerobjects.JobSchedulingInfo{Lifetime: 2}
+	input3 := &schedulerobjects.JobSchedulingInfo{Lifetime: 3}
+	hash1, err := HashMany([]*schedulerobjects.JobSchedulingInfo{input1, input2})
+	require.NoError(t, err)
+	require.Equal(t, 20, len(hash1))
+	hash2, err := HashMany([]*schedulerobjects.JobSchedulingInfo{input1, input2})
+	require.NoError(t, err)
+	require.Equal(t, 20, len(hash2))
+	hash3, err := HashMany([]*schedulerobjects.JobSchedulingInfo{input1, input3})
+	require.NoError(t, err)
+	require.Equal(t, 20, len(hash3))
+	assert.Equal(t, hash1, hash2)
+	assert.NotEqual(t, hash1, hash3)
+}
+
+func TestHash_NoCollisions(t *testing.T) {
+	hashes := make(map[string]bool)
+	for i := 0; i < 1000000; i++ {
+		intialHash, err := Hash(&schedulerobjects.JobSchedulingInfo{Lifetime: uint32(i)})
+		require.NoError(t, err)
+		hashStr := string(intialHash)
+		_, ok := hashes[hashStr]
+		require.False(t, ok, "Hash collision detected for %d", i)
+		hashes[hashStr] = true
+	}
+}
+
 func TestHash_TestConsistent(t *testing.T) {
 	schedulingInfo := &schedulerobjects.JobSchedulingInfo{
 		Lifetime:          1,


### PR DESCRIPTION
protoutil.hash was (embarrassingly) returning the bytes of the json serialized message rather than the hash  This PR fixes that and adds some more testing to ensure this never happens again.

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-228) by [Unito](https://www.unito.io)
