### PR TITLE
Add scheduling algo preemption tests

### DIFF
--- a/internal/scheduler/scheduling_algo_test.go
+++ b/internal/scheduler/scheduling_algo_test.go
@@ -38,8 +38,8 @@ func TestLegacySchedulingAlgo_TestSchedule(t *testing.T) {
 	}{
 		"fill up both clusters": {
 			executors: []*schedulerobjects.Executor{
-				testfixtures.Test1Node32CoreExecutor("executor1", nil, testfixtures.BaseTime),
-				testfixtures.Test1Node32CoreExecutor("executor2", nil, testfixtures.BaseTime),
+				testfixtures.Test1Node32CoreExecutor("executor1", testfixtures.BaseTime),
+				testfixtures.Test1Node32CoreExecutor("executor2", testfixtures.BaseTime),
 			},
 			queues:     []*database.Queue{testfixtures.TestDbQueue()},
 			queuedJobs: queuedJobs,
@@ -52,8 +52,8 @@ func TestLegacySchedulingAlgo_TestSchedule(t *testing.T) {
 		},
 		"one executor stale": {
 			executors: []*schedulerobjects.Executor{
-				testfixtures.Test1Node32CoreExecutor("executor1", nil, testfixtures.BaseTime),
-				testfixtures.Test1Node32CoreExecutor("executor2", nil, testfixtures.BaseTime.Add(-1*time.Hour)),
+				testfixtures.Test1Node32CoreExecutor("executor1", testfixtures.BaseTime),
+				testfixtures.Test1Node32CoreExecutor("executor2", testfixtures.BaseTime.Add(-1*time.Hour)),
 			},
 			queues:     []*database.Queue{testfixtures.TestDbQueue()},
 			queuedJobs: queuedJobs,
@@ -64,12 +64,12 @@ func TestLegacySchedulingAlgo_TestSchedule(t *testing.T) {
 		},
 		"one executor exceeds unacknowledged": {
 			executors: []*schedulerobjects.Executor{
-				testfixtures.Test1Node32CoreExecutor("executor1", nil, testfixtures.BaseTime),
-				testfixtures.Test1Node32CoreExecutor("executor2", nil, testfixtures.BaseTime),
+				testfixtures.Test1Node32CoreExecutor("executor1", testfixtures.BaseTime),
+				testfixtures.Test1Node32CoreExecutor("executor2", testfixtures.BaseTime),
 			},
 			queues:             []*database.Queue{testfixtures.TestDbQueue()},
 			queuedJobs:         queuedJobs,
-			unacknowledgedJobs: []*jobdb.Job{runningJobs[0], runningJobs[1]},
+			unacknowledgedJobs: runningJobs,
 			expectedJobs: map[string]string{
 				queuedJobs[0].Id(): "executor2",
 				queuedJobs[1].Id(): "executor2",
@@ -77,12 +77,12 @@ func TestLegacySchedulingAlgo_TestSchedule(t *testing.T) {
 		},
 		"one executor full": {
 			executors: []*schedulerobjects.Executor{
-				testfixtures.Test1Node32CoreExecutor("executor1", runningJobs, testfixtures.BaseTime),
-				testfixtures.Test1Node32CoreExecutor("executor2", nil, testfixtures.BaseTime),
+				testfixtures.Test1Node32CoreExecutor("executor1", testfixtures.BaseTime),
+				testfixtures.Test1Node32CoreExecutor("executor2", testfixtures.BaseTime),
 			},
 			queues:      []*database.Queue{testfixtures.TestDbQueue()},
 			queuedJobs:  queuedJobs,
-			runningJobs: []*jobdb.Job{runningJobs[0], runningJobs[1]},
+			runningJobs: runningJobs,
 			expectedJobs: map[string]string{
 				queuedJobs[0].Id(): "executor2",
 				queuedJobs[1].Id(): "executor2",
@@ -90,8 +90,8 @@ func TestLegacySchedulingAlgo_TestSchedule(t *testing.T) {
 		},
 		"user is at usage cap before scheduling": {
 			executors: []*schedulerobjects.Executor{
-				testfixtures.Test1Node32CoreExecutor("executor1", runningJobs, testfixtures.BaseTime),
-				testfixtures.Test1Node32CoreExecutor("executor2", nil, testfixtures.BaseTime),
+				testfixtures.Test1Node32CoreExecutor("executor1", testfixtures.BaseTime),
+				testfixtures.Test1Node32CoreExecutor("executor2", testfixtures.BaseTime),
 			},
 			queues:        []*database.Queue{testfixtures.TestDbQueue()},
 			queuedJobs:    queuedJobs,
@@ -101,8 +101,8 @@ func TestLegacySchedulingAlgo_TestSchedule(t *testing.T) {
 		},
 		"user hits usage cap during scheduling": {
 			executors: []*schedulerobjects.Executor{
-				testfixtures.Test1Node32CoreExecutor("executor1", []*jobdb.Job{runningJobs[0]}, testfixtures.BaseTime),
-				testfixtures.Test1Node32CoreExecutor("executor2", nil, testfixtures.BaseTime),
+				testfixtures.Test1Node32CoreExecutor("executor1", testfixtures.BaseTime),
+				testfixtures.Test1Node32CoreExecutor("executor2", testfixtures.BaseTime),
 			},
 			queues:                           []*database.Queue{testfixtures.TestDbQueue()},
 			queuedJobs:                       queuedJobs,
@@ -115,11 +115,10 @@ func TestLegacySchedulingAlgo_TestSchedule(t *testing.T) {
 		},
 		"no queuedJobs to schedule": {
 			executors: []*schedulerobjects.Executor{
-				testfixtures.Test1Node32CoreExecutor("executor1", nil, testfixtures.BaseTime),
-				testfixtures.Test1Node32CoreExecutor("executor2", nil, testfixtures.BaseTime),
+				testfixtures.Test1Node32CoreExecutor("executor1", testfixtures.BaseTime),
+				testfixtures.Test1Node32CoreExecutor("executor2", testfixtures.BaseTime),
 			},
 			queues:       []*database.Queue{testfixtures.TestDbQueue()},
-			queuedJobs:   nil,
 			expectedJobs: map[string]string{},
 		},
 		"no executor available": {
@@ -130,11 +129,7 @@ func TestLegacySchedulingAlgo_TestSchedule(t *testing.T) {
 		},
 		"The scheduling algorithm computes allocated resources by priority class, not by per-queue priority.": {
 			executors: []*schedulerobjects.Executor{
-				testfixtures.Test1Node32CoreExecutor(
-					"executor1",
-					[]*jobdb.Job{runningJobs[0].WithPriority(0)},
-					testfixtures.BaseTime,
-				),
+				testfixtures.Test1Node32CoreExecutor("executor1", testfixtures.BaseTime),
 			},
 			runningJobs: []*jobdb.Job{runningJobs[0].WithPriority(0)},
 			queues:      []*database.Queue{testfixtures.TestDbQueue()},
@@ -191,6 +186,15 @@ func TestLegacySchedulingAlgo_TestSchedule(t *testing.T) {
 			err = jobDb.Upsert(txn, tc.unacknowledgedJobs)
 			require.NoError(t, err)
 
+			executorsById := make(map[string]*schedulerobjects.Executor, len(tc.executors))
+			for _, executor := range tc.executors {
+				executorsById[executor.Id] = executor
+			}
+			for _, job := range tc.runningJobs {
+				run := job.LatestRun()
+				executor := executorsById[run.Executor()]
+				executor.UnassignedJobRuns = append(executor.UnassignedJobRuns, run.Id().String())
+			}
 			err = jobDb.Upsert(txn, tc.runningJobs)
 			require.NoError(t, err)
 
@@ -221,10 +225,10 @@ func TestLegacySchedulingAlgo_TestSchedule(t *testing.T) {
 }
 
 func TestGetExecutorsToSchedule(t *testing.T) {
-	executorA := testfixtures.Test1Node32CoreExecutor("a", nil, testfixtures.BaseTime)
-	executorA1 := testfixtures.Test1Node32CoreExecutor("a1", nil, testfixtures.BaseTime)
-	executorB := testfixtures.Test1Node32CoreExecutor("b", nil, testfixtures.BaseTime)
-	executorC := testfixtures.Test1Node32CoreExecutor("c", nil, testfixtures.BaseTime)
+	executorA := testfixtures.Test1Node32CoreExecutor("a", testfixtures.BaseTime)
+	executorA1 := testfixtures.Test1Node32CoreExecutor("a1", testfixtures.BaseTime)
+	executorB := testfixtures.Test1Node32CoreExecutor("b", testfixtures.BaseTime)
+	executorC := testfixtures.Test1Node32CoreExecutor("c", testfixtures.BaseTime)
 
 	tests := map[string]struct {
 		executors          []*schedulerobjects.Executor
@@ -299,8 +303,8 @@ func TestLegacySchedulingAlgo_TestSchedule_ExecutorOrdering(t *testing.T) {
 			rounds: []executorOrderingTest{
 				{
 					executors: []*schedulerobjects.Executor{
-						testfixtures.Test1Node32CoreExecutor("executor1", nil, testfixtures.BaseTime),
-						testfixtures.Test1Node32CoreExecutor("executor2", nil, testfixtures.BaseTime),
+						testfixtures.Test1Node32CoreExecutor("executor1", testfixtures.BaseTime),
+						testfixtures.Test1Node32CoreExecutor("executor2", testfixtures.BaseTime),
 					},
 					expectedExecutorsScheduled:          []string{"executor1", "executor2"},
 					expectedPreviousScheduledExecutorId: "executor2",
@@ -313,16 +317,16 @@ func TestLegacySchedulingAlgo_TestSchedule_ExecutorOrdering(t *testing.T) {
 			rounds: []executorOrderingTest{
 				{
 					executors: []*schedulerobjects.Executor{
-						testfixtures.Test1Node32CoreExecutor("executor1", nil, testfixtures.BaseTime),
-						testfixtures.Test1Node32CoreExecutor("executor2", nil, testfixtures.BaseTime),
+						testfixtures.Test1Node32CoreExecutor("executor1", testfixtures.BaseTime),
+						testfixtures.Test1Node32CoreExecutor("executor2", testfixtures.BaseTime),
 					},
 					expectedExecutorsScheduled:          []string{"executor1"},
 					expectedPreviousScheduledExecutorId: "executor1",
 				},
 				{
 					executors: []*schedulerobjects.Executor{
-						testfixtures.Test1Node32CoreExecutor("executor1", nil, testfixtures.BaseTime),
-						testfixtures.Test1Node32CoreExecutor("executor2", nil, testfixtures.BaseTime),
+						testfixtures.Test1Node32CoreExecutor("executor1", testfixtures.BaseTime),
+						testfixtures.Test1Node32CoreExecutor("executor2", testfixtures.BaseTime),
 					},
 					expectedExecutorsScheduled:          []string{"executor2"},
 					expectedPreviousScheduledExecutorId: "executor2",
@@ -335,25 +339,25 @@ func TestLegacySchedulingAlgo_TestSchedule_ExecutorOrdering(t *testing.T) {
 			rounds: []executorOrderingTest{
 				{
 					executors: []*schedulerobjects.Executor{
-						testfixtures.Test1Node32CoreExecutor("executor1", nil, testfixtures.BaseTime),
-						testfixtures.Test1Node32CoreExecutor("executor3", nil, testfixtures.BaseTime),
+						testfixtures.Test1Node32CoreExecutor("executor1", testfixtures.BaseTime),
+						testfixtures.Test1Node32CoreExecutor("executor3", testfixtures.BaseTime),
 					},
 					expectedExecutorsScheduled:          []string{"executor1"},
 					expectedPreviousScheduledExecutorId: "executor1",
 				},
 				{
 					executors: []*schedulerobjects.Executor{
-						testfixtures.Test1Node32CoreExecutor("executor1", nil, testfixtures.BaseTime),
-						testfixtures.Test1Node32CoreExecutor("executor2", nil, testfixtures.BaseTime),
-						testfixtures.Test1Node32CoreExecutor("executor3", nil, testfixtures.BaseTime),
+						testfixtures.Test1Node32CoreExecutor("executor1", testfixtures.BaseTime),
+						testfixtures.Test1Node32CoreExecutor("executor2", testfixtures.BaseTime),
+						testfixtures.Test1Node32CoreExecutor("executor3", testfixtures.BaseTime),
 					},
 					expectedExecutorsScheduled:          []string{"executor2"},
 					expectedPreviousScheduledExecutorId: "executor2",
 				},
 				{
 					executors: []*schedulerobjects.Executor{
-						testfixtures.Test1Node32CoreExecutor("executor1", nil, testfixtures.BaseTime),
-						testfixtures.Test1Node32CoreExecutor("executor2", nil, testfixtures.BaseTime),
+						testfixtures.Test1Node32CoreExecutor("executor1", testfixtures.BaseTime),
+						testfixtures.Test1Node32CoreExecutor("executor2", testfixtures.BaseTime),
 					},
 					expectedExecutorsScheduled:          []string{"executor1"},
 					expectedPreviousScheduledExecutorId: "executor1",

--- a/internal/scheduler/scheduling_algo_test.go
+++ b/internal/scheduler/scheduling_algo_test.go
@@ -331,7 +331,7 @@ func TestLegacySchedulingAlgo_TestSchedule(t *testing.T) {
 			schedulerResult, err := algo.Schedule(ctx, txn, jobDb)
 			require.NoError(t, err)
 
-			expectedScheduledJobs := make(map[string]string, 0)
+			expectedScheduledJobs := make(map[string]string)
 			for executorId, jobIndices := range tc.expectedScheduledIndices {
 				for _, i := range jobIndices {
 					expectedScheduledJobs[tc.queuedJobs[i].Id()] = executorId

--- a/internal/scheduler/scheduling_algo_test.go
+++ b/internal/scheduler/scheduling_algo_test.go
@@ -38,8 +38,8 @@ func TestLegacySchedulingAlgo_TestSchedule(t *testing.T) {
 	}{
 		"fill up both clusters": {
 			executors: []*schedulerobjects.Executor{
-				testfixtures.Test1Node32CoreExecutor("executor1", testfixtures.BaseTime),
-				testfixtures.Test1Node32CoreExecutor("executor2", testfixtures.BaseTime),
+				testfixtures.Test1Node32CoreExecutor("executor1"),
+				testfixtures.Test1Node32CoreExecutor("executor2"),
 			},
 			queues:     []*database.Queue{testfixtures.TestDbQueue()},
 			queuedJobs: queuedJobs,
@@ -52,8 +52,8 @@ func TestLegacySchedulingAlgo_TestSchedule(t *testing.T) {
 		},
 		"one executor stale": {
 			executors: []*schedulerobjects.Executor{
-				testfixtures.Test1Node32CoreExecutor("executor1", testfixtures.BaseTime),
-				testfixtures.Test1Node32CoreExecutor("executor2", testfixtures.BaseTime.Add(-1*time.Hour)),
+				testfixtures.Test1Node32CoreExecutor("executor1"),
+				testfixtures.WithLastUpdateTimeExecutor(testfixtures.BaseTime.Add(-1*time.Hour), testfixtures.Test1Node32CoreExecutor("executor2")),
 			},
 			queues:     []*database.Queue{testfixtures.TestDbQueue()},
 			queuedJobs: queuedJobs,
@@ -64,8 +64,8 @@ func TestLegacySchedulingAlgo_TestSchedule(t *testing.T) {
 		},
 		"one executor exceeds unacknowledged": {
 			executors: []*schedulerobjects.Executor{
-				testfixtures.Test1Node32CoreExecutor("executor1", testfixtures.BaseTime),
-				testfixtures.Test1Node32CoreExecutor("executor2", testfixtures.BaseTime),
+				testfixtures.Test1Node32CoreExecutor("executor1"),
+				testfixtures.Test1Node32CoreExecutor("executor2"),
 			},
 			queues:             []*database.Queue{testfixtures.TestDbQueue()},
 			queuedJobs:         queuedJobs,
@@ -77,8 +77,8 @@ func TestLegacySchedulingAlgo_TestSchedule(t *testing.T) {
 		},
 		"one executor full": {
 			executors: []*schedulerobjects.Executor{
-				testfixtures.Test1Node32CoreExecutor("executor1", testfixtures.BaseTime),
-				testfixtures.Test1Node32CoreExecutor("executor2", testfixtures.BaseTime),
+				testfixtures.Test1Node32CoreExecutor("executor1"),
+				testfixtures.Test1Node32CoreExecutor("executor2"),
 			},
 			queues:      []*database.Queue{testfixtures.TestDbQueue()},
 			queuedJobs:  queuedJobs,
@@ -90,8 +90,8 @@ func TestLegacySchedulingAlgo_TestSchedule(t *testing.T) {
 		},
 		"user is at usage cap before scheduling": {
 			executors: []*schedulerobjects.Executor{
-				testfixtures.Test1Node32CoreExecutor("executor1", testfixtures.BaseTime),
-				testfixtures.Test1Node32CoreExecutor("executor2", testfixtures.BaseTime),
+				testfixtures.Test1Node32CoreExecutor("executor1"),
+				testfixtures.Test1Node32CoreExecutor("executor2"),
 			},
 			queues:        []*database.Queue{testfixtures.TestDbQueue()},
 			queuedJobs:    queuedJobs,
@@ -101,8 +101,8 @@ func TestLegacySchedulingAlgo_TestSchedule(t *testing.T) {
 		},
 		"user hits usage cap during scheduling": {
 			executors: []*schedulerobjects.Executor{
-				testfixtures.Test1Node32CoreExecutor("executor1", testfixtures.BaseTime),
-				testfixtures.Test1Node32CoreExecutor("executor2", testfixtures.BaseTime),
+				testfixtures.Test1Node32CoreExecutor("executor1"),
+				testfixtures.Test1Node32CoreExecutor("executor2"),
 			},
 			queues:                           []*database.Queue{testfixtures.TestDbQueue()},
 			queuedJobs:                       queuedJobs,
@@ -115,8 +115,8 @@ func TestLegacySchedulingAlgo_TestSchedule(t *testing.T) {
 		},
 		"no queuedJobs to schedule": {
 			executors: []*schedulerobjects.Executor{
-				testfixtures.Test1Node32CoreExecutor("executor1", testfixtures.BaseTime),
-				testfixtures.Test1Node32CoreExecutor("executor2", testfixtures.BaseTime),
+				testfixtures.Test1Node32CoreExecutor("executor1"),
+				testfixtures.Test1Node32CoreExecutor("executor2"),
 			},
 			queues:       []*database.Queue{testfixtures.TestDbQueue()},
 			expectedJobs: map[string]string{},
@@ -128,9 +128,7 @@ func TestLegacySchedulingAlgo_TestSchedule(t *testing.T) {
 			expectedJobs: map[string]string{},
 		},
 		"The scheduling algorithm computes allocated resources by priority class, not by per-queue priority.": {
-			executors: []*schedulerobjects.Executor{
-				testfixtures.Test1Node32CoreExecutor("executor1", testfixtures.BaseTime),
-			},
+			executors:   []*schedulerobjects.Executor{testfixtures.Test1Node32CoreExecutor("executor1")},
 			runningJobs: []*jobdb.Job{runningJobs[0].WithPriority(0)},
 			queues:      []*database.Queue{testfixtures.TestDbQueue()},
 			queuedJobs: []*jobdb.Job{
@@ -225,10 +223,10 @@ func TestLegacySchedulingAlgo_TestSchedule(t *testing.T) {
 }
 
 func TestGetExecutorsToSchedule(t *testing.T) {
-	executorA := testfixtures.Test1Node32CoreExecutor("a", testfixtures.BaseTime)
-	executorA1 := testfixtures.Test1Node32CoreExecutor("a1", testfixtures.BaseTime)
-	executorB := testfixtures.Test1Node32CoreExecutor("b", testfixtures.BaseTime)
-	executorC := testfixtures.Test1Node32CoreExecutor("c", testfixtures.BaseTime)
+	executorA := testfixtures.Test1Node32CoreExecutor("a")
+	executorA1 := testfixtures.Test1Node32CoreExecutor("a1")
+	executorB := testfixtures.Test1Node32CoreExecutor("b")
+	executorC := testfixtures.Test1Node32CoreExecutor("c")
 
 	tests := map[string]struct {
 		executors          []*schedulerobjects.Executor
@@ -303,8 +301,8 @@ func TestLegacySchedulingAlgo_TestSchedule_ExecutorOrdering(t *testing.T) {
 			rounds: []executorOrderingTest{
 				{
 					executors: []*schedulerobjects.Executor{
-						testfixtures.Test1Node32CoreExecutor("executor1", testfixtures.BaseTime),
-						testfixtures.Test1Node32CoreExecutor("executor2", testfixtures.BaseTime),
+						testfixtures.Test1Node32CoreExecutor("executor1"),
+						testfixtures.Test1Node32CoreExecutor("executor2"),
 					},
 					expectedExecutorsScheduled:          []string{"executor1", "executor2"},
 					expectedPreviousScheduledExecutorId: "executor2",
@@ -317,16 +315,16 @@ func TestLegacySchedulingAlgo_TestSchedule_ExecutorOrdering(t *testing.T) {
 			rounds: []executorOrderingTest{
 				{
 					executors: []*schedulerobjects.Executor{
-						testfixtures.Test1Node32CoreExecutor("executor1", testfixtures.BaseTime),
-						testfixtures.Test1Node32CoreExecutor("executor2", testfixtures.BaseTime),
+						testfixtures.Test1Node32CoreExecutor("executor1"),
+						testfixtures.Test1Node32CoreExecutor("executor2"),
 					},
 					expectedExecutorsScheduled:          []string{"executor1"},
 					expectedPreviousScheduledExecutorId: "executor1",
 				},
 				{
 					executors: []*schedulerobjects.Executor{
-						testfixtures.Test1Node32CoreExecutor("executor1", testfixtures.BaseTime),
-						testfixtures.Test1Node32CoreExecutor("executor2", testfixtures.BaseTime),
+						testfixtures.Test1Node32CoreExecutor("executor1"),
+						testfixtures.Test1Node32CoreExecutor("executor2"),
 					},
 					expectedExecutorsScheduled:          []string{"executor2"},
 					expectedPreviousScheduledExecutorId: "executor2",
@@ -339,25 +337,25 @@ func TestLegacySchedulingAlgo_TestSchedule_ExecutorOrdering(t *testing.T) {
 			rounds: []executorOrderingTest{
 				{
 					executors: []*schedulerobjects.Executor{
-						testfixtures.Test1Node32CoreExecutor("executor1", testfixtures.BaseTime),
-						testfixtures.Test1Node32CoreExecutor("executor3", testfixtures.BaseTime),
+						testfixtures.Test1Node32CoreExecutor("executor1"),
+						testfixtures.Test1Node32CoreExecutor("executor3"),
 					},
 					expectedExecutorsScheduled:          []string{"executor1"},
 					expectedPreviousScheduledExecutorId: "executor1",
 				},
 				{
 					executors: []*schedulerobjects.Executor{
-						testfixtures.Test1Node32CoreExecutor("executor1", testfixtures.BaseTime),
-						testfixtures.Test1Node32CoreExecutor("executor2", testfixtures.BaseTime),
-						testfixtures.Test1Node32CoreExecutor("executor3", testfixtures.BaseTime),
+						testfixtures.Test1Node32CoreExecutor("executor1"),
+						testfixtures.Test1Node32CoreExecutor("executor2"),
+						testfixtures.Test1Node32CoreExecutor("executor3"),
 					},
 					expectedExecutorsScheduled:          []string{"executor2"},
 					expectedPreviousScheduledExecutorId: "executor2",
 				},
 				{
 					executors: []*schedulerobjects.Executor{
-						testfixtures.Test1Node32CoreExecutor("executor1", testfixtures.BaseTime),
-						testfixtures.Test1Node32CoreExecutor("executor2", testfixtures.BaseTime),
+						testfixtures.Test1Node32CoreExecutor("executor1"),
+						testfixtures.Test1Node32CoreExecutor("executor2"),
 					},
 					expectedExecutorsScheduled:          []string{"executor1"},
 					expectedPreviousScheduledExecutorId: "executor1",

--- a/internal/scheduler/scheduling_algo_test.go
+++ b/internal/scheduler/scheduling_algo_test.go
@@ -239,6 +239,24 @@ func TestLegacySchedulingAlgo_TestSchedule(t *testing.T) {
 				"executor1": {0, 1},
 			},
 		},
+		"Fair share preemption.": {
+			schedulingConfig: testfixtures.TestSchedulingConfig(),
+
+			executors: []*schedulerobjects.Executor{testfixtures.Test1Node32CoreExecutor("executor1")},
+			queues:    []*database.Queue{{Name: "queue1", Weight: 100}, {Name: "queue2", Weight: 100}},
+
+			existingJobs: testfixtures.N16CpuJobs("queue1", testfixtures.PriorityClass0, 2),
+			existingRunningIndices: map[string]map[string][]int{
+				"executor1": {"executor1-node": {0, 1}},
+			},
+
+			queuedJobs: testfixtures.N16CpuJobs("queue2", testfixtures.PriorityClass0, 2),
+
+			expectedPreemptedIndices: []int{1},
+			expectedScheduledIndices: map[string][]int{
+				"executor1": {0},
+			},
+		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/internal/scheduler/scheduling_algo_test.go
+++ b/internal/scheduler/scheduling_algo_test.go
@@ -2,16 +2,16 @@ package scheduler
 
 import (
 	"context"
-	"github.com/armadaproject/armada/internal/armada/configuration"
-	"golang.org/x/exp/slices"
 	"testing"
 	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
 	"k8s.io/apimachinery/pkg/util/clock"
 
+	"github.com/armadaproject/armada/internal/armada/configuration"
 	"github.com/armadaproject/armada/internal/scheduler/database"
 	"github.com/armadaproject/armada/internal/scheduler/jobdb"
 	schedulermocks "github.com/armadaproject/armada/internal/scheduler/mocks"

--- a/internal/scheduler/testfixtures/testfixtures.go
+++ b/internal/scheduler/testfixtures/testfixtures.go
@@ -240,6 +240,16 @@ func WithAnnotationsPodReqs(annotations map[string]string, reqs []*schedulerobje
 	return reqs
 }
 
+func WithRequestsPodReqs(rl schedulerobjects.ResourceList, reqs []*schedulerobjects.PodRequirements) []*schedulerobjects.PodRequirements {
+	for _, req := range reqs {
+		maps.Copy(
+			req.ResourceRequirements.Requests,
+			schedulerobjects.V1ResourceListFromResourceList(rl),
+		)
+	}
+	return reqs
+}
+
 func WithGangAnnotationsJobs(jobs []*jobdb.Job) []*jobdb.Job {
 	gangId := uuid.NewString()
 	gangCardinality := fmt.Sprintf("%d", len(jobs))
@@ -259,16 +269,6 @@ func WithAnnotationsJobs(annotations map[string]string, jobs []*jobdb.Job) []*jo
 		}
 	}
 	return jobs
-}
-
-func WithRequestsPodReqs(rl schedulerobjects.ResourceList, reqs []*schedulerobjects.PodRequirements) []*schedulerobjects.PodRequirements {
-	for _, req := range reqs {
-		maps.Copy(
-			req.ResourceRequirements.Requests,
-			schedulerobjects.V1ResourceListFromResourceList(rl),
-		)
-	}
-	return reqs
 }
 
 func N1CpuJobs(queue string, priorityClassName string, n int) []*jobdb.Job {

--- a/internal/scheduler/testfixtures/testfixtures.go
+++ b/internal/scheduler/testfixtures/testfixtures.go
@@ -628,14 +628,19 @@ func Test8GpuNode(priorities []int32) *schedulerobjects.Node {
 	return node
 }
 
-func Test1Node32CoreExecutor(name string, lastUpdateTime time.Time) *schedulerobjects.Executor {
+func WithLastUpdateTimeExecutor(lastUpdateTime time.Time, executor *schedulerobjects.Executor) *schedulerobjects.Executor {
+	executor.LastUpdateTime = lastUpdateTime
+	return executor
+}
+
+func Test1Node32CoreExecutor(name string) *schedulerobjects.Executor {
 	node := Test32CpuNode(TestPriorities)
 	node.Name = fmt.Sprintf("%s-node", name)
 	return &schedulerobjects.Executor{
 		Id:             name,
 		Pool:           TestPool,
 		Nodes:          []*schedulerobjects.Node{node},
-		LastUpdateTime: lastUpdateTime,
+		LastUpdateTime: BaseTime,
 	}
 }
 

--- a/internal/scheduler/testfixtures/testfixtures.go
+++ b/internal/scheduler/testfixtures/testfixtures.go
@@ -628,19 +628,14 @@ func Test8GpuNode(priorities []int32) *schedulerobjects.Node {
 	return node
 }
 
-func Test1Node32CoreExecutor(name string, jobs []*jobdb.Job, lastUpdateTime time.Time) *schedulerobjects.Executor {
+func Test1Node32CoreExecutor(name string, lastUpdateTime time.Time) *schedulerobjects.Executor {
 	node := Test32CpuNode(TestPriorities)
 	node.Name = fmt.Sprintf("%s-node", name)
-	unassignedJobRuns := make([]string, len(jobs))
-	for i, job := range jobs {
-		unassignedJobRuns[i] = job.LatestRun().Id().String()
-	}
 	return &schedulerobjects.Executor{
-		Id:                name,
-		Pool:              TestPool,
-		Nodes:             []*schedulerobjects.Node{node},
-		LastUpdateTime:    lastUpdateTime,
-		UnassignedJobRuns: unassignedJobRuns,
+		Id:             name,
+		Pool:           TestPool,
+		Nodes:          []*schedulerobjects.Node{node},
+		LastUpdateTime: lastUpdateTime,
 	}
 }
 

--- a/internal/scheduler/testfixtures/testfixtures.go
+++ b/internal/scheduler/testfixtures/testfixtures.go
@@ -188,15 +188,6 @@ func WithNodeSelectorPodReqs(selector map[string]string, reqs []*schedulerobject
 	return reqs
 }
 
-func WithNodeSelectorJobs(selector map[string]string, jobs []*jobdb.Job) []*jobdb.Job {
-	for _, job := range jobs {
-		for _, req := range job.GetRequirements(nil).GetObjectRequirements() {
-			req.GetPodRequirements().NodeSelector = maps.Clone(selector)
-		}
-	}
-	return jobs
-}
-
 func WithNodeSelectorPodReq(selector map[string]string, req *schedulerobjects.PodRequirements) *schedulerobjects.PodRequirements {
 	req.NodeSelector = maps.Clone(selector)
 	return req
@@ -248,6 +239,15 @@ func WithRequestsPodReqs(rl schedulerobjects.ResourceList, reqs []*schedulerobje
 		)
 	}
 	return reqs
+}
+
+func WithNodeSelectorJobs(selector map[string]string, jobs []*jobdb.Job) []*jobdb.Job {
+	for _, job := range jobs {
+		for _, req := range job.GetRequirements(nil).GetObjectRequirements() {
+			req.GetPodRequirements().NodeSelector = maps.Clone(selector)
+		}
+	}
+	return jobs
 }
 
 func WithGangAnnotationsJobs(jobs []*jobdb.Job) []*jobdb.Job {


### PR DESCRIPTION
This PR is probably easier to follow by looking at the individual commits, since it contains a complete rewrite of the scheduling algo test harness.