### PR TITLE
Add queue and job filters for scheduling reports

### DIFF
--- a/cmd/armadactl/cmd/scheduling.go
+++ b/cmd/armadactl/cmd/scheduling.go
@@ -18,9 +18,39 @@ func getSchedulingReportCmd(a *armadactl.App) *cobra.Command {
 			return initParams(cmd, a.Params)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return a.GetSchedulingReport()
+			verbosity, err := cmd.Flags().GetCount("verbose")
+			if err != nil {
+				return err
+			}
+
+			queueName, err := cmd.Flags().GetString("queue")
+			if err != nil {
+				return err
+			}
+			queueName = strings.TrimSpace(queueName)
+			if queueName != "" {
+				return a.GetSchedulingReportForQueue(queueName, int32(verbosity))
+			}
+
+			jobId, err := cmd.Flags().GetString("job")
+			if err != nil {
+				return err
+			}
+			jobId = strings.TrimSpace(jobId)
+			if jobId != "" {
+				return a.GetSchedulingReportForJob(jobId, int32(verbosity))
+			}
+
+			return a.GetSchedulingReport(int32(verbosity))
 		},
 	}
+
+	cmd.Flags().CountP("verbose", "v", "report verbosity; specify multiple times (for example: -vvv) to increase verbosity")
+
+	cmd.Flags().String("queue", "", "only get scheduler reports containing this queue")
+	cmd.Flags().String("job", "", "only get scheduler reports containing this job ID")
+	cmd.MarkFlagsMutuallyExclusive("queue", "job")
+
 	return cmd
 }
 

--- a/cmd/armadactl/cmd/scheduling.go
+++ b/cmd/armadactl/cmd/scheduling.go
@@ -64,15 +64,25 @@ func getQueueSchedulingReportCmd(a *armadactl.App) *cobra.Command {
 			return initParams(cmd, a.Params)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			queue, err := cmd.Flags().GetString("queue")
+			verbosity, err := cmd.Flags().GetCount("verbose")
 			if err != nil {
 				return err
 			}
-			queue = strings.TrimSpace(queue)
-			return a.GetQueueSchedulingReport(queue)
+
+			queueName, err := cmd.Flags().GetString("queue")
+			if err != nil {
+				return err
+			}
+			queueName = strings.TrimSpace(queueName)
+
+			return a.GetQueueSchedulingReport(queueName, int32(verbosity))
 		},
 	}
+
+	cmd.Flags().CountP("verbose", "v", "report verbosity; repeat (e.g., -vvv) to increase verbosity")
+
 	cmd.Flags().String("queue", "", "Queue name to query reports for.")
+
 	return cmd
 }
 

--- a/cmd/armadactl/cmd/scheduling.go
+++ b/cmd/armadactl/cmd/scheduling.go
@@ -45,10 +45,10 @@ func getSchedulingReportCmd(a *armadactl.App) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().CountP("verbose", "v", "report verbosity; specify multiple times (for example: -vvv) to increase verbosity")
+	cmd.Flags().CountP("verbose", "v", "report verbosity; repeat (e.g., -vvv) to increase verbosity")
 
-	cmd.Flags().String("queue", "", "only get scheduler reports containing this queue")
-	cmd.Flags().String("job", "", "only get scheduler reports containing this job ID")
+	cmd.Flags().String("queue", "", "get scheduler reports relevant for this queue; mutually exclusive with --job")
+	cmd.Flags().String("job", "", "get scheduler reports relevant for this job; mutually exclusive with --queue")
 	cmd.MarkFlagsMutuallyExclusive("queue", "job")
 
 	return cmd

--- a/internal/armadactl/scheduling.go
+++ b/internal/armadactl/scheduling.go
@@ -57,11 +57,11 @@ func (a *App) GetSchedulingReport(verbosity int32) error {
 	)
 }
 
-func (a *App) GetQueueSchedulingReport(queue string) error {
+func (a *App) GetQueueSchedulingReport(queueName string, verbosity int32) error {
 	return client.WithSchedulerReportingClient(a.Params.ApiConnectionDetails, func(c schedulerobjects.SchedulerReportingClient) error {
 		ctx, cancel := common.ContextWithDefaultTimeout()
 		defer cancel()
-		report, err := c.GetQueueReport(ctx, &schedulerobjects.QueueReportRequest{QueueName: queue})
+		report, err := c.GetQueueReport(ctx, &schedulerobjects.QueueReportRequest{QueueName: queueName, Verbosity: verbosity})
 		if err != nil {
 			return err
 		}

--- a/internal/armadactl/scheduling.go
+++ b/internal/armadactl/scheduling.go
@@ -3,18 +3,16 @@ package armadactl
 import (
 	"fmt"
 
-	"github.com/gogo/protobuf/types"
-
 	"github.com/armadaproject/armada/internal/common"
 	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
 	"github.com/armadaproject/armada/pkg/client"
 )
 
-func (a *App) GetSchedulingReport() error {
+func (a *App) executeGetSchedulingReport(request *schedulerobjects.SchedulingReportRequest) error {
 	return client.WithSchedulerReportingClient(a.Params.ApiConnectionDetails, func(c schedulerobjects.SchedulerReportingClient) error {
 		ctx, cancel := common.ContextWithDefaultTimeout()
 		defer cancel()
-		report, err := c.GetSchedulingReport(ctx, &types.Empty{})
+		report, err := c.GetSchedulingReport(ctx, request)
 		if err != nil {
 			return err
 		}
@@ -23,11 +21,47 @@ func (a *App) GetSchedulingReport() error {
 	})
 }
 
+func (a *App) GetSchedulingReportForQueue(queueName string, verbosity int32) error {
+	return a.executeGetSchedulingReport(
+		&schedulerobjects.SchedulingReportRequest{
+			Filter: &schedulerobjects.SchedulingReportRequest_MostRecentForQueue{
+				MostRecentForQueue: &schedulerobjects.MostRecentForQueue{
+					QueueName: queueName,
+				},
+			},
+
+			Verbosity: verbosity,
+		},
+	)
+}
+
+func (a *App) GetSchedulingReportForJob(jobId string, verbosity int32) error {
+	return a.executeGetSchedulingReport(
+		&schedulerobjects.SchedulingReportRequest{
+			Filter: &schedulerobjects.SchedulingReportRequest_MostRecentForJob{
+				MostRecentForJob: &schedulerobjects.MostRecentForJob{
+					JobId: jobId,
+				},
+			},
+
+			Verbosity: verbosity,
+		},
+	)
+}
+
+func (a *App) GetSchedulingReport(verbosity int32) error {
+	return a.executeGetSchedulingReport(
+		&schedulerobjects.SchedulingReportRequest{
+			Verbosity: verbosity,
+		},
+	)
+}
+
 func (a *App) GetQueueSchedulingReport(queue string) error {
 	return client.WithSchedulerReportingClient(a.Params.ApiConnectionDetails, func(c schedulerobjects.SchedulerReportingClient) error {
 		ctx, cancel := common.ContextWithDefaultTimeout()
 		defer cancel()
-		report, err := c.GetQueueReport(ctx, &schedulerobjects.Queue{Name: queue})
+		report, err := c.GetQueueReport(ctx, &schedulerobjects.QueueReportRequest{QueueName: queue})
 		if err != nil {
 			return err
 		}
@@ -40,7 +74,7 @@ func (a *App) GetJobSchedulingReport(jobId string) error {
 	return client.WithSchedulerReportingClient(a.Params.ApiConnectionDetails, func(c schedulerobjects.SchedulerReportingClient) error {
 		ctx, cancel := common.ContextWithDefaultTimeout()
 		defer cancel()
-		report, err := c.GetJobReport(ctx, &schedulerobjects.JobId{Id: jobId})
+		report, err := c.GetJobReport(ctx, &schedulerobjects.JobReportRequest{JobId: jobId})
 		if err != nil {
 			return err
 		}

--- a/internal/scheduler/context/context.go
+++ b/internal/scheduler/context/context.go
@@ -6,6 +6,7 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/openconfig/goyang/pkg/indent"
 	"github.com/pkg/errors"
 	"golang.org/x/exp/maps"
 	v1 "k8s.io/api/core/v1"
@@ -116,26 +117,51 @@ func (sctx *SchedulingContext) AddQueueSchedulingContext(queue string, priorityF
 }
 
 func (sctx *SchedulingContext) String() string {
+	return sctx.ReportString(0)
+}
+
+func (sctx *SchedulingContext) ReportString(verbosity int32) string {
 	var sb strings.Builder
 	w := tabwriter.NewWriter(&sb, 1, 1, 1, ' ', 0)
 	fmt.Fprintf(w, "Started:\t%s\n", sctx.Started)
 	fmt.Fprintf(w, "Finished:\t%s\n", sctx.Finished)
 	fmt.Fprintf(w, "Duration:\t%s\n", sctx.Finished.Sub(sctx.Started))
-	fmt.Fprintf(w, "Total capacity:\t%s\n", sctx.TotalResources.CompactString())
-	fmt.Fprintf(w, "Jobs scheduled:\t%d\n", sctx.NumScheduledJobs)
-	fmt.Fprintf(w, "Total scheduled resources:\t%s\n", sctx.ScheduledResources.CompactString())
-	fmt.Fprintf(
-		w, "Scheduled queues:\t%v\n",
-		maps.Keys(
-			armadamaps.Filter(
-				sctx.QueueSchedulingContexts,
-				func(_ string, qctx *QueueSchedulingContext) bool {
-					return len(qctx.SuccessfulJobSchedulingContexts) > 0
-				},
-			),
-		),
-	)
 	fmt.Fprintf(w, "Termination reason:\t%s\n", sctx.TerminationReason)
+	fmt.Fprintf(w, "Available resources before scheduling:\t%s\n", sctx.TotalResources.CompactString())
+	fmt.Fprintf(w, "Scheduled resources:\t%s\n", sctx.ScheduledResources.CompactString())
+	fmt.Fprintf(w, "Number of jobs scheduled:\t%d\n", sctx.NumScheduledJobs)
+	if verbosity <= 0 {
+		fmt.Fprintf(
+			w,
+			"Scheduled queues:\t%v\n",
+			maps.Keys(
+				armadamaps.Filter(
+					sctx.QueueSchedulingContexts,
+					func(_ string, qctx *QueueSchedulingContext) bool {
+						return len(qctx.SuccessfulJobSchedulingContexts) > 0
+					},
+				),
+			),
+		)
+		fmt.Fprintf(
+			w,
+			"Preempted queues:\t%v\n",
+			maps.Keys(
+				armadamaps.Filter(
+					sctx.QueueSchedulingContexts,
+					func(_ string, qctx *QueueSchedulingContext) bool {
+						return len(qctx.EvictedJobsById) > 0
+					},
+				),
+			),
+		)
+	} else {
+		fmt.Fprint(w, "Queues:\n")
+		for queueName, qctx := range sctx.QueueSchedulingContexts {
+			fmt.Fprintf(w, "\t%s:\n", queueName)
+			fmt.Fprintf(w, indent.String("\t\t", qctx.ReportString(verbosity-1)))
+		}
+	}
 	w.Flush()
 	return sb.String()
 }
@@ -277,67 +303,81 @@ type QueueSchedulingContext struct {
 	EvictedJobsById map[string]bool
 }
 
-const maxPrintedJobIdsByReason = 1
+func GetSchedulingContextFromQueueSchedulingContext(qctx *QueueSchedulingContext) *SchedulingContext {
+	if qctx == nil {
+		return nil
+	}
+	return qctx.SchedulingContext
+}
 
 func (qctx *QueueSchedulingContext) String() string {
+	return qctx.ReportString(0)
+}
+
+const maxPrintedJobIdsByReason = 1
+
+func (qctx *QueueSchedulingContext) ReportString(verbosity int32) string {
 	var sb strings.Builder
 	w := tabwriter.NewWriter(&sb, 1, 1, 1, ' ', 0)
-	fmt.Fprintf(w, "Time:\t%s\n", qctx.Created)
-	fmt.Fprintf(w, "Queue:\t%s\n", qctx.Queue)
-	fmt.Fprintf(w, "Total allocated resources after scheduling:\t%s\n", qctx.AllocatedByPriority.AggregateByResource().CompactString())
-	fmt.Fprintf(w, "Total allocated resources after scheduling (by priority):\t%s\n", qctx.AllocatedByPriority.String())
+	if verbosity > 0 {
+		fmt.Fprintf(w, "Created:\t%s\n", qctx.Created)
+	}
 	fmt.Fprintf(w, "Scheduled resources:\t%s\n", qctx.ScheduledResourcesByPriority.AggregateByResource().CompactString())
 	fmt.Fprintf(w, "Scheduled resources (by priority):\t%s\n", qctx.ScheduledResourcesByPriority.String())
 	fmt.Fprintf(w, "Preempted resources:\t%s\n", qctx.EvictedResourcesByPriority.AggregateByResource().CompactString())
 	fmt.Fprintf(w, "Preempted resources (by priority):\t%s\n", qctx.EvictedResourcesByPriority.String())
-	fmt.Fprintf(w, "Number of jobs scheduled:\t%d\n", len(qctx.SuccessfulJobSchedulingContexts))
-	fmt.Fprintf(w, "Number of jobs that could not be scheduled:\t%d\n", len(qctx.UnsuccessfulJobSchedulingContexts))
-	fmt.Fprintf(w, "Number of jobs preempted:\t%d\n", len(qctx.EvictedJobsById))
-	if len(qctx.SuccessfulJobSchedulingContexts) > 0 {
-		jobIdsToPrint := maps.Keys(qctx.SuccessfulJobSchedulingContexts)
-		if len(jobIdsToPrint) > maxPrintedJobIdsByReason {
-			jobIdsToPrint = jobIdsToPrint[0:maxPrintedJobIdsByReason]
-		}
-		fmt.Fprintf(w, "Scheduled jobs:\t%v", jobIdsToPrint)
-		if len(jobIdsToPrint) != len(qctx.SuccessfulJobSchedulingContexts) {
-			fmt.Fprintf(w, " (and %d others not shown)\n", len(qctx.SuccessfulJobSchedulingContexts)-len(jobIdsToPrint))
-		} else {
-			fmt.Fprint(w, "\n")
-		}
-	}
-	if len(qctx.UnsuccessfulJobSchedulingContexts) > 0 {
-		fmt.Fprint(w, "Unschedulable jobs:\n")
-		for reason, jobIds := range armadaslices.MapAndGroupByFuncs(
-			maps.Values(qctx.UnsuccessfulJobSchedulingContexts),
-			func(jctx *JobSchedulingContext) string {
-				return jctx.UnschedulableReason
-			},
-			func(jctx *JobSchedulingContext) string {
-				return jctx.JobId
-			},
-		) {
-			jobIdsToPrint := jobIds
-			if len(jobIdsToPrint) > maxPrintedJobIdsByReason {
-				jobIdsToPrint = jobIds[0:maxPrintedJobIdsByReason]
+	if verbosity > 0 {
+		fmt.Fprintf(w, "Total allocated resources after scheduling:\t%s\n", qctx.AllocatedByPriority.AggregateByResource().CompactString())
+		fmt.Fprintf(w, "Total allocated resources after scheduling (by priority):\t%s\n", qctx.AllocatedByPriority.String())
+		fmt.Fprintf(w, "Number of jobs scheduled:\t%d\n", len(qctx.SuccessfulJobSchedulingContexts))
+		fmt.Fprintf(w, "Number of jobs that could not be scheduled:\t%d\n", len(qctx.UnsuccessfulJobSchedulingContexts))
+		fmt.Fprintf(w, "Number of jobs preempted:\t%d\n", len(qctx.EvictedJobsById))
+		if len(qctx.SuccessfulJobSchedulingContexts) > 0 {
+			jobIdsToPrint := maps.Keys(qctx.SuccessfulJobSchedulingContexts)
+			if verbosity <= 1 && len(jobIdsToPrint) > maxPrintedJobIdsByReason {
+				jobIdsToPrint = jobIdsToPrint[0:maxPrintedJobIdsByReason]
 			}
-			fmt.Fprintf(w, "\t%d:\t%s jobs\t%v", len(qctx.UnsuccessfulJobSchedulingContexts), reason, jobIdsToPrint)
-			if len(jobIdsToPrint) != len(jobIds) {
-				fmt.Fprintf(w, " (and %d others not shown)\n", len(jobIds)-len(jobIdsToPrint))
+			fmt.Fprintf(w, "Scheduled jobs:\t%v", jobIdsToPrint)
+			if len(jobIdsToPrint) != len(qctx.SuccessfulJobSchedulingContexts) {
+				fmt.Fprintf(w, " (and %d others not shown)\n", len(qctx.SuccessfulJobSchedulingContexts)-len(jobIdsToPrint))
 			} else {
 				fmt.Fprint(w, "\n")
 			}
 		}
-	}
-	if len(qctx.EvictedJobsById) > 0 {
-		jobIdsToPrint := maps.Keys(qctx.EvictedJobsById)
-		if len(jobIdsToPrint) > maxPrintedJobIdsByReason {
-			jobIdsToPrint = jobIdsToPrint[0:maxPrintedJobIdsByReason]
+		if len(qctx.UnsuccessfulJobSchedulingContexts) > 0 {
+			fmt.Fprint(w, "Unschedulable jobs:\n")
+			for reason, jobIds := range armadaslices.MapAndGroupByFuncs(
+				maps.Values(qctx.UnsuccessfulJobSchedulingContexts),
+				func(jctx *JobSchedulingContext) string {
+					return jctx.UnschedulableReason
+				},
+				func(jctx *JobSchedulingContext) string {
+					return jctx.JobId
+				},
+			) {
+				jobIdsToPrint := jobIds
+				if verbosity <= 1 && len(jobIdsToPrint) > maxPrintedJobIdsByReason {
+					jobIdsToPrint = jobIds[0:maxPrintedJobIdsByReason]
+				}
+				fmt.Fprintf(w, "\t%d:\t%s jobs\t%v", len(qctx.UnsuccessfulJobSchedulingContexts), reason, jobIdsToPrint)
+				if len(jobIdsToPrint) != len(jobIds) {
+					fmt.Fprintf(w, " (and %d others not shown)\n", len(jobIds)-len(jobIdsToPrint))
+				} else {
+					fmt.Fprint(w, "\n")
+				}
+			}
 		}
-		fmt.Fprintf(w, "Preempted jobs:\t%v", jobIdsToPrint)
-		if len(jobIdsToPrint) != len(qctx.EvictedJobsById) {
-			fmt.Fprintf(w, " (and %d others not shown)\n", len(qctx.EvictedJobsById)-len(jobIdsToPrint))
-		} else {
-			fmt.Fprint(w, "\n")
+		if len(qctx.EvictedJobsById) > 0 {
+			jobIdsToPrint := maps.Keys(qctx.EvictedJobsById)
+			if verbosity <= 1 && len(jobIdsToPrint) > maxPrintedJobIdsByReason {
+				jobIdsToPrint = jobIdsToPrint[0:maxPrintedJobIdsByReason]
+			}
+			fmt.Fprintf(w, "Preempted jobs:\t%v", jobIdsToPrint)
+			if len(jobIdsToPrint) != len(qctx.EvictedJobsById) {
+				fmt.Fprintf(w, " (and %d others not shown)\n", len(qctx.EvictedJobsById)-len(jobIdsToPrint))
+			} else {
+				fmt.Fprint(w, "\n")
+			}
 		}
 	}
 	w.Flush()

--- a/internal/scheduler/context/context.go
+++ b/internal/scheduler/context/context.go
@@ -127,7 +127,7 @@ func (sctx *SchedulingContext) ReportString(verbosity int32) string {
 	fmt.Fprintf(w, "Finished:\t%s\n", sctx.Finished)
 	fmt.Fprintf(w, "Duration:\t%s\n", sctx.Finished.Sub(sctx.Started))
 	fmt.Fprintf(w, "Termination reason:\t%s\n", sctx.TerminationReason)
-	fmt.Fprintf(w, "Available resources before scheduling:\t%s\n", sctx.TotalResources.CompactString())
+	fmt.Fprintf(w, "Total capacity:\t%s\n", sctx.TotalResources.CompactString())
 	fmt.Fprintf(w, "Scheduled resources:\t%s\n", sctx.ScheduledResources.CompactString())
 	fmt.Fprintf(w, "Number of jobs scheduled:\t%d\n", sctx.NumScheduledJobs)
 	if verbosity <= 0 {

--- a/internal/scheduler/reports.go
+++ b/internal/scheduler/reports.go
@@ -222,6 +222,7 @@ func (repo *SchedulingContextRepository) addQueueSchedulingContexts(qctxs []*sch
 
 	repo.mostRecentQueueSchedulingContextByExecutorByQueueP.Store(&mostRecentQueueSchedulingContextByExecutorByQueue)
 	repo.mostRecentSuccessfulQueueSchedulingContextByExecutorByQueueP.Store(&mostRecentSuccessfulQueueSchedulingContextByExecutorByQueue)
+	repo.mostRecentPreemptingQueueSchedulingContextByExecutorByQueueP.Store(&mostRecentPreemptingQueueSchedulingContextByExecutorByQueue)
 
 	return nil
 }

--- a/internal/scheduler/reports.go
+++ b/internal/scheduler/reports.go
@@ -304,7 +304,7 @@ func (repo *SchedulingContextRepository) getSchedulingReportForJob(jobId string)
 	mostRecentSuccessful := make(map[string]*schedulercontext.QueueSchedulingContext)
 	for _, byExecutor := range *repo.mostRecentSuccessfulQueueSchedulingContextByExecutorByQueueP.Load() {
 		for executorId, qctx := range byExecutor {
-			if existing, existed := mostRecent[executorId]; existed && qctx.Created.Before(existing.Created) {
+			if existing, existed := mostRecentSuccessful[executorId]; existed && qctx.Created.Before(existing.Created) {
 				continue
 			}
 			if _, successful := qctx.SuccessfulJobSchedulingContexts[jobId]; successful {
@@ -316,7 +316,7 @@ func (repo *SchedulingContextRepository) getSchedulingReportForJob(jobId string)
 	mostRecentPreempting := make(map[string]*schedulercontext.QueueSchedulingContext)
 	for _, byExecutor := range *repo.mostRecentPreemptingQueueSchedulingContextByExecutorByQueueP.Load() {
 		for executorId, qctx := range byExecutor {
-			if existing, existed := mostRecent[executorId]; existed && qctx.Created.Before(existing.Created) {
+			if existing, existed := mostRecentPreempting[executorId]; existed && qctx.Created.Before(existing.Created) {
 				continue
 			}
 			if _, preempted := qctx.EvictedJobsById[jobId]; preempted {

--- a/internal/scheduler/reports.go
+++ b/internal/scheduler/reports.go
@@ -8,7 +8,6 @@ import (
 	"sync/atomic"
 	"text/tabwriter"
 
-	"github.com/gogo/protobuf/types"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/oklog/ulid"
 	"github.com/openconfig/goyang/pkg/indent"
@@ -17,6 +16,7 @@ import (
 	"golang.org/x/exp/slices"
 
 	"github.com/armadaproject/armada/internal/common/armadaerrors"
+	armadamaps "github.com/armadaproject/armada/internal/common/maps"
 	schedulercontext "github.com/armadaproject/armada/internal/scheduler/context"
 	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
 )
@@ -39,7 +39,7 @@ type SchedulingContextRepository struct {
 	mostRecentQueueSchedulingContextByExecutorByQueueP atomic.Pointer[map[string]QueueSchedulingContextByExecutor]
 	// The most recent attempt where a non-zero amount of resources were scheduled.
 	mostRecentSuccessfulQueueSchedulingContextByExecutorByQueueP atomic.Pointer[map[string]QueueSchedulingContextByExecutor]
-	// Map from queue name to most recent attempt that preempted at least one job belonging to this queue.
+	// The most recent attempt that preempted at least one job belonging to this queue.
 	mostRecentPreemptingQueueSchedulingContextByExecutorByQueueP atomic.Pointer[map[string]QueueSchedulingContextByExecutor]
 
 	// Maps job id to JobSchedulingContextByExecutor.
@@ -271,41 +271,129 @@ func extractQueueAndJobContexts(sctx *schedulercontext.SchedulingContext) (map[s
 	return queueSchedulingContextByQueue, jobSchedulingContextByJobId
 }
 
-// GetSchedulingReport is a gRPC endpoint for querying scheduler reports.
-// TODO: Further separate this from internal contexts.
-func (repo *SchedulingContextRepository) GetSchedulingReport(_ context.Context, _ *types.Empty) (*schedulerobjects.SchedulingReport, error) {
-	return &schedulerobjects.SchedulingReport{
-		Report: repo.getSchedulingReportString(),
-	}, nil
+func (repo *SchedulingContextRepository) getSchedulingReportForQueue(queueName string) schedulingReport {
+	mostRecent, _ := repo.GetMostRecentQueueSchedulingContextByExecutor(queueName)
+	mostRecentSuccessful, _ := repo.GetMostRecentSuccessfulQueueSchedulingContextByExecutor(queueName)
+	mostRecentPreempting, _ := repo.GetMostRecentPreemptingQueueSchedulingContextByExecutor(queueName)
+
+	return schedulingReport{
+		mostRecentSchedulingContextByExecutor:           armadamaps.MapValues(mostRecent, schedulercontext.GetSchedulingContextFromQueueSchedulingContext),
+		mostRecentSuccessfulSchedulingContextByExecutor: armadamaps.MapValues(mostRecentSuccessful, schedulercontext.GetSchedulingContextFromQueueSchedulingContext),
+		mostRecentPreemptingSchedulingContextByExecutor: armadamaps.MapValues(mostRecentPreempting, schedulercontext.GetSchedulingContextFromQueueSchedulingContext),
+
+		sortedExecutorIds: repo.GetSortedExecutorIds(),
+	}
 }
 
-func (repo *SchedulingContextRepository) getSchedulingReportString() string {
-	sortedExecutorIds := repo.GetSortedExecutorIds()
-	mostRecentSchedulingContextByExecutor := repo.GetMostRecentSchedulingContextByExecutor()
-	mostRecentSuccessfulSchedulingContextByExecutor := repo.GetMostRecentSuccessfulSchedulingContextByExecutor()
-	mostRecentPreemptingSchedulingContextByExecutor := repo.GetMostRecentPreemptingSchedulingContextByExecutor()
+func (repo *SchedulingContextRepository) getSchedulingReportForJob(jobId string) schedulingReport {
+	mostRecent := make(map[string]*schedulercontext.QueueSchedulingContext)
+	for _, byExecutor := range *repo.mostRecentQueueSchedulingContextByExecutorByQueueP.Load() {
+		for executorId, qctx := range byExecutor {
+			if existing, existed := mostRecent[executorId]; existed && qctx.Created.Before(existing.Created) {
+				continue
+			}
+			_, successful := qctx.SuccessfulJobSchedulingContexts[jobId]
+			_, unsuccessful := qctx.UnsuccessfulJobSchedulingContexts[jobId]
+			_, preempted := qctx.EvictedJobsById[jobId]
+			if successful || unsuccessful || preempted {
+				mostRecent[executorId] = qctx
+			}
+		}
+	}
+
+	mostRecentSuccessful := make(map[string]*schedulercontext.QueueSchedulingContext)
+	for _, byExecutor := range *repo.mostRecentSuccessfulQueueSchedulingContextByExecutorByQueueP.Load() {
+		for executorId, qctx := range byExecutor {
+			if existing, existed := mostRecent[executorId]; existed && qctx.Created.Before(existing.Created) {
+				continue
+			}
+			if _, successful := qctx.SuccessfulJobSchedulingContexts[jobId]; successful {
+				mostRecentSuccessful[executorId] = qctx
+			}
+		}
+	}
+
+	mostRecentPreempting := make(map[string]*schedulercontext.QueueSchedulingContext)
+	for _, byExecutor := range *repo.mostRecentPreemptingQueueSchedulingContextByExecutorByQueueP.Load() {
+		for executorId, qctx := range byExecutor {
+			if existing, existed := mostRecent[executorId]; existed && qctx.Created.Before(existing.Created) {
+				continue
+			}
+			if _, preempted := qctx.EvictedJobsById[jobId]; preempted {
+				mostRecentPreempting[executorId] = qctx
+			}
+		}
+	}
+
+	return schedulingReport{
+		mostRecentSchedulingContextByExecutor:           armadamaps.MapValues(mostRecent, schedulercontext.GetSchedulingContextFromQueueSchedulingContext),
+		mostRecentSuccessfulSchedulingContextByExecutor: armadamaps.MapValues(mostRecentSuccessful, schedulercontext.GetSchedulingContextFromQueueSchedulingContext),
+		mostRecentPreemptingSchedulingContextByExecutor: armadamaps.MapValues(mostRecentPreempting, schedulercontext.GetSchedulingContextFromQueueSchedulingContext),
+
+		sortedExecutorIds: repo.GetSortedExecutorIds(),
+	}
+}
+
+func (repo *SchedulingContextRepository) getSchedulingReport() schedulingReport {
+	return schedulingReport{
+		mostRecentSchedulingContextByExecutor:           repo.GetMostRecentSchedulingContextByExecutor(),
+		mostRecentSuccessfulSchedulingContextByExecutor: repo.GetMostRecentSuccessfulSchedulingContextByExecutor(),
+		mostRecentPreemptingSchedulingContextByExecutor: repo.GetMostRecentPreemptingSchedulingContextByExecutor(),
+
+		sortedExecutorIds: repo.GetSortedExecutorIds(),
+	}
+}
+
+// GetSchedulingReport is a gRPC endpoint for querying scheduler reports.
+// TODO: Further separate this from internal contexts.
+func (repo *SchedulingContextRepository) GetSchedulingReport(_ context.Context, request *schedulerobjects.SchedulingReportRequest) (*schedulerobjects.SchedulingReport, error) {
+	var sr schedulingReport
+
+	switch filter := request.GetFilter().(type) {
+	case *schedulerobjects.SchedulingReportRequest_MostRecentForQueue:
+		queueName := strings.TrimSpace(filter.MostRecentForQueue.GetQueueName())
+		sr = repo.getSchedulingReportForQueue(queueName)
+	case *schedulerobjects.SchedulingReportRequest_MostRecentForJob:
+		jobId := strings.TrimSpace(filter.MostRecentForJob.GetJobId())
+		sr = repo.getSchedulingReportForJob(jobId)
+	default:
+		sr = repo.getSchedulingReport()
+	}
+
+	return &schedulerobjects.SchedulingReport{Report: sr.ReportString(request.GetVerbosity())}, nil
+}
+
+type schedulingReport struct {
+	mostRecentSchedulingContextByExecutor           SchedulingContextByExecutor
+	mostRecentSuccessfulSchedulingContextByExecutor SchedulingContextByExecutor
+	mostRecentPreemptingSchedulingContextByExecutor SchedulingContextByExecutor
+
+	sortedExecutorIds []string
+}
+
+func (sr schedulingReport) ReportString(verbosity int32) string {
 	var sb strings.Builder
 	w := tabwriter.NewWriter(&sb, 1, 1, 1, ' ', 0)
-	for _, executorId := range sortedExecutorIds {
+	for _, executorId := range sr.sortedExecutorIds {
 		fmt.Fprintf(w, "%s:\n", executorId)
-		sctx := mostRecentSchedulingContextByExecutor[executorId]
+		sctx := sr.mostRecentSchedulingContextByExecutor[executorId]
 		if sctx != nil {
 			fmt.Fprint(w, indent.String("\t", "Most recent attempt:\n"))
-			fmt.Fprint(w, indent.String("\t\t", sctx.String()))
+			fmt.Fprint(w, indent.String("\t\t", sctx.ReportString(verbosity)))
 		} else {
 			fmt.Fprint(w, indent.String("\t", "Most recent attempt: none\n"))
 		}
-		sctx = mostRecentSuccessfulSchedulingContextByExecutor[executorId]
+		sctx = sr.mostRecentSuccessfulSchedulingContextByExecutor[executorId]
 		if sctx != nil {
 			fmt.Fprint(w, indent.String("\t", "Most recent successful attempt:\n"))
-			fmt.Fprint(w, indent.String("\t\t", sctx.String()))
+			fmt.Fprint(w, indent.String("\t\t", sctx.ReportString(verbosity)))
 		} else {
 			fmt.Fprint(w, indent.String("\t", "Most recent successful attempt: none\n"))
 		}
-		sctx = mostRecentPreemptingSchedulingContextByExecutor[executorId]
+		sctx = sr.mostRecentPreemptingSchedulingContextByExecutor[executorId]
 		if sctx != nil {
 			fmt.Fprint(w, indent.String("\t", "Most recent preempting attempt:\n"))
-			fmt.Fprint(w, indent.String("\t\t", sctx.String()))
+			fmt.Fprint(w, indent.String("\t\t", sctx.ReportString(verbosity)))
 		} else {
 			fmt.Fprint(w, indent.String("\t", "Most recent preempting attempt: none\n"))
 		}
@@ -316,14 +404,15 @@ func (repo *SchedulingContextRepository) getSchedulingReportString() string {
 
 // GetQueueReport is a gRPC endpoint for querying queue reports.
 // TODO: Further separate this from internal contexts.
-func (repo *SchedulingContextRepository) GetQueueReport(_ context.Context, queue *schedulerobjects.Queue) (*schedulerobjects.QueueReport, error) {
-	queueName := strings.TrimSpace(queue.Name)
+func (repo *SchedulingContextRepository) GetQueueReport(_ context.Context, request *schedulerobjects.QueueReportRequest) (*schedulerobjects.QueueReport, error) {
+	queueName := strings.TrimSpace(request.GetQueueName())
+	verbosity := request.GetVerbosity()
 	return &schedulerobjects.QueueReport{
-		Report: repo.getQueueReportString(queueName),
+		Report: repo.getQueueReportString(queueName, verbosity),
 	}, nil
 }
 
-func (repo *SchedulingContextRepository) getQueueReportString(queue string) string {
+func (repo *SchedulingContextRepository) getQueueReportString(queue string, verbosity int32) string {
 	var sb strings.Builder
 	w := tabwriter.NewWriter(&sb, 1, 1, 1, ' ', 0)
 	sortedExecutorIds := repo.GetSortedExecutorIds()
@@ -335,21 +424,21 @@ func (repo *SchedulingContextRepository) getQueueReportString(queue string) stri
 		qctx := mostRecentQueueSchedulingContextByExecutor[executorId]
 		if qctx != nil {
 			fmt.Fprint(w, indent.String("\t", "Most recent attempt:\n"))
-			fmt.Fprint(w, indent.String("\t\t", qctx.String()))
+			fmt.Fprint(w, indent.String("\t\t", qctx.ReportString(verbosity)))
 		} else {
 			fmt.Fprint(w, indent.String("\t", "Most recent attempt: none\n"))
 		}
 		qctx = mostRecentSuccessfulQueueSchedulingContextByExecutor[executorId]
 		if qctx != nil {
 			fmt.Fprint(w, indent.String("\t", "Most recent successful attempt:\n"))
-			fmt.Fprint(w, indent.String("\t\t", qctx.String()))
+			fmt.Fprint(w, indent.String("\t\t", qctx.ReportString(verbosity)))
 		} else {
 			fmt.Fprint(w, indent.String("\t", "Most recent successful attempt: none\n"))
 		}
 		qctx = mostRecentPreemptingQueueSchedulingContextByExecutor[executorId]
 		if qctx != nil {
 			fmt.Fprint(w, indent.String("\t", "Most recent preempting attempt:\n"))
-			fmt.Fprint(w, indent.String("\t\t", qctx.String()))
+			fmt.Fprint(w, indent.String("\t\t", qctx.ReportString(verbosity)))
 		} else {
 			fmt.Fprint(w, indent.String("\t", "Most recent preempting attempt: none\n"))
 		}
@@ -360,17 +449,17 @@ func (repo *SchedulingContextRepository) getQueueReportString(queue string) stri
 
 // GetJobReport is a gRPC endpoint for querying job reports.
 // TODO: Further separate this from internal contexts.
-func (repo *SchedulingContextRepository) GetJobReport(_ context.Context, jobId *schedulerobjects.JobId) (*schedulerobjects.JobReport, error) {
-	key := strings.TrimSpace(jobId.Id)
-	if _, err := ulid.Parse(key); err != nil {
+func (repo *SchedulingContextRepository) GetJobReport(_ context.Context, request *schedulerobjects.JobReportRequest) (*schedulerobjects.JobReport, error) {
+	jobId := strings.TrimSpace(request.GetJobId())
+	if _, err := ulid.Parse(jobId); err != nil {
 		return nil, &armadaerrors.ErrInvalidArgument{
 			Name:    "jobId",
-			Value:   jobId.Id,
-			Message: fmt.Sprintf("%s is not a valid jobId", jobId.Id),
+			Value:   request.GetJobId(),
+			Message: fmt.Sprintf("%s is not a valid jobId", request.GetJobId()),
 		}
 	}
 	return &schedulerobjects.JobReport{
-		Report: repo.getJobReportString(key),
+		Report: repo.getJobReportString(jobId),
 	}, nil
 }
 

--- a/internal/scheduler/reports_test.go
+++ b/internal/scheduler/reports_test.go
@@ -220,8 +220,8 @@ func TestTestAddGetSchedulingContextConcurrency(t *testing.T) {
 			default:
 			}
 			repo.getJobReportString(fmt.Sprintf("failure%s", queue))
-			repo.getQueueReportString(queue)
-			repo.getSchedulingReportString()
+			repo.getQueueReportString(queue, 0)
+			repo.getSchedulingReport().ReportString(0)
 		}(queue)
 	}
 	<-ctx.Done()

--- a/internal/scheduler/schedulerobjects/reporting.pb.go
+++ b/internal/scheduler/schedulerobjects/reporting.pb.go
@@ -11,7 +11,7 @@ import (
 	math_bits "math/bits"
 
 	proto "github.com/gogo/protobuf/proto"
-	types "github.com/gogo/protobuf/types"
+	_ "github.com/gogo/protobuf/types"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -28,6 +28,188 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+type MostRecentForQueue struct {
+	QueueName string `protobuf:"bytes,1,opt,name=queue_name,json=queueName,proto3" json:"queueName,omitempty"`
+}
+
+func (m *MostRecentForQueue) Reset()         { *m = MostRecentForQueue{} }
+func (m *MostRecentForQueue) String() string { return proto.CompactTextString(m) }
+func (*MostRecentForQueue) ProtoMessage()    {}
+func (*MostRecentForQueue) Descriptor() ([]byte, []int) {
+	return fileDescriptor_131a439a3ff6540b, []int{0}
+}
+func (m *MostRecentForQueue) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MostRecentForQueue) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MostRecentForQueue.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MostRecentForQueue) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MostRecentForQueue.Merge(m, src)
+}
+func (m *MostRecentForQueue) XXX_Size() int {
+	return m.Size()
+}
+func (m *MostRecentForQueue) XXX_DiscardUnknown() {
+	xxx_messageInfo_MostRecentForQueue.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MostRecentForQueue proto.InternalMessageInfo
+
+func (m *MostRecentForQueue) GetQueueName() string {
+	if m != nil {
+		return m.QueueName
+	}
+	return ""
+}
+
+type MostRecentForJob struct {
+	JobId string `protobuf:"bytes,1,opt,name=job_id,json=jobId,proto3" json:"jobId,omitempty"`
+}
+
+func (m *MostRecentForJob) Reset()         { *m = MostRecentForJob{} }
+func (m *MostRecentForJob) String() string { return proto.CompactTextString(m) }
+func (*MostRecentForJob) ProtoMessage()    {}
+func (*MostRecentForJob) Descriptor() ([]byte, []int) {
+	return fileDescriptor_131a439a3ff6540b, []int{1}
+}
+func (m *MostRecentForJob) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MostRecentForJob) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MostRecentForJob.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MostRecentForJob) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MostRecentForJob.Merge(m, src)
+}
+func (m *MostRecentForJob) XXX_Size() int {
+	return m.Size()
+}
+func (m *MostRecentForJob) XXX_DiscardUnknown() {
+	xxx_messageInfo_MostRecentForJob.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MostRecentForJob proto.InternalMessageInfo
+
+func (m *MostRecentForJob) GetJobId() string {
+	if m != nil {
+		return m.JobId
+	}
+	return ""
+}
+
+type SchedulingReportRequest struct {
+	// Types that are valid to be assigned to Filter:
+	//
+	//	*SchedulingReportRequest_MostRecentForQueue
+	//	*SchedulingReportRequest_MostRecentForJob
+	Filter    isSchedulingReportRequest_Filter `protobuf_oneof:"filter"`
+	Verbosity int32                            `protobuf:"varint,3,opt,name=verbosity,proto3" json:"verbosity,omitempty"`
+}
+
+func (m *SchedulingReportRequest) Reset()         { *m = SchedulingReportRequest{} }
+func (m *SchedulingReportRequest) String() string { return proto.CompactTextString(m) }
+func (*SchedulingReportRequest) ProtoMessage()    {}
+func (*SchedulingReportRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_131a439a3ff6540b, []int{2}
+}
+func (m *SchedulingReportRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *SchedulingReportRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_SchedulingReportRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *SchedulingReportRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SchedulingReportRequest.Merge(m, src)
+}
+func (m *SchedulingReportRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *SchedulingReportRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_SchedulingReportRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_SchedulingReportRequest proto.InternalMessageInfo
+
+type isSchedulingReportRequest_Filter interface {
+	isSchedulingReportRequest_Filter()
+	MarshalTo([]byte) (int, error)
+	Size() int
+}
+
+type SchedulingReportRequest_MostRecentForQueue struct {
+	MostRecentForQueue *MostRecentForQueue `protobuf:"bytes,1,opt,name=most_recent_for_queue,json=mostRecentForQueue,proto3,oneof" json:"mostRecentForQueue,omitempty"`
+}
+type SchedulingReportRequest_MostRecentForJob struct {
+	MostRecentForJob *MostRecentForJob `protobuf:"bytes,2,opt,name=most_recent_for_job,json=mostRecentForJob,proto3,oneof" json:"mostRecentForJob,omitempty"`
+}
+
+func (*SchedulingReportRequest_MostRecentForQueue) isSchedulingReportRequest_Filter() {}
+func (*SchedulingReportRequest_MostRecentForJob) isSchedulingReportRequest_Filter()   {}
+
+func (m *SchedulingReportRequest) GetFilter() isSchedulingReportRequest_Filter {
+	if m != nil {
+		return m.Filter
+	}
+	return nil
+}
+
+func (m *SchedulingReportRequest) GetMostRecentForQueue() *MostRecentForQueue {
+	if x, ok := m.GetFilter().(*SchedulingReportRequest_MostRecentForQueue); ok {
+		return x.MostRecentForQueue
+	}
+	return nil
+}
+
+func (m *SchedulingReportRequest) GetMostRecentForJob() *MostRecentForJob {
+	if x, ok := m.GetFilter().(*SchedulingReportRequest_MostRecentForJob); ok {
+		return x.MostRecentForJob
+	}
+	return nil
+}
+
+func (m *SchedulingReportRequest) GetVerbosity() int32 {
+	if m != nil {
+		return m.Verbosity
+	}
+	return 0
+}
+
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*SchedulingReportRequest) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
+		(*SchedulingReportRequest_MostRecentForQueue)(nil),
+		(*SchedulingReportRequest_MostRecentForJob)(nil),
+	}
+}
+
 type SchedulingReport struct {
 	Report string `protobuf:"bytes,1,opt,name=report,proto3" json:"report,omitempty"`
 }
@@ -36,7 +218,7 @@ func (m *SchedulingReport) Reset()         { *m = SchedulingReport{} }
 func (m *SchedulingReport) String() string { return proto.CompactTextString(m) }
 func (*SchedulingReport) ProtoMessage()    {}
 func (*SchedulingReport) Descriptor() ([]byte, []int) {
-	return fileDescriptor_131a439a3ff6540b, []int{0}
+	return fileDescriptor_131a439a3ff6540b, []int{3}
 }
 func (m *SchedulingReport) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -72,22 +254,23 @@ func (m *SchedulingReport) GetReport() string {
 	return ""
 }
 
-type Queue struct {
-	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+type QueueReportRequest struct {
+	QueueName string `protobuf:"bytes,1,opt,name=queue_name,json=queueName,proto3" json:"queueName,omitempty"`
+	Verbosity int32  `protobuf:"varint,2,opt,name=verbosity,proto3" json:"verbosity,omitempty"`
 }
 
-func (m *Queue) Reset()         { *m = Queue{} }
-func (m *Queue) String() string { return proto.CompactTextString(m) }
-func (*Queue) ProtoMessage()    {}
-func (*Queue) Descriptor() ([]byte, []int) {
-	return fileDescriptor_131a439a3ff6540b, []int{1}
+func (m *QueueReportRequest) Reset()         { *m = QueueReportRequest{} }
+func (m *QueueReportRequest) String() string { return proto.CompactTextString(m) }
+func (*QueueReportRequest) ProtoMessage()    {}
+func (*QueueReportRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_131a439a3ff6540b, []int{4}
 }
-func (m *Queue) XXX_Unmarshal(b []byte) error {
+func (m *QueueReportRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *Queue) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *QueueReportRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
-		return xxx_messageInfo_Queue.Marshal(b, m, deterministic)
+		return xxx_messageInfo_QueueReportRequest.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
 		n, err := m.MarshalToSizedBuffer(b)
@@ -97,23 +280,30 @@ func (m *Queue) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
-func (m *Queue) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Queue.Merge(m, src)
+func (m *QueueReportRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueueReportRequest.Merge(m, src)
 }
-func (m *Queue) XXX_Size() int {
+func (m *QueueReportRequest) XXX_Size() int {
 	return m.Size()
 }
-func (m *Queue) XXX_DiscardUnknown() {
-	xxx_messageInfo_Queue.DiscardUnknown(m)
+func (m *QueueReportRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueueReportRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_Queue proto.InternalMessageInfo
+var xxx_messageInfo_QueueReportRequest proto.InternalMessageInfo
 
-func (m *Queue) GetName() string {
+func (m *QueueReportRequest) GetQueueName() string {
 	if m != nil {
-		return m.Name
+		return m.QueueName
 	}
 	return ""
+}
+
+func (m *QueueReportRequest) GetVerbosity() int32 {
+	if m != nil {
+		return m.Verbosity
+	}
+	return 0
 }
 
 type QueueReport struct {
@@ -124,7 +314,7 @@ func (m *QueueReport) Reset()         { *m = QueueReport{} }
 func (m *QueueReport) String() string { return proto.CompactTextString(m) }
 func (*QueueReport) ProtoMessage()    {}
 func (*QueueReport) Descriptor() ([]byte, []int) {
-	return fileDescriptor_131a439a3ff6540b, []int{2}
+	return fileDescriptor_131a439a3ff6540b, []int{5}
 }
 func (m *QueueReport) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -160,22 +350,22 @@ func (m *QueueReport) GetReport() string {
 	return ""
 }
 
-type JobId struct {
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+type JobReportRequest struct {
+	JobId string `protobuf:"bytes,1,opt,name=job_id,json=jobId,proto3" json:"jobId,omitempty"`
 }
 
-func (m *JobId) Reset()         { *m = JobId{} }
-func (m *JobId) String() string { return proto.CompactTextString(m) }
-func (*JobId) ProtoMessage()    {}
-func (*JobId) Descriptor() ([]byte, []int) {
-	return fileDescriptor_131a439a3ff6540b, []int{3}
+func (m *JobReportRequest) Reset()         { *m = JobReportRequest{} }
+func (m *JobReportRequest) String() string { return proto.CompactTextString(m) }
+func (*JobReportRequest) ProtoMessage()    {}
+func (*JobReportRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_131a439a3ff6540b, []int{6}
 }
-func (m *JobId) XXX_Unmarshal(b []byte) error {
+func (m *JobReportRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *JobId) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *JobReportRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
-		return xxx_messageInfo_JobId.Marshal(b, m, deterministic)
+		return xxx_messageInfo_JobReportRequest.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
 		n, err := m.MarshalToSizedBuffer(b)
@@ -185,21 +375,21 @@ func (m *JobId) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
-func (m *JobId) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_JobId.Merge(m, src)
+func (m *JobReportRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_JobReportRequest.Merge(m, src)
 }
-func (m *JobId) XXX_Size() int {
+func (m *JobReportRequest) XXX_Size() int {
 	return m.Size()
 }
-func (m *JobId) XXX_DiscardUnknown() {
-	xxx_messageInfo_JobId.DiscardUnknown(m)
+func (m *JobReportRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_JobReportRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_JobId proto.InternalMessageInfo
+var xxx_messageInfo_JobReportRequest proto.InternalMessageInfo
 
-func (m *JobId) GetId() string {
+func (m *JobReportRequest) GetJobId() string {
 	if m != nil {
-		return m.Id
+		return m.JobId
 	}
 	return ""
 }
@@ -212,7 +402,7 @@ func (m *JobReport) Reset()         { *m = JobReport{} }
 func (m *JobReport) String() string { return proto.CompactTextString(m) }
 func (*JobReport) ProtoMessage()    {}
 func (*JobReport) Descriptor() ([]byte, []int) {
-	return fileDescriptor_131a439a3ff6540b, []int{4}
+	return fileDescriptor_131a439a3ff6540b, []int{7}
 }
 func (m *JobReport) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -249,10 +439,13 @@ func (m *JobReport) GetReport() string {
 }
 
 func init() {
+	proto.RegisterType((*MostRecentForQueue)(nil), "schedulerobjects.MostRecentForQueue")
+	proto.RegisterType((*MostRecentForJob)(nil), "schedulerobjects.MostRecentForJob")
+	proto.RegisterType((*SchedulingReportRequest)(nil), "schedulerobjects.SchedulingReportRequest")
 	proto.RegisterType((*SchedulingReport)(nil), "schedulerobjects.SchedulingReport")
-	proto.RegisterType((*Queue)(nil), "schedulerobjects.Queue")
+	proto.RegisterType((*QueueReportRequest)(nil), "schedulerobjects.QueueReportRequest")
 	proto.RegisterType((*QueueReport)(nil), "schedulerobjects.QueueReport")
-	proto.RegisterType((*JobId)(nil), "schedulerobjects.JobId")
+	proto.RegisterType((*JobReportRequest)(nil), "schedulerobjects.JobReportRequest")
 	proto.RegisterType((*JobReport)(nil), "schedulerobjects.JobReport")
 }
 
@@ -261,30 +454,41 @@ func init() {
 }
 
 var fileDescriptor_131a439a3ff6540b = []byte{
-	// 356 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x92, 0xc1, 0x6a, 0xea, 0x40,
-	0x14, 0x86, 0x8d, 0x5c, 0x05, 0xcf, 0x15, 0x09, 0x73, 0x2f, 0xf7, 0x96, 0x48, 0xa3, 0x64, 0x51,
-	0x5a, 0x90, 0x19, 0xa8, 0xab, 0xd2, 0x4d, 0xb1, 0x2d, 0xb6, 0xee, 0xd4, 0x5d, 0xa1, 0x8b, 0xc4,
-	0x9c, 0xc6, 0x29, 0x26, 0x13, 0xc6, 0xc9, 0xa2, 0x6f, 0xd1, 0xc7, 0xea, 0xd2, 0x65, 0x57, 0x52,
-	0x74, 0xe7, 0x0b, 0x74, 0x5b, 0x9c, 0x44, 0x14, 0xb5, 0x50, 0xdc, 0x65, 0xf2, 0x9f, 0xef, 0x3f,
-	0xe4, 0xcb, 0x40, 0x93, 0x47, 0x0a, 0x65, 0xe4, 0x8e, 0xd8, 0x78, 0x30, 0x44, 0x3f, 0x19, 0xa1,
-	0x5c, 0x3f, 0x09, 0xef, 0x19, 0x07, 0x6a, 0xcc, 0x24, 0xc6, 0x42, 0x2a, 0x1e, 0x05, 0x34, 0x96,
-	0x42, 0x09, 0x62, 0x6e, 0x4f, 0x58, 0xd5, 0x40, 0x88, 0x60, 0x84, 0x4c, 0xe7, 0x5e, 0xf2, 0xc4,
-	0x30, 0x8c, 0xd5, 0x4b, 0x3a, 0xee, 0x5c, 0x81, 0xd9, 0x4f, 0x01, 0x1e, 0x05, 0x3d, 0xdd, 0x45,
-	0x1a, 0x50, 0x4c, 0x5b, 0x8f, 0x8c, 0xba, 0x71, 0x5a, 0x6a, 0xfd, 0x5d, 0x4c, 0x6b, 0x66, 0xfa,
-	0xa6, 0x21, 0x42, 0xae, 0x34, 0xdf, 0xcb, 0x66, 0x1c, 0x06, 0x85, 0x6e, 0x82, 0x09, 0x92, 0x13,
-	0xf8, 0x15, 0xb9, 0x21, 0x66, 0x10, 0x59, 0x4c, 0x6b, 0x95, 0xe5, 0x79, 0x03, 0xd1, 0xb9, 0x73,
-	0x09, 0xbf, 0x35, 0x70, 0xd0, 0xb6, 0x33, 0x28, 0x74, 0x84, 0x77, 0xef, 0x93, 0x3a, 0xe4, 0xb9,
-	0x9f, 0x21, 0xe6, 0x62, 0x5a, 0x2b, 0x73, 0x7f, 0x63, 0x3c, 0xcf, 0x7d, 0xe7, 0x02, 0x4a, 0x1d,
-	0xe1, 0x1d, 0xb2, 0xe5, 0xfc, 0xd3, 0x00, 0xd2, 0x5f, 0x79, 0xec, 0xad, 0x0c, 0x93, 0x2e, 0xfc,
-	0x69, 0xa3, 0xda, 0xf1, 0xf5, 0x8f, 0xa6, 0x86, 0xe9, 0xca, 0x30, 0xbd, 0x5d, 0xb6, 0x59, 0x0e,
-	0xdd, 0xfe, 0x17, 0x74, 0x87, 0xbd, 0x83, 0x4a, 0x1b, 0xd5, 0xa6, 0x8f, 0xff, 0xbb, 0x94, 0x8e,
-	0xad, 0xe3, 0x6f, 0x82, 0x8c, 0xbb, 0x81, 0x72, 0x1b, 0xd5, 0xfa, 0x8b, 0xf7, 0xf4, 0x68, 0x73,
-	0x56, 0x75, 0x6f, 0x90, 0x52, 0xad, 0xc7, 0xb7, 0x99, 0x6d, 0x4c, 0x66, 0xb6, 0xf1, 0x31, 0xb3,
-	0x8d, 0xd7, 0xb9, 0x9d, 0x9b, 0xcc, 0xed, 0xdc, 0xfb, 0xdc, 0xce, 0x3d, 0x5c, 0x07, 0x5c, 0x0d,
-	0x13, 0x8f, 0x0e, 0x44, 0xc8, 0x5c, 0x19, 0xba, 0xbe, 0x1b, 0x4b, 0xb1, 0xc4, 0xb3, 0x13, 0xfb,
-	0xc1, 0x6d, 0xf5, 0x8a, 0x5a, 0x51, 0xf3, 0x2b, 0x00, 0x00, 0xff, 0xff, 0xcd, 0xc1, 0x68, 0xdb,
-	0xdb, 0x02, 0x00, 0x00,
+	// 529 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x54, 0xcf, 0x6a, 0x13, 0x5f,
+	0x14, 0xce, 0xe4, 0x47, 0xc3, 0x2f, 0xa7, 0xa2, 0xc3, 0x8d, 0xd2, 0x90, 0xea, 0x24, 0x0c, 0x2e,
+	0xaa, 0x94, 0x0c, 0xb4, 0x28, 0x88, 0x50, 0x24, 0x82, 0xd1, 0xe0, 0x1f, 0x9c, 0xe2, 0x46, 0x90,
+	0x30, 0x37, 0x39, 0x49, 0x27, 0x64, 0xe6, 0xa4, 0x77, 0xee, 0x08, 0xc5, 0xa5, 0x2f, 0xe0, 0x33,
+	0xf8, 0x34, 0x2e, 0x5c, 0x74, 0xe9, 0x2a, 0x48, 0xb2, 0x9b, 0xa7, 0x90, 0xde, 0x49, 0x93, 0xf9,
+	0x53, 0xdb, 0xc6, 0xdd, 0xcc, 0x77, 0xcf, 0xfd, 0xce, 0xf9, 0xce, 0x77, 0xce, 0x85, 0x7d, 0xd7,
+	0x97, 0x28, 0x7c, 0x67, 0x6c, 0x05, 0xbd, 0x23, 0xec, 0x87, 0x63, 0x14, 0xab, 0x2f, 0xe2, 0x23,
+	0xec, 0xc9, 0xc0, 0x12, 0x38, 0x21, 0x21, 0x5d, 0x7f, 0xd8, 0x9c, 0x08, 0x92, 0xc4, 0xf4, 0x6c,
+	0x44, 0x6d, 0x7b, 0x48, 0x34, 0x1c, 0xa3, 0xa5, 0xce, 0x79, 0x38, 0xb0, 0xd0, 0x9b, 0xc8, 0x93,
+	0x38, 0xdc, 0x7c, 0x0d, 0xec, 0x0d, 0x05, 0xd2, 0xc6, 0x1e, 0xfa, 0xf2, 0x05, 0x89, 0xf7, 0x21,
+	0x86, 0xc8, 0x1e, 0x03, 0x1c, 0x9f, 0x7d, 0x74, 0x7d, 0xc7, 0xc3, 0xaa, 0xd6, 0xd0, 0x76, 0xca,
+	0xad, 0xad, 0x68, 0x5a, 0xaf, 0x28, 0xf4, 0xad, 0xe3, 0xe1, 0x2e, 0x79, 0xae, 0x54, 0x44, 0x76,
+	0x79, 0x09, 0x9a, 0x07, 0xa0, 0xa7, 0xd8, 0x3a, 0xc4, 0xd9, 0x43, 0x28, 0x8d, 0x88, 0x77, 0xdd,
+	0xfe, 0x82, 0xa7, 0x12, 0x4d, 0xeb, 0xb7, 0x46, 0xc4, 0x5f, 0xf5, 0x13, 0x1c, 0x1b, 0x0a, 0x30,
+	0x7f, 0x16, 0x61, 0xeb, 0x30, 0xae, 0xdf, 0xf5, 0x87, 0xb6, 0x92, 0x66, 0xe3, 0x71, 0x88, 0x81,
+	0x64, 0x5f, 0xe0, 0x8e, 0x47, 0x81, 0xec, 0x0a, 0x45, 0xde, 0x1d, 0x90, 0xe8, 0xaa, 0xc4, 0x8a,
+	0x76, 0x73, 0xef, 0x7e, 0x33, 0x2b, 0xbc, 0x99, 0x17, 0xd6, 0x6a, 0x44, 0xd3, 0xfa, 0x5d, 0x2f,
+	0x87, 0xaf, 0x2a, 0x79, 0x59, 0xb0, 0x59, 0xfe, 0x9c, 0x05, 0x50, 0xc9, 0x26, 0x1f, 0x11, 0xaf,
+	0x16, 0x55, 0x6a, 0xf3, 0x8a, 0xd4, 0x1d, 0xe2, 0x2d, 0x23, 0x9a, 0xd6, 0x6b, 0x5e, 0x06, 0x4d,
+	0xa5, 0xd5, 0xb3, 0xa7, 0xec, 0x11, 0x94, 0x3f, 0xa3, 0xe0, 0x14, 0xb8, 0xf2, 0xa4, 0xfa, 0x5f,
+	0x43, 0xdb, 0xd9, 0x88, 0x4d, 0x58, 0x82, 0x49, 0x13, 0x96, 0x60, 0xeb, 0x7f, 0x28, 0x0d, 0xdc,
+	0xb1, 0x44, 0x61, 0x3e, 0x03, 0x3d, 0xdb, 0x4d, 0xb6, 0x0b, 0xa5, 0x78, 0x64, 0x16, 0x76, 0xdc,
+	0x8e, 0xa6, 0x75, 0x3d, 0x46, 0x12, 0x74, 0x8b, 0x18, 0xf3, 0xab, 0x06, 0x4c, 0x75, 0x20, 0xed,
+	0xc5, 0x3f, 0xce, 0x47, 0x5a, 0x51, 0xf1, 0xba, 0x8a, 0xcc, 0xa7, 0xb0, 0x99, 0x28, 0x62, 0x4d,
+	0x09, 0x07, 0xa0, 0x77, 0x88, 0xa7, 0xeb, 0x5f, 0x67, 0x26, 0x9f, 0x40, 0x79, 0x79, 0x7f, 0xbd,
+	0xd4, 0x7b, 0xdf, 0x8b, 0xc0, 0x0e, 0xcf, 0x47, 0xc3, 0x3e, 0x5f, 0x54, 0xd6, 0x87, 0x4a, 0x1b,
+	0x65, 0xce, 0x99, 0x07, 0xf9, 0x31, 0xfa, 0xcb, 0x2e, 0xd4, 0xcc, 0xab, 0x43, 0xd9, 0x07, 0xb8,
+	0xd9, 0x46, 0x99, 0xec, 0xdb, 0x05, 0x2b, 0x92, 0xf7, 0xb6, 0x76, 0xef, 0xd2, 0x28, 0xf6, 0x0e,
+	0x6e, 0xb4, 0x51, 0xae, 0x3a, 0x72, 0x41, 0x29, 0xd9, 0x76, 0xd7, 0xb6, 0x2f, 0x89, 0x69, 0x7d,
+	0xfa, 0x31, 0x33, 0xb4, 0xd3, 0x99, 0xa1, 0xfd, 0x9e, 0x19, 0xda, 0xb7, 0xb9, 0x51, 0x38, 0x9d,
+	0x1b, 0x85, 0x5f, 0x73, 0xa3, 0xf0, 0xf1, 0xf9, 0xd0, 0x95, 0x47, 0x21, 0x6f, 0xf6, 0xc8, 0xb3,
+	0x1c, 0xe1, 0x39, 0x7d, 0x67, 0x22, 0xe8, 0xec, 0xfa, 0xe2, 0xcf, 0xba, 0xc6, 0xfb, 0xc8, 0x4b,
+	0xea, 0x9d, 0xdb, 0xff, 0x13, 0x00, 0x00, 0xff, 0xff, 0xf1, 0xb4, 0x16, 0xb6, 0x4d, 0x05, 0x00,
+	0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -300,11 +504,11 @@ const _ = grpc.SupportPackageIsVersion4
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type SchedulerReportingClient interface {
 	// Return the most recent scheduling report for each executor.
-	GetSchedulingReport(ctx context.Context, in *types.Empty, opts ...grpc.CallOption) (*SchedulingReport, error)
+	GetSchedulingReport(ctx context.Context, in *SchedulingReportRequest, opts ...grpc.CallOption) (*SchedulingReport, error)
 	// Return the most recent report scheduling for each executor for the given queue.
-	GetQueueReport(ctx context.Context, in *Queue, opts ...grpc.CallOption) (*QueueReport, error)
+	GetQueueReport(ctx context.Context, in *QueueReportRequest, opts ...grpc.CallOption) (*QueueReport, error)
 	// Return the most recent scheduling report for each executor for the given job.
-	GetJobReport(ctx context.Context, in *JobId, opts ...grpc.CallOption) (*JobReport, error)
+	GetJobReport(ctx context.Context, in *JobReportRequest, opts ...grpc.CallOption) (*JobReport, error)
 }
 
 type schedulerReportingClient struct {
@@ -315,7 +519,7 @@ func NewSchedulerReportingClient(cc *grpc.ClientConn) SchedulerReportingClient {
 	return &schedulerReportingClient{cc}
 }
 
-func (c *schedulerReportingClient) GetSchedulingReport(ctx context.Context, in *types.Empty, opts ...grpc.CallOption) (*SchedulingReport, error) {
+func (c *schedulerReportingClient) GetSchedulingReport(ctx context.Context, in *SchedulingReportRequest, opts ...grpc.CallOption) (*SchedulingReport, error) {
 	out := new(SchedulingReport)
 	err := c.cc.Invoke(ctx, "/schedulerobjects.SchedulerReporting/GetSchedulingReport", in, out, opts...)
 	if err != nil {
@@ -324,7 +528,7 @@ func (c *schedulerReportingClient) GetSchedulingReport(ctx context.Context, in *
 	return out, nil
 }
 
-func (c *schedulerReportingClient) GetQueueReport(ctx context.Context, in *Queue, opts ...grpc.CallOption) (*QueueReport, error) {
+func (c *schedulerReportingClient) GetQueueReport(ctx context.Context, in *QueueReportRequest, opts ...grpc.CallOption) (*QueueReport, error) {
 	out := new(QueueReport)
 	err := c.cc.Invoke(ctx, "/schedulerobjects.SchedulerReporting/GetQueueReport", in, out, opts...)
 	if err != nil {
@@ -333,7 +537,7 @@ func (c *schedulerReportingClient) GetQueueReport(ctx context.Context, in *Queue
 	return out, nil
 }
 
-func (c *schedulerReportingClient) GetJobReport(ctx context.Context, in *JobId, opts ...grpc.CallOption) (*JobReport, error) {
+func (c *schedulerReportingClient) GetJobReport(ctx context.Context, in *JobReportRequest, opts ...grpc.CallOption) (*JobReport, error) {
 	out := new(JobReport)
 	err := c.cc.Invoke(ctx, "/schedulerobjects.SchedulerReporting/GetJobReport", in, out, opts...)
 	if err != nil {
@@ -345,24 +549,24 @@ func (c *schedulerReportingClient) GetJobReport(ctx context.Context, in *JobId, 
 // SchedulerReportingServer is the server API for SchedulerReporting service.
 type SchedulerReportingServer interface {
 	// Return the most recent scheduling report for each executor.
-	GetSchedulingReport(context.Context, *types.Empty) (*SchedulingReport, error)
+	GetSchedulingReport(context.Context, *SchedulingReportRequest) (*SchedulingReport, error)
 	// Return the most recent report scheduling for each executor for the given queue.
-	GetQueueReport(context.Context, *Queue) (*QueueReport, error)
+	GetQueueReport(context.Context, *QueueReportRequest) (*QueueReport, error)
 	// Return the most recent scheduling report for each executor for the given job.
-	GetJobReport(context.Context, *JobId) (*JobReport, error)
+	GetJobReport(context.Context, *JobReportRequest) (*JobReport, error)
 }
 
 // UnimplementedSchedulerReportingServer can be embedded to have forward compatible implementations.
 type UnimplementedSchedulerReportingServer struct {
 }
 
-func (*UnimplementedSchedulerReportingServer) GetSchedulingReport(ctx context.Context, req *types.Empty) (*SchedulingReport, error) {
+func (*UnimplementedSchedulerReportingServer) GetSchedulingReport(ctx context.Context, req *SchedulingReportRequest) (*SchedulingReport, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetSchedulingReport not implemented")
 }
-func (*UnimplementedSchedulerReportingServer) GetQueueReport(ctx context.Context, req *Queue) (*QueueReport, error) {
+func (*UnimplementedSchedulerReportingServer) GetQueueReport(ctx context.Context, req *QueueReportRequest) (*QueueReport, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetQueueReport not implemented")
 }
-func (*UnimplementedSchedulerReportingServer) GetJobReport(ctx context.Context, req *JobId) (*JobReport, error) {
+func (*UnimplementedSchedulerReportingServer) GetJobReport(ctx context.Context, req *JobReportRequest) (*JobReport, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetJobReport not implemented")
 }
 
@@ -371,7 +575,7 @@ func RegisterSchedulerReportingServer(s *grpc.Server, srv SchedulerReportingServ
 }
 
 func _SchedulerReporting_GetSchedulingReport_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(types.Empty)
+	in := new(SchedulingReportRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -383,13 +587,13 @@ func _SchedulerReporting_GetSchedulingReport_Handler(srv interface{}, ctx contex
 		FullMethod: "/schedulerobjects.SchedulerReporting/GetSchedulingReport",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(SchedulerReportingServer).GetSchedulingReport(ctx, req.(*types.Empty))
+		return srv.(SchedulerReportingServer).GetSchedulingReport(ctx, req.(*SchedulingReportRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
 func _SchedulerReporting_GetQueueReport_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(Queue)
+	in := new(QueueReportRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -401,13 +605,13 @@ func _SchedulerReporting_GetQueueReport_Handler(srv interface{}, ctx context.Con
 		FullMethod: "/schedulerobjects.SchedulerReporting/GetQueueReport",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(SchedulerReportingServer).GetQueueReport(ctx, req.(*Queue))
+		return srv.(SchedulerReportingServer).GetQueueReport(ctx, req.(*QueueReportRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
 func _SchedulerReporting_GetJobReport_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(JobId)
+	in := new(JobReportRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -419,7 +623,7 @@ func _SchedulerReporting_GetJobReport_Handler(srv interface{}, ctx context.Conte
 		FullMethod: "/schedulerobjects.SchedulerReporting/GetJobReport",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(SchedulerReportingServer).GetJobReport(ctx, req.(*JobId))
+		return srv.(SchedulerReportingServer).GetJobReport(ctx, req.(*JobReportRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -445,6 +649,145 @@ var _SchedulerReporting_serviceDesc = grpc.ServiceDesc{
 	Metadata: "internal/scheduler/schedulerobjects/reporting.proto",
 }
 
+func (m *MostRecentForQueue) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MostRecentForQueue) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MostRecentForQueue) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.QueueName) > 0 {
+		i -= len(m.QueueName)
+		copy(dAtA[i:], m.QueueName)
+		i = encodeVarintReporting(dAtA, i, uint64(len(m.QueueName)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *MostRecentForJob) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MostRecentForJob) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MostRecentForJob) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.JobId) > 0 {
+		i -= len(m.JobId)
+		copy(dAtA[i:], m.JobId)
+		i = encodeVarintReporting(dAtA, i, uint64(len(m.JobId)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *SchedulingReportRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *SchedulingReportRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *SchedulingReportRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Verbosity != 0 {
+		i = encodeVarintReporting(dAtA, i, uint64(m.Verbosity))
+		i--
+		dAtA[i] = 0x18
+	}
+	if m.Filter != nil {
+		{
+			size := m.Filter.Size()
+			i -= size
+			if _, err := m.Filter.MarshalTo(dAtA[i:]); err != nil {
+				return 0, err
+			}
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *SchedulingReportRequest_MostRecentForQueue) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *SchedulingReportRequest_MostRecentForQueue) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.MostRecentForQueue != nil {
+		{
+			size, err := m.MostRecentForQueue.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintReporting(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+func (m *SchedulingReportRequest_MostRecentForJob) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *SchedulingReportRequest_MostRecentForJob) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.MostRecentForJob != nil {
+		{
+			size, err := m.MostRecentForJob.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintReporting(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x12
+	}
+	return len(dAtA) - i, nil
+}
 func (m *SchedulingReport) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -475,7 +818,7 @@ func (m *SchedulingReport) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-func (m *Queue) Marshal() (dAtA []byte, err error) {
+func (m *QueueReportRequest) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -485,20 +828,25 @@ func (m *Queue) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *Queue) MarshalTo(dAtA []byte) (int, error) {
+func (m *QueueReportRequest) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *Queue) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *QueueReportRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.Name) > 0 {
-		i -= len(m.Name)
-		copy(dAtA[i:], m.Name)
-		i = encodeVarintReporting(dAtA, i, uint64(len(m.Name)))
+	if m.Verbosity != 0 {
+		i = encodeVarintReporting(dAtA, i, uint64(m.Verbosity))
+		i--
+		dAtA[i] = 0x10
+	}
+	if len(m.QueueName) > 0 {
+		i -= len(m.QueueName)
+		copy(dAtA[i:], m.QueueName)
+		i = encodeVarintReporting(dAtA, i, uint64(len(m.QueueName)))
 		i--
 		dAtA[i] = 0xa
 	}
@@ -535,7 +883,7 @@ func (m *QueueReport) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-func (m *JobId) Marshal() (dAtA []byte, err error) {
+func (m *JobReportRequest) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -545,20 +893,20 @@ func (m *JobId) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *JobId) MarshalTo(dAtA []byte) (int, error) {
+func (m *JobReportRequest) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *JobId) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *JobReportRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.Id) > 0 {
-		i -= len(m.Id)
-		copy(dAtA[i:], m.Id)
-		i = encodeVarintReporting(dAtA, i, uint64(len(m.Id)))
+	if len(m.JobId) > 0 {
+		i -= len(m.JobId)
+		copy(dAtA[i:], m.JobId)
+		i = encodeVarintReporting(dAtA, i, uint64(len(m.JobId)))
 		i--
 		dAtA[i] = 0xa
 	}
@@ -606,6 +954,71 @@ func encodeVarintReporting(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+func (m *MostRecentForQueue) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.QueueName)
+	if l > 0 {
+		n += 1 + l + sovReporting(uint64(l))
+	}
+	return n
+}
+
+func (m *MostRecentForJob) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.JobId)
+	if l > 0 {
+		n += 1 + l + sovReporting(uint64(l))
+	}
+	return n
+}
+
+func (m *SchedulingReportRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Filter != nil {
+		n += m.Filter.Size()
+	}
+	if m.Verbosity != 0 {
+		n += 1 + sovReporting(uint64(m.Verbosity))
+	}
+	return n
+}
+
+func (m *SchedulingReportRequest_MostRecentForQueue) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.MostRecentForQueue != nil {
+		l = m.MostRecentForQueue.Size()
+		n += 1 + l + sovReporting(uint64(l))
+	}
+	return n
+}
+func (m *SchedulingReportRequest_MostRecentForJob) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.MostRecentForJob != nil {
+		l = m.MostRecentForJob.Size()
+		n += 1 + l + sovReporting(uint64(l))
+	}
+	return n
+}
 func (m *SchedulingReport) Size() (n int) {
 	if m == nil {
 		return 0
@@ -619,15 +1032,18 @@ func (m *SchedulingReport) Size() (n int) {
 	return n
 }
 
-func (m *Queue) Size() (n int) {
+func (m *QueueReportRequest) Size() (n int) {
 	if m == nil {
 		return 0
 	}
 	var l int
 	_ = l
-	l = len(m.Name)
+	l = len(m.QueueName)
 	if l > 0 {
 		n += 1 + l + sovReporting(uint64(l))
+	}
+	if m.Verbosity != 0 {
+		n += 1 + sovReporting(uint64(m.Verbosity))
 	}
 	return n
 }
@@ -645,13 +1061,13 @@ func (m *QueueReport) Size() (n int) {
 	return n
 }
 
-func (m *JobId) Size() (n int) {
+func (m *JobReportRequest) Size() (n int) {
 	if m == nil {
 		return 0
 	}
 	var l int
 	_ = l
-	l = len(m.Id)
+	l = len(m.JobId)
 	if l > 0 {
 		n += 1 + l + sovReporting(uint64(l))
 	}
@@ -676,6 +1092,309 @@ func sovReporting(x uint64) (n int) {
 }
 func sozReporting(x uint64) (n int) {
 	return sovReporting(uint64((x << 1) ^ uint64((int64(x) >> 63))))
+}
+func (m *MostRecentForQueue) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowReporting
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MostRecentForQueue: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MostRecentForQueue: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field QueueName", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowReporting
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthReporting
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthReporting
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.QueueName = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipReporting(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthReporting
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MostRecentForJob) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowReporting
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MostRecentForJob: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MostRecentForJob: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field JobId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowReporting
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthReporting
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthReporting
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.JobId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipReporting(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthReporting
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *SchedulingReportRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowReporting
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: SchedulingReportRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: SchedulingReportRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MostRecentForQueue", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowReporting
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthReporting
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthReporting
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			v := &MostRecentForQueue{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			m.Filter = &SchedulingReportRequest_MostRecentForQueue{v}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MostRecentForJob", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowReporting
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthReporting
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthReporting
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			v := &MostRecentForJob{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			m.Filter = &SchedulingReportRequest_MostRecentForJob{v}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Verbosity", wireType)
+			}
+			m.Verbosity = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowReporting
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Verbosity |= int32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		default:
+			iNdEx = preIndex
+			skippy, err := skipReporting(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthReporting
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
 }
 func (m *SchedulingReport) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
@@ -759,7 +1478,7 @@ func (m *SchedulingReport) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *Queue) Unmarshal(dAtA []byte) error {
+func (m *QueueReportRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -782,15 +1501,15 @@ func (m *Queue) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: Queue: wiretype end group for non-group")
+			return fmt.Errorf("proto: QueueReportRequest: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: Queue: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: QueueReportRequest: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field QueueName", wireType)
 			}
 			var stringLen uint64
 			for shift := uint(0); ; shift += 7 {
@@ -818,8 +1537,27 @@ func (m *Queue) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Name = string(dAtA[iNdEx:postIndex])
+			m.QueueName = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Verbosity", wireType)
+			}
+			m.Verbosity = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowReporting
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Verbosity |= int32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := skipReporting(dAtA[iNdEx:])
@@ -923,7 +1661,7 @@ func (m *QueueReport) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *JobId) Unmarshal(dAtA []byte) error {
+func (m *JobReportRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -946,15 +1684,15 @@ func (m *JobId) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: JobId: wiretype end group for non-group")
+			return fmt.Errorf("proto: JobReportRequest: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: JobId: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: JobReportRequest: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Id", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field JobId", wireType)
 			}
 			var stringLen uint64
 			for shift := uint(0); ; shift += 7 {
@@ -982,7 +1720,7 @@ func (m *JobId) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Id = string(dAtA[iNdEx:postIndex])
+			m.JobId = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/internal/scheduler/schedulerobjects/reporting.proto
+++ b/internal/scheduler/schedulerobjects/reporting.proto
@@ -3,20 +3,39 @@ package schedulerobjects;
 import "google/protobuf/empty.proto";
 option go_package = "github.com/armadaproject/armada/internal/scheduler/schedulerobjects";
 
+message MostRecentForQueue {
+    string queue_name = 1;
+}
+
+message MostRecentForJob {
+    string job_id = 1;
+}
+
+message SchedulingReportRequest {
+    oneof filter {
+        MostRecentForQueue most_recent_for_queue = 1;
+        MostRecentForJob most_recent_for_job = 2;
+    }
+
+    int32 verbosity = 3;
+}
+
 message SchedulingReport {
     string report = 1;
 }
 
-message Queue {
-    string name = 1;
+message QueueReportRequest {
+    string queue_name = 1;
+
+    int32 verbosity = 2;
 }
 
 message QueueReport {
     string report = 1;
 }
 
-message JobId {
-    string id = 1;
+message JobReportRequest {
+    string job_id = 1;
 }
 
 message JobReport {
@@ -25,9 +44,9 @@ message JobReport {
 
 service SchedulerReporting {
     // Return the most recent scheduling report for each executor.
-    rpc GetSchedulingReport (google.protobuf.Empty) returns (SchedulingReport);
+    rpc GetSchedulingReport (SchedulingReportRequest) returns (SchedulingReport);
     // Return the most recent report scheduling for each executor for the given queue.
-    rpc GetQueueReport (Queue) returns (QueueReport);
+    rpc GetQueueReport (QueueReportRequest) returns (QueueReport);
     // Return the most recent scheduling report for each executor for the given job.
-    rpc GetJobReport (JobId) returns (JobReport);
+    rpc GetJobReport (JobReportRequest) returns (JobReport);
 }


### PR DESCRIPTION
# Summary

This PR implements the extended scheduling report interface from #2456.

The `scheduling-report` command of `armadactl` gains three new flags:

* `--queue` and `--job` can be used to get the most recent scheduling reports for the given queue or job.
* `-v`/`--verbose` increases the level of detail in the scheduling reports; repeating the argument (for example: `-vvv`) increases the level of detail further.

# Example

Here is the same report, generated by setting `--job` to the ID of a preempted job, at different levels of verbosity:

<details>
<summary>Verbosity: <code>0</code></summary>

```console
$ go run cmd/armadactl/main.go scheduling-report --job 01h2qdv3gs0651b4rv36kkv3cj
executor-01:
 Most recent attempt:
  Started:                  2023-03-22 16:34:39.5035361 +0000 GMT
  Finished:                 2023-03-22 16:34:39.5055666 +0000 GMT
  Duration:                 2.0305ms
  Termination reason:       no remaining candidate jobs
  Total capacity:           {cpu: 32, memory: 256Gi}
  Scheduled resources:      {memory: 128Gi, cpu: 16}
  Number of jobs scheduled: 16
  Scheduled queues:         [queue-bob]
  Preempted queues:         [queue-alice]
 Most recent successful attempt:
  Started:                  2023-03-22 16:29:39.5035361 +0000 GMT
  Finished:                 2023-03-22 16:29:39.5045666 +0000 GMT
  Duration:                 1.0305ms
  Termination reason:       no remaining candidate jobs
  Total capacity:           {cpu: 32, memory: 256Gi}
  Scheduled resources:      {cpu: 32, memory: 256Gi}
  Number of jobs scheduled: 32
  Scheduled queues:         [queue-alice]
  Preempted queues:         []
 Most recent preempting attempt:
  Started:                  2023-03-22 16:34:39.5035361 +0000 GMT
  Finished:                 2023-03-22 16:34:39.5055666 +0000 GMT
  Duration:                 2.0305ms
  Termination reason:       no remaining candidate jobs
  Total capacity:           {cpu: 32, memory: 256Gi}
  Scheduled resources:      {memory: 128Gi, cpu: 16}
  Number of jobs scheduled: 16
  Scheduled queues:         [queue-bob]
  Preempted queues:         [queue-alice]

```
</details>

<details>
<summary>Verbosity: <code>1</code></summary>

```console
$ go run cmd/armadactl/main.go scheduling-report --job 01h2qdv3gs0651b4rv36kkv3cj -v
executor-01:
 Most recent attempt:
  Started:                  2023-03-22 16:34:39.5035361 +0000 GMT
  Finished:                 2023-03-22 16:34:39.5055666 +0000 GMT
  Duration:                 2.0305ms
  Termination reason:       no remaining candidate jobs
  Total capacity:           {cpu: 32, memory: 256Gi}
  Scheduled resources:      {cpu: 16, memory: 128Gi}
  Number of jobs scheduled: 16
  Queues:
   queue-alice:
    Scheduled resources:               {}
    Scheduled resources (by priority): {}
    Preempted resources:               {memory: 128Gi, cpu: 16}
    Preempted resources (by priority): {0: {cpu: 16, memory: 128Gi}}
   queue-bob:
    Scheduled resources:               {cpu: 16, memory: 128Gi}
    Scheduled resources (by priority): {0: {cpu: 16, memory: 128Gi}}
    Preempted resources:               {}
    Preempted resources (by priority): {}
 Most recent successful attempt:
  Started:                  2023-03-22 16:29:39.5035361 +0000 GMT
  Finished:                 2023-03-22 16:29:39.5045666 +0000 GMT
  Duration:                 1.0305ms
  Termination reason:       no remaining candidate jobs
  Total capacity:           {cpu: 32, memory: 256Gi}
  Scheduled resources:      {cpu: 32, memory: 256Gi}
  Number of jobs scheduled: 32
  Queues:
   queue-alice:
    Scheduled resources:               {cpu: 32, memory: 256Gi}
    Scheduled resources (by priority): {0: {cpu: 32, memory: 256Gi}}
    Preempted resources:               {}
    Preempted resources (by priority): {}
   queue-bob:
    Scheduled resources:               {}
    Scheduled resources (by priority): {}
    Preempted resources:               {}
    Preempted resources (by priority): {}
 Most recent preempting attempt:
  Started:                  2023-03-22 16:34:39.5035361 +0000 GMT
  Finished:                 2023-03-22 16:34:39.5055666 +0000 GMT
  Duration:                 2.0305ms
  Termination reason:       no remaining candidate jobs
  Total capacity:           {cpu: 32, memory: 256Gi}
  Scheduled resources:      {cpu: 16, memory: 128Gi}
  Number of jobs scheduled: 16
  Queues:
   queue-alice:
    Scheduled resources:               {}
    Scheduled resources (by priority): {}
    Preempted resources:               {memory: 128Gi, cpu: 16}
    Preempted resources (by priority): {0: {memory: 128Gi, cpu: 16}}
   queue-bob:
    Scheduled resources:               {cpu: 16, memory: 128Gi}
    Scheduled resources (by priority): {0: {cpu: 16, memory: 128Gi}}
    Preempted resources:               {}
    Preempted resources (by priority): {}

```
</details>

<details>
<summary>Verbosity: <code>2</code></summary>

```console
$ go run cmd/armadactl/main.go scheduling-report --job 01h2qdv3gs0651b4rv36kkv3cj -vv
executor-01:
 Most recent attempt:
  Started:                  2023-03-22 16:34:39.5035361 +0000 GMT
  Finished:                 2023-03-22 16:34:39.5055666 +0000 GMT
  Duration:                 2.0305ms
  Termination reason:       no remaining candidate jobs
  Total capacity:           {memory: 256Gi, cpu: 32}
  Scheduled resources:      {cpu: 16, memory: 128Gi}
  Number of jobs scheduled: 16
  Queues:
   queue-bob:
    Created:                                                  2023-03-22 16:34:39.5035361 +0000 GMT
    Scheduled resources:                                      {cpu: 16, memory: 128Gi}
    Scheduled resources (by priority):                        {0: {memory: 128Gi, cpu: 16}}
    Preempted resources:                                      {}
    Preempted resources (by priority):                        {}
    Total allocated resources after scheduling:               {memory: 128Gi, cpu: 16}
    Total allocated resources after scheduling (by priority): {0: {cpu: 16, memory: 128Gi}}
    Number of jobs scheduled:                                 16
    Number of jobs that could not be scheduled:               0
    Number of jobs preempted:                                 0
    Scheduled jobs:                                           [01h2qdv3gtm1mp01rc6h1afzqx] (and 15 others not shown)
   queue-alice:
    Created:                                                  2023-03-22 16:34:39.5035361 +0000 GMT
    Scheduled resources:                                      {}
    Scheduled resources (by priority):                        {}
    Preempted resources:                                      {memory: 128Gi, cpu: 16}
    Preempted resources (by priority):                        {0: {memory: 128Gi, cpu: 16}}
    Total allocated resources after scheduling:               {cpu: 16, memory: 128Gi}
    Total allocated resources after scheduling (by priority): {0: {cpu: 16, memory: 128Gi}}
    Number of jobs scheduled:                                 0
    Number of jobs that could not be scheduled:               16
    Number of jobs preempted:                                 16
    Unschedulable jobs:
                    16: maximum total resources for this queue exceeded jobs [01h2qdv3gs0651b4rv36kkv3cj] (and 15 others not shown)
    Preempted jobs: [01h2qdv3gs0651b4rv36kkv3cj] (and 15 others not shown)
 Most recent successful attempt:
  Started:                  2023-03-22 16:29:39.5035361 +0000 GMT
  Finished:                 2023-03-22 16:29:39.5045666 +0000 GMT
  Duration:                 1.0305ms
  Termination reason:       no remaining candidate jobs
  Total capacity:           {cpu: 32, memory: 256Gi}
  Scheduled resources:      {cpu: 32, memory: 256Gi}
  Number of jobs scheduled: 32
  Queues:
   queue-alice:
    Created:                                                  2023-03-22 16:29:39.5035361 +0000 GMT
    Scheduled resources:                                      {cpu: 32, memory: 256Gi}
    Scheduled resources (by priority):                        {0: {cpu: 32, memory: 256Gi}}
    Preempted resources:                                      {}
    Preempted resources (by priority):                        {}
    Total allocated resources after scheduling:               {cpu: 48, memory: 384Gi}
    Total allocated resources after scheduling (by priority): {0: {cpu: 48, memory: 384Gi}}
    Number of jobs scheduled:                                 32
    Number of jobs that could not be scheduled:               0
    Number of jobs preempted:                                 0
    Scheduled jobs:                                           [01h2qdv3gs0651b4rv4dd2hkw9] (and 31 others not shown)
   queue-bob:
    Created:                                                  2023-03-22 16:29:39.5035361 +0000 GMT
    Scheduled resources:                                      {}
    Scheduled resources (by priority):                        {}
    Preempted resources:                                      {}
    Preempted resources (by priority):                        {}
    Total allocated resources after scheduling:               {}
    Total allocated resources after scheduling (by priority): {}
    Number of jobs scheduled:                                 0
    Number of jobs that could not be scheduled:               0
    Number of jobs preempted:                                 0
 Most recent preempting attempt:
  Started:                  2023-03-22 16:34:39.5035361 +0000 GMT
  Finished:                 2023-03-22 16:34:39.5055666 +0000 GMT
  Duration:                 2.0305ms
  Termination reason:       no remaining candidate jobs
  Total capacity:           {cpu: 32, memory: 256Gi}
  Scheduled resources:      {cpu: 16, memory: 128Gi}
  Number of jobs scheduled: 16
  Queues:
   queue-alice:
    Created:                                                  2023-03-22 16:34:39.5035361 +0000 GMT
    Scheduled resources:                                      {}
    Scheduled resources (by priority):                        {}
    Preempted resources:                                      {memory: 128Gi, cpu: 16}
    Preempted resources (by priority):                        {0: {memory: 128Gi, cpu: 16}}
    Total allocated resources after scheduling:               {cpu: 16, memory: 128Gi}
    Total allocated resources after scheduling (by priority): {0: {memory: 128Gi, cpu: 16}}
    Number of jobs scheduled:                                 0
    Number of jobs that could not be scheduled:               16
    Number of jobs preempted:                                 16
    Unschedulable jobs:
                    16: maximum total resources for this queue exceeded jobs [01h2qdv3gs0651b4rv3a4113yf] (and 15 others not shown)
    Preempted jobs: [01h2qdv3gs0651b4rv3kp81yps] (and 15 others not shown)
   queue-bob:
    Created:                                                  2023-03-22 16:34:39.5035361 +0000 GMT
    Scheduled resources:                                      {cpu: 16, memory: 128Gi}
    Scheduled resources (by priority):                        {0: {cpu: 16, memory: 128Gi}}
    Preempted resources:                                      {}
    Preempted resources (by priority):                        {}
    Total allocated resources after scheduling:               {cpu: 16, memory: 128Gi}
    Total allocated resources after scheduling (by priority): {0: {cpu: 16, memory: 128Gi}}
    Number of jobs scheduled:                                 16
    Number of jobs that could not be scheduled:               0
    Number of jobs preempted:                                 0
    Scheduled jobs:                                           [01h2qdv3gtm1mp01rc6ph4tkb8] (and 15 others not shown)

```
</details>

Note that the report points out which queues were scheduled when this job was preempted; at verbosities greater than `0`, it also points out the resources allocated to each of these queues.

# Implementation

The gRPC server implements this new behavior in terms of the existing `SchedulingContextRepository` type.