### PR TITLE
Remove invocation of now-removed 'upload-docker-images' workflow.

### DIFF
--- a/.github/workflows/build-release-images.yml
+++ b/.github/workflows/build-release-images.yml
@@ -55,8 +55,3 @@ jobs:
           name: docker-images
           path: docker-images.tar.gz
           if-no-files-found: error
-  invoke-image-push:
-    name: Push Docker Image artifacts to Docker Hub
-    needs: test-and-build-images
-    uses: ./.github/workflows/upload-docker-images.yml
-    secrets: inherit

--- a/.github/workflows/docker-readme/action.yml
+++ b/.github/workflows/docker-readme/action.yml
@@ -102,7 +102,7 @@ runs:
         DOCKER_USER: ${{ inputs.docker_user }}
         DOCKER_PASS: ${{ inputs.docker_pwd }}
       with:
-        destination_container_repo: ${{ inputs.docker_owner }}/armada-lookoutingester
+        destination_container_repo: ${{ inputs.docker_owner }}/armada-lookout-ingester
         provider: ${{ inputs.docker_provider }}
         short_description: 'Armada Lookout Ingester is responsible for ingesting the state of jobs and workflows'
         readme_file: 'README.md'
@@ -113,7 +113,7 @@ runs:
         DOCKER_USER: ${{ inputs.docker_user }}
         DOCKER_PASS: ${{ inputs.docker_pwd }}
       with:
-        destination_container_repo: ${{ inputs.docker_owner }}/armada-lookoutingesterv2
+        destination_container_repo: ${{ inputs.docker_owner }}/armada-lookout-ingester-v2
         provider: ${{ inputs.docker_provider }}
         short_description: 'Armada Lookout Ingester V2 is responsible for ingesting the state of jobs and workflows'
         readme_file: 'README.md'
@@ -124,7 +124,7 @@ runs:
         DOCKER_USER: ${{ inputs.docker_user }}
         DOCKER_PASS: ${{ inputs.docker_pwd }}
       with:
-        destination_container_repo: ${{ inputs.docker_owner }}/armada-eventingester
+        destination_container_repo: ${{ inputs.docker_owner }}/armada-event-ingester
         provider: ${{ inputs.docker_provider }}
         short_description: 'Armada Event Ingester is responsible for ingesting events from Kubernetes'
         readme_file: 'README.md'
@@ -146,7 +146,7 @@ runs:
         DOCKER_USER: ${{ inputs.docker_user }}
         DOCKER_PASS: ${{ inputs.docker_pwd }}
       with:
-        destination_container_repo: ${{ inputs.docker_owner }}/armada-scheduleringester
+        destination_container_repo: ${{ inputs.docker_owner }}/armada-scheduler-ingester
         provider: ${{ inputs.docker_provider }}
         short_description: 'Armada Scheduler Ingester is responsible for ingesting the state of jobs and workflows'
         readme_file: 'README.md'


### PR DESCRIPTION
Recent Goreleaser changes have removed the `upload-docker-images.yaml` workflow - remove the invocation of that from the `build-release-images` workflow.

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-268) by [Unito](https://www.unito.io)
