### PR TITLE
add back ci cluster for python integration tests

### DIFF
--- a/magefiles/ci.go
+++ b/magefiles/ci.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -34,6 +35,52 @@ func TestSuite() error {
 	}
 
 	fmt.Println(out)
+	return nil
+}
+
+func ciSetup() error {
+	if err := os.MkdirAll(".kube", os.ModeDir|0o755); err != nil {
+		return err
+	}
+	err := dockerComposeRun("up", "-d", "redis", "postgres", "pulsar")
+	if err != nil {
+		return err
+	}
+
+	mg.Deps(CheckForPulsarRunning)
+
+	// By starting the executor first,
+	// we can ensure that the server will be able to register the executor cluster
+	// on its first attempt.
+	err = dockerComposeRun("up", "-d", "executor")
+	if err != nil {
+		return err
+	}
+	err = dockerComposeRun("up", "-d", "server")
+	if err != nil {
+		return err
+	}
+
+	err = goRun("run", "cmd/armadactl/main.go", "create", "queue", "e2e-test-queue")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Build images, spin up a test environment, and run the integration tests against it.
+func ciRunTests() error {
+	mg.Deps(CheckForArmadaRunning)
+
+	out, err := goOutput("run", "cmd/testsuite/main.go", "test",
+		"--tests", "testsuite/testcases/basic/*",
+		"--junit", "junit.xml",
+	)
+	fmt.Println(out)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/magefiles/main.go
+++ b/magefiles/main.go
@@ -104,6 +104,18 @@ func BootstrapProto() {
 	mg.Deps(protoInstallProtocArmadaPlugin, protoPrepareThirdPartyProtos)
 }
 
+func BuildCICluster() {
+	mg.Deps(BootstrapTools)
+	mg.Deps(mg.F(goreleaserMinimalRelease, "bundle"), Kind)
+	mg.Deps(ciSetup)
+}
+
+// run integration test
+func CiIntegrationTests() {
+	mg.Deps(BuildCICluster)
+	mg.Deps(ciRunTests)
+}
+
 func BuildDockers(arg string) error {
 	dockerIds := make([]string, 0)
 	for _, s := range strings.Split(arg, ",") {


### PR DESCRIPTION
We need these functions for airflow/python tests.

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-245) by [Unito](https://www.unito.io)
