### PR TITLE
[scheduler-ingester] Fix all inserts not being inside same transaction

### DIFF
--- a/internal/scheduleringester/schedulerdb.go
+++ b/internal/scheduleringester/schedulerdb.go
@@ -131,7 +131,7 @@ func (s *SchedulerDb) WriteDbOp(ctx context.Context, tx pgx.Tx, op DbOperation) 
 			batch.Queue(updateJobInfoSqlStatement, value.JobSchedulingInfo, value.JobSchedulingInfoVersion, key)
 		}
 
-		err := s.execBatch(ctx, batch)
+		err := execBatch(ctx, tx, batch)
 		if err != nil {
 			return errors.WithStack(err)
 		}
@@ -143,7 +143,7 @@ func (s *SchedulerDb) WriteDbOp(ctx context.Context, tx pgx.Tx, op DbOperation) 
 			batch.Queue(updateQueuedStateSqlStatement, value.Queued, value.QueuedStateVersion, key)
 		}
 
-		err := s.execBatch(ctx, batch)
+		err := execBatch(ctx, tx, batch)
 		if err != nil {
 			return errors.WithStack(err)
 		}
@@ -255,8 +255,8 @@ func (s *SchedulerDb) WriteDbOp(ctx context.Context, tx pgx.Tx, op DbOperation) 
 	return nil
 }
 
-func (s *SchedulerDb) execBatch(ctx context.Context, batch *pgx.Batch) error {
-	result := s.db.SendBatch(ctx, batch)
+func execBatch(ctx context.Context, tx pgx.Tx, batch *pgx.Batch) error {
+	result := tx.SendBatch(ctx, batch)
 	for i := 0; i < batch.Len(); i++ {
 		_, err := result.Exec()
 		if err != nil {


### PR DESCRIPTION
We were accidentally inserting rows outside of the main insert transaction

This was causing the scheduler to see intermediate states and get itself into unexpected states.

This should make it so all inserts are now happening in a single transaction as expected

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-235) by [Unito](https://www.unito.io)
