### PR TITLE
Lookout v2 improve selection further

### DIFF
--- a/internal/lookout/ui/src/components/lookoutV2/JobsTableCell.tsx
+++ b/internal/lookout/ui/src/components/lookoutV2/JobsTableCell.tsx
@@ -2,8 +2,8 @@ import { RefObject } from "react"
 
 import { KeyboardArrowRight, KeyboardArrowDown } from "@mui/icons-material"
 import { TableCell, IconButton, TableSortLabel, Box } from "@mui/material"
-import { Cell, ColumnResizeMode, flexRender, Header } from "@tanstack/react-table"
-import { JobRow } from "models/jobsTableModels"
+import { Cell, ColumnResizeMode, flexRender, Header, Row } from "@tanstack/react-table"
+import { JobRow, JobTableRow } from "models/jobsTableModels"
 import { Match } from "models/lookoutV2Models"
 import { getColumnMetadata, toColId } from "utils/jobsTableColumns"
 
@@ -192,8 +192,9 @@ export interface BodyCellProps {
   rowIsGroup: boolean
   rowIsExpanded: boolean
   onExpandedChange: () => void
+  onClickRowCheckbox: (row: Row<JobTableRow>) => void
 }
-export const BodyCell = ({ cell, rowIsGroup, rowIsExpanded, onExpandedChange }: BodyCellProps) => {
+export const BodyCell = ({ cell, rowIsGroup, rowIsExpanded, onExpandedChange, onClickRowCheckbox }: BodyCellProps) => {
   const columnMetadata = getColumnMetadata(cell.column.columnDef)
   const cellHasValue = cell.renderValue()
   const isRightAligned = columnMetadata.isRightAligned ?? false
@@ -243,9 +244,15 @@ export const BodyCell = ({ cell, rowIsGroup, rowIsExpanded, onExpandedChange }: 
       ) : cell.getIsAggregated() ? (
         // If the cell is aggregated, use the Aggregated
         // renderer for cell
-        flexRender(cell.column.columnDef.aggregatedCell ?? cell.column.columnDef.cell, cell.getContext())
+        flexRender(cell.column.columnDef.aggregatedCell ?? cell.column.columnDef.cell, {
+          ...cell.getContext(),
+          onClickRowCheckbox,
+        })
       ) : (
-        flexRender(cell.column.columnDef.cell, cell.getContext())
+        flexRender(cell.column.columnDef.cell, {
+          ...cell.getContext(),
+          onClickRowCheckbox,
+        })
       )}
     </TableCell>
   )

--- a/internal/lookout/ui/src/components/lookoutV2/JobsTableRow.tsx
+++ b/internal/lookout/ui/src/components/lookoutV2/JobsTableRow.tsx
@@ -2,7 +2,7 @@ import React, { useState, MouseEvent } from "react"
 
 import { TableRow } from "@mui/material"
 import { Row } from "@tanstack/table-core"
-import { JobTableRow, JobRow, isJobGroupRow } from "models/jobsTableModels"
+import { JobTableRow, isJobGroupRow } from "models/jobsTableModels"
 
 import { BodyCell } from "./JobsTableCell"
 import styles from "./JobsTableRow.module.css"
@@ -10,9 +10,10 @@ import styles from "./JobsTableRow.module.css"
 export interface JobsTableRowProps {
   row: Row<JobTableRow>
   isOpenInSidebar: boolean
-  onClick?: (row: JobRow, e: MouseEvent<HTMLTableRowElement>) => void
+  onClick?: (e: MouseEvent<HTMLTableRowElement>) => void
+  onClickRowCheckbox: (row: Row<JobTableRow>) => void
 }
-export const JobsTableRow = ({ row, isOpenInSidebar, onClick }: JobsTableRowProps) => {
+export const JobsTableRow = ({ row, isOpenInSidebar, onClick, onClickRowCheckbox }: JobsTableRowProps) => {
   // Helpers to avoid triggering onClick if the user is selecting text
   const [{ pageX, pageY }, setPagePosition] = useState({ pageX: -1, pageY: -1 })
   const isDragging = (e: React.MouseEvent) => {
@@ -47,7 +48,7 @@ export const JobsTableRow = ({ row, isOpenInSidebar, onClick }: JobsTableRowProp
       onMouseDown={(e) => setPagePosition(e)}
       onClick={(e) => {
         if (!isDragging(e) && onClick) {
-          onClick(row.original, e)
+          onClick(e)
         }
       }}
     >
@@ -57,6 +58,7 @@ export const JobsTableRow = ({ row, isOpenInSidebar, onClick }: JobsTableRowProp
           rowIsGroup={rowIsGroup}
           rowIsExpanded={row.getIsExpanded()}
           onExpandedChange={row.toggleExpanded}
+          onClickRowCheckbox={onClickRowCheckbox}
           key={cell.id}
         />
       ))}

--- a/internal/lookout/ui/src/utils/jobsTableColumns.tsx
+++ b/internal/lookout/ui/src/utils/jobsTableColumns.tsx
@@ -1,4 +1,5 @@
 import { Checkbox } from "@mui/material"
+import { CellContext, Row } from "@tanstack/react-table"
 import { ColumnDef, createColumnHelper, VisibilityState } from "@tanstack/table-core"
 import { JobStateLabel } from "components/lookoutV2/JobStateLabel"
 import { EnumFilterOption } from "components/lookoutV2/JobsTableFilter"
@@ -112,22 +113,45 @@ export const JOB_COLUMNS: JobTableColumn[] = [
       <Checkbox
         checked={table.getIsAllRowsSelected()}
         indeterminate={table.getIsSomeRowsSelected()}
-        onChange={table.getToggleAllRowsSelectedHandler()}
+        onChange={(event) => {
+          if (!event.currentTarget.checked || table.getIsSomeRowsSelected()) {
+            table.toggleAllRowsSelected(false)
+            return
+          }
+          table.toggleAllRowsSelected(true)
+        }}
         size="small"
         sx={{ p: 0 }}
       />
     ),
-    cell: ({ row }) => (
-      <Checkbox
-        checked={row.getIsGrouped() ? row.getIsAllSubRowsSelected() : row.getIsSelected()}
-        indeterminate={row.getIsSomeSelected()}
-        size="small"
-        sx={{
-          p: 0,
-          ml: `${row.depth * 6}px`,
-        }}
-      />
-    ),
+    cell: (item: unknown) => {
+      const itemCasted = item as CellContext<JobTableRow, unknown>
+      const row = itemCasted.row
+      const onClickRowCheckbox = (itemCasted as any).onClickRowCheckbox as (row: Row<JobTableRow>) => void
+      return (
+        <Checkbox
+          checked={row.getIsGrouped() ? row.getIsAllSubRowsSelected() : row.getIsSelected()}
+          indeterminate={row.getIsSomeSelected()}
+          size="small"
+          onClick={(e) => {
+            // Do normal flow for when the shift key is pressed
+            if (e.shiftKey) {
+              return
+            }
+            if (onClickRowCheckbox !== undefined) {
+              console.log("HIT")
+              console.log(onClickRowCheckbox)
+              onClickRowCheckbox(row)
+            }
+            e.stopPropagation()
+          }}
+          sx={{
+            p: 0,
+            ml: `${row.depth * 6}px`,
+          }}
+        />
+      )
+    },
     meta: {
       displayName: "Select Column",
     } as JobTableColumnMetadata,

--- a/internal/lookout/ui/src/utils/jobsTableColumns.tsx
+++ b/internal/lookout/ui/src/utils/jobsTableColumns.tsx
@@ -139,8 +139,6 @@ export const JOB_COLUMNS: JobTableColumn[] = [
               return
             }
             if (onClickRowCheckbox !== undefined) {
-              console.log("HIT")
-              console.log(onClickRowCheckbox)
               onClickRowCheckbox(row)
             }
             e.stopPropagation()


### PR DESCRIPTION
Similar flow to ag-grid

Select all button:
* If some jobs are selected, clicking it will deselect all.
* Clicking button if unselected will select all

Row selection:
* Clicking anywhere on the row (not on the checkbox) selects/deselects only that row, irrespective of previous selection
* Shift clicking works as before
* Ctrl/alt clicking on the row adds row to selection (like before)
* Clicking on checkbox adds row to selection (like ctrl/alt clicking)