### PR TITLE
Lookout v2 enable grouping by annotations in UI, add exists match for annotation keys

### DIFF
--- a/internal/lookout/ui/src/components/lookoutV2/JobsTableFilter.tsx
+++ b/internal/lookout/ui/src/components/lookoutV2/JobsTableFilter.tsx
@@ -19,6 +19,7 @@ const FILTER_TYPE_DISPLAY_STRINGS: Record<Match, string> = {
   [Match.GreaterThanOrEqual]: `Greater than${ELLIPSIS}`,
   [Match.LessThanOrEqual]: `Less than${ELLIPSIS}`,
   [Match.AnyOf]: `Filter${ELLIPSIS}`,
+  [Match.Exists]: `Annotation exists`,
 }
 
 export interface JobsTableFilterProps {

--- a/internal/lookout/ui/src/hooks/useJobsTableData.ts
+++ b/internal/lookout/ui/src/hooks/useJobsTableData.ts
@@ -169,7 +169,6 @@ export const useFetchJobsTableData = ({
           const groupedCol = groupedColumns[expandedLevel]
           const groupedField = columnToGroupedField(groupedCol)
 
-          console.log(groupedColumns.slice(expandedLevel + 1))
           // Only relevant if we are grouping by annotations: Filter by all remaining annotations in the group by filter
           rowRequest.filters.push(...getFiltersForGroupedAnnotations(groupedColumns.slice(expandedLevel + 1)))
 

--- a/internal/lookout/ui/src/hooks/useJobsTableData.ts
+++ b/internal/lookout/ui/src/hooks/useJobsTableData.ts
@@ -19,6 +19,7 @@ import {
   fetchJobGroups,
   fetchJobs,
   FetchRowRequest,
+  getFiltersForGroupedAnnotations,
   getFiltersForRows,
   groupsToRows,
   jobsToRows,
@@ -166,6 +167,11 @@ export const useFetchJobsTableData = ({
           setJobInfoMap(new Map([...jobInfoMap.entries(), ...jobs.map((j): [JobId, Job] => [j.jobId, j])]))
         } else {
           const groupedCol = groupedColumns[expandedLevel]
+          const groupedField = columnToGroupedField(groupedCol)
+
+          console.log(groupedColumns.slice(expandedLevel + 1))
+          // Only relevant if we are grouping by annotations: Filter by all remaining annotations in the group by filter
+          rowRequest.filters.push(...getFiltersForGroupedAnnotations(groupedColumns.slice(expandedLevel + 1)))
 
           const colsToAggregate = visibleColumns
             .filter((col) => aggregatableFields.has(col))
@@ -174,11 +180,11 @@ export const useFetchJobsTableData = ({
           const { groups, count: totalGroups } = await fetchJobGroups(
             rowRequest,
             groupJobsService,
-            columnToGroupedField(groupedCol),
+            groupedField,
             colsToAggregate,
             abortController.signal,
           )
-          newData = groupsToRows(groups, parentRowInfo?.rowId, groupedCol)
+          newData = groupsToRows(groups, parentRowInfo?.rowId, groupedField)
           totalCount = totalGroups
         }
       } catch (err) {

--- a/internal/lookout/ui/src/models/lookoutV2Models.ts
+++ b/internal/lookout/ui/src/models/lookoutV2Models.ts
@@ -102,6 +102,7 @@ export enum Match {
   GreaterThanOrEqual = "greaterThanOrEqualTo",
   LessThanOrEqual = "lessThanOrEqualTo",
   AnyOf = "anyOf",
+  Exists = "exists",
 }
 
 export const MATCH_DISPLAY_STRINGS: Record<Match, string> = {
@@ -113,6 +114,7 @@ export const MATCH_DISPLAY_STRINGS: Record<Match, string> = {
   [Match.GreaterThanOrEqual]: "Greater than or equal to",
   [Match.LessThanOrEqual]: "Less than or equal to",
   [Match.AnyOf]: "Any of",
+  [Match.Exists]: "Exists",
 }
 
 export const isValidMatch = (match: string): match is Match => (Object.values(Match) as string[]).includes(match)

--- a/internal/lookout/ui/src/services/lookoutV2/mocks/FakeGroupJobsService.ts
+++ b/internal/lookout/ui/src/services/lookoutV2/mocks/FakeGroupJobsService.ts
@@ -44,6 +44,9 @@ function groupBy(jobs: Job[], groupedField: GroupedField, aggregates: string[]):
   const groups = new Map<string | number, Job[]>()
   for (const job of jobs) {
     let value = job[groupedField.field as JobKey]
+    if (groupedField.isAnnotation) {
+      value = job.annotations[groupedField.field]
+    }
     if (value === undefined) {
       continue
     }

--- a/internal/lookout/ui/src/utils/fakeJobsUtils.ts
+++ b/internal/lookout/ui/src/utils/fakeJobsUtils.ts
@@ -45,6 +45,8 @@ export function makeRandomJobs(nJobs: number, seed: number, nQueues = 10, nJobSe
   const rand = mulberry32(seed)
   const uuid = seededUuid(rand)
   const annotationKeys = ["hyperparameter", "some/very/long/annotation/key/name/with/forward/slashes", "region"]
+  const numAnnotationValues = 10
+  const annotationValues = [...Array(numAnnotationValues)].map(() => uuid())
 
   const queues = Array.from(Array(nQueues).keys()).map((i) => `queue-${i + 1}`)
   const jobSets = Array.from(Array(nJobSets).keys()).map((i) => `job-set-${i + 1}`)
@@ -65,7 +67,7 @@ export function makeRandomJobs(nJobs: number, seed: number, nQueues = 10, nJobSe
       ephemeralStorage: randomInt(2, 2048, rand) * 1024 ** 3,
       memory: randomInt(2, 1024, rand) * 1024 ** 2,
       queue: queues[i % queues.length],
-      annotations: createAnnotations(annotationKeys, uuid),
+      annotations: createAnnotations(annotationKeys, annotationValues, rand),
       jobId: jobId,
       jobSet: jobSets[i % jobSets.length],
       state: state ? state : randomProperty(JobState, rand),
@@ -109,10 +111,14 @@ function randomProperty<T>(obj: Record<string, T>, rand: () => number): T {
   return obj[keys[(keys.length * rand()) << 0]]
 }
 
-function createAnnotations(annotationKeys: string[], uuid: () => string): Record<string, string> {
+function createAnnotations(
+  annotationKeys: string[],
+  annotationValues: string[],
+  rand: () => number,
+): Record<string, string> {
   const annotations: Record<string, string> = {}
   for (const key of annotationKeys) {
-    annotations[key] = uuid()
+    annotations[key] = annotationValues[randomInt(0, annotationValues.length, rand)]
   }
   return annotations
 }
@@ -130,7 +136,7 @@ export function filterFn(filter: JobFilter): (job: Job) => boolean {
 
     if (!Object.prototype.hasOwnProperty.call(objectToFilter, filter.field)) {
       if (filter.isAnnotation === undefined || !filter.isAnnotation) {
-        console.error(`Unknown filter field provided: ${filter}`)
+        console.error(`Unknown filter field provided: ${JSON.stringify(filter)}`)
       }
       return false
     }

--- a/internal/lookout/ui/src/utils/jobsTableColumns.tsx
+++ b/internal/lookout/ui/src/utils/jobsTableColumns.tsx
@@ -446,6 +446,7 @@ export const createAnnotationColumn = (annotationKey: string): JobTableColumn =>
     displayName: annotationKey,
     additionalOptions: {
       enableColumnFilter: true,
+      enableGrouping: true,
     },
     additionalMetadata: {
       annotation: {

--- a/internal/lookout/ui/src/utils/jobsTableUtils.ts
+++ b/internal/lookout/ui/src/utils/jobsTableUtils.ts
@@ -6,13 +6,7 @@ import { IGetJobsService } from "services/lookoutV2/GetJobsService"
 import { GroupedField, IGroupJobsService } from "services/lookoutV2/GroupJobsService"
 
 import { LookoutColumnFilter } from "../containers/lookoutV2/JobsTableContainer"
-import {
-  AnnotationColumnId,
-  ColumnId,
-  DEFAULT_COLUMN_MATCHES,
-  fromAnnotationColId,
-  isStandardColId,
-} from "./jobsTableColumns"
+import { AnnotationColumnId, DEFAULT_COLUMN_MATCHES, fromAnnotationColId, isStandardColId } from "./jobsTableColumns"
 import { findRowInData, RowId, RowIdParts, toRowId } from "./reactTableUtils"
 
 export interface PendingData {
@@ -89,6 +83,9 @@ export function getFiltersForRows(
       match: Match.Exact,
       isAnnotation: false,
     }
+    if (!isStandardColId(rowIdParts.type)) {
+      filter.isAnnotation = true
+    }
     if (filterColumnsIndexes.has(rowIdParts.type)) {
       const i = filterColumnsIndexes.get(rowIdParts.type) as number
       jobFilters[i] = filter
@@ -98,6 +95,19 @@ export function getFiltersForRows(
   }
 
   return jobFilters
+}
+
+export function getFiltersForGroupedAnnotations(remainingGroups: string[]): JobFilter[] {
+  return remainingGroups
+    .filter((group) => !isStandardColId(group))
+    .map((annotationColId) => {
+      return {
+        field: fromAnnotationColId(annotationColId as AnnotationColumnId),
+        value: "",
+        match: Match.Exists,
+        isAnnotation: true,
+      }
+    })
 }
 
 export interface FetchRowRequest {
@@ -124,7 +134,6 @@ export const fetchJobGroups = async (
   abortSignal: AbortSignal,
 ) => {
   const { filters, skip, take, order } = rowRequest
-
   return await groupJobsService.groupJobs(filters, order, groupedColumn, columnsToAggregate, skip, take, abortSignal)
 }
 
@@ -140,13 +149,13 @@ export const jobsToRows = (jobs: Job[]): JobRow[] => {
 export const groupsToRows = (
   groups: JobGroup[],
   baseRowId: RowId | undefined,
-  groupingField: ColumnId,
+  groupedField: GroupedField,
 ): JobGroupRow[] => {
   return groups.map((group): JobGroupRow => {
     const row: JobGroupRow = {
-      rowId: toRowId({ type: groupingField, value: group.name, parentRowId: baseRowId }),
-      [groupingField]: group.name,
-      groupedField: groupingField,
+      rowId: toRowId({ type: groupedField.field, value: group.name, parentRowId: baseRowId }),
+      groupedField: groupedField.field,
+      [groupedField.field]: group.name,
 
       isGroup: true,
       jobCount: group.count,
@@ -154,6 +163,11 @@ export const groupsToRows = (
       // Will be set later if expanded
       subRowCount: undefined,
       subRows: [],
+    }
+    if (groupedField.isAnnotation) {
+      row.annotations = {
+        [groupedField.field]: group.name,
+      }
     }
     for (const [key, val] of Object.entries(group.aggregates)) {
       switch (key) {

--- a/internal/lookoutv2/gen/models/filter.go
+++ b/internal/lookoutv2/gen/models/filter.go
@@ -30,7 +30,7 @@ type Filter struct {
 
 	// match
 	// Required: true
-	// Enum: [exact anyOf startsWith contains greaterThan lessThan greaterThanOrEqualTo lessThanOrEqualTo]
+	// Enum: [exact anyOf startsWith contains greaterThan lessThan greaterThanOrEqualTo lessThanOrEqualTo exists]
 	Match string `json:"match"`
 
 	// value
@@ -77,7 +77,7 @@ var filterTypeMatchPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["exact","anyOf","startsWith","contains","greaterThan","lessThan","greaterThanOrEqualTo","lessThanOrEqualTo"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["exact","anyOf","startsWith","contains","greaterThan","lessThan","greaterThanOrEqualTo","lessThanOrEqualTo","exists"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -110,6 +110,9 @@ const (
 
 	// FilterMatchLessThanOrEqualTo captures enum value "lessThanOrEqualTo"
 	FilterMatchLessThanOrEqualTo string = "lessThanOrEqualTo"
+
+	// FilterMatchExists captures enum value "exists"
+	FilterMatchExists string = "exists"
 )
 
 // prop value enum

--- a/internal/lookoutv2/gen/restapi/embedded_spec.go
+++ b/internal/lookoutv2/gen/restapi/embedded_spec.go
@@ -405,7 +405,8 @@ func init() {
             "greaterThan",
             "lessThan",
             "greaterThanOrEqualTo",
-            "lessThanOrEqualTo"
+            "lessThanOrEqualTo",
+            "exists"
           ],
           "x-nullable": false
         },
@@ -1060,7 +1061,8 @@ func init() {
             "greaterThan",
             "lessThan",
             "greaterThanOrEqualTo",
-            "lessThanOrEqualTo"
+            "lessThanOrEqualTo",
+            "exists"
           ],
           "x-nullable": false
         },

--- a/internal/lookoutv2/model/model.go
+++ b/internal/lookoutv2/model/model.go
@@ -13,6 +13,7 @@ const (
 	MatchLessThan             = "lessThan"
 	MatchGreaterThanOrEqualTo = "greaterThanOrEqualTo"
 	MatchLessThanOrEqualTo    = "lessThanOrEqualTo"
+	MatchExists               = "exists"
 
 	DirectionAsc  = "ASC"
 	DirectionDesc = "DESC"

--- a/internal/lookoutv2/swagger.yaml
+++ b/internal/lookoutv2/swagger.yaml
@@ -204,6 +204,7 @@ definitions:
           - lessThan
           - greaterThanOrEqualTo
           - lessThanOrEqualTo
+          - exists
         x-nullable: false
       isAnnotation:
         type: boolean


### PR DESCRIPTION
Grouping by annotations, similar to other grouping logic.
Main difference is that grouping by an annotation implicitly filters for only jobs that include that annotation key.
Added "exists" filtering functionality on API side to suppor this.

https://github.com/armadaproject/armada/assets/14963658/62188031-fa43-4ba3-8dea-46876d068568

