### PR TITLE
WIP: Example for getting armada to work with Yunikorn/Kueue

### DIFF
--- a/config/executor/config.yaml
+++ b/config/executor/config.yaml
@@ -7,6 +7,7 @@ application:
   deleteConcurrencyLimit: 2
   useExecutorApi: false
   useLegacyApi: true
+  useJobShim: true
 task:
   utilisationReportingInterval: 1s
   missingJobEventReconciliationInterval: 15s

--- a/example/jobs.yaml
+++ b/example/jobs.yaml
@@ -2,6 +2,8 @@ queue: test
 jobSetId: job-set-1
 jobs:
   - priority: 0
+    labels:
+      kueue.x-k8s.io/queue-name: user-queue
     namespace: personal-anonymous
     podSpec:
       terminationGracePeriodSeconds: 0

--- a/example/kueue.yaml
+++ b/example/kueue.yaml
@@ -1,0 +1,30 @@
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: "default-flavor"
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata:
+  name: "cluster-queue"
+spec:
+  namespaceSelector: {} # match all.
+  resourceGroups:
+  - coveredResources: ["cpu", "memory"]
+    flavors:
+    - name: "default-flavor"
+      resources:
+      - name: "cpu"
+        nominalQuota: 9
+      - name: "memory"
+        nominalQuota: 36Gi
+      - name: "ephemeral-storage"
+        nominalQuota: 10Gi
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: LocalQueue
+metadata:
+  namespace: "personal-anonymous"
+  name: "user-queue"
+spec:
+  clusterQueue: "cluster-queue"

--- a/example/kueue.yaml
+++ b/example/kueue.yaml
@@ -18,8 +18,6 @@ spec:
         nominalQuota: 9
       - name: "memory"
         nominalQuota: 36Gi
-      - name: "ephemeral-storage"
-        nominalQuota: 10Gi
 ---
 apiVersion: kueue.x-k8s.io/v1beta1
 kind: LocalQueue

--- a/example/yunikorn-example.yaml
+++ b/example/yunikorn-example.yaml
@@ -1,0 +1,29 @@
+queue: e2e-test-queue
+jobSetId: job-set-1
+labels:
+  app: sleep
+  applicationId: "application-sleep-0001"
+  queue: "root.sandbox"
+jobs:
+  - priority: 0
+    namespace: personal-anonymous
+    podSpec:
+      schedulerName: yunikorn
+      terminationGracePeriodSeconds: 0
+      restartPolicy: Never
+      containers:
+        - name: sleep
+          imagePullPolicy: IfNotPresent
+          image: alpine:latest
+          command:
+            - sh
+            - -c
+          args:
+            - sleep $(( (RANDOM % 30) + 30 ))
+          resources:
+            limits:
+              memory: 64Mi
+              cpu: 150m
+            requests:
+              memory: 64Mi
+              cpu: 150m

--- a/internal/executor/application.go
+++ b/internal/executor/application.go
@@ -169,6 +169,7 @@ func setupExecutorApiComponents(
 		config.Kubernetes.PodDefaults,
 		config.Application.SubmitConcurrencyLimit,
 		config.Kubernetes.FatalPodSubmissionErrors,
+		config.Application.UseJobShim,
 	)
 
 	leaseRequester := service.NewJobLeaseRequester(
@@ -280,6 +281,7 @@ func setupServerApiComponents(
 		config.Kubernetes.PodDefaults,
 		config.Application.SubmitConcurrencyLimit,
 		config.Kubernetes.FatalPodSubmissionErrors,
+		config.Application.UseJobShim,
 	)
 
 	clusterAllocationService := service.NewLegacyClusterAllocationService(

--- a/internal/executor/configuration/types.go
+++ b/internal/executor/configuration/types.go
@@ -18,6 +18,7 @@ type ApplicationConfiguration struct {
 	DeleteConcurrencyLimit int
 	UseExecutorApi         bool
 	UseLegacyApi           bool
+	UseJobShim             bool
 }
 
 type PodDefaults struct {

--- a/internal/executor/context/fake/sync_cluster_context.go
+++ b/internal/executor/context/fake/sync_cluster_context.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	networking "k8s.io/api/networking/v1"
@@ -96,6 +97,10 @@ func (c *SyncFakeClusterContext) DeleteIngress(ingress *networking.Ingress) erro
 func (c *SyncFakeClusterContext) SubmitPod(pod *v1.Pod, owner string, ownerGroups []string) (*v1.Pod, error) {
 	c.Pods[pod.Labels[domain.JobId]] = pod
 	return pod, nil
+}
+
+func (c *SyncFakeClusterContext) SubmitJob(pod *v1.Pod, owner string, ownerGroups []string) (*batchv1.Job, error) {
+	return nil, fmt.Errorf("SubmitJob not implemented in SyncFakeClusterContext")
 }
 
 func (c *SyncFakeClusterContext) AddAnnotation(pod *v1.Pod, annotations map[string]string) error {

--- a/internal/executor/fake/context/context.go
+++ b/internal/executor/fake/context/context.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	networking "k8s.io/api/networking/v1"
@@ -171,6 +172,10 @@ func (c *FakeClusterContext) SubmitPod(pod *v1.Pod, owner string, ownerGroups []
 	}()
 
 	return pod, nil
+}
+
+func (c *FakeClusterContext) SubmitJob(pod *v1.Pod, owner string, ownerGroups []string) (*batchv1.Job, error) {
+	return nil, nil
 }
 
 func (c *FakeClusterContext) savePod(pod *v1.Pod) *v1.Pod {

--- a/internal/executor/job/submit.go
+++ b/internal/executor/job/submit.go
@@ -28,6 +28,7 @@ type Submitter interface {
 type SubmitService struct {
 	clusterContext           context.ClusterContext
 	podDefaults              *configuration.PodDefaults
+	useJobShim               bool
 	submissionThreadCount    int
 	fatalPodSubmissionErrors []string
 }
@@ -37,12 +38,14 @@ func NewSubmitter(
 	podDefaults *configuration.PodDefaults,
 	submissionThreadCount int,
 	fatalPodSubmissionErrors []string,
+	useJobShim bool,
 ) *SubmitService {
 	return &SubmitService{
 		clusterContext:           clusterContext,
 		podDefaults:              podDefaults,
 		submissionThreadCount:    submissionThreadCount,
 		fatalPodSubmissionErrors: fatalPodSubmissionErrors,
+		useJobShim:               useJobShim,
 	}
 }
 
@@ -93,6 +96,7 @@ func (submitService *SubmitService) submitWorker(wg *sync.WaitGroup, jobsToSubmi
 
 	for job := range jobsToSubmitChannel {
 		jobPods := []*v1.Pod{}
+
 		pod, err := submitService.submitPod(job)
 		jobPods = append(jobPods, pod)
 
@@ -129,10 +133,22 @@ func (submitService *SubmitService) submitPod(job *SubmitJob) (*v1.Pod, error) {
 			domain.AssociatedIngressesCount: fmt.Sprintf("%d", len(job.Ingresses)),
 		})
 	}
-
-	submittedPod, err := submitService.clusterContext.SubmitPod(pod, job.Meta.Owner, job.Meta.OwnershipGroups)
-	if err != nil {
-		return pod, err
+	var submittedPod *v1.Pod
+	var err error
+	if submitService.useJobShim {
+		job, err := submitService.clusterContext.SubmitJob(pod, job.Meta.Owner, job.Meta.OwnershipGroups)
+		if err != nil {
+			return pod, err
+		}
+		submittedPod = &v1.Pod{
+			ObjectMeta: job.ObjectMeta,
+			Spec:       job.Spec.Template.Spec,
+		}
+	} else {
+		submittedPod, err = submitService.clusterContext.SubmitPod(pod, job.Meta.Owner, job.Meta.OwnershipGroups)
+		if err != nil {
+			return pod, err
+		}
 	}
 
 	for _, service := range job.Services {

--- a/internal/executor/job/submit_test.go
+++ b/internal/executor/job/submit_test.go
@@ -27,7 +27,7 @@ func TestIsRecoverable_ArbitraryErrorIsNotRecoverable(t *testing.T) {
 		AdmissionWebhookRegex,
 		HelloRegex,
 		NamespaceNotFoundRegex,
-	})
+	}, false)
 
 	recoverable := submitter.isRecoverable(newArbitraryError("some error"))
 	assert.False(t, recoverable)
@@ -35,7 +35,7 @@ func TestIsRecoverable_ArbitraryErrorIsNotRecoverable(t *testing.T) {
 
 func TestIsRecoverable_KubernetesStatusInvalidIsUnrecoverable(t *testing.T) {
 	clusterContext := context.NewFakeClusterContext(testAppConfig, "kubernetes.io/hostname", []*context.NodeSpec{})
-	submitter := NewSubmitter(clusterContext, &configuration.PodDefaults{}, 1, []string{})
+	submitter := NewSubmitter(clusterContext, &configuration.PodDefaults{}, 1, []string{}, false)
 
 	recoverable := submitter.isRecoverable(newK8sApiError("", metav1.StatusReasonInvalid))
 	assert.False(t, recoverable)
@@ -43,7 +43,7 @@ func TestIsRecoverable_KubernetesStatusInvalidIsUnrecoverable(t *testing.T) {
 
 func TestIsRecoverable_KubernetesStatusForbiddenIsUnrecoverable(t *testing.T) {
 	clusterContext := context.NewFakeClusterContext(testAppConfig, "kubernetes.io/hostname", []*context.NodeSpec{})
-	submitter := NewSubmitter(clusterContext, &configuration.PodDefaults{}, 1, []string{})
+	submitter := NewSubmitter(clusterContext, &configuration.PodDefaults{}, 1, []string{}, false)
 
 	recoverable := submitter.isRecoverable(newK8sApiError("", metav1.StatusReasonForbidden))
 	assert.False(t, recoverable)
@@ -55,7 +55,7 @@ func TestIsRecoverable_K8sApiMatchingRegexIsUnrecoverable(t *testing.T) {
 		AdmissionWebhookRegex,
 		HelloRegex,
 		NamespaceNotFoundRegex,
-	})
+	}, false)
 
 	recoverable := submitter.isRecoverable(newK8sApiError("admission webhook failure: some webhook failed validation", "other status"))
 	assert.False(t, recoverable)
@@ -72,7 +72,7 @@ func TestIsRecoverable_K8sApiMatchingRegexIsUnrecoverable(t *testing.T) {
 
 func TestIsRecoverable_ArmadaErrCreateResourceIsRecoverable(t *testing.T) {
 	clusterContext := context.NewFakeClusterContext(testAppConfig, "kubernetes.io/hostname", []*context.NodeSpec{})
-	submitter := NewSubmitter(clusterContext, &configuration.PodDefaults{}, 1, []string{})
+	submitter := NewSubmitter(clusterContext, &configuration.PodDefaults{}, 1, []string{}, false)
 
 	recoverable := submitter.isRecoverable(newArmadaErrCreateResource())
 	assert.True(t, recoverable)

--- a/internal/executor/util/kubernetes_object.go
+++ b/internal/executor/util/kubernetes_object.go
@@ -334,12 +334,13 @@ func setRestartPolicyNever(podSpec *v1.PodSpec) {
 }
 
 func BuildKubernetesJobFromPod(pod *v1.Pod) batchv1.Job {
-
 	backoffLimit := int32(0)
+	ttlCleanup := int32(100)
 	return batchv1.Job{
 		ObjectMeta: pod.ObjectMeta,
 		Spec: batchv1.JobSpec{
-			BackoffLimit: &backoffLimit,
+			BackoffLimit:            &backoffLimit,
+			TTLSecondsAfterFinished: &ttlCleanup,
 			Template: v1.PodTemplateSpec{
 				Spec:       pod.Spec,
 				ObjectMeta: pod.ObjectMeta,

--- a/internal/executor/util/kubernetes_object.go
+++ b/internal/executor/util/kubernetes_object.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 
+	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -330,4 +331,19 @@ func applyDefaults(spec *v1.PodSpec, defaults *configuration.PodDefaults) {
 
 func setRestartPolicyNever(podSpec *v1.PodSpec) {
 	podSpec.RestartPolicy = v1.RestartPolicyNever
+}
+
+func BuildKubernetesJobFromPod(pod *v1.Pod) batchv1.Job {
+
+	backoffLimit := int32(0)
+	return batchv1.Job{
+		ObjectMeta: pod.ObjectMeta,
+		Spec: batchv1.JobSpec{
+			BackoffLimit: &backoffLimit,
+			Template: v1.PodTemplateSpec{
+				Spec:       pod.Spec,
+				ObjectMeta: pod.ObjectMeta,
+			},
+		},
+	}
 }


### PR DESCRIPTION
Yunikorn requires very little changes as it is a replacement of the K8 scheduler.

Kueue requires use to use the job controller but we are able to use Kueue if we assume 1on1 mapping between Pod and Job.



┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-301) by [Unito](https://www.unito.io)
