### PR TITLE
Make lookout ingesters process PodUnschedulable errors

### DIFF
--- a/internal/lookoutingester/instructions/instructions.go
+++ b/internal/lookoutingester/instructions/instructions.go
@@ -392,84 +392,77 @@ func (c *InstructionConverter) handleJobRunErrors(ts time.Time, event *armadaeve
 	}
 
 	for _, e := range event.GetErrors() {
-		// We just interpret the first terminal error
+		// Certain legacy events mean we don't have a valid run id
+		// In this case we have to invent a fake run
+		// TODO: remove this when the legacy messages go away!
+		isLegacyEvent := runId == eventutil.LEGACY_RUN_ID
+		if isLegacyEvent {
+			jobRun := createFakeJobRun(jobId, ts)
+			runId = jobRun.RunId
+			objectMeta := extractMetaFromError(e)
+			if objectMeta != nil && objectMeta.ExecutorId != "" {
+				jobRun.Cluster = objectMeta.ExecutorId
+			}
+			update.JobRunsToCreate = append(update.JobRunsToCreate, jobRun)
+		}
+
+		jobRunUpdate := &model.UpdateJobRunInstruction{
+			RunId: runId,
+		}
+		if isLegacyEvent {
+			jobRunUpdate.Started = &ts
+		}
 		if e.Terminal {
+			jobRunUpdate.Finished = &ts
+			jobRunUpdate.Succeeded = pointer.Bool(false)
+		}
 
-			// Certain legacy events mean we don't have a valid run id
-			// In this case we have to invent a fake run
-			// TODO: remove this when the legacy messages go away!
-			isLegacyEvent := runId == eventutil.LEGACY_RUN_ID
-			if isLegacyEvent {
-				jobRun := createFakeJobRun(jobId, ts)
-				runId = jobRun.RunId
-				objectMeta := extractMetaFromError(e)
-				if objectMeta != nil && objectMeta.ExecutorId != "" {
-					jobRun.Cluster = objectMeta.ExecutorId
-				}
-				update.JobRunsToCreate = append(update.JobRunsToCreate, jobRun)
-			}
+		// Error_LeaseExpired has an implied reset of the job state to queued
+		// Ideally we would send an explicit queued message here, but until this change is made we correct the job
+		// state here
+		// Note that this should also apply to PodLeaseReturned messages, but right now the executor can send
+		// phantom messages, which leads to the job being shown as queued in lookout forever.
+		resetStateToQueued := false
 
-			jobRunUpdate := &model.UpdateJobRunInstruction{
-				RunId:     runId,
-				Succeeded: pointer.Bool(false),
-				Finished:  &ts,
-			}
-			if isLegacyEvent {
-				jobRunUpdate.Started = &ts
-			}
-
-			// Error_LeaseExpired has an implied reset of the job state to queued
-			// Ideally we would send an explicit queued message here, but until this change is made we correct the job
-			// state here
-			// Note that this should also apply to PodLeaseReturned messages, but right now the executor can send
-			// phantom messages, which leads to the job being shown as queued in lookout forever.
-			resetStateToQueued := false
-
-			switch reason := e.Reason.(type) {
-			case *armadaevents.Error_PodError:
-				truncatedMsg := util.Truncate(util.RemoveNullsFromString(reason.PodError.GetMessage()), util.MaxMessageLength)
-				jobRunUpdate.Error = pointer.String(truncatedMsg)
-				jobRunUpdate.Node = extractNodeName(reason.PodError)
-				for _, containerError := range reason.PodError.ContainerErrors {
-					update.JobRunContainersToCreate = append(update.JobRunContainersToCreate, &model.CreateJobRunContainerInstruction{
-						RunId:         jobRunUpdate.RunId,
-						ExitCode:      containerError.ExitCode,
-						ContainerName: containerError.GetObjectMeta().GetName(),
-					})
-				}
-			case *armadaevents.Error_PodTerminated:
-				truncatedMsg := util.Truncate(util.RemoveNullsFromString(reason.PodTerminated.GetMessage()), util.MaxMessageLength)
-				jobRunUpdate.Error = pointer.String(truncatedMsg)
-				jobRunUpdate.Node = extractNodeName(reason.PodTerminated)
-			case *armadaevents.Error_PodUnschedulable:
-				truncatedMsg := util.Truncate(util.RemoveNullsFromString(reason.PodUnschedulable.GetMessage()), util.MaxMessageLength)
-				jobRunUpdate.Error = pointer.String(truncatedMsg)
-				jobRunUpdate.UnableToSchedule = pointer.Bool(true)
-				jobRunUpdate.Node = extractNodeName(reason.PodUnschedulable)
-			case *armadaevents.Error_PodLeaseReturned:
-				truncatedMsg := util.Truncate(util.RemoveNullsFromString(reason.PodLeaseReturned.GetMessage()), util.MaxMessageLength)
-				jobRunUpdate.Error = pointer.String(truncatedMsg)
-				jobRunUpdate.UnableToSchedule = pointer.Bool(true)
-				// TODO: re-enable this once the executor stops sending phantom PodLeaseReturned messages
-				// resetStateToQueued = true
-			case *armadaevents.Error_LeaseExpired:
-				jobRunUpdate.Error = pointer.String("Lease Expired")
-				jobRunUpdate.UnableToSchedule = pointer.Bool(true)
-				resetStateToQueued = true
-			default:
-				jobRunUpdate.Error = pointer.String("Unknown error")
-				log.Debugf("Ignoring event %T", reason)
-			}
-			update.JobRunsToUpdate = append(update.JobRunsToUpdate, jobRunUpdate)
-			if resetStateToQueued {
-				update.JobsToUpdate = append(update.JobsToUpdate, &model.UpdateJobInstruction{
-					JobId:   jobId,
-					State:   pointer.Int32(int32(repository.JobQueuedOrdinal)),
-					Updated: ts,
+		switch reason := e.Reason.(type) {
+		case *armadaevents.Error_PodError:
+			truncatedMsg := util.Truncate(util.RemoveNullsFromString(reason.PodError.GetMessage()), util.MaxMessageLength)
+			jobRunUpdate.Error = pointer.String(truncatedMsg)
+			jobRunUpdate.Node = extractNodeName(reason.PodError)
+			for _, containerError := range reason.PodError.ContainerErrors {
+				update.JobRunContainersToCreate = append(update.JobRunContainersToCreate, &model.CreateJobRunContainerInstruction{
+					RunId:         jobRunUpdate.RunId,
+					ExitCode:      containerError.ExitCode,
+					ContainerName: containerError.GetObjectMeta().GetName(),
 				})
 			}
-			break
+		case *armadaevents.Error_PodTerminated:
+			continue
+		case *armadaevents.Error_PodUnschedulable:
+			jobRunUpdate.Node = extractNodeName(reason.PodUnschedulable)
+		case *armadaevents.Error_PodLeaseReturned:
+			truncatedMsg := util.Truncate(util.RemoveNullsFromString(reason.PodLeaseReturned.GetMessage()), util.MaxMessageLength)
+			jobRunUpdate.Error = pointer.String(truncatedMsg)
+			jobRunUpdate.UnableToSchedule = pointer.Bool(true)
+			// TODO: re-enable this once the executor stops sending phantom PodLeaseReturned messages
+			// resetStateToQueued = true
+		case *armadaevents.Error_LeaseExpired:
+			jobRunUpdate.Error = pointer.String("Lease Expired")
+			jobRunUpdate.UnableToSchedule = pointer.Bool(true)
+			resetStateToQueued = true
+		default:
+			jobRunUpdate.Error = pointer.String("Unknown error")
+			log.Debugf("Ignoring event %T", reason)
 		}
+		update.JobRunsToUpdate = append(update.JobRunsToUpdate, jobRunUpdate)
+		if resetStateToQueued {
+			update.JobsToUpdate = append(update.JobsToUpdate, &model.UpdateJobInstruction{
+				JobId:   jobId,
+				State:   pointer.Int32(int32(repository.JobQueuedOrdinal)),
+				Updated: ts,
+			})
+		}
+		break
 	}
 	return nil
 }

--- a/internal/lookoutingester/instructions/instructions_test.go
+++ b/internal/lookoutingester/instructions/instructions_test.go
@@ -618,6 +618,10 @@ func TestHandlePodUnschedulable(t *testing.T) {
 	msg := NewMsg(podUnschedulable)
 	instructions := svc.Convert(context.Background(), msg)
 	expected := &model.InstructionSet{
+		JobRunsToUpdate: []*model.UpdateJobRunInstruction{{
+			RunId: runIdString,
+			Node:  pointer.String(nodeName),
+		}},
 		MessageIds: msg.MessageIds,
 	}
 	assert.Equal(t, expected, instructions)

--- a/internal/lookoutingesterv2/instructions/instructions.go
+++ b/internal/lookoutingesterv2/instructions/instructions.go
@@ -427,7 +427,7 @@ func (c *InstructionConverter) handleJobRunErrors(ts time.Time, event *armadaeve
 	}
 
 	for _, e := range event.GetErrors() {
-		// We just interpret the error
+		// We just interpret the first error
 
 		// Certain legacy events mean we don't have a valid run id
 		// In this case we have to invent a fake run

--- a/internal/lookoutingesterv2/instructions/instructions.go
+++ b/internal/lookoutingesterv2/instructions/instructions.go
@@ -427,8 +427,6 @@ func (c *InstructionConverter) handleJobRunErrors(ts time.Time, event *armadaeve
 	}
 
 	for _, e := range event.GetErrors() {
-		// We just interpret the first error
-
 		// Certain legacy events mean we don't have a valid run id
 		// In this case we have to invent a fake run
 		// TODO: remove this when the legacy messages go away!

--- a/internal/lookoutingesterv2/instructions/instructions.go
+++ b/internal/lookoutingesterv2/instructions/instructions.go
@@ -427,66 +427,62 @@ func (c *InstructionConverter) handleJobRunErrors(ts time.Time, event *armadaeve
 	}
 
 	for _, e := range event.GetErrors() {
-		// We just interpret the first terminal error
-		if e.Terminal {
+		// We just interpret the error
 
-			// Certain legacy events mean we don't have a valid run id
-			// In this case we have to invent a fake run
-			// TODO: remove this when the legacy messages go away!
-			isLegacyEvent := runId == eventutil.LEGACY_RUN_ID
-			if isLegacyEvent {
-				jobRun := createFakeJobRun(jobId, ts)
-				runId = jobRun.RunId
-				objectMeta := extractMetaFromError(e)
-				if objectMeta != nil && objectMeta.ExecutorId != "" {
-					jobRun.Cluster = util.Truncate(objectMeta.ExecutorId, maxClusterLen)
-				}
-				update.JobRunsToCreate = append(update.JobRunsToCreate, jobRun)
+		// Certain legacy events mean we don't have a valid run id
+		// In this case we have to invent a fake run
+		// TODO: remove this when the legacy messages go away!
+		isLegacyEvent := runId == eventutil.LEGACY_RUN_ID
+		if isLegacyEvent {
+			jobRun := createFakeJobRun(jobId, ts)
+			runId = jobRun.RunId
+			objectMeta := extractMetaFromError(e)
+			if objectMeta != nil && objectMeta.ExecutorId != "" {
+				jobRun.Cluster = util.Truncate(objectMeta.ExecutorId, maxClusterLen)
 			}
-
-			jobRunUpdate := &model.UpdateJobRunInstruction{
-				RunId:    runId,
-				Finished: &ts,
-			}
-			if isLegacyEvent {
-				jobRunUpdate.Started = &ts
-			}
-
-			switch reason := e.Reason.(type) {
-			case *armadaevents.Error_PodError:
-				jobRunUpdate.Node = extractNodeName(reason.PodError)
-				jobRunUpdate.JobRunState = pointer.Int32(lookout.JobRunFailedOrdinal)
-				jobRunUpdate.Error = tryCompressError(jobId, reason.PodError.GetMessage(), c.compressor)
-				var exitCode int32 = 0
-				for _, containerError := range reason.PodError.ContainerErrors {
-					if containerError.ExitCode != 0 {
-						exitCode = containerError.ExitCode
-						break
-					}
-				}
-				jobRunUpdate.ExitCode = pointer.Int32(exitCode)
-			case *armadaevents.Error_PodTerminated:
-				jobRunUpdate.Node = extractNodeName(reason.PodTerminated)
-				jobRunUpdate.JobRunState = pointer.Int32(lookout.JobRunTerminatedOrdinal)
-				jobRunUpdate.Error = tryCompressError(jobId, reason.PodTerminated.GetMessage(), c.compressor)
-			case *armadaevents.Error_PodUnschedulable:
-				jobRunUpdate.Node = extractNodeName(reason.PodUnschedulable)
-				jobRunUpdate.JobRunState = pointer.Int32(lookout.JobRunUnableToScheduleOrdinal)
-				jobRunUpdate.Error = tryCompressError(jobId, reason.PodUnschedulable.GetMessage(), c.compressor)
-			case *armadaevents.Error_PodLeaseReturned:
-				jobRunUpdate.JobRunState = pointer.Int32(lookout.JobRunLeaseReturnedOrdinal)
-				jobRunUpdate.Error = tryCompressError(jobId, reason.PodLeaseReturned.GetMessage(), c.compressor)
-			case *armadaevents.Error_LeaseExpired:
-				jobRunUpdate.JobRunState = pointer.Int32(lookout.JobRunLeaseExpiredOrdinal)
-				jobRunUpdate.Error = tryCompressError(jobId, "Lease expired", c.compressor)
-			default:
-				jobRunUpdate.JobRunState = pointer.Int32(lookout.JobRunFailedOrdinal)
-				jobRunUpdate.Error = tryCompressError(jobId, "Unknown error", c.compressor)
-				log.Debugf("Ignoring event %T", reason)
-			}
-			update.JobRunsToUpdate = append(update.JobRunsToUpdate, jobRunUpdate)
-			break
+			update.JobRunsToCreate = append(update.JobRunsToCreate, jobRun)
 		}
+
+		jobRunUpdate := &model.UpdateJobRunInstruction{
+			RunId: runId,
+		}
+		if e.Terminal {
+			jobRunUpdate.Finished = &ts
+		}
+		if isLegacyEvent {
+			jobRunUpdate.Started = &ts
+		}
+
+		switch reason := e.Reason.(type) {
+		case *armadaevents.Error_PodError:
+			jobRunUpdate.Node = extractNodeName(reason.PodError)
+			jobRunUpdate.JobRunState = pointer.Int32(lookout.JobRunFailedOrdinal)
+			jobRunUpdate.Error = tryCompressError(jobId, reason.PodError.GetMessage(), c.compressor)
+			var exitCode int32 = 0
+			for _, containerError := range reason.PodError.ContainerErrors {
+				if containerError.ExitCode != 0 {
+					exitCode = containerError.ExitCode
+					break
+				}
+			}
+			jobRunUpdate.ExitCode = pointer.Int32(exitCode)
+		case *armadaevents.Error_PodTerminated:
+			continue
+		case *armadaevents.Error_PodUnschedulable:
+			jobRunUpdate.Node = extractNodeName(reason.PodUnschedulable)
+		case *armadaevents.Error_PodLeaseReturned:
+			jobRunUpdate.JobRunState = pointer.Int32(lookout.JobRunLeaseReturnedOrdinal)
+			jobRunUpdate.Error = tryCompressError(jobId, reason.PodLeaseReturned.GetMessage(), c.compressor)
+		case *armadaevents.Error_LeaseExpired:
+			jobRunUpdate.JobRunState = pointer.Int32(lookout.JobRunLeaseExpiredOrdinal)
+			jobRunUpdate.Error = tryCompressError(jobId, "Lease expired", c.compressor)
+		default:
+			jobRunUpdate.JobRunState = pointer.Int32(lookout.JobRunFailedOrdinal)
+			jobRunUpdate.Error = tryCompressError(jobId, "Unknown error", c.compressor)
+			log.Debugf("Ignoring event %T", reason)
+		}
+		update.JobRunsToUpdate = append(update.JobRunsToUpdate, jobRunUpdate)
+		break
 	}
 	return nil
 }

--- a/internal/lookoutingesterv2/instructions/instructions_test.go
+++ b/internal/lookoutingesterv2/instructions/instructions_test.go
@@ -109,6 +109,11 @@ var expectedFailedRun = model.UpdateJobRunInstruction{
 	ExitCode:    pointer.Int32(testfixtures.ExitCode),
 }
 
+var expectedUnschedulable = model.UpdateJobRunInstruction{
+	RunId: testfixtures.RunIdString,
+	Node:  pointer.String(testfixtures.NodeName),
+}
+
 var expectedPreempted = model.UpdateJobInstruction{
 	JobId:                     testfixtures.JobIdString,
 	State:                     pointer.Int32(lookout.JobPreemptedOrdinal),
@@ -320,7 +325,8 @@ func TestConvert(t *testing.T) {
 				MessageIds:     []pulsar.MessageID{pulsarutils.NewMessageId(1)},
 			},
 			expected: &model.InstructionSet{
-				MessageIds: []pulsar.MessageID{pulsarutils.NewMessageId(1)},
+				JobRunsToUpdate: []*model.UpdateJobRunInstruction{&expectedUnschedulable},
+				MessageIds:      []pulsar.MessageID{pulsarutils.NewMessageId(1)},
 			},
 		},
 		"duplicate submit is ignored": {


### PR DESCRIPTION
The motivation for this change is that we have many runs that never get the node name set - because this information is on the PodUnschedulable error events.

This makes tracking if certain nodes have most of the issues very difficult, as most runs with errors don't get the node set

This PR:
 - No longer skips non-terminal errors, this should be fine as:
    - The only events that are non-terminal are PodUnschedulable and PodTerminated and the ingester handles both of these explicitly
    - Each event will only have 1 error
 - Sets the nodeName on PodUnschedulable error events

Longer term this flow needs more thought:
 - Possibly add a PodNodeAssigned event
 - Possibly add other events to display start up status
 - Add NodeName to other events

However for now this is a minimal change to help with investigation into problem nodes

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-292) by [Unito](https://www.unito.io)
