### PR TITLE
duplicate checks in constraints

### DIFF
--- a/internal/scheduler/constraints/constraints.go
+++ b/internal/scheduler/constraints/constraints.go
@@ -19,7 +19,7 @@ const (
 
 // IsTerminalUnschedulableReason returns true if reason indicates it's not possible to schedule any more jobs in this round.
 func IsTerminalUnschedulableReason(reason string) bool {
-	if reason == UnschedulableReasonMaximumNumberOfJobsScheduled {
+	if reason == UnschedulableReasonMaximumResourcesScheduled {
 		return true
 	}
 	if reason == UnschedulableReasonMaximumNumberOfJobsScheduled {


### PR DESCRIPTION
Found a bug in constraints file in the scheduler.  

We had a duplicate check.

```
	if reason == UnschedulableReasonMaximumNumberOfJobsScheduled {
		return true
	}
	if reason == UnschedulableReasonMaximumNumberOfJobsScheduled {
```
The reason is equilvanet but we should check all three conditions.