### PR TITLE
Scheduling key optimisations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,10 @@
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
+  exclude-rules:
+    - path: internal/scheduler/schedulerobjects/podutils_test.go
+      linters:
+        - lll
 
 output:
   print-issued-lines: true

--- a/go.mod
+++ b/go.mod
@@ -88,6 +88,7 @@ require (
 	github.com/jackc/pgx/v5 v5.3.1
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/magefile/mage v1.14.0
+	github.com/minio/highwayhash v1.0.2
 	github.com/openconfig/goyang v1.2.0
 	github.com/prometheus/common v0.37.0
 	github.com/sanity-io/litter v1.5.5

--- a/go.sum
+++ b/go.sum
@@ -655,6 +655,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
+github.com/minio/highwayhash v1.0.2 h1:Aak5U0nElisjDCfPSG79Tgzkn2gl66NxOMspRrKnA/g=
+github.com/minio/highwayhash v1.0.2/go.mod h1:BQskDq+xkJ12lmlUUi7U0M5Swg3EWR+dLTk+kldvVxY=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
@@ -1105,6 +1107,7 @@ golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181026203630-95b1ffbd15a5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190130150945-aca44879d564/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190204203706-41f3e6584952/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/internal/scheduler/context/context.go
+++ b/internal/scheduler/context/context.go
@@ -51,7 +51,7 @@ type SchedulingContext struct {
 	// Reason for why the scheduling round finished.
 	TerminationReason string
 	// Used to efficiently generate scheduling keys.
-	schedulingKeyGenerator *schedulerobjects.SchedulingKeyGenerator
+	SchedulingKeyGenerator *schedulerobjects.SchedulingKeyGenerator
 	// Record of job scheduling requirements known to be unfeasible.
 	// Used to immediately reject new jobs with identical reqirements.
 	// Maps to the JobSchedulingContext of a previous job attempted to schedule with the same key.
@@ -78,7 +78,7 @@ func NewSchedulingContext(
 		ScheduledResources:           schedulerobjects.NewResourceListWithDefaultSize(),
 		ScheduledResourcesByPriority: make(schedulerobjects.QuantityByPriorityAndResourceType),
 		EvictedResourcesByPriority:   make(schedulerobjects.QuantityByPriorityAndResourceType),
-		schedulingKeyGenerator:       schedulerobjects.NewSchedulingKeyGenerator(),
+		SchedulingKeyGenerator:       schedulerobjects.NewSchedulingKeyGenerator(),
 		UnfeasibleSchedulingKeys:     make(map[schedulerobjects.SchedulingKey]*JobSchedulingContext),
 	}
 }
@@ -88,7 +88,7 @@ func (sctx *SchedulingContext) SchedulingKeyFromLegacySchedulerJob(job interface
 	if priorityClass, ok := sctx.PriorityClasses[job.GetPriorityClassName()]; ok {
 		priority = priorityClass.Priority
 	}
-	return sctx.schedulingKeyGenerator.Key(
+	return sctx.SchedulingKeyGenerator.Key(
 		job.GetNodeSelector(),
 		job.GetAffinity(),
 		job.GetTolerations(),

--- a/internal/scheduler/context/context.go
+++ b/internal/scheduler/context/context.go
@@ -50,6 +50,8 @@ type SchedulingContext struct {
 	NumScheduledGangs int
 	// Reason for why the scheduling round finished.
 	TerminationReason string
+	// Used to efficiently generate scheduling keys.
+	schedulingKeyGenerator *schedulerobjects.SchedulingKeyGenerator
 	// Record of job scheduling requirements known to be unfeasible.
 	// Used to immediately reject new jobs with identical reqirements.
 	// Maps to the JobSchedulingContext of a previous job attempted to schedule with the same key.
@@ -76,8 +78,23 @@ func NewSchedulingContext(
 		ScheduledResources:           schedulerobjects.NewResourceListWithDefaultSize(),
 		ScheduledResourcesByPriority: make(schedulerobjects.QuantityByPriorityAndResourceType),
 		EvictedResourcesByPriority:   make(schedulerobjects.QuantityByPriorityAndResourceType),
+		schedulingKeyGenerator:       schedulerobjects.NewSchedulingKeyGenerator(),
 		UnfeasibleSchedulingKeys:     make(map[schedulerobjects.SchedulingKey]*JobSchedulingContext),
 	}
+}
+
+func (sctx *SchedulingContext) SchedulingKeyFromLegacySchedulerJob(job interfaces.LegacySchedulerJob) schedulerobjects.SchedulingKey {
+	var priority int32
+	if priorityClass, ok := sctx.PriorityClasses[job.GetPriorityClassName()]; ok {
+		priority = priorityClass.Priority
+	}
+	return sctx.schedulingKeyGenerator.Key(
+		job.GetNodeSelector(),
+		job.GetAffinity(),
+		job.GetTolerations(),
+		job.GetResourceRequirements().Requests,
+		priority,
+	)
 }
 
 func (sctx *SchedulingContext) ClearUnfeasibleSchedulingKeys() {

--- a/internal/scheduler/interfaces/interfaces.go
+++ b/internal/scheduler/interfaces/interfaces.go
@@ -1,6 +1,8 @@
 package interfaces
 
 import (
+	v1 "k8s.io/api/core/v1"
+
 	"github.com/armadaproject/armada/internal/armada/configuration"
 	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
 )
@@ -13,6 +15,10 @@ type LegacySchedulerJob interface {
 	GetAnnotations() map[string]string
 	GetRequirements(map[string]configuration.PriorityClass) *schedulerobjects.JobSchedulingInfo
 	GetPriorityClassName() string
+	GetNodeSelector() map[string]string
+	GetAffinity() *v1.Affinity
+	GetTolerations() []v1.Toleration
+	GetResourceRequirements() v1.ResourceRequirements
 }
 
 func PodRequirementFromLegacySchedulerJob(job LegacySchedulerJob, priorityClasses map[string]configuration.PriorityClass) *schedulerobjects.PodRequirements {

--- a/internal/scheduler/pool_assigner.go
+++ b/internal/scheduler/pool_assigner.go
@@ -29,17 +29,18 @@ type executor struct {
 }
 
 type DefaultPoolAssigner struct {
-	executorTimeout    time.Duration
-	priorityClasses    map[string]configuration.PriorityClass
-	priorities         []int32
-	indexedResources   []string
-	indexedTaints      []string
-	indexedNodeLabels  []string
-	poolByExecutorId   map[string]string
-	executorsByPool    map[string][]*executor
-	executorRepository database.ExecutorRepository
-	poolCache          *lru.Cache
-	clock              clock.Clock
+	executorTimeout        time.Duration
+	priorityClasses        map[string]configuration.PriorityClass
+	priorities             []int32
+	indexedResources       []string
+	indexedTaints          []string
+	indexedNodeLabels      []string
+	poolByExecutorId       map[string]string
+	executorsByPool        map[string][]*executor
+	executorRepository     database.ExecutorRepository
+	schedulingKeyGenerator *schedulerobjects.SchedulingKeyGenerator
+	poolCache              *lru.Cache
+	clock                  clock.Clock
 }
 
 func NewPoolAssigner(executorTimeout time.Duration,
@@ -51,17 +52,18 @@ func NewPoolAssigner(executorTimeout time.Duration,
 		return nil, errors.Wrap(err, "error  creating PoolAssigner pool cache")
 	}
 	return &DefaultPoolAssigner{
-		executorTimeout:    executorTimeout,
-		priorityClasses:    schedulingConfig.Preemption.PriorityClasses,
-		executorsByPool:    map[string][]*executor{},
-		poolByExecutorId:   map[string]string{},
-		priorities:         schedulingConfig.Preemption.AllowedPriorities(),
-		indexedResources:   schedulingConfig.IndexedResources,
-		indexedTaints:      schedulingConfig.IndexedTaints,
-		indexedNodeLabels:  schedulingConfig.IndexedNodeLabels,
-		executorRepository: executorRepository,
-		poolCache:          poolCache,
-		clock:              clock.RealClock{},
+		executorTimeout:        executorTimeout,
+		priorityClasses:        schedulingConfig.Preemption.PriorityClasses,
+		executorsByPool:        map[string][]*executor{},
+		poolByExecutorId:       map[string]string{},
+		priorities:             schedulingConfig.Preemption.AllowedPriorities(),
+		indexedResources:       schedulingConfig.IndexedResources,
+		indexedTaints:          schedulingConfig.IndexedTaints,
+		indexedNodeLabels:      schedulingConfig.IndexedNodeLabels,
+		executorRepository:     executorRepository,
+		schedulingKeyGenerator: schedulerobjects.NewSchedulingKeyGenerator(),
+		poolCache:              poolCache,
+		clock:                  clock.RealClock{},
 	}, nil
 }
 
@@ -88,6 +90,7 @@ func (p *DefaultPoolAssigner) Refresh(ctx context.Context) error {
 	}
 	p.executorsByPool = executorsByPool
 	p.poolByExecutorId = poolByExecutorId
+	p.schedulingKeyGenerator = schedulerobjects.NewSchedulingKeyGenerator()
 	p.poolCache.Purge()
 	return nil
 }
@@ -100,10 +103,19 @@ func (p *DefaultPoolAssigner) AssignPool(j *jobdb.Job) (string, error) {
 	}
 
 	// See if we have this set of reqs cached.
-	if schedulingKey, ok := j.JobSchedulingInfo().SchedulingKey(); ok {
-		if cachedPool, ok := p.poolCache.Get(schedulingKey); ok {
-			return cachedPool.(string), nil
-		}
+	var priority int32
+	if priorityClass, ok := p.priorityClasses[j.GetPriorityClassName()]; ok {
+		priority = priorityClass.Priority
+	}
+	schedulingKey := p.schedulingKeyGenerator.Key(
+		j.GetNodeSelector(),
+		j.GetAffinity(),
+		j.GetTolerations(),
+		j.GetResourceRequirements().Requests,
+		priority,
+	)
+	if cachedPool, ok := p.poolCache.Get(schedulingKey); ok {
+		return cachedPool.(string), nil
 	}
 
 	req := PodRequirementFromJobSchedulingInfo(j.JobSchedulingInfo())
@@ -124,9 +136,7 @@ func (p *DefaultPoolAssigner) AssignPool(j *jobdb.Job) (string, error) {
 					return "", errors.WithMessagef(err, "error selecting node for job %s", j.Id())
 				}
 				if report.Node != nil {
-					if schedulingKey, ok := j.JobSchedulingInfo().SchedulingKey(); ok {
-						p.poolCache.Add(schedulingKey, pool)
-					}
+					p.poolCache.Add(schedulingKey, pool)
 					return pool, nil
 				}
 			}

--- a/internal/scheduler/queue_scheduler.go
+++ b/internal/scheduler/queue_scheduler.go
@@ -212,21 +212,20 @@ func (it *QueuedGangIterator) Peek() (*schedulercontext.GangSchedulingContext, e
 
 		// Skip this job if it's known to be unschedulable.
 		if len(it.schedulingContext.UnfeasibleSchedulingKeys) > 0 {
-			if schedulingKey, ok := schedulingKeyFromLegacySchedulerJob(job, it.schedulingContext.PriorityClasses); ok {
-				if unsuccessfulJctx, ok := it.schedulingContext.UnfeasibleSchedulingKeys[schedulingKey]; ok {
-					jctx := &schedulercontext.JobSchedulingContext{
-						Created:              time.Now(),
-						ExecutorId:           it.schedulingContext.ExecutorId,
-						JobId:                job.GetId(),
-						Job:                  job,
-						UnschedulableReason:  unsuccessfulJctx.UnschedulableReason,
-						PodSchedulingContext: unsuccessfulJctx.PodSchedulingContext,
-					}
-					if _, err := it.schedulingContext.AddJobSchedulingContext(jctx); err != nil {
-						return nil, err
-					}
-					continue
+			schedulingKey := it.schedulingContext.SchedulingKeyFromLegacySchedulerJob(job)
+			if unsuccessfulJctx, ok := it.schedulingContext.UnfeasibleSchedulingKeys[schedulingKey]; ok {
+				jctx := &schedulercontext.JobSchedulingContext{
+					Created:              time.Now(),
+					ExecutorId:           it.schedulingContext.ExecutorId,
+					JobId:                job.GetId(),
+					Job:                  job,
+					UnschedulableReason:  unsuccessfulJctx.UnschedulableReason,
+					PodSchedulingContext: unsuccessfulJctx.PodSchedulingContext,
 				}
+				if _, err := it.schedulingContext.AddJobSchedulingContext(jctx); err != nil {
+					return nil, err
+				}
+				continue
 			}
 		}
 

--- a/internal/scheduler/reports_test.go
+++ b/internal/scheduler/reports_test.go
@@ -264,5 +264,6 @@ func testSchedulingContext(executorId string) *schedulercontext.SchedulingContex
 	)
 	sctx.Started = time.Time{}
 	sctx.Finished = time.Time{}
+	sctx.SchedulingKeyGenerator = nil
 	return sctx
 }

--- a/internal/scheduler/schedulerobjects/podutils.go
+++ b/internal/scheduler/schedulerobjects/podutils.go
@@ -53,10 +53,6 @@ func NewSchedulingKeyGenerator() *SchedulingKeyGenerator {
 	}
 }
 
-func (skg *SchedulingKeyGenerator) SetPrefix(v uint64) {
-	skg.prefix = v
-}
-
 func (skg *SchedulingKeyGenerator) Key(
 	nodeSelector map[string]string,
 	affinity *v1.Affinity,

--- a/internal/scheduler/schedulerobjects/podutils_test.go
+++ b/internal/scheduler/schedulerobjects/podutils_test.go
@@ -642,27 +642,8 @@ func TestSchedulingKey(t *testing.T) {
 				},
 			},
 		},
-		"affinity MatchLabels": {
+		"affinity PodAffinity ignored": {
 			a: &PodRequirements{
-				NodeSelector: map[string]string{
-					"property1": "value1",
-					"property3": "value3",
-				},
-				Tolerations: []v1.Toleration{{
-					Key:               "a",
-					Operator:          "b",
-					Value:             "b",
-					Effect:            "d",
-					TolerationSeconds: pointer.Int64(1),
-				}},
-				Priority: 1,
-				ResourceRequirements: v1.ResourceRequirements{
-					Requests: map[v1.ResourceName]resource.Quantity{
-						"cpu":    resource.MustParse("4"),
-						"memory": resource.MustParse("5"),
-						"gpu":    resource.MustParse("6"),
-					},
-				},
 				Affinity: &v1.Affinity{
 					NodeAffinity: &v1.NodeAffinity{
 						RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
@@ -726,25 +707,6 @@ func TestSchedulingKey(t *testing.T) {
 				},
 			},
 			b: &PodRequirements{
-				NodeSelector: map[string]string{
-					"property3": "value3",
-					"property1": "value1",
-				},
-				Tolerations: []v1.Toleration{{
-					Key:               "a",
-					Operator:          "b",
-					Value:             "b",
-					Effect:            "d",
-					TolerationSeconds: pointer.Int64(1),
-				}},
-				Priority: 1,
-				ResourceRequirements: v1.ResourceRequirements{
-					Requests: map[v1.ResourceName]resource.Quantity{
-						"cpu":    resource.MustParse("4"),
-						"memory": resource.MustParse("5"),
-						"gpu":    resource.MustParse("6"),
-					},
-				},
 				Affinity: &v1.Affinity{
 					NodeAffinity: &v1.NodeAffinity{
 						RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
@@ -807,12 +769,197 @@ func TestSchedulingKey(t *testing.T) {
 					PodAntiAffinity: nil,
 				},
 			},
+			equal: true,
+		},
+		"affinity NodeAffinity MatchExpressions": {
+			a: &PodRequirements{
+				Affinity: &v1.Affinity{
+					NodeAffinity: &v1.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+							NodeSelectorTerms: []v1.NodeSelectorTerm{
+								{
+									MatchExpressions: []v1.NodeSelectorRequirement{
+										{
+											Key:      "k1",
+											Operator: "o1",
+											Values:   []string{"v1", "v2"},
+										},
+									},
+									MatchFields: []v1.NodeSelectorRequirement{
+										{
+											Key:      "k2",
+											Operator: "o2",
+											Values:   []string{"v10", "v20"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			b: &PodRequirements{
+				Affinity: &v1.Affinity{
+					NodeAffinity: &v1.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+							NodeSelectorTerms: []v1.NodeSelectorTerm{
+								{
+									MatchExpressions: []v1.NodeSelectorRequirement{
+										{
+											Key:      "k1",
+											Operator: "o1",
+											Values:   []string{"v1", "v3"},
+										},
+									},
+									MatchFields: []v1.NodeSelectorRequirement{
+										{
+											Key:      "k2",
+											Operator: "o2",
+											Values:   []string{"v10", "v20"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			equal: false,
+		},
+		"affinity NodeAffinity MatchFields": {
+			a: &PodRequirements{
+				Affinity: &v1.Affinity{
+					NodeAffinity: &v1.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+							NodeSelectorTerms: []v1.NodeSelectorTerm{
+								{
+									MatchExpressions: []v1.NodeSelectorRequirement{
+										{
+											Key:      "k1",
+											Operator: "o1",
+											Values:   []string{"v1", "v2"},
+										},
+									},
+									MatchFields: []v1.NodeSelectorRequirement{
+										{
+											Key:      "k2",
+											Operator: "o2",
+											Values:   []string{"v10", "v20"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			b: &PodRequirements{
+				Affinity: &v1.Affinity{
+					NodeAffinity: &v1.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+							NodeSelectorTerms: []v1.NodeSelectorTerm{
+								{
+									MatchExpressions: []v1.NodeSelectorRequirement{
+										{
+											Key:      "k1",
+											Operator: "o1",
+											Values:   []string{"v1", "v2"},
+										},
+									},
+									MatchFields: []v1.NodeSelectorRequirement{
+										{
+											Key:      "k2",
+											Operator: "o2",
+											Values:   []string{"v10", "v21"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			equal: false,
+		},
+		"affinity NodeAffinity multiple MatchFields": {
+			a: &PodRequirements{
+				Affinity: &v1.Affinity{
+					NodeAffinity: &v1.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+							NodeSelectorTerms: []v1.NodeSelectorTerm{
+								{
+									MatchExpressions: []v1.NodeSelectorRequirement{
+										{
+											Key:      "k1",
+											Operator: "o1",
+											Values:   []string{"v1", "v2"},
+										},
+									},
+									MatchFields: []v1.NodeSelectorRequirement{
+										{
+											Key:      "k2",
+											Operator: "o2",
+											Values:   []string{"v10", "v20"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			b: &PodRequirements{
+				Affinity: &v1.Affinity{
+					NodeAffinity: &v1.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+							NodeSelectorTerms: []v1.NodeSelectorTerm{
+								{
+									MatchExpressions: []v1.NodeSelectorRequirement{
+										{
+											Key:      "k1",
+											Operator: "o1",
+											Values:   []string{"v1", "v2"},
+										},
+									},
+									MatchFields: []v1.NodeSelectorRequirement{
+										{
+											Key:      "k2",
+											Operator: "o2",
+											Values:   []string{"v10", "v20"},
+										},
+										{
+											Key:      "k3",
+											Operator: "o2",
+											Values:   []string{"v10", "v20"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			equal: false,
 		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			schedulingKeyA := tc.a.SchedulingKey()
-			schedulingKeyB := tc.b.SchedulingKey()
+			skg := NewSchedulingKeyGenerator()
+			schedulingKeyA := skg.Key(
+				tc.a.NodeSelector,
+				tc.a.Affinity,
+				tc.a.Tolerations,
+				tc.a.ResourceRequirements.Requests,
+				tc.a.Priority,
+			)
+			schedulingKeyB := skg.Key(
+				tc.b.NodeSelector,
+				tc.b.Affinity,
+				tc.b.Tolerations,
+				tc.b.ResourceRequirements.Requests,
+				tc.b.Priority,
+			)
+
 			var prevSchedulingKeyA SchedulingKey
 			var prevSchedulingKeyB SchedulingKey
 			n := defaultN
@@ -820,8 +967,6 @@ func TestSchedulingKey(t *testing.T) {
 				n = tc.n
 			}
 			for i := 0; i < n; i++ {
-				tc.a.ClearCachedSchedulingKey()
-				tc.b.ClearCachedSchedulingKey()
 				if tc.equal {
 					assert.Equal(t, schedulingKeyA, schedulingKeyB)
 				} else {
@@ -838,8 +983,31 @@ func TestSchedulingKey(t *testing.T) {
 	}
 }
 
+func benchmarkSchedulingKey(b *testing.B, jobSchedulingInfo *JobSchedulingInfo) {
+	skg := NewSchedulingKeyGenerator()
+	req := (jobSchedulingInfo.ObjectRequirements[0]).GetPodRequirements()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		skg.Key(
+			req.NodeSelector,
+			req.Affinity,
+			req.Tolerations,
+			req.ResourceRequirements.Requests,
+			req.Priority,
+		)
+	}
+}
+
 func BenchmarkSchedulingKey(b *testing.B) {
-	jobSchedulingInfo := &JobSchedulingInfo{
+	benchmarkSchedulingKey(b, getBenchmarkJobSchedulingSchedulingInfo())
+}
+
+func BenchmarkSchedulingKey_Affinity(b *testing.B) {
+	benchmarkSchedulingKey(b, getBenchmarkJobSchedulingSchedulingInfoWithAffinity())
+}
+
+func getBenchmarkJobSchedulingSchedulingInfo() *JobSchedulingInfo {
+	return &JobSchedulingInfo{
 		Lifetime:          1,
 		AtMostOnce:        true,
 		Preemptible:       true,
@@ -885,15 +1053,10 @@ func BenchmarkSchedulingKey(b *testing.B) {
 			},
 		},
 	}
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		jobSchedulingInfo.ClearCachedSchedulingKey()
-		jobSchedulingInfo.SchedulingKey()
-	}
 }
 
-func BenchmarkSchedulingKey_Affinity(b *testing.B) {
-	jobSchedulingInfo := &JobSchedulingInfo{
+func getBenchmarkJobSchedulingSchedulingInfoWithAffinity() *JobSchedulingInfo {
+	return &JobSchedulingInfo{
 		Lifetime:          1,
 		AtMostOnce:        true,
 		Preemptible:       true,
@@ -999,10 +1162,5 @@ func BenchmarkSchedulingKey_Affinity(b *testing.B) {
 				},
 			},
 		},
-	}
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		jobSchedulingInfo.ClearCachedSchedulingKey()
-		jobSchedulingInfo.SchedulingKey()
 	}
 }

--- a/internal/scheduler/schedulerobjects/podutils_test.go
+++ b/internal/scheduler/schedulerobjects/podutils_test.go
@@ -983,6 +983,32 @@ func TestSchedulingKey(t *testing.T) {
 	}
 }
 
+func benchmarPodRequirementsSerialiser(b *testing.B, jobSchedulingInfo *JobSchedulingInfo) {
+	skg := NewPodRequirementsSerialiser()
+	req := (jobSchedulingInfo.ObjectRequirements[0]).GetPodRequirements()
+	out := make([]byte, 0, 1024)
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		out = out[0:0]
+		out = skg.AppendRequirements(
+			out,
+			req.NodeSelector,
+			req.Affinity,
+			req.Tolerations,
+			req.ResourceRequirements.Requests,
+			req.Priority,
+		)
+	}
+}
+
+func BenchmarkPodRequirementsSerialiser(b *testing.B) {
+	benchmarPodRequirementsSerialiser(b, getBenchmarkJobSchedulingSchedulingInfo())
+}
+
+func BenchmarkPodRequirementsSerialiser_Affinity(b *testing.B) {
+	benchmarPodRequirementsSerialiser(b, getBenchmarkJobSchedulingSchedulingInfoWithAffinity())
+}
+
 func benchmarkSchedulingKey(b *testing.B, jobSchedulingInfo *JobSchedulingInfo) {
 	skg := NewSchedulingKeyGenerator()
 	req := (jobSchedulingInfo.ObjectRequirements[0]).GetPodRequirements()

--- a/internal/scheduler/schedulerobjects/podutils_test.go
+++ b/internal/scheduler/schedulerobjects/podutils_test.go
@@ -10,6 +10,128 @@ import (
 	"k8s.io/utils/pointer"
 )
 
+// TestPodRequirementsSerialiser_AffinityDocsUnchanged fails if the docs for the parts of v1.Affinity
+// we use for scheduling change, so that we are warned if its definition changes and need to update PodRequirementsSerialiser.
+func TestPodRequirementsSerialiser_AffinityDocsUnchanged(t *testing.T) {
+	affinity := &v1.Affinity{
+		NodeAffinity: &v1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+				NodeSelectorTerms: []v1.NodeSelectorTerm{
+					{
+						MatchExpressions: []v1.NodeSelectorRequirement{
+							{
+								Key:      "k1",
+								Operator: "o1",
+								Values:   []string{"v1", "v2"},
+							},
+						},
+						MatchFields: []v1.NodeSelectorRequirement{
+							{
+								Key:      "k2",
+								Operator: "o2",
+								Values:   []string{"v10", "v20"},
+							},
+						},
+					},
+				},
+			},
+		},
+		PodAffinity: &v1.PodAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
+				{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"label1": "labelval1",
+							"label2": "labelval2",
+							"label3": "labelval3",
+						},
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      "k1",
+								Operator: "o1",
+								Values:   []string{"v1", "v2", "v3"},
+							},
+						},
+					},
+					Namespaces:  []string{"n1, n2, n3"},
+					TopologyKey: "topkey1",
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"label10": "labelval1",
+							"label20": "labelval2",
+							"label30": "labelval3",
+						},
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      "k10",
+								Operator: "o10",
+								Values:   []string{"v10", "v20", "v30"},
+							},
+						},
+					},
+				},
+			},
+		},
+		PodAntiAffinity: nil,
+	}
+	assert.Equal(
+		t,
+		map[string]string{
+			"":                "Affinity is a group of affinity scheduling rules.",
+			"nodeAffinity":    "Describes node affinity scheduling rules for the pod.",
+			"podAffinity":     "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+			"podAntiAffinity": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+		},
+		affinity.SwaggerDoc(),
+	)
+	assert.Equal(
+		t,
+		map[string]string{
+			"": "Node affinity is a group of node affinity scheduling rules.",
+			"requiredDuringSchedulingIgnoredDuringExecution":  "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+			"preferredDuringSchedulingIgnoredDuringExecution": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+		},
+		affinity.NodeAffinity.SwaggerDoc(),
+	)
+	assert.Equal(
+		t,
+		map[string]string{
+			"":                  "A node selector represents the union of the results of one or more label queries over a set of nodes; that is, it represents the OR of the selectors represented by the node selector terms.",
+			"nodeSelectorTerms": "Required. A list of node selector terms. The terms are ORed.",
+		},
+		affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.SwaggerDoc(),
+	)
+	assert.Equal(
+		t,
+		map[string]string{
+			"":                 "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+			"matchExpressions": "A list of node selector requirements by node's labels.",
+			"matchFields":      "A list of node selector requirements by node's fields.",
+		},
+		affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].SwaggerDoc(),
+	)
+	assert.Equal(
+		t,
+		map[string]string{
+			"":         "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+			"key":      "The label key that the selector applies to.",
+			"operator": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+			"values":   "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+		},
+		affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions[0].SwaggerDoc(),
+	)
+	assert.Equal(
+		t,
+		map[string]string{
+			"":         "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+			"key":      "The label key that the selector applies to.",
+			"operator": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+			"values":   "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+		},
+		affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchFields[0].SwaggerDoc(),
+	)
+}
+
 func TestSchedulingKey(t *testing.T) {
 	defaultN := 10 // Run the check several times to check for consistency.
 	tests := map[string]struct {

--- a/internal/scheduler/submitcheck.go
+++ b/internal/scheduler/submitcheck.go
@@ -124,7 +124,6 @@ func (srv *SubmitChecker) updateExecutors(ctx context.Context) {
 		} else {
 			log.WithError(err).Warnf("Error clearing nodedb for executor %s", executor.Id)
 		}
-
 	}
 
 	// Reset cache as the executors may have updated, changing what can be scheduled.
@@ -178,6 +177,7 @@ func GroupJobsByAnnotation(annotation string, jobs []*api.Job) map[string][]*api
 }
 
 func (srv *SubmitChecker) getSchedulingResult(req *schedulerobjects.PodRequirements) schedulingResult {
+	srv.mu.Lock()
 	schedulingKey := srv.schedulingKeyGenerator.Key(
 		req.NodeSelector,
 		req.Affinity,
@@ -185,6 +185,7 @@ func (srv *SubmitChecker) getSchedulingResult(req *schedulerobjects.PodRequireme
 		req.ResourceRequirements.Requests,
 		req.Priority,
 	)
+	srv.mu.Unlock()
 	var result schedulingResult
 	if obj, ok := srv.jobSchedulingResultsCache.Get(schedulingKey); ok {
 		result = obj.(schedulingResult)

--- a/internal/scheduler/submitcheck.go
+++ b/internal/scheduler/submitcheck.go
@@ -50,6 +50,7 @@ type SubmitChecker struct {
 	executorRepository        database.ExecutorRepository
 	clock                     clock.Clock
 	mu                        sync.Mutex
+	schedulingKeyGenerator    *schedulerobjects.SchedulingKeyGenerator
 	jobSchedulingResultsCache *lru.Cache
 }
 
@@ -73,6 +74,7 @@ func NewSubmitChecker(
 		indexedNodeLabels:         schedulingConfig.IndexedNodeLabels,
 		executorRepository:        executorRepository,
 		clock:                     clock.RealClock{},
+		schedulingKeyGenerator:    schedulerobjects.NewSchedulingKeyGenerator(),
 		jobSchedulingResultsCache: jobSchedulingResultsCache,
 	}
 }
@@ -125,12 +127,14 @@ func (srv *SubmitChecker) updateExecutors(ctx context.Context) {
 
 	}
 
-	// Reset cache as the executors may have updated - changing what can be scheduled
+	// Reset cache as the executors may have updated, changing what can be scheduled.
+	// Create a new schedulingKeyGenerator to get a new initial state.
+	srv.schedulingKeyGenerator = schedulerobjects.NewSchedulingKeyGenerator()
 	srv.jobSchedulingResultsCache.Purge()
 }
 
-func (srv *SubmitChecker) CheckPodRequirements(podRequirement *schedulerobjects.PodRequirements) (bool, string) {
-	schedulingResult := srv.getSchedulingResult([]*schedulerobjects.PodRequirements{podRequirement})
+func (srv *SubmitChecker) CheckPodRequirements(req *schedulerobjects.PodRequirements) (bool, string) {
+	schedulingResult := srv.getSchedulingResult(req)
 	if !schedulingResult.isSchedulable {
 		return schedulingResult.isSchedulable, fmt.Sprintf("requirements unschedulable:\n%s", schedulingResult.reason)
 	}
@@ -140,8 +144,8 @@ func (srv *SubmitChecker) CheckPodRequirements(podRequirement *schedulerobjects.
 func (srv *SubmitChecker) CheckApiJobs(jobs []*api.Job) (bool, string) {
 	// First, check if all jobs can be scheduled individually.
 	for i, job := range jobs {
-		reqs := PodRequirementFromLegacySchedulerJob(job, srv.priorityClasses)
-		schedulingResult := srv.getSchedulingResult([]*schedulerobjects.PodRequirements{reqs})
+		req := PodRequirementFromLegacySchedulerJob(job, srv.priorityClasses)
+		schedulingResult := srv.getSchedulingResult(req)
 		if !schedulingResult.isSchedulable {
 			return schedulingResult.isSchedulable, fmt.Sprintf("%d-th job unschedulable:\n%s", i, schedulingResult.reason)
 		}
@@ -173,19 +177,23 @@ func GroupJobsByAnnotation(annotation string, jobs []*api.Job) map[string][]*api
 	return rv
 }
 
-func (srv *SubmitChecker) getSchedulingResult(reqs []*schedulerobjects.PodRequirements) schedulingResult {
-	for _, req := range reqs {
-		schedulingKey := req.SchedulingKey()
-		var result schedulingResult
-		if obj, ok := srv.jobSchedulingResultsCache.Get(schedulingKey); ok {
-			result = obj.(schedulingResult)
-		} else {
-			result = srv.check(reqs)
-			srv.jobSchedulingResultsCache.Add(schedulingKey, result)
-		}
-		if !result.isSchedulable {
-			return result
-		}
+func (srv *SubmitChecker) getSchedulingResult(req *schedulerobjects.PodRequirements) schedulingResult {
+	schedulingKey := srv.schedulingKeyGenerator.Key(
+		req.NodeSelector,
+		req.Affinity,
+		req.Tolerations,
+		req.ResourceRequirements.Requests,
+		req.Priority,
+	)
+	var result schedulingResult
+	if obj, ok := srv.jobSchedulingResultsCache.Get(schedulingKey); ok {
+		result = obj.(schedulingResult)
+	} else {
+		result = srv.check([]*schedulerobjects.PodRequirements{req})
+		srv.jobSchedulingResultsCache.Add(schedulingKey, result)
+	}
+	if !result.isSchedulable {
+		return result
 	}
 	return schedulingResult{isSchedulable: true}
 }

--- a/internal/scheduleringester/instructions.go
+++ b/internal/scheduleringester/instructions.go
@@ -381,9 +381,5 @@ func (c *InstructionConverter) schedulingInfoFromSubmitJob(submitJob *armadaeven
 	default:
 		return nil, errors.Errorf("unsupported object type %T", object)
 	}
-
-	// Call SchedulingKey() to trigger computing and caching the key.
-	_, _ = schedulingInfo.SchedulingKey()
-
 	return schedulingInfo, nil
 }

--- a/internal/scheduleringester/instructions_test.go
+++ b/internal/scheduleringester/instructions_test.go
@@ -300,6 +300,5 @@ func getExpectedSubmitMessageSchedulingInfo(t *testing.T) *schedulerobjects.JobS
 			},
 		},
 	}
-	_, _ = expectedSubmitSchedulingInfo.SchedulingKey()
 	return expectedSubmitSchedulingInfo
 }


### PR DESCRIPTION
The current scheduling key implementation is relatively slow and requires many allocs, causing unnecessary GC pressure. Here, I've switched to a new implementation that is much faster and doesn't require allocs. Further, affinities that are equivalent from a scheduling point of view but differ in some other way will now map to the same hash. I've added tests to check that the affinity docs don't change unexpectedly to avoid the affinity definition changing causing us issues.

The new implementation is about 5x faster for jobs without affinities and about 100x faster for jobs with affinities.

The speedup is in large part due to using a 256-bit highway hash instead of sha1. While sha1 is designed to make it hard to find X and Y such that hash(X) = hash(Y), highway hash is designed to make it hard to find Y such that hash(Y) = hash(X, k), where k is an unknown key and X and hash(X) are known. As a result, highway hash can be made more efficient and is a better fit for this application than sha1. For affinities, the speedup is largely due to hashing the relevant parts of the affinities directly instead of serialising to json and hashing the resulting byte array. 

Current implementation:
```
go.exe test -benchmem -run=^$ -bench ^BenchmarkSchedulingKey$ github.com/armadaproject/armada/internal/scheduler/schedulerobjects
goos: windows
goarch: amd64
pkg: github.com/armadaproject/armada/internal/scheduler/schedulerobjects
cpu: 12th Gen Intel(R) Core(TM) i7-12700H
BenchmarkSchedulingKey-20         646980              1796 ns/op             640 B/op         39 allocs/op
PASS
ok      github.com/armadaproject/armada/internal/scheduler/schedulerobjects     1.218s


go.exe test -benchmem -run=^$ -bench ^BenchmarkSchedulingKey_Affinity$ github.com/armadaproject/armada/internal/scheduler/schedulerobjects
goos: windows
goarch: amd64
pkg: github.com/armadaproject/armada/internal/scheduler/schedulerobjects
cpu: 12th Gen Intel(R) Core(TM) i7-12700H
BenchmarkSchedulingKey_Affinity-20         31515             38902 ns/op           17025 B/op        504 allocs/op
PASS
ok      github.com/armadaproject/armada/internal/scheduler/schedulerobjects     1.651s
```

New implementation:
```
go.exe test -v -benchmem -run=^$ -bench ^BenchmarkSchedulingKey$ github.com/armadaproject/armada/internal/scheduler/schedulerobjects
goos: windows
goarch: amd64
pkg: github.com/armadaproject/armada/internal/scheduler/schedulerobjects
cpu: 12th Gen Intel(R) Core(TM) i7-12700H
BenchmarkSchedulingKey
BenchmarkSchedulingKey-20        3922611               304.3 ns/op             0 B/op          0 allocs/op
PASS
ok      github.com/armadaproject/armada/internal/scheduler/schedulerobjects     1.540s

go.exe test -v -benchmem -run=^$ -bench ^BenchmarkSchedulingKey_Affinity$ github.com/armadaproject/armada/internal/scheduler/schedulerobjects
goos: windows
goarch: amd64
pkg: github.com/armadaproject/armada/internal/scheduler/schedulerobjects
cpu: 12th Gen Intel(R) Core(TM) i7-12700H
BenchmarkSchedulingKey_Affinity
BenchmarkSchedulingKey_Affinity-20       3030038               394.9 ns/op             0 B/op          0 allocs/op
PASS
ok      github.com/armadaproject/armada/internal/scheduler/schedulerobjects     1.636s
```

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-319) by [Unito](https://www.unito.io)
