### PR TITLE
Scheduling limit improvements

### DIFF
--- a/internal/armada/configuration/types.go
+++ b/internal/armada/configuration/types.go
@@ -86,23 +86,15 @@ type SchedulingConfig struct {
 	EnableAssertions bool
 	Preemption       PreemptionConfig
 	// Number of jobs to load from the database at a time.
-	QueueLeaseBatchSize uint
-	// Maximum total size in bytes of all jobs returned in a single lease jobs call.
-	// Applies to the old scheduler. But is not necessary since we now stream job leases.
-	MaximumLeasePayloadSizeBytes int
-	// Fraction of total resources across clusters that can be assigned in a single lease jobs call.
-	// Applies to both the old and new scheduler.
-	MaximalClusterFractionToSchedule map[string]float64
-	// Fraction of resources that can be assigned to any single queue,
-	// within a single lease jobs call.
-	// Applies to both the old and new scheduler.
-	MaximalResourceFractionToSchedulePerQueue map[string]float64
-	// Fraction of resources that can be assigned to any single queue.
-	// Applies to both the old and new scheduler.
-	MaximalResourceFractionPerQueue map[string]float64
-	// Max number of jobs to scheduler per lease jobs call.
+	MaxQueueLookback uint
+	// In each invocation of the scheduler, no more jobs are scheduled once this limit has been exceeded.
+	// Note that the total scheduled resources may be greater than this limit.
+	MaximumResourceFractionToSchedule map[string]float64
+	// Overrides MaximalClusterFractionToSchedule if set for the current pool.
+	MaximumResourceFractionToScheduleByPool map[string]map[string]float64
+	// Max number of jobs to schedule in each invocation of the scheduler.
 	MaximumJobsToSchedule uint
-	// Max number of gangs to scheduler per lease jobs call.
+	// Max number of gangs to schedule in each invocation of the scheduler.
 	MaximumGangsToSchedule uint
 	// Armada stores contexts associated with recent job scheduling attempts.
 	// This setting limits the number of such contexts to store.
@@ -234,10 +226,10 @@ type PriorityClass struct {
 	// Limits resources assigned to jobs of priority equal to or lower than that of this priority class.
 	// Specifically, jobs of this priority class are only scheduled if doing so does not exceed this limit.
 	//
-	// For example, if priority is 10 and MaximalResourceFractionPerQueue is map[string]float64{"cpu": 0.3},
+	// For example, if priority is 10 and MaximumResourceFractionPerQueue is map[string]float64{"cpu": 0.3},
 	// jobs of this priority class are not scheduled if doing so would cause the total resources assigned
 	// to jobs of priority 10 or lower from the same queue to exceed 30% of the total.
-	MaximalResourceFractionPerQueue map[string]float64
+	MaximumResourceFractionPerQueue map[string]float64
 }
 
 func (p PreemptionConfig) PriorityByPriorityClassName() map[string]int32 {

--- a/internal/armada/server/lease.go
+++ b/internal/armada/server/lease.go
@@ -478,6 +478,7 @@ func (q *AggregatedQueueServer) getJobs(ctx context.Context, req *api.StreamingL
 		allocatedByQueueForPool,
 	)
 	constraints := schedulerconstraints.SchedulingConstraintsFromSchedulingConfig(
+		req.Pool,
 		schedulerobjects.ResourceList{Resources: req.MinimumJobSize},
 		q.schedulingConfig,
 	)

--- a/internal/scheduler/constraints/constraints_test.go
+++ b/internal/scheduler/constraints/constraints_test.go
@@ -19,7 +19,7 @@ func TestConstraints(t *testing.T) {
 	}{} // TODO: Add tests.
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			ok, unschedulableReason, err := tc.constraints.CheckGlobalConstraints(tc.sctx)
+			ok, unschedulableReason, err := tc.constraints.CheckRoundConstraints(tc.sctx)
 			require.NoError(t, err)
 			require.Equal(t, tc.globalUnschedulableReason == "", ok)
 			require.Equal(t, tc.globalUnschedulableReason, unschedulableReason)

--- a/internal/scheduler/gang_scheduler.go
+++ b/internal/scheduler/gang_scheduler.go
@@ -25,6 +25,9 @@ type GangScheduler struct {
 	unsuccessfulSchedulingKeys map[schedulerobjects.SchedulingKey]*schedulercontext.JobSchedulingContext
 	// If true, the unsuccessfulSchedulingKeys check is omitted.
 	skipUnsuccessfulSchedulingKeyCheck bool
+	// Name of the queue that was scheduled in the previous call to Schedule().
+	// Empty is no job was scheduled in the previous call to Schedule(), or if this is the first call.
+	queueScheduledInPreviousCall string
 }
 
 func NewGangScheduler(
@@ -45,25 +48,43 @@ func (sch *GangScheduler) SkipUnsuccessfulSchedulingKeyCheck() {
 }
 
 func (sch *GangScheduler) Schedule(ctx context.Context, gctx *schedulercontext.GangSchedulingContext) (ok bool, unschedulableReason string, err error) {
+	// Exit immediately if we've hit any round limits. Otherwise, try scheduling the job.
+	if !gctx.AllJobsEvicted && sch.queueScheduledInPreviousCall != "" {
+		if ok, unschedulableReason, err = sch.constraints.CheckRoundConstraints(sch.schedulingContext); err != nil || !ok {
+			return
+		}
+	}
+
+	// This deferred function ensures unschedulable jobs are registered as such
+	// and sets sch.queueScheduledInPreviousCall.
 	gangAddedToSchedulingContext := false
 	defer func() {
-		// If any job in a gang fails to schedule, set the unschedulableReason for all jobs in the gang,
-		// and remove it from the scheduling context.
-		if err == nil && !ok {
+		// Do nothing if an error occurred.
+		if err != nil {
+			return
+		}
+		if ok {
+			sch.queueScheduledInPreviousCall = gctx.Queue
+		} else {
+			// Clear the scheduled queue, since no job was scheduled in this call.
+			sch.queueScheduledInPreviousCall = ""
+
+			// Register the job as unschedulable. If the job was added to the context, remove it first.
 			if gangAddedToSchedulingContext {
 				jobs := util.Map(gctx.JobSchedulingContexts, func(jctx *schedulercontext.JobSchedulingContext) interfaces.LegacySchedulerJob { return jctx.Job })
 				sch.schedulingContext.EvictGang(jobs)
 			}
-
 			for _, jctx := range gctx.JobSchedulingContexts {
 				jctx.UnschedulableReason = unschedulableReason
 			}
 			sch.schedulingContext.AddGangSchedulingContext(gctx)
 
+			// Register unfeasible scheduling keys.
+			//
 			// Only record unfeasible scheduling keys for single-job gangs.
 			// Since a gang may be unschedulable even if all its members are individually schedulable.
 			if !sch.skipUnsuccessfulSchedulingKeyCheck {
-				if schedulingKey, jctx, ok := schedulingKeyFromSingleJobGang(gctx, sch.schedulingContext.PriorityClasses); ok {
+				if schedulingKey, jctx, ok := schedulingKeyIfSingleJobGang(gctx, sch.schedulingContext.PriorityClasses); ok {
 					if _, ok := sch.unsuccessfulSchedulingKeys[schedulingKey]; !ok {
 						// Keep the first jctx for each unique schedulingKey.
 						sch.unsuccessfulSchedulingKeys[schedulingKey] = jctx
@@ -97,25 +118,20 @@ func (sch *GangScheduler) Schedule(ctx context.Context, gctx *schedulercontext.G
 	// Try scheduling the gang.
 	sch.schedulingContext.AddGangSchedulingContext(gctx)
 	gangAddedToSchedulingContext = true
-	if !allGangsJobsEvicted(gctx) {
+	if !gctx.AllJobsEvicted {
 		// Check that the job is large enough for this executor.
 		// This check needs to be here, since it relates to a specific job.
-		// Omit limit checks for evicted jobs to avoid preempting jobs if, e.g., MinimumJobSize changes.
+		// Only perform limit checks for new jobs to avoid preempting jobs if, e.g., MinimumJobSize changes.
 		if ok, unschedulableReason = requestIsLargeEnough(gctx.TotalResourceRequests, sch.constraints.MinimumJobSize); !ok {
 			return
 		}
-	}
-	if ok, unschedulableReason, err = sch.constraints.CheckGlobalConstraints(
-		sch.schedulingContext,
-	); err != nil || !ok {
-		return
-	}
-	if ok, unschedulableReason, err = sch.constraints.CheckPerQueueAndPriorityClassConstraints(
-		sch.schedulingContext,
-		gctx.Queue,
-		gctx.PriorityClassName,
-	); err != nil || !ok {
-		return
+		if ok, unschedulableReason, err = sch.constraints.CheckPerQueueAndPriorityClassConstraints(
+			sch.schedulingContext,
+			gctx.Queue,
+			gctx.PriorityClassName,
+		); err != nil || !ok {
+			return
+		}
 	}
 	if ok, unschedulableReason, err = sch.trySchedule(ctx, gctx); err != nil || ok {
 		return
@@ -150,14 +166,6 @@ func (sch *GangScheduler) trySchedule(ctx context.Context, gctx *schedulercontex
 	return true, "", nil
 }
 
-func allGangsJobsEvicted(gctx *schedulercontext.GangSchedulingContext) bool {
-	rv := true
-	for _, jctx := range gctx.JobSchedulingContexts {
-		rv = rv && isEvictedJob(jctx.Job)
-	}
-	return rv
-}
-
 func requestIsLargeEnough(totalResourceRequests, minRequest schedulerobjects.ResourceList) (bool, string) {
 	if len(minRequest.Resources) == 0 {
 		return true, ""
@@ -171,7 +179,7 @@ func requestIsLargeEnough(totalResourceRequests, minRequest schedulerobjects.Res
 	return true, ""
 }
 
-func schedulingKeyFromSingleJobGang(
+func schedulingKeyIfSingleJobGang(
 	gctx *schedulercontext.GangSchedulingContext,
 	priorityClasses map[string]configuration.PriorityClass,
 ) (schedulerobjects.SchedulingKey, *schedulercontext.JobSchedulingContext, bool) {
@@ -180,7 +188,7 @@ func schedulingKeyFromSingleJobGang(
 		schedulingKey, ok := schedulingKeyFromLegacySchedulerJob(jctx.Job, priorityClasses)
 		return schedulingKey, jctx, ok
 	}
-	return [schedulerobjects.SchedulingKeySize]byte{}, nil, false
+	return schedulerobjects.SchedulingKey{}, nil, false
 }
 
 func schedulingKeyFromLegacySchedulerJob(job interfaces.LegacySchedulerJob, priorityClasses map[string]configuration.PriorityClass) (schedulerobjects.SchedulingKey, bool) {

--- a/internal/scheduler/preempting_queue_scheduler_test.go
+++ b/internal/scheduler/preempting_queue_scheduler_test.go
@@ -649,17 +649,11 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 				"A": 1,
 			},
 		},
-		"rescheduled jobs don't count towards maxLookbackPerQueue": {
+		"rescheduled jobs don't count towards maxQueueLookback": {
 			SchedulingConfig: testfixtures.WithMaxLookbackPerQueueConfig(5, testfixtures.TestSchedulingConfig()),
 			Nodes:            testfixtures.TestNCpuNode(1, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
-					// JobsByQueue: map[string][]*jobdb.Job{
-					// 	"A": testfixtures.NSmallCpuJob("A", testfixtures.PriorityClass0, 10),
-					// },
-					// ExpectedScheduledIndices: map[string][]int{
-					// 	"A": testfixtures.IntRange(0, 4),
-					// },
 					JobsByQueue: map[string][]*jobdb.Job{
 						"A": testfixtures.NSmallCpuJob("A", testfixtures.PriorityClass0, 2),
 					},
@@ -680,37 +674,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 				"A": 1,
 			},
 		},
-		"rescheduled jobs don't count towards MaximalResourceFractionToSchedulePerQueue": {
-			SchedulingConfig: testfixtures.WithPerQueueRoundLimitsConfig(
-				map[string]float64{
-					"cpu": 5.0 / 32.0,
-				},
-				testfixtures.TestSchedulingConfig(),
-			),
-			Nodes: testfixtures.TestNCpuNode(1, testfixtures.TestPriorities),
-			Rounds: []SchedulingRound{
-				{
-					JobsByQueue: map[string][]*jobdb.Job{
-						"A": testfixtures.NSmallCpuJob("A", testfixtures.PriorityClass0, 10),
-					},
-					ExpectedScheduledIndices: map[string][]int{
-						"A": testfixtures.IntRange(0, 4),
-					},
-				},
-				{
-					JobsByQueue: map[string][]*jobdb.Job{
-						"A": testfixtures.NSmallCpuJob("A", testfixtures.PriorityClass0, 10),
-					},
-					ExpectedScheduledIndices: map[string][]int{
-						"A": testfixtures.IntRange(0, 4),
-					},
-				},
-			},
-			PriorityFactorByQueue: map[string]float64{
-				"A": 1,
-			},
-		},
-		"rescheduled jobs don't count towards MaximalClusterFractionToSchedule": {
+		"rescheduled jobs don't count towards MaximumClusterFractionToSchedule": {
 			SchedulingConfig: testfixtures.WithRoundLimitsConfig(
 				map[string]float64{
 					"cpu": 5.0 / 32.0,
@@ -724,7 +688,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 						"A": testfixtures.NSmallCpuJob("A", testfixtures.PriorityClass0, 10),
 					},
 					ExpectedScheduledIndices: map[string][]int{
-						"A": testfixtures.IntRange(0, 4),
+						"A": testfixtures.IntRange(0, 5),
 					},
 				},
 				{
@@ -732,7 +696,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 						"A": testfixtures.NSmallCpuJob("A", testfixtures.PriorityClass0, 10),
 					},
 					ExpectedScheduledIndices: map[string][]int{
-						"A": testfixtures.IntRange(0, 4),
+						"A": testfixtures.IntRange(0, 5),
 					},
 				},
 			},
@@ -930,7 +894,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 		},
 		"MaximalClusterFractionToSchedule": {
 			SchedulingConfig: testfixtures.WithRoundLimitsConfig(
-				map[string]float64{"cpu": 0.25},
+				map[string]float64{"cpu": 15.0 / 64.0},
 				testfixtures.TestSchedulingConfig(),
 			),
 			Nodes: testfixtures.TestNCpuNode(2, testfixtures.TestPriorities),
@@ -976,80 +940,6 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 			PriorityFactorByQueue: map[string]float64{
 				"A": 1,
 				"B": 1,
-			},
-		},
-		"MaximalResourceFractionToSchedulePerQueue": {
-			SchedulingConfig: testfixtures.WithPerQueueRoundLimitsConfig(
-				map[string]float64{"cpu": 0.25},
-				testfixtures.TestSchedulingConfig(),
-			),
-			Nodes: testfixtures.TestNCpuNode(2, testfixtures.TestPriorities),
-			Rounds: []SchedulingRound{
-				{
-					JobsByQueue: map[string][]*jobdb.Job{
-						"A": testfixtures.NSmallCpuJob("A", testfixtures.PriorityClass0, 64),
-					},
-					ExpectedScheduledIndices: map[string][]int{
-						"A": testfixtures.IntRange(0, 15),
-					},
-				},
-				{
-					JobsByQueue: map[string][]*jobdb.Job{
-						"A": testfixtures.NSmallCpuJob("A", testfixtures.PriorityClass0, 64),
-					},
-					ExpectedScheduledIndices: map[string][]int{
-						"A": testfixtures.IntRange(0, 15),
-					},
-				},
-				{
-					JobsByQueue: map[string][]*jobdb.Job{
-						"A": testfixtures.NSmallCpuJob("A", testfixtures.PriorityClass0, 64),
-					},
-					ExpectedScheduledIndices: map[string][]int{
-						"A": testfixtures.IntRange(0, 15),
-					},
-				},
-				{
-					JobsByQueue: map[string][]*jobdb.Job{
-						"A": testfixtures.NSmallCpuJob("A", testfixtures.PriorityClass0, 64),
-					},
-					ExpectedScheduledIndices: map[string][]int{
-						"A": testfixtures.IntRange(0, 15),
-					},
-				},
-				{
-					JobsByQueue: map[string][]*jobdb.Job{
-						"A": testfixtures.NSmallCpuJob("A", testfixtures.PriorityClass0, 64),
-					},
-				},
-			},
-			PriorityFactorByQueue: map[string]float64{
-				"A": 1,
-			},
-		},
-		"MaximalResourceFractionPerQueue": {
-			SchedulingConfig: testfixtures.WithPerQueueLimitsConfig(
-				map[string]float64{"cpu": 0.5},
-				testfixtures.TestSchedulingConfig(),
-			),
-			Nodes: testfixtures.TestNCpuNode(1, testfixtures.TestPriorities),
-			Rounds: []SchedulingRound{
-				{
-					JobsByQueue: map[string][]*jobdb.Job{
-						"A": testfixtures.NSmallCpuJob("A", testfixtures.PriorityClass0, 32),
-					},
-					ExpectedScheduledIndices: map[string][]int{
-						"A": testfixtures.IntRange(0, 15),
-					},
-				},
-				{
-					JobsByQueue: map[string][]*jobdb.Job{
-						"A": testfixtures.NSmallCpuJob("A", testfixtures.PriorityClass0, 32),
-					},
-				},
-			},
-			PriorityFactorByQueue: map[string]float64{
-				"A": 1,
 			},
 		},
 		"Queued jobs are not preempted cross queue": {
@@ -1258,6 +1148,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 					allocatedByQueueAndPriority,
 				)
 				constraints := schedulerconstraints.SchedulingConstraintsFromSchedulingConfig(
+					"pool",
 					schedulerobjects.ResourceList{Resources: tc.MinimumJobSize},
 					tc.SchedulingConfig,
 				)
@@ -1512,6 +1403,7 @@ func BenchmarkPreemptingQueueScheduler(b *testing.B) {
 				usageByQueue,
 			)
 			constraints := schedulerconstraints.SchedulingConstraintsFromSchedulingConfig(
+				"pool",
 				schedulerobjects.ResourceList{Resources: tc.MinimumJobSize},
 				tc.SchedulingConfig,
 			)

--- a/internal/scheduler/queue_scheduler_test.go
+++ b/internal/scheduler/queue_scheduler_test.go
@@ -96,7 +96,7 @@ func TestQueueScheduler(t *testing.T) {
 			),
 			PriorityFactorByQueue:         map[string]float64{"A": 1},
 			ExpectedScheduledIndices:      []int{0, 11},
-			ExpectedNeverAttemptedIndices: []int{13},
+			ExpectedNeverAttemptedIndices: []int{12, 13},
 		},
 		"MaximumGangsToSchedule": {
 			SchedulingConfig: testfixtures.WithMaxGangsToScheduleConfig(2, testfixtures.TestSchedulingConfig()),
@@ -123,96 +123,20 @@ func TestQueueScheduler(t *testing.T) {
 			),
 			PriorityFactorByQueue:         map[string]float64{"A": 1},
 			ExpectedScheduledIndices:      []int{0, 1, 6, 7},
-			ExpectedNeverAttemptedIndices: []int{10, 11},
+			ExpectedNeverAttemptedIndices: []int{8, 9, 10, 11},
 		},
-		"round limits": {
-			SchedulingConfig: testfixtures.WithRoundLimitsConfig(
-				map[string]float64{"cpu": 2.0 / 32.0},
-				testfixtures.TestSchedulingConfig(),
-			),
-			Nodes:                    testfixtures.TestNCpuNode(1, testfixtures.TestPriorities),
-			Jobs:                     testfixtures.NSmallCpuJob("A", testfixtures.PriorityClass0, 5),
-			PriorityFactorByQueue:    map[string]float64{"A": 1},
-			ExpectedScheduledIndices: []int{0, 1},
-		},
-		"round per-queue limits": {
-			SchedulingConfig: testfixtures.WithPerQueueRoundLimitsConfig(map[string]float64{"cpu": 2.0 / 32.0}, testfixtures.TestSchedulingConfig()),
-			Nodes:            testfixtures.TestNCpuNode(1, testfixtures.TestPriorities),
-			Jobs:             armadaslices.Concatenate(testfixtures.NSmallCpuJob("A", testfixtures.PriorityClass0, 5), testfixtures.NSmallCpuJob("B", testfixtures.PriorityClass0, 5)),
-			PriorityFactorByQueue: map[string]float64{
-				"A": 1,
-				"B": 1,
-			},
-			ExpectedScheduledIndices: []int{0, 1, 5, 6},
-		},
-		"overall per-queue limits": {
-			SchedulingConfig: testfixtures.WithPerQueueLimitsConfig(map[string]float64{"cpu": 2.0 / 32.0}, testfixtures.TestSchedulingConfig()),
-			Nodes:            testfixtures.TestNCpuNode(1, testfixtures.TestPriorities),
-			Jobs:             armadaslices.Concatenate(testfixtures.NSmallCpuJob("A", testfixtures.PriorityClass0, 5), testfixtures.NSmallCpuJob("B", testfixtures.PriorityClass0, 5)),
-			PriorityFactorByQueue: map[string]float64{
-				"A": 1,
-				"B": 1,
-			},
-			ExpectedScheduledIndices: []int{0, 1, 5, 6},
-		},
-		"overall per-queue limits with large memory amount": {
-			SchedulingConfig: testfixtures.WithPerQueueLimitsConfig(
-				map[string]float64{
-					"cpu":    2.0 / 162975640.0,
-					"memory": 0.1,
-				},
-				testfixtures.TestSchedulingConfig()),
-			Nodes: testfixtures.TestNCpuNode(1, testfixtures.TestPriorities),
-			Jobs:  armadaslices.Concatenate(testfixtures.NSmallCpuJob("A", testfixtures.PriorityClass0, 5), testfixtures.NSmallCpuJob("B", testfixtures.PriorityClass0, 5)),
-			PriorityFactorByQueue: map[string]float64{
-				"A": 1,
-				"B": 1,
-			},
-			TotalResources: schedulerobjects.ResourceList{
-				Resources: map[string]resource.Quantity{
-					"memory": resource.MustParse("5188205838208Ki"),
-					"cpu":    resource.MustParse("162975640"),
-				},
-			},
-			ExpectedScheduledIndices: []int{0, 1, 5, 6},
-		},
-		"overall per-queue limits with initial usage": {
-			SchedulingConfig: testfixtures.WithPerQueueLimitsConfig(map[string]float64{"cpu": 2.0 / 32.0}, testfixtures.TestSchedulingConfig()),
-			Nodes:            testfixtures.TestNCpuNode(1, testfixtures.TestPriorities),
-			Jobs:             armadaslices.Concatenate(testfixtures.NSmallCpuJob("A", testfixtures.PriorityClass0, 5), testfixtures.NSmallCpuJob("B", testfixtures.PriorityClass0, 5)),
-			PriorityFactorByQueue: map[string]float64{
-				"A": 1,
-				"B": 1,
-			},
-			InitialAllocationByQueue: map[string]schedulerobjects.QuantityByPriorityAndResourceType{
-				"A": {
-					0: schedulerobjects.ResourceList{
-						Resources: map[string]resource.Quantity{
-							"cpu": resource.MustParse("0"),
-						},
-					},
-				},
-				"B": {
-					0: schedulerobjects.ResourceList{
-						Resources: map[string]resource.Quantity{
-							"cpu": resource.MustParse("1"),
-						},
-					},
-				},
-			},
-			ExpectedScheduledIndices: []int{0, 1, 5},
-		},
-		"MaximalClusterFractionToSchedule": {
+		"MaximumResourceFractionToSchedule": {
 			SchedulingConfig: testfixtures.WithRoundLimitsConfig(
 				map[string]float64{"cpu": 0.5},
 				testfixtures.TestSchedulingConfig(),
 			),
-			PriorityFactorByQueue:    map[string]float64{"A": 1.0},
-			Nodes:                    testfixtures.TestNCpuNode(1, testfixtures.TestPriorities),
-			Jobs:                     testfixtures.NSmallCpuJob("A", testfixtures.PriorityClass0, 32),
-			ExpectedScheduledIndices: testfixtures.IntRange(0, 15),
+			PriorityFactorByQueue:         map[string]float64{"A": 1.0},
+			Nodes:                         testfixtures.TestNCpuNode(1, testfixtures.TestPriorities),
+			Jobs:                          testfixtures.NSmallCpuJob("A", testfixtures.PriorityClass0, 32),
+			ExpectedScheduledIndices:      testfixtures.IntRange(0, 16),
+			ExpectedNeverAttemptedIndices: testfixtures.IntRange(17, 31),
 		},
-		"per priority per-queue limits": {
+		"PerPriorityLimits": {
 			SchedulingConfig: testfixtures.WithPerPriorityLimitsConfig(
 				map[int32]map[string]float64{
 					0: {"cpu": 1.0},
@@ -237,7 +161,7 @@ func TestQueueScheduler(t *testing.T) {
 				testfixtures.IntRange(18, 34),
 			),
 		},
-		"per priority per queue limits equal limits": {
+		"PerPriorityLimits equal MaximumResourceFractionToSchedule": {
 			SchedulingConfig: testfixtures.WithPerPriorityLimitsConfig(
 				map[int32]map[string]float64{
 					0: {"cpu": 0.9}, // 28 cpu
@@ -494,8 +418,8 @@ func TestQueueScheduler(t *testing.T) {
 			PriorityFactorByQueue:    map[string]float64{"A": 1},
 			ExpectedScheduledIndices: []int{0},
 		},
-		"QueueLeaseBatchSize": {
-			SchedulingConfig: testfixtures.WithQueueLeaseBatchSizeConfig(3, testfixtures.TestSchedulingConfig()),
+		"MaxQueueLookback": {
+			SchedulingConfig: testfixtures.WithMaxQueueLookbackConfig(3, testfixtures.TestSchedulingConfig()),
 			Nodes:            testfixtures.TestNCpuNode(1, testfixtures.TestPriorities),
 			Jobs: armadaslices.Concatenate(
 				testfixtures.NSmallCpuJob("A", testfixtures.PriorityClass0, 1),
@@ -542,22 +466,6 @@ func TestQueueScheduler(t *testing.T) {
 			PriorityFactorByQueue:    map[string]float64{"A": 1},
 			ExpectedScheduledIndices: []int{1},
 		},
-		"MaximalResourceFractionPerQueue non-consecutive gang": {
-			SchedulingConfig: testfixtures.WithPerQueueLimitsConfig(
-				map[string]float64{
-					"cpu": 2.0 / 32.0,
-				},
-				testfixtures.TestSchedulingConfig(),
-			),
-			Nodes: testfixtures.TestNCpuNode(1, testfixtures.TestPriorities),
-			Jobs: armadaslices.Concatenate(
-				testfixtures.WithAnnotationsJobs(map[string]string{configuration.GangIdAnnotation: "my-gang", configuration.GangCardinalityAnnotation: "2"}, testfixtures.NSmallCpuJob("A", testfixtures.PriorityClass0, 1)),
-				testfixtures.NSmallCpuJob("A", testfixtures.PriorityClass0, 1),
-				testfixtures.WithAnnotationsJobs(map[string]string{configuration.GangIdAnnotation: "my-gang", configuration.GangCardinalityAnnotation: "2"}, testfixtures.NSmallCpuJob("A", testfixtures.PriorityClass0, 1)),
-			),
-			PriorityFactorByQueue:    map[string]float64{"A": 1},
-			ExpectedScheduledIndices: []int{1},
-		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -592,6 +500,7 @@ func TestQueueScheduler(t *testing.T) {
 				tc.InitialAllocationByQueue,
 			)
 			constraints := schedulerconstraints.SchedulingConstraintsFromSchedulingConfig(
+				"pool",
 				schedulerobjects.ResourceList{Resources: tc.MinimumJobSize},
 				tc.SchedulingConfig,
 			)

--- a/internal/scheduler/scheduling_algo.go
+++ b/internal/scheduler/scheduling_algo.go
@@ -264,6 +264,7 @@ func (l *FairSchedulingAlgo) scheduleOnExecutor(
 		accounting.totalAllocationByPoolAndQueue[executor.Pool],
 	)
 	constraints := schedulerconstraints.SchedulingConstraintsFromSchedulingConfig(
+		executor.Pool,
 		executor.MinimumJobSize,
 		l.config,
 	)

--- a/internal/scheduler/scheduling_algo_test.go
+++ b/internal/scheduler/scheduling_algo_test.go
@@ -152,7 +152,8 @@ func TestLegacySchedulingAlgo_TestSchedule(t *testing.T) {
 			defer cancel()
 			config := testfixtures.TestSchedulingConfig()
 			if tc.perQueueLimit != nil {
-				config = testfixtures.WithPerQueueLimitsConfig(tc.perQueueLimit, config)
+				priorityClass := testfixtures.TestPriorityClasses[testfixtures.PriorityClass0]
+				config = testfixtures.WithPerPriorityLimitsConfig(map[int32]map[string]float64{priorityClass.Priority: tc.perQueueLimit}, config)
 			}
 			if tc.maxUnacknowledgedJobsPerExecutor != 0 {
 				config = testfixtures.WithMaxUnacknowledgedJobsPerExecutor(tc.maxUnacknowledgedJobsPerExecutor, config)
@@ -254,6 +255,7 @@ func TwoCoreExecutor(name string, jobs []*jobdb.Job, updateTime time.Time) *sche
 
 func OneCpuJob(creationTime int64) *jobdb.Job {
 	schedulingInfo := &schedulerobjects.JobSchedulingInfo{
+		PriorityClassName: testfixtures.PriorityClass0,
 		ObjectRequirements: []*schedulerobjects.ObjectRequirements{
 			{
 				Requirements: &schedulerobjects.ObjectRequirements_PodRequirements{

--- a/internal/scheduler/testfixtures/testfixtures.go
+++ b/internal/scheduler/testfixtures/testfixtures.go
@@ -42,7 +42,7 @@ var (
 		PriorityClass2: {2, true, nil},
 		PriorityClass3: {3, false, nil},
 	}
-	TestDefaultPriorityClass         = "priority-3"
+	TestDefaultPriorityClass         = PriorityClass3
 	TestPriorities                   = []int32{0, 1, 2, 3}
 	TestMaxExtraNodesToConsider uint = 1
 	TestResources                    = []string{"cpu", "memory", "gpu"}
@@ -102,12 +102,12 @@ func WithNodeOversubscriptionEvictionProbabilityConfig(p float64, config configu
 }
 
 func WithRoundLimitsConfig(limits map[string]float64, config configuration.SchedulingConfig) configuration.SchedulingConfig {
-	config.MaximalClusterFractionToSchedule = limits
+	config.MaximumResourceFractionToSchedule = limits
 	return config
 }
 
-func WithPerQueueLimitsConfig(limits map[string]float64, config configuration.SchedulingConfig) configuration.SchedulingConfig {
-	config.MaximalResourceFractionPerQueue = limits
+func WithRoundLimitsPoolConfig(limits map[string]map[string]float64, config configuration.SchedulingConfig) configuration.SchedulingConfig {
+	config.MaximumResourceFractionToScheduleByPool = limits
 	return config
 }
 
@@ -115,14 +115,10 @@ func WithPerPriorityLimitsConfig(limits map[int32]map[string]float64, config con
 	for k, v := range config.Preemption.PriorityClasses {
 		config.Preemption.PriorityClasses[k] = configuration.PriorityClass{
 			Priority:                        v.Priority,
-			MaximalResourceFractionPerQueue: limits[v.Priority],
+			Preemptible:                     v.Preemptible,
+			MaximumResourceFractionPerQueue: limits[v.Priority],
 		}
 	}
-	return config
-}
-
-func WithPerQueueRoundLimitsConfig(limits map[string]float64, config configuration.SchedulingConfig) configuration.SchedulingConfig {
-	config.MaximalResourceFractionToSchedulePerQueue = limits
 	return config
 }
 
@@ -138,7 +134,7 @@ func WithMaxGangsToScheduleConfig(n uint, config configuration.SchedulingConfig)
 
 func WithMaxLookbackPerQueueConfig(n uint, config configuration.SchedulingConfig) configuration.SchedulingConfig {
 	// For legacy reasons, it's called QueueLeaseBatchSize in config.
-	config.QueueLeaseBatchSize = n
+	config.MaxQueueLookback = n
 	return config
 }
 
@@ -152,8 +148,8 @@ func WithIndexedNodeLabelsConfig(indexedNodeLabels []string, config configuratio
 	return config
 }
 
-func WithQueueLeaseBatchSizeConfig(queueLeasebatchSize uint, config configuration.SchedulingConfig) configuration.SchedulingConfig {
-	config.QueueLeaseBatchSize = queueLeasebatchSize
+func WithMaxQueueLookbackConfig(maxQueueLookback uint, config configuration.SchedulingConfig) configuration.SchedulingConfig {
+	config.MaxQueueLookback = maxQueueLookback
 	return config
 }
 


### PR DESCRIPTION
Specifically:
- Remove per queue and round limits. Since these limits may result in scheduling a queue over its fair share instead of one below it, thus causing unnecessary preemptions in subsequent rounds.
- Remove overall resource limits. We don't need them now that we have per-PC limits.
- Fix a bug where reaching the max scheduled jobs may cause evicted jobs to not be-rescheduled.
- Add per-pool scheduling limits.
- Rename various limits for clarity.