### PR TITLE
Add preemptions to scheduling context repository

### DIFF
--- a/internal/scheduler/context/context.go
+++ b/internal/scheduler/context/context.go
@@ -279,7 +279,6 @@ type QueueSchedulingContext struct {
 
 const maxPrintedJobIdsByReason = 1
 
-// TODO: Update with preemptions.
 func (qctx *QueueSchedulingContext) String() string {
 	var sb strings.Builder
 	w := tabwriter.NewWriter(&sb, 1, 1, 1, ' ', 0)
@@ -289,8 +288,11 @@ func (qctx *QueueSchedulingContext) String() string {
 	fmt.Fprintf(w, "Total allocated resources after scheduling (by priority):\t%s\n", qctx.AllocatedByPriority.String())
 	fmt.Fprintf(w, "Scheduled resources:\t%s\n", qctx.ScheduledResourcesByPriority.AggregateByResource().CompactString())
 	fmt.Fprintf(w, "Scheduled resources (by priority):\t%s\n", qctx.ScheduledResourcesByPriority.String())
+	fmt.Fprintf(w, "Preempted resources:\t%s\n", qctx.EvictedResourcesByPriority.AggregateByResource().CompactString())
+	fmt.Fprintf(w, "Preempted resources (by priority):\t%s\n", qctx.EvictedResourcesByPriority.String())
 	fmt.Fprintf(w, "Number of jobs scheduled:\t%d\n", len(qctx.SuccessfulJobSchedulingContexts))
 	fmt.Fprintf(w, "Number of jobs that could not be scheduled:\t%d\n", len(qctx.UnsuccessfulJobSchedulingContexts))
+	fmt.Fprintf(w, "Number of jobs preempted:\t%d\n", len(qctx.EvictedJobsById))
 	if len(qctx.SuccessfulJobSchedulingContexts) > 0 {
 		jobIdsToPrint := maps.Keys(qctx.SuccessfulJobSchedulingContexts)
 		if len(jobIdsToPrint) > maxPrintedJobIdsByReason {


### PR DESCRIPTION
This is essentially a manual cherry-pick of the part of #2456 that adds information about preemptions to `SchedulingContextRepository`.