### PR TITLE
Set correct per-queue job priority in test fixtures

### DIFF
--- a/internal/scheduler/testfixtures/testfixtures.go
+++ b/internal/scheduler/testfixtures/testfixtures.go
@@ -316,7 +316,8 @@ func TestJob(queue string, jobId ulid.ULID, priorityClassName string, req *sched
 		jobId.String(),
 		TestJobset,
 		queue,
-		uint32(extractPriority(priorityClassName)),
+		// This is the per-queue priority of this job, which is unrelated to `priorityClassName`.
+		1000,
 		&schedulerobjects.JobSchedulingInfo{
 			PriorityClassName: priorityClassName,
 			SubmitTime:        submitTime,


### PR DESCRIPTION
I introduced this mistake in #2502, so it should be unrelated to other ongoing confusion of the two "priority" concepts.