### PR TITLE
Use AsApproximateFloat64 to improve scheduler performance

### DIFF
--- a/internal/scheduler/common.go
+++ b/internal/scheduler/common.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/armadaproject/armada/internal/armada/configuration"
 	armadamaps "github.com/armadaproject/armada/internal/common/maps"
-	armadaresource "github.com/armadaproject/armada/internal/common/resource"
 	armadaslices "github.com/armadaproject/armada/internal/common/slices"
 	schedulerconfig "github.com/armadaproject/armada/internal/scheduler/configuration"
 	schedulercontext "github.com/armadaproject/armada/internal/scheduler/context"
@@ -234,7 +233,7 @@ func ResourceListAsWeightedApproximateFloat64(resourceScarcity map[string]float6
 	usage := 0.0
 	for resourceName, quantity := range rl.Resources {
 		scarcity := resourceScarcity[resourceName]
-		usage += armadaresource.QuantityAsFloat64(quantity) * scarcity
+		usage += quantity.AsApproximateFloat64() * scarcity
 	}
 	return usage
 }


### PR DESCRIPTION
Swapping this to use `AsApproximateFloat64` gives a 5-10% performance improvement to scheduling

The reason it should be safe is because the behaviour is only different if the float exceeds max int and we don't expect any pod resource requests to exceed max int

Longer term we could get around this by computing this weighted resource list on the job upfront, rather than on the fly in the scheduler (as the weightings are static). This would mean the performance wouldn't matter - and we could go back to the "safe" call if we wanted

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-284) by [Unito](https://www.unito.io)
