### PR TITLE
Only apply dynamic checks for evicted jobs

### DIFF
--- a/config/executor/config.yaml
+++ b/config/executor/config.yaml
@@ -47,8 +47,8 @@ kubernetes:
   stuckTerminatingPodExpiry: 1m
   podKillTimeout: 5m
   minimumResourcesMarkedAllocatedToNonArmadaPodsPerNode:
-    cpu: 100m
-    memory: 50Mi
+    cpu: 1
+    memory: 200Mi
   minimumResourcesMarkedAllocatedToNonArmadaPodsPerNodePriority: 2000001000 # same priority as system-node-critical
   podDefaults:
     ingress:

--- a/internal/scheduler/nodedb/nodedb.go
+++ b/internal/scheduler/nodedb/nodedb.go
@@ -359,7 +359,7 @@ func (nodeDb *NodeDb) SelectNodeForPodWithTxn(txn *memdb.Txn, req *schedulerobje
 		if it, err := txn.Get("nodes", "id", nodeId); err != nil {
 			return nil, errors.WithStack(err)
 		} else {
-			if _, err := nodeDb.selectNodeForPodWithIt(pctx, it, req.Priority, req); err != nil {
+			if _, err := nodeDb.selectNodeForPodWithIt(pctx, it, req.Priority, req, true); err != nil {
 				return nil, err
 			} else {
 				return pctx, nil
@@ -419,7 +419,7 @@ func (nodeDb *NodeDb) selectNodeForPodAtPriority(
 		return nil, err
 	}
 
-	if node, err := nodeDb.selectNodeForPodWithIt(pctx, it, priority, req); err != nil {
+	if node, err := nodeDb.selectNodeForPodWithIt(pctx, it, priority, req, false); err != nil {
 		return nil, err
 	} else if node != nil {
 		return node, nil
@@ -433,6 +433,7 @@ func (nodeDb *NodeDb) selectNodeForPodWithIt(
 	it memdb.ResultIterator,
 	priority int32,
 	req *schedulerobjects.PodRequirements,
+	onlyCheckDynamicRequirements bool,
 ) (*schedulerobjects.Node, error) {
 	var selectedNode *schedulerobjects.Node
 	var selectedNodeScore int
@@ -442,7 +443,15 @@ func (nodeDb *NodeDb) selectNodeForPodWithIt(
 		if node == nil {
 			return nil, nil
 		}
-		matches, score, reason, err := node.PodRequirementsMet(priority, req)
+		var matches bool
+		var score int
+		var reason schedulerobjects.PodRequirementsNotMetReason
+		var err error
+		if onlyCheckDynamicRequirements {
+			matches, score, reason, err = node.DynamicPodRequirementsMet(priority, req)
+		} else {
+			matches, score, reason, err = node.PodRequirementsMet(priority, req)
+		}
 		if err != nil {
 			return nil, err
 		} else if matches {

--- a/internal/scheduler/preempting_queue_scheduler.go
+++ b/internal/scheduler/preempting_queue_scheduler.go
@@ -861,6 +861,9 @@ func defaultPostEvictFunc(ctx context.Context, job interfaces.LegacySchedulerJob
 	}
 
 	// Add a toleration to allow the job to be re-scheduled even if node is unschedulable.
+	//
+	// TODO: Because req is created with a new tolerations slice above, this toleration doesn't persist.
+	// In practice, this isn't an issue now since we don't check static requirements for evicted jobs.
 	if node.Unschedulable {
 		req.Tolerations = append(req.Tolerations, nodedb.UnschedulableToleration())
 	}


### PR DESCRIPTION
To avoid preempting jobs if, e.g., a taint is added to a node.

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-287) by [Unito](https://www.unito.io)
