### PR TITLE
Bind jobs to nodes in scheduling algo test harness

### DIFF
--- a/internal/scheduler/scheduling_algo_test.go
+++ b/internal/scheduler/scheduling_algo_test.go
@@ -363,9 +363,6 @@ func TestLegacySchedulingAlgo_TestSchedule(t *testing.T) {
 			for executorId, jobsByNodeName := range tc.existingRunningIndices {
 				for nodeName, jobIndices := range jobsByNodeName {
 					node := nodes[executorId][nodeName]
-					if node.StateByJobRunId == nil {
-						node.StateByJobRunId = make(map[string]schedulerobjects.JobRunState)
-					}
 
 					for _, i := range jobIndices {
 						job := tc.existingJobs[i].WithQueued(false).WithNewRun(executorId, nodeName)

--- a/internal/scheduler/testfixtures/testfixtures.go
+++ b/internal/scheduler/testfixtures/testfixtures.go
@@ -586,6 +586,7 @@ func TestNode(priorities []int32, resources map[string]resource.Quantity) *sched
 			priorities,
 			schedulerobjects.ResourceList{Resources: resources},
 		),
+		StateByJobRunId: make(map[string]schedulerobjects.JobRunState),
 		Labels: map[string]string{
 			TestHostnameLabel: id,
 		},


### PR DESCRIPTION
This means that we also set fields like `AllocatedByJobId` on the node.