### PR TITLE
remove tls for jobservice as this is a prod config

### DIFF
--- a/config/jobservice/config.yaml
+++ b/config/jobservice/config.yaml
@@ -33,4 +33,3 @@ grpcPool:
   capacity: 5
 apiConnection:
   armadaUrl: "server:50051"
-  forceNoTls: true

--- a/config/jobservice/config.yaml
+++ b/config/jobservice/config.yaml
@@ -31,5 +31,9 @@ grpc:
 grpcPool:
   initialConnections: 5
   capacity: 5
+# These connections can be used in production if not explicity overridden.
+# Do not add ForceNoTls as that can cause silent failures
+# If you want that for local testing, then use an override.
 apiConnection:
   armadaUrl: "server:50051"
+


### PR DESCRIPTION
Remove tls config from default jobservice config.

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-249) by [Unito](https://www.unito.io)
