### PR TITLE
Add Leased column to job_run lookoutv2

### DIFF
--- a/internal/lookoutingesterv2/instructions/instructions.go
+++ b/internal/lookoutingesterv2/instructions/instructions.go
@@ -418,6 +418,7 @@ func (c *InstructionConverter) handleJobRunLeased(ts time.Time, event *armadaeve
 		JobId:       jobId,
 		Cluster:     event.ExecutorId,
 		Node:        pointer.String(event.NodeId),
+		Leased:      &ts,
 		JobRunState: lookout.JobRunLeasedOrdinal,
 	}
 	update.JobRunsToCreate = append(update.JobRunsToCreate, &jobRun)
@@ -488,6 +489,7 @@ func (c *InstructionConverter) handleLegacyJobRunAssigned(ts time.Time, event *a
 		RunId:       runId,
 		JobId:       jobId,
 		Cluster:     cluster,
+		Leased:      &ts,
 		Pending:     &ts,
 		JobRunState: lookout.JobRunPendingOrdinal,
 	}

--- a/internal/lookoutingesterv2/instructions/instructions_test.go
+++ b/internal/lookoutingesterv2/instructions/instructions_test.go
@@ -63,6 +63,7 @@ var expectedLeasedRun = model.CreateJobRunInstruction{
 	RunId:       testfixtures.RunIdString,
 	JobId:       testfixtures.JobIdString,
 	Cluster:     testfixtures.ExecutorId,
+	Leased:      &testfixtures.BaseTime,
 	Node:        pointer.String(testfixtures.NodeName),
 	JobRunState: lookout.JobRunLeasedOrdinal,
 }
@@ -77,6 +78,7 @@ var expectedLegacyPendingRun = model.CreateJobRunInstruction{
 	RunId:       testfixtures.RunIdString,
 	JobId:       testfixtures.JobIdString,
 	Cluster:     testfixtures.ExecutorId,
+	Leased:      &testfixtures.BaseTime,
 	Pending:     &testfixtures.BaseTime,
 	JobRunState: lookout.JobRunPendingOrdinal,
 }

--- a/internal/lookoutingesterv2/lookoutdb/insertion.go
+++ b/internal/lookoutingesterv2/lookoutdb/insertion.go
@@ -404,6 +404,7 @@ func (l *LookoutDb) CreateJobRunsBatch(ctx context.Context, instructions []*mode
 					job_id        varchar(32),
 					cluster       varchar(512),
 					node          varchar(512),
+					leased        timestamp,
 					pending       timestamp,
 					job_run_state smallint
 				) ON COMMIT DROP;`, tmpTable))
@@ -421,6 +422,7 @@ func (l *LookoutDb) CreateJobRunsBatch(ctx context.Context, instructions []*mode
 					"job_id",
 					"cluster",
 					"node",
+					"leased",
 					"pending",
 					"job_run_state",
 				},
@@ -430,6 +432,7 @@ func (l *LookoutDb) CreateJobRunsBatch(ctx context.Context, instructions []*mode
 						instructions[i].JobId,
 						instructions[i].Cluster,
 						instructions[i].Node,
+						instructions[i].Leased,
 						instructions[i].Pending,
 						instructions[i].JobRunState,
 					}, nil
@@ -447,6 +450,7 @@ func (l *LookoutDb) CreateJobRunsBatch(ctx context.Context, instructions []*mode
 						job_id,
 						cluster,
 						node,
+						leased,
 						pending,
 						job_run_state
 					) SELECT * from %s
@@ -466,9 +470,10 @@ func (l *LookoutDb) CreateJobRunsScalar(ctx context.Context, instructions []*mod
 			job_id,
 			cluster,
 			node,
+			leased,
 			pending,
 			job_run_state)
-		VALUES ($1, $2, $3, $4, $5, $6)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
 		ON CONFLICT DO NOTHING`
 	for _, i := range instructions {
 		err := l.withDatabaseRetryInsert(func() error {
@@ -477,6 +482,7 @@ func (l *LookoutDb) CreateJobRunsScalar(ctx context.Context, instructions []*mod
 				i.JobId,
 				i.Cluster,
 				i.Node,
+				i.Leased,
 				i.Pending,
 				i.JobRunState)
 			if err != nil {

--- a/internal/lookoutingesterv2/lookoutdb/insertion_test.go
+++ b/internal/lookoutingesterv2/lookoutdb/insertion_test.go
@@ -109,6 +109,7 @@ func defaultInstructionSet() *model.InstructionSet {
 			RunId:       runIdString,
 			JobId:       jobIdString,
 			Cluster:     executorId,
+			Leased:      &updateTime,
 			Pending:     &updateTime,
 			JobRunState: lookout.JobRunPendingOrdinal,
 		}},

--- a/internal/lookoutingesterv2/model/model.go
+++ b/internal/lookoutingesterv2/model/model.go
@@ -53,6 +53,7 @@ type CreateJobRunInstruction struct {
 	JobId       string
 	Cluster     string
 	Node        *string
+	Leased      *time.Time
 	Pending     *time.Time
 	JobRunState int32
 }

--- a/internal/lookoutv2/schema/migrations/003_run_leased_column.sql
+++ b/internal/lookoutv2/schema/migrations/003_run_leased_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE job_run ALTER pending DROP NOT NULL;
+ALTER TABLE job_run ADD COLUMN leased timestamp NULL;


### PR DESCRIPTION
We now have a new state called Leased - so this PR adds a column that holds the time run was leased

Also removed not null constraint on Pending - as this is now null on run creation when using the armada-scheduler events

