### PR TITLE
Lookout v2 - clickable annotations if detected as links

### DIFF
--- a/internal/lookout/ui/src/components/lookoutV2/sidebar/KeyValuePairTable.tsx
+++ b/internal/lookout/ui/src/components/lookoutV2/sidebar/KeyValuePairTable.tsx
@@ -1,4 +1,5 @@
-import { Table, TableBody, TableCell, TableRow } from "@mui/material"
+import { Table, TableBody, TableCell, TableRow, Link } from "@mui/material"
+import validator from "validator"
 
 import styles from "./KeyValuePairTable.module.css"
 
@@ -6,17 +7,34 @@ export interface KeyValuePairTable {
   data: {
     key: string
     value: string
+    isAnnotation?: boolean
   }[]
 }
+
+const ensureAbsoluteLink = (link: string): string => {
+  if (link.startsWith("//")) {
+    return link
+  }
+  return "//" + link
+}
+
 export const KeyValuePairTable = ({ data }: KeyValuePairTable) => {
   return (
     <Table size="small">
       <TableBody>
-        {data.map(({ key, value }) => {
+        {data.map(({ key, value, isAnnotation }) => {
           return (
             <TableRow key={key}>
               <TableCell className={styles.cell}>{key}</TableCell>
-              <TableCell className={styles.cell}>{value}</TableCell>
+              <TableCell className={styles.cell}>
+                {isAnnotation && validator.isURL(value) ? (
+                  <Link href={ensureAbsoluteLink(value)} target="_blank">
+                    {value}
+                  </Link>
+                ) : (
+                  <span>{value}</span>
+                )}
+              </TableCell>
             </TableRow>
           )
         })}

--- a/internal/lookout/ui/src/components/lookoutV2/sidebar/KeyValuePairTable.tsx
+++ b/internal/lookout/ui/src/components/lookoutV2/sidebar/KeyValuePairTable.tsx
@@ -12,7 +12,7 @@ export interface KeyValuePairTable {
 }
 
 const ensureAbsoluteLink = (link: string): string => {
-  if (link.startsWith("//")) {
+  if (link.startsWith("//") || link.startsWith("http")) {
     return link
   }
   return "//" + link

--- a/internal/lookout/ui/src/components/lookoutV2/sidebar/SidebarTabJobDetails.tsx
+++ b/internal/lookout/ui/src/components/lookoutV2/sidebar/SidebarTabJobDetails.tsx
@@ -38,6 +38,7 @@ export const SidebarTabJobDetails = ({ job }: SidebarTabJobDetailsProps) => {
           data={Object.keys(job.annotations).map((annotationKey) => ({
             key: annotationKey,
             value: job.annotations[annotationKey],
+            isAnnotation: true,
           }))}
         />
       ) : (


### PR DESCRIPTION
Similar behavior to Lookout v1.
The only difference with the previous behavior is that we ensure that the link uses an absolute path.
Without this change, if a user was to submit an annotation with a simplified URL e.g. example.com, clicking on the link will redirect to <lookout-url>/example.com, which is not the desired behavior.

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-276) by [Unito](https://www.unito.io)
