### PR TITLE
Improve CI steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -453,24 +453,24 @@ workflows:
       - release-armadactl:
           filters:
             tags:
-              only: /.*/
+              only: /v[0-9]+\.[0-9]+\.[0-9]+/
             branches:
               ignore: /.*/
       - release-docker-images:
           filters:
             tags:
-              only: /.*/
+              only: /v[0-9]+\.[0-9]+\.[0-9]+/
             branches:
               ignore: /.*/
       - release-charts:
           filters:
             tags:
-              only: /.*/
+              only: /v[0-9]+\.[0-9]+\.[0-9]+/
             branches:
               ignore: /.*/
       - release-dotnet-client:
           filters:
             tags:
-              only: /.*/
+              only: /v[0-9]+\.[0-9]+\.[0-9]+/
             branches:
               ignore: /.*/

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,7 +28,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: "latest"
+          version: "v1.53.1"
           skip-pkg-cache: true
           skip-build-cache: true
           args: "-c ./.golangci.yml --timeout=10m --issues-exit-code=1 --max-issues-per-linter=0 --sort-results ./..."


### PR DESCRIPTION
 - Pin golangci-lint version so we don't get failed builds when this dependency changes
 - Only release components on release tags (rather than all tags)
   - We only used to create tags on releases, but now we create tags for all commits