### PR TITLE
Change armada-scheduler to be deployed as a statefulset

### DIFF
--- a/deployment/scheduler/templates/scheduler-statefulset.yaml
+++ b/deployment/scheduler/templates/scheduler-statefulset.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "armada-scheduler.name" . }}
   namespace: {{ .Release.Namespace }}
@@ -10,10 +10,11 @@ spec:
   selector:
     matchLabels:
       {{- include "armada-scheduler.labels.identity" . | nindent 6 }}
-  {{- if .Values.scheduler.strategy }}
-  strategy:
-    {{- toYaml .Values.scheduler.strategy | nindent 4 }}
+  {{- if .Values.scheduler.updateStrategy }}
+  updateStrategy:
+    {{- toYaml .Values.scheduler.updateStrategy | nindent 4 }}
   {{- end }}
+  serviceName: {{ include "armada-scheduler.name" . }}
   template:
     metadata:
       name: {{ include "armada-scheduler.name" . }}

--- a/deployment/scheduler/values.yaml
+++ b/deployment/scheduler/values.yaml
@@ -20,7 +20,7 @@ scheduler:
     metrics:
       port: 9001
     pulsar: {}
-  strategy:
+  updateStrategy:
     rollingUpdate:
       maxUnavailable: 1
     type: RollingUpdate


### PR DESCRIPTION
This gives us stable pod names - with names that are in dns (so we can reference them like <podname>.<service>.<namespace>.svc)

This will allow us to easily communicate between scheduler pods - as the pods will be easily addressible

