### PR TITLE
Use correct priority to compute allocated resources

### DIFF
--- a/internal/scheduler/schedulerapp.go
+++ b/internal/scheduler/schedulerapp.go
@@ -158,7 +158,10 @@ func Run(config schedulerconfig.Configuration) error {
 	if err != nil {
 		return errors.WithMessage(err, "error creating submit checker")
 	}
-	schedulingAlgo := NewFairSchedulingAlgo(config.Scheduling, config.MaxSchedulingDuration, executorRepository, queueRepository)
+	schedulingAlgo, err := NewFairSchedulingAlgo(config.Scheduling, config.MaxSchedulingDuration, executorRepository, queueRepository)
+	if err != nil {
+		return errors.WithMessage(err, "error creating scheduling algo")
+	}
 	scheduler, err := NewScheduler(
 		jobRepository,
 		executorRepository,

--- a/internal/scheduler/scheduling_algo.go
+++ b/internal/scheduler/scheduling_algo.go
@@ -58,7 +58,7 @@ func NewFairSchedulingAlgo(
 	queueRepository database.QueueRepository,
 ) (*FairSchedulingAlgo, error) {
 	if _, ok := config.Preemption.PriorityClasses[config.Preemption.DefaultPriorityClass]; !ok {
-		return nil, errors.Errorf("expected the priority class mapping in the preemption configuration to contain the default priority class %s, but it does not; these are the keys that it contains: %v", config.Preemption.DefaultPriorityClass, maps.Keys(config.Preemption.PriorityClasses))
+		return nil, errors.Errorf("default priority class %s is missing from priority class mapping %v", config.Preemption.DefaultPriorityClass, config.Preemption.PriorityClasses)
 	}
 
 	indexedResources := config.IndexedResources

--- a/internal/scheduler/scheduling_algo.go
+++ b/internal/scheduler/scheduling_algo.go
@@ -2,7 +2,6 @@ package scheduler
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
 	"strings"
 	"time"
@@ -59,7 +58,7 @@ func NewFairSchedulingAlgo(
 	queueRepository database.QueueRepository,
 ) (*FairSchedulingAlgo, error) {
 	if _, ok := config.Preemption.PriorityClasses[config.Preemption.DefaultPriorityClass]; !ok {
-		return nil, fmt.Errorf("expected the priority class mapping in the preemption configuration to contain the default priority class %s, but it does not; these are the keys that it contains: %v", config.Preemption.DefaultPriorityClass, maps.Keys(config.Preemption.PriorityClasses))
+		return nil, errors.Errorf("expected the priority class mapping in the preemption configuration to contain the default priority class %s, but it does not; these are the keys that it contains: %v", config.Preemption.DefaultPriorityClass, maps.Keys(config.Preemption.PriorityClasses))
 	}
 
 	indexedResources := config.IndexedResources

--- a/internal/scheduler/scheduling_algo.go
+++ b/internal/scheduler/scheduling_algo.go
@@ -545,7 +545,7 @@ func (l *FairSchedulingAlgo) totalAllocationByPoolAndQueue(executors []*schedule
 				if ok {
 					allocation.AddResourceList(priorityClass.Priority, jobSchedulingInfo.GetTotalResourceRequest())
 				} else {
-					log.Errorf("Job %s has unknown priority class name %s; ignoring the resources allocated to this job.", job.Id(), jobSchedulingInfo.PriorityClassName)
+					log.Errorf("job %s has unknown priority class name %s; ignoring the resources allocated to this job", job.Id(), jobSchedulingInfo.PriorityClassName)
 				}
 			}
 		}

--- a/internal/scheduler/scheduling_algo.go
+++ b/internal/scheduler/scheduling_algo.go
@@ -58,8 +58,8 @@ func NewFairSchedulingAlgo(
 	executorRepository database.ExecutorRepository,
 	queueRepository database.QueueRepository,
 ) (*FairSchedulingAlgo, error) {
-	if len(config.Preemption.PriorityClasses) <= 0 {
-		return nil, fmt.Errorf("expected the priority class mapping in the preemption configuration to contain at least one element (associated with the default priority class %s), but it was empty", config.Preemption.DefaultPriorityClass)
+	if _, ok := config.Preemption.PriorityClasses[config.Preemption.DefaultPriorityClass]; !ok {
+		return nil, fmt.Errorf("expected the priority class mapping in the preemption configuration to contain the default priority class %s, but it does not; these are the keys that it contains: %v", config.Preemption.DefaultPriorityClass, maps.Keys(config.Preemption.PriorityClasses))
 	}
 
 	indexedResources := config.IndexedResources

--- a/internal/scheduler/scheduling_algo_test.go
+++ b/internal/scheduler/scheduling_algo_test.go
@@ -170,12 +170,13 @@ func TestLegacySchedulingAlgo_TestSchedule(t *testing.T) {
 			mockExecutorRepo.EXPECT().GetExecutors(ctx).Return(tc.executors, nil).AnyTimes()
 			mockQueueRepo.EXPECT().GetAllQueues().Return(tc.queues, nil).AnyTimes()
 
-			algo := NewFairSchedulingAlgo(
+			algo, err := NewFairSchedulingAlgo(
 				config,
 				time.Second*5,
 				mockExecutorRepo,
 				mockQueueRepo,
 			)
+			require.NoError(t, err)
 
 			// Use a test clock so we can control time
 			algo.clock = clock.NewFakeClock(testfixtures.BaseTime)
@@ -184,7 +185,7 @@ func TestLegacySchedulingAlgo_TestSchedule(t *testing.T) {
 			jobDb := jobdb.NewJobDb()
 
 			txn := jobDb.WriteTxn()
-			err := jobDb.Upsert(txn, tc.queuedJobs)
+			err = jobDb.Upsert(txn, tc.queuedJobs)
 			require.NoError(t, err)
 
 			err = jobDb.Upsert(txn, tc.unacknowledgedJobs)
@@ -372,12 +373,13 @@ func TestLegacySchedulingAlgo_TestSchedule_ExecutorOrdering(t *testing.T) {
 			mockQueueRepo := schedulermocks.NewMockQueueRepository(ctrl)
 			mockQueueRepo.EXPECT().GetAllQueues().Return([]*database.Queue{}, nil).AnyTimes()
 
-			algo := NewFairSchedulingAlgo(
+			algo, err := NewFairSchedulingAlgo(
 				config,
 				tc.maxScheduleDuration,
 				mockExecutorRepo,
 				mockQueueRepo,
 			)
+			require.NoError(t, err)
 			scheduledExecutorsIds := []string{}
 			// Use a test clock so we can control time
 			algo.clock = clock.NewFakeClock(testfixtures.BaseTime)


### PR DESCRIPTION
The issue that I'm addressing here is that `totalAllocationByPoolAndQueue` uses the `Priority` field of `JobSchedulingInfo`:

https://github.com/armadaproject/armada/blob/f3fa267c875dd7908a7efc6fd62dd38a8a014a77/internal/scheduler/scheduling_algo.go#L544-L551

… even though that field represents the per-queue priority of the job, not its priority class:

https://github.com/armadaproject/armada/blob/f3fa267c875dd7908a7efc6fd62dd38a8a014a77/internal/scheduler/schedulerobjects/schedulerobjects.pb.go#L621-L622

It might be worth having a separate type for the priority number associated with each priority class, in order to distinguish it from the other integers that are floating around.