### PR TITLE
Improve binoculars permission error message

### DIFF
--- a/internal/binoculars/service/cordon.go
+++ b/internal/binoculars/service/cordon.go
@@ -93,7 +93,7 @@ func GetPatchBytes(patchData *nodePatch) ([]byte, error) {
 
 func checkPermission(p authorization.PermissionChecker, ctx context.Context, permission permission.Permission) error {
 	if !p.UserHasPermission(ctx, permission) {
-		return fmt.Errorf("user %s does not have permission %s", authorization.GetPrincipal(ctx), permission)
+		return fmt.Errorf("user %s does not have permission %s", authorization.GetPrincipal(ctx).GetName(), permission)
 	}
 	return nil
 }


### PR DESCRIPTION
The error just needs to contain the requesters name - it does not need to include all groups that user belongs to in the error message


