### PR TITLE
Job Service: remove redundant call

### DIFF
--- a/internal/jobservice/repository/sql_job_service_test.go
+++ b/internal/jobservice/repository/sql_job_service_test.go
@@ -308,14 +308,6 @@ func TestUpdateJobSetTime(t *testing.T) {
 	})
 }
 
-func TestUpdateJobSetTimeWithoutSubscribe(t *testing.T) {
-	WithSqlServiceRepo(purgeTime, func(r SQLJobService) {
-		ctx := context.Background()
-		updateErr := r.UpdateJobSetDb(ctx, "test", "job-set-1", "")
-		assert.EqualError(t, updateErr, "queue test jobSet job-set-1 is already unsubscribed")
-	})
-}
-
 func TestGetJobStatusAllStates(t *testing.T) {
 	WithSqlServiceRepo(purgeTime, func(r SQLJobService) {
 		ctx := context.Background()

--- a/internal/jobservice/repository/sqlite.go
+++ b/internal/jobservice/repository/sqlite.go
@@ -148,14 +148,11 @@ func (s *JSRepoSQLite) UpdateJobServiceDb(ctx context.Context, jobTable *JobStat
 	return errExec
 }
 
+// We should check if a JobSet exists first before updating the database and return an error if it doesn't exist.
+// However, The only caller of this function, in jobservice/server/server.go, does this check before calling.
+// Adding the check here will be redundant and a performance botteneck.
+// TODO: We should descend the check here and adjust the JobSet subscription logic in jobservice/server/server.go
 func (s *JSRepoSQLite) UpdateJobSetDb(ctx context.Context, queue string, jobSet string, fromMessageId string) error {
-	subscribe, _, err := s.IsJobSetSubscribed(ctx, queue, jobSet)
-	if err != nil {
-		return err
-	}
-	if !subscribe {
-		return fmt.Errorf("queue %s jobSet %s is already unsubscribed", queue, jobSet)
-	}
 	s.lock.Lock()
 	defer s.lock.Unlock()
 


### PR DESCRIPTION
Partially addresses #2494 
This is a temporary fix for the redundant call of `UpdateJobSetDb`. 
It is not a prefect to remove subscription check from `UpdateJobSetDb` because we should update only subscribed jobsets. However, the logic in `server.go` has to do this check first to subscribe any new incoming jobsets. So, I believe the current fix is not perfect but it is safe until a further broader changes to how we perform new jobset subscriptions.

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-350) by [Unito](https://www.unito.io)
