### PR TITLE
Store `SchedulingContext` for queues and jobs

### DIFF
--- a/internal/scheduler/reports.go
+++ b/internal/scheduler/reports.go
@@ -414,9 +414,18 @@ func (repo *SchedulingContextRepository) getQueueReportString(queue string, verb
 	var sb strings.Builder
 	w := tabwriter.NewWriter(&sb, 1, 1, 1, ' ', 0)
 	sortedExecutorIds := repo.GetSortedExecutorIds()
-	mostRecentByExecutor, _ := repo.GetMostRecentQueueSchedulingContextByExecutor(queue)
-	mostRecentSuccessfulByExecutor, _ := repo.GetMostRecentSuccessfulQueueSchedulingContextByExecutor(queue)
-	mostRecentPreemptingByExecutor, _ := repo.GetMostRecentPreemptingQueueSchedulingContextByExecutor(queue)
+	mostRecentByExecutor, ok := repo.GetMostRecentQueueSchedulingContextByExecutor(queue)
+	if !ok {
+		mostRecentByExecutor = make(QueueSchedulingContextByExecutor)
+	}
+	mostRecentSuccessfulByExecutor, ok := repo.GetMostRecentSuccessfulQueueSchedulingContextByExecutor(queue)
+	if !ok {
+		mostRecentSuccessfulByExecutor = make(QueueSchedulingContextByExecutor)
+	}
+	mostRecentPreemptingByExecutor, ok := repo.GetMostRecentPreemptingQueueSchedulingContextByExecutor(queue)
+	if !ok {
+		mostRecentPreemptingByExecutor = make(QueueSchedulingContextByExecutor)
+	}
 	for _, executorId := range sortedExecutorIds {
 		fmt.Fprintf(w, "%s:\n", executorId)
 		qctx := mostRecentByExecutor[executorId]

--- a/internal/scheduler/reports.go
+++ b/internal/scheduler/reports.go
@@ -269,18 +269,9 @@ func extractQueueAndJobSchedulingContexts(sctx *schedulercontext.SchedulingConte
 }
 
 func (repo *SchedulingContextRepository) getSchedulingReportStringForQueue(queue string, verbosity int32) string {
-	mostRecentByExecutor, ok := repo.GetMostRecentSchedulingContextByExecutorForQueue(queue)
-	if !ok {
-		mostRecentByExecutor = make(SchedulingContextByExecutor)
-	}
-	mostRecentSuccessfulByExecutor, ok := repo.GetMostRecentSuccessfulSchedulingContextByExecutorForQueue(queue)
-	if !ok {
-		mostRecentSuccessfulByExecutor = make(SchedulingContextByExecutor)
-	}
-	mostRecentPreemptingByExecutor, ok := repo.GetMostRecentPreemptingSchedulingContextByExecutorForQueue(queue)
-	if !ok {
-		mostRecentPreemptingByExecutor = make(SchedulingContextByExecutor)
-	}
+	mostRecentByExecutor, _ := repo.GetMostRecentSchedulingContextByExecutorForQueue(queue)
+	mostRecentSuccessfulByExecutor, _ := repo.GetMostRecentSuccessfulSchedulingContextByExecutorForQueue(queue)
+	mostRecentPreemptingByExecutor, _ := repo.GetMostRecentPreemptingSchedulingContextByExecutorForQueue(queue)
 	sr := schedulingReport{
 		mostRecentByExecutor:           mostRecentByExecutor,
 		mostRecentSuccessfulByExecutor: mostRecentSuccessfulByExecutor,
@@ -292,10 +283,7 @@ func (repo *SchedulingContextRepository) getSchedulingReportStringForQueue(queue
 }
 
 func (repo *SchedulingContextRepository) getSchedulingReportStringForJob(jobId string, verbosity int32) string {
-	mostRecentByExecutor, ok := repo.GetMostRecentSchedulingContextByExecutorForJob(jobId)
-	if !ok {
-		mostRecentByExecutor = make(SchedulingContextByExecutor)
-	}
+	mostRecentByExecutor, _ := repo.GetMostRecentSchedulingContextByExecutorForJob(jobId)
 	var sb strings.Builder
 	w := tabwriter.NewWriter(&sb, 1, 1, 1, ' ', 0)
 	for _, executorId := range repo.GetSortedExecutorIds() {
@@ -391,18 +379,9 @@ func (repo *SchedulingContextRepository) getQueueReportString(queue string, verb
 	var sb strings.Builder
 	w := tabwriter.NewWriter(&sb, 1, 1, 1, ' ', 0)
 	sortedExecutorIds := repo.GetSortedExecutorIds()
-	mostRecentByExecutor, ok := repo.GetMostRecentSchedulingContextByExecutorForQueue(queue)
-	if !ok {
-		mostRecentByExecutor = make(SchedulingContextByExecutor)
-	}
-	mostRecentSuccessfulByExecutor, ok := repo.GetMostRecentSuccessfulSchedulingContextByExecutorForQueue(queue)
-	if !ok {
-		mostRecentSuccessfulByExecutor = make(SchedulingContextByExecutor)
-	}
-	mostRecentPreemptingByExecutor, ok := repo.GetMostRecentPreemptingSchedulingContextByExecutorForQueue(queue)
-	if !ok {
-		mostRecentPreemptingByExecutor = make(SchedulingContextByExecutor)
-	}
+	mostRecentByExecutor, _ := repo.GetMostRecentSchedulingContextByExecutorForQueue(queue)
+	mostRecentSuccessfulByExecutor, _ := repo.GetMostRecentSuccessfulSchedulingContextByExecutorForQueue(queue)
+	mostRecentPreemptingByExecutor, _ := repo.GetMostRecentPreemptingSchedulingContextByExecutorForQueue(queue)
 	for _, executorId := range sortedExecutorIds {
 		fmt.Fprintf(w, "%s:\n", executorId)
 		if sctx := mostRecentByExecutor[executorId]; sctx != nil {
@@ -448,10 +427,7 @@ func (repo *SchedulingContextRepository) GetJobReport(_ context.Context, request
 }
 
 func (repo *SchedulingContextRepository) getJobReportString(jobId string) string {
-	byExecutor, ok := repo.GetMostRecentSchedulingContextByExecutorForJob(jobId)
-	if !ok {
-		byExecutor = make(SchedulingContextByExecutor)
-	}
+	byExecutor, _ := repo.GetMostRecentSchedulingContextByExecutorForJob(jobId)
 	var sb strings.Builder
 	w := tabwriter.NewWriter(&sb, 1, 1, 1, ' ', 0)
 	for _, executorId := range repo.GetSortedExecutorIds() {

--- a/internal/scheduler/reports.go
+++ b/internal/scheduler/reports.go
@@ -102,10 +102,10 @@ func (repo *SchedulingContextRepository) AddSchedulingContext(sctx *schedulercon
 	qctxs, jctxs := extractQueueAndJobContexts(sctx)
 	repo.mu.Lock()
 	defer repo.mu.Unlock()
-	if err := repo.addJobSchedulingContexts(sctx, jctxs); err != nil {
+	if err := repo.addSchedulingContextForJobs(sctx, jctxs); err != nil {
 		return err
 	}
-	if err := repo.addQueueSchedulingContexts(sctx, qctxs); err != nil {
+	if err := repo.addSchedulingContextForQueues(sctx, qctxs); err != nil {
 		return err
 	}
 	if err := repo.addSchedulingContext(sctx); err != nil {
@@ -155,7 +155,7 @@ func (repo *SchedulingContextRepository) addSchedulingContext(sctx *schedulercon
 }
 
 // Should only be called from AddSchedulingContext to avoid dirty writes.
-func (repo *SchedulingContextRepository) addQueueSchedulingContexts(sctx *schedulercontext.SchedulingContext, qctxs []*schedulercontext.QueueSchedulingContext) error {
+func (repo *SchedulingContextRepository) addSchedulingContextForQueues(sctx *schedulercontext.SchedulingContext, qctxs []*schedulercontext.QueueSchedulingContext) error {
 	executorId := sctx.ExecutorId
 	if executorId == "" {
 		return errors.WithStack(
@@ -220,7 +220,7 @@ func (repo *SchedulingContextRepository) addQueueSchedulingContexts(sctx *schedu
 }
 
 // Should only be called from AddSchedulingContext to avoid dirty writes.
-func (repo *SchedulingContextRepository) addJobSchedulingContexts(sctx *schedulercontext.SchedulingContext, jctxs []*schedulercontext.JobSchedulingContext) error {
+func (repo *SchedulingContextRepository) addSchedulingContextForJobs(sctx *schedulercontext.SchedulingContext, jctxs []*schedulercontext.JobSchedulingContext) error {
 	executorId := sctx.ExecutorId
 	if executorId == "" {
 		return errors.WithStack(

--- a/internal/scheduler/reports.go
+++ b/internal/scheduler/reports.go
@@ -408,23 +408,23 @@ func (repo *SchedulingContextRepository) getQueueReportString(queue string, verb
 	}
 	for _, executorId := range sortedExecutorIds {
 		fmt.Fprintf(w, "%s:\n", executorId)
-		qctx := mostRecentByExecutor[executorId]
-		if qctx != nil {
+		if sctx := mostRecentByExecutor[executorId]; sctx != nil {
 			fmt.Fprint(w, indent.String("\t", "Most recent attempt:\n"))
+			qctx := sctx.QueueSchedulingContexts[queue]
 			fmt.Fprint(w, indent.String("\t\t", qctx.ReportString(verbosity)))
 		} else {
 			fmt.Fprint(w, indent.String("\t", "Most recent attempt: none\n"))
 		}
-		qctx = mostRecentSuccessfulByExecutor[executorId]
-		if qctx != nil {
+		if sctx := mostRecentSuccessfulByExecutor[executorId]; sctx != nil {
 			fmt.Fprint(w, indent.String("\t", "Most recent successful attempt:\n"))
+			qctx := sctx.QueueSchedulingContexts[queue]
 			fmt.Fprint(w, indent.String("\t\t", qctx.ReportString(verbosity)))
 		} else {
 			fmt.Fprint(w, indent.String("\t", "Most recent successful attempt: none\n"))
 		}
-		qctx = mostRecentPreemptingByExecutor[executorId]
-		if qctx != nil {
+		if sctx := mostRecentPreemptingByExecutor[executorId]; sctx != nil {
 			fmt.Fprint(w, indent.String("\t", "Most recent preempting attempt:\n"))
+			qctx := sctx.QueueSchedulingContexts[queue]
 			fmt.Fprint(w, indent.String("\t\t", qctx.ReportString(verbosity)))
 		} else {
 			fmt.Fprint(w, indent.String("\t", "Most recent preempting attempt: none\n"))

--- a/internal/scheduler/reports.go
+++ b/internal/scheduler/reports.go
@@ -269,9 +269,18 @@ func extractQueueAndJobSchedulingContexts(sctx *schedulercontext.SchedulingConte
 }
 
 func (repo *SchedulingContextRepository) getSchedulingReportStringForQueue(queue string, verbosity int32) string {
-	mostRecentByExecutor, _ := repo.GetMostRecentSchedulingContextByExecutorForQueue(queue)
-	mostRecentSuccessfulByExecutor, _ := repo.GetMostRecentSuccessfulSchedulingContextByExecutorForQueue(queue)
-	mostRecentPreemptingByExecutor, _ := repo.GetMostRecentPreemptingSchedulingContextByExecutorForQueue(queue)
+	mostRecentByExecutor, ok := repo.GetMostRecentSchedulingContextByExecutorForQueue(queue)
+	if !ok {
+		mostRecentByExecutor = make(SchedulingContextByExecutor)
+	}
+	mostRecentSuccessfulByExecutor, ok := repo.GetMostRecentSuccessfulSchedulingContextByExecutorForQueue(queue)
+	if !ok {
+		mostRecentSuccessfulByExecutor = make(SchedulingContextByExecutor)
+	}
+	mostRecentPreemptingByExecutor, ok := repo.GetMostRecentPreemptingSchedulingContextByExecutorForQueue(queue)
+	if !ok {
+		mostRecentPreemptingByExecutor = make(SchedulingContextByExecutor)
+	}
 	sr := schedulingReport{
 		mostRecentByExecutor:           mostRecentByExecutor,
 		mostRecentSuccessfulByExecutor: mostRecentSuccessfulByExecutor,

--- a/internal/scheduler/reports.go
+++ b/internal/scheduler/reports.go
@@ -55,11 +55,7 @@ type SchedulingContextRepository struct {
 	mu sync.Mutex
 }
 
-type (
-	SchedulingContextByExecutor      map[string]*schedulercontext.SchedulingContext
-	QueueSchedulingContextByExecutor map[string]*schedulercontext.QueueSchedulingContext
-	JobSchedulingContextByExecutor   map[string]*schedulercontext.JobSchedulingContext
-)
+type SchedulingContextByExecutor map[string]*schedulercontext.SchedulingContext
 
 func NewSchedulingContextRepository(jobCacheSize uint) (*SchedulingContextRepository, error) {
 	mostRecentByExecutorByJobId, err := lru.New(int(jobCacheSize))
@@ -526,34 +522,6 @@ func (m SchedulingContextByExecutor) String() string {
 		sctx := m[executorId]
 		fmt.Fprintf(w, "%s:\n", executorId)
 		fmt.Fprint(w, indent.String("\t", sctx.String()))
-	}
-	w.Flush()
-	return sb.String()
-}
-
-func (m QueueSchedulingContextByExecutor) String() string {
-	var sb strings.Builder
-	w := tabwriter.NewWriter(&sb, 1, 1, 1, ' ', 0)
-	executorIds := maps.Keys(m)
-	slices.Sort(executorIds)
-	for _, executorId := range executorIds {
-		qctx := m[executorId]
-		fmt.Fprintf(w, "%s:\n", executorId)
-		fmt.Fprint(w, indent.String("\t", qctx.String()))
-	}
-	w.Flush()
-	return sb.String()
-}
-
-func (m JobSchedulingContextByExecutor) String() string {
-	var sb strings.Builder
-	w := tabwriter.NewWriter(&sb, 1, 1, 1, ' ', 0)
-	executorIds := maps.Keys(m)
-	slices.Sort(executorIds)
-	for _, executorId := range executorIds {
-		jctx := m[executorId]
-		fmt.Fprintf(w, "%s:\n", executorId)
-		fmt.Fprint(w, indent.String("\t", jctx.String()))
 	}
 	w.Flush()
 	return sb.String()

--- a/internal/scheduler/reports.go
+++ b/internal/scheduler/reports.go
@@ -354,22 +354,19 @@ func (sr schedulingReport) ReportString(verbosity int32) string {
 	w := tabwriter.NewWriter(&sb, 1, 1, 1, ' ', 0)
 	for _, executorId := range sr.sortedExecutorIds {
 		fmt.Fprintf(w, "%s:\n", executorId)
-		sctx := sr.mostRecentByExecutor[executorId]
-		if sctx != nil {
+		if sctx := sr.mostRecentByExecutor[executorId]; sctx != nil {
 			fmt.Fprint(w, indent.String("\t", "Most recent attempt:\n"))
 			fmt.Fprint(w, indent.String("\t\t", sctx.ReportString(verbosity)))
 		} else {
 			fmt.Fprint(w, indent.String("\t", "Most recent attempt: none\n"))
 		}
-		sctx = sr.mostRecentSuccessfulByExecutor[executorId]
-		if sctx != nil {
+		if sctx := sr.mostRecentSuccessfulByExecutor[executorId]; sctx != nil {
 			fmt.Fprint(w, indent.String("\t", "Most recent successful attempt:\n"))
 			fmt.Fprint(w, indent.String("\t\t", sctx.ReportString(verbosity)))
 		} else {
 			fmt.Fprint(w, indent.String("\t", "Most recent successful attempt: none\n"))
 		}
-		sctx = sr.mostRecentPreemptingByExecutor[executorId]
-		if sctx != nil {
+		if sctx := sr.mostRecentPreemptingByExecutor[executorId]; sctx != nil {
 			fmt.Fprint(w, indent.String("\t", "Most recent preempting attempt:\n"))
 			fmt.Fprint(w, indent.String("\t\t", sctx.ReportString(verbosity)))
 		} else {

--- a/internal/scheduler/reports.go
+++ b/internal/scheduler/reports.go
@@ -287,7 +287,10 @@ func (repo *SchedulingContextRepository) getSchedulingReportStringForQueue(queue
 }
 
 func (repo *SchedulingContextRepository) getSchedulingReportStringForJob(jobId string, verbosity int32) string {
-	mostRecentByExecutor, _ := repo.GetMostRecentSchedulingContextByExecutorForJob(jobId)
+	mostRecentByExecutor, ok := repo.GetMostRecentSchedulingContextByExecutorForJob(jobId)
+	if !ok {
+		mostRecentByExecutor = make(SchedulingContextByExecutor)
+	}
 	var sb strings.Builder
 	w := tabwriter.NewWriter(&sb, 1, 1, 1, ' ', 0)
 	for _, executorId := range repo.GetSortedExecutorIds() {

--- a/internal/scheduler/reports.go
+++ b/internal/scheduler/reports.go
@@ -99,7 +99,7 @@ func NewSchedulingContextRepository(jobCacheSize uint) (*SchedulingContextReposi
 // Job contexts are stored first, then queue contexts, and finally the scheduling context itself.
 // This avoids having a stored scheduling (queue) context referring to a queue (job) context that isn't stored yet.
 func (repo *SchedulingContextRepository) AddSchedulingContext(sctx *schedulercontext.SchedulingContext) error {
-	qctxs, jctxs := extractQueueAndJobContexts(sctx)
+	qctxs, jctxs := extractQueueAndJobSchedulingContexts(sctx)
 	repo.mu.Lock()
 	defer repo.mu.Unlock()
 	if err := repo.addSchedulingContextForJobs(sctx, jctxs); err != nil {
@@ -251,9 +251,9 @@ func (repo *SchedulingContextRepository) addSchedulingContextForJobs(sctx *sched
 	return nil
 }
 
-// extractQueueAndJobContexts extracts the job and queue scheduling contexts from the scheduling context,
+// extractQueueAndJobSchedulingContexts extracts the job and queue scheduling contexts from the scheduling context,
 // and returns those separately.
-func extractQueueAndJobContexts(sctx *schedulercontext.SchedulingContext) ([]*schedulercontext.QueueSchedulingContext, []*schedulercontext.JobSchedulingContext) {
+func extractQueueAndJobSchedulingContexts(sctx *schedulercontext.SchedulingContext) ([]*schedulercontext.QueueSchedulingContext, []*schedulercontext.JobSchedulingContext) {
 	qctxs := make([]*schedulercontext.QueueSchedulingContext, 0)
 	jctxs := make([]*schedulercontext.JobSchedulingContext, 0)
 	for _, qctx := range sctx.QueueSchedulingContexts {

--- a/internal/scheduler/reports_test.go
+++ b/internal/scheduler/reports_test.go
@@ -8,24 +8,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/armadaproject/armada/internal/common/util"
 	schedulercontext "github.com/armadaproject/armada/internal/scheduler/context"
 	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
 )
-
-func TestExtractQueueAndJobContexts(t *testing.T) {
-	sctx := withUnsuccessfulJobSchedulingContext(withSuccessfulJobSchedulingContext(testSchedulingContext("executor"), "queue", "success"), "queue", "failure")
-	qctxs, jctxs := extractQueueAndJobSchedulingContexts(sctx)
-	queues := util.Map(qctxs, func(qctx *schedulercontext.QueueSchedulingContext) string { return qctx.Queue })
-	slices.Sort(queues)
-	jobIds := util.Map(jctxs, func(jctx *schedulercontext.JobSchedulingContext) string { return jctx.JobId })
-	slices.Sort(jobIds)
-	assert.Equal(t, []string{"queue"}, queues)
-	assert.Equal(t, []string{"failure", "success"}, jobIds)
-}
 
 func TestAddGetSchedulingContext(t *testing.T) {
 	repo, err := NewSchedulingContextRepository(10)

--- a/internal/scheduler/reports_test.go
+++ b/internal/scheduler/reports_test.go
@@ -57,87 +57,102 @@ func TestAddGetSchedulingContext(t *testing.T) {
 	err = repo.AddSchedulingContext(sctx)
 	require.NoError(t, err)
 
-	actualJobSchedulingContextByExecutor, ok := repo.GetMostRecentJobSchedulingContextByExecutor("doesNotExist")
-	require.Nil(t, actualJobSchedulingContextByExecutor)
+	var actualSchedulingContextByExecutor SchedulingContextByExecutor
+	var ok bool
+
+	actualSchedulingContextByExecutor, ok = repo.GetMostRecentSchedulingContextByExecutorForJob("doesNotExist")
+	require.Nil(t, actualSchedulingContextByExecutor)
 	require.False(t, ok)
 
-	actualJobSchedulingContextByExecutor, ok = repo.GetMostRecentJobSchedulingContextByExecutor("successFooA")
+	actualSchedulingContextByExecutor, ok = repo.GetMostRecentSchedulingContextByExecutorForJob("successFooA")
 	require.True(t, ok)
 	assert.Equal(
 		t,
-		JobSchedulingContextByExecutor{
-			"foo": withSuccessfulJobSchedulingContext(testSchedulingContext("foo"), "A", "successFooA").QueueSchedulingContexts["A"].SuccessfulJobSchedulingContexts["successFooA"],
+		SchedulingContextByExecutor{
+			"foo": withSuccessfulJobSchedulingContext(testSchedulingContext("foo"), "A", "successFooA"),
 		},
-		actualJobSchedulingContextByExecutor,
+		actualSchedulingContextByExecutor,
 	)
 
-	actualJobSchedulingContextByExecutor, ok = repo.GetMostRecentJobSchedulingContextByExecutor("failureA")
+	actualSchedulingContextByExecutor, ok = repo.GetMostRecentSchedulingContextByExecutorForJob("failureA")
 	require.True(t, ok)
 	assert.Equal(
 		t,
-		JobSchedulingContextByExecutor{
-			"foo": withUnsuccessfulJobSchedulingContext(testSchedulingContext("foo"), "A", "failureA").QueueSchedulingContexts["A"].UnsuccessfulJobSchedulingContexts["failureA"],
-			"bar": withUnsuccessfulJobSchedulingContext(testSchedulingContext("bar"), "A", "failureA").QueueSchedulingContexts["A"].UnsuccessfulJobSchedulingContexts["failureA"],
+		SchedulingContextByExecutor{
+			"foo": withUnsuccessfulJobSchedulingContext(testSchedulingContext("foo"), "A", "failureA"),
 		},
-		actualJobSchedulingContextByExecutor,
+		actualSchedulingContextByExecutor,
+	)
+	assert.Equal(
+		t,
+		SchedulingContextByExecutor{
+			"bar": withUnsuccessfulJobSchedulingContext(testSchedulingContext("bar"), "A", "failureA"),
+		},
+		actualSchedulingContextByExecutor,
 	)
 
-	actualQueueSchedulingContextByExecutor, ok := repo.GetMostRecentQueueSchedulingContextByExecutor("doesNotExist")
-	require.Nil(t, actualQueueSchedulingContextByExecutor)
+	actualSchedulingContextByExecutor, ok = repo.GetMostRecentSchedulingContextByExecutorForQueue("doesNotExist")
+	require.Nil(t, actualSchedulingContextByExecutor)
 	require.False(t, ok)
 
-	actualQueueSchedulingContextByExecutor, ok = repo.GetMostRecentQueueSchedulingContextByExecutor("A")
+	actualSchedulingContextByExecutor, ok = repo.GetMostRecentSchedulingContextByExecutorForQueue("A")
 	require.True(t, ok)
 	assert.Equal(
 		t,
-		QueueSchedulingContextByExecutor{
-			"foo": withUnsuccessfulJobSchedulingContext(testSchedulingContext("foo"), "A", "failureA").QueueSchedulingContexts["A"],
-			"bar": withUnsuccessfulJobSchedulingContext(testSchedulingContext("bar"), "A", "failureA").QueueSchedulingContexts["A"],
+		SchedulingContextByExecutor{
+			"foo": withUnsuccessfulJobSchedulingContext(testSchedulingContext("foo"), "A", "failureA"),
 		},
-		actualQueueSchedulingContextByExecutor,
+		actualSchedulingContextByExecutor["foo"],
+	)
+	assert.Equal(
+		t,
+		SchedulingContextByExecutor{
+			"bar": withUnsuccessfulJobSchedulingContext(testSchedulingContext("bar"), "A", "failureA"),
+		},
+		actualSchedulingContextByExecutor["bar"],
 	)
 
-	actualQueueSchedulingContextByExecutor, ok = repo.GetMostRecentSuccessfulQueueSchedulingContextByExecutor("A")
+	actualSchedulingContextByExecutor, ok = repo.GetMostRecentSuccessfulSchedulingContextByExecutorForQueue("A")
 	require.True(t, ok)
 	assert.Equal(
 		t,
-		QueueSchedulingContextByExecutor{
-			"foo": withSuccessfulJobSchedulingContext(testSchedulingContext("foo"), "A", "successFooA").QueueSchedulingContexts["A"],
+		SchedulingContextByExecutor{
+			"foo": withSuccessfulJobSchedulingContext(testSchedulingContext("foo"), "A", "successFooA"),
 		},
-		actualQueueSchedulingContextByExecutor,
+		actualSchedulingContextByExecutor["foo"],
 	)
 
-	actualQueueSchedulingContextByExecutor, ok = repo.GetMostRecentQueueSchedulingContextByExecutor("B")
+	actualSchedulingContextByExecutor, ok = repo.GetMostRecentSchedulingContextByExecutorForQueue("B")
 	require.True(t, ok)
 	assert.Equal(
 		t,
-		QueueSchedulingContextByExecutor{
-			"bar": withUnsuccessfulJobSchedulingContext(testSchedulingContext("bar"), "B", "failureB").QueueSchedulingContexts["B"],
+		SchedulingContextByExecutor{
+			"bar": withUnsuccessfulJobSchedulingContext(testSchedulingContext("bar"), "B", "failureB"),
 		},
-		actualQueueSchedulingContextByExecutor,
+		actualSchedulingContextByExecutor["bar"],
 	)
 
-	actualQueueSchedulingContextByExecutor, ok = repo.GetMostRecentSuccessfulQueueSchedulingContextByExecutor("B")
+	actualSchedulingContextByExecutor, ok = repo.GetMostRecentSuccessfulSchedulingContextByExecutorForQueue("B")
 	require.True(t, ok)
 	assert.Equal(
 		t,
-		QueueSchedulingContextByExecutor{
-			"bar": withSuccessfulJobSchedulingContext(testSchedulingContext("bar"), "B", "successBarB").QueueSchedulingContexts["B"],
+		SchedulingContextByExecutor{
+			"bar": withSuccessfulJobSchedulingContext(testSchedulingContext("bar"), "B", "successBarB"),
 		},
-		actualQueueSchedulingContextByExecutor,
+		actualSchedulingContextByExecutor["bar"],
 	)
 
-	actualQueueSchedulingContextByExecutor, ok = repo.GetMostRecentQueueSchedulingContextByExecutor("C")
+	actualSchedulingContextByExecutor, ok = repo.GetMostRecentSchedulingContextByExecutorForQueue("C")
 	require.True(t, ok)
 	assert.Equal(
 		t,
-		QueueSchedulingContextByExecutor{
-			"baz": withPreemptingJobSchedulingContext(testSchedulingContext("baz"), "C", "preempted").QueueSchedulingContexts["C"],
+		SchedulingContextByExecutor{
+			"baz": withPreemptingJobSchedulingContext(testSchedulingContext("baz"), "C", "preempted"),
 		},
-		actualQueueSchedulingContextByExecutor,
+		actualSchedulingContextByExecutor["baz"],
 	)
 
-	actualSchedulingContextByExecutor := repo.GetMostRecentSchedulingContextByExecutor()
+	actualSchedulingContextByExecutor = repo.GetMostRecentSchedulingContextByExecutor()
 	assert.Equal(
 		t,
 		SchedulingContextByExecutor{
@@ -204,7 +219,7 @@ func TestTestAddGetSchedulingContextConcurrency(t *testing.T) {
 			}
 			repo.getJobReportString(fmt.Sprintf("failure%s", queue))
 			repo.getQueueReportString(queue, 0)
-			repo.getSchedulingReport().ReportString(0)
+			repo.getSchedulingReportString(0)
 		}(queue)
 	}
 	<-ctx.Done()

--- a/internal/scheduler/reports_test.go
+++ b/internal/scheduler/reports_test.go
@@ -78,17 +78,13 @@ func TestAddGetSchedulingContext(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(
 		t,
-		SchedulingContextByExecutor{
-			"foo": withUnsuccessfulJobSchedulingContext(testSchedulingContext("foo"), "A", "failureA"),
-		},
-		actualSchedulingContextByExecutor,
+		withUnsuccessfulJobSchedulingContext(testSchedulingContext("foo"), "A", "failureA").QueueSchedulingContexts["A"],
+		actualSchedulingContextByExecutor["foo"].QueueSchedulingContexts["A"],
 	)
 	assert.Equal(
 		t,
-		SchedulingContextByExecutor{
-			"bar": withUnsuccessfulJobSchedulingContext(testSchedulingContext("bar"), "A", "failureA"),
-		},
-		actualSchedulingContextByExecutor,
+		withUnsuccessfulJobSchedulingContext(testSchedulingContext("bar"), "A", "failureA").QueueSchedulingContexts["A"],
+		actualSchedulingContextByExecutor["bar"].QueueSchedulingContexts["A"],
 	)
 
 	actualSchedulingContextByExecutor, ok = repo.GetMostRecentSchedulingContextByExecutorForQueue("doesNotExist")
@@ -99,57 +95,45 @@ func TestAddGetSchedulingContext(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(
 		t,
-		SchedulingContextByExecutor{
-			"foo": withUnsuccessfulJobSchedulingContext(testSchedulingContext("foo"), "A", "failureA"),
-		},
-		actualSchedulingContextByExecutor["foo"],
+		withUnsuccessfulJobSchedulingContext(testSchedulingContext("foo"), "A", "failureA").QueueSchedulingContexts["A"],
+		actualSchedulingContextByExecutor["foo"].QueueSchedulingContexts["A"],
 	)
 	assert.Equal(
 		t,
-		SchedulingContextByExecutor{
-			"bar": withUnsuccessfulJobSchedulingContext(testSchedulingContext("bar"), "A", "failureA"),
-		},
-		actualSchedulingContextByExecutor["bar"],
+		withUnsuccessfulJobSchedulingContext(testSchedulingContext("bar"), "A", "failureA").QueueSchedulingContexts["A"],
+		actualSchedulingContextByExecutor["bar"].QueueSchedulingContexts["A"],
 	)
 
 	actualSchedulingContextByExecutor, ok = repo.GetMostRecentSuccessfulSchedulingContextByExecutorForQueue("A")
 	require.True(t, ok)
 	assert.Equal(
 		t,
-		SchedulingContextByExecutor{
-			"foo": withSuccessfulJobSchedulingContext(testSchedulingContext("foo"), "A", "successFooA"),
-		},
-		actualSchedulingContextByExecutor["foo"],
+		withSuccessfulJobSchedulingContext(testSchedulingContext("foo"), "A", "successFooA").QueueSchedulingContexts["A"],
+		actualSchedulingContextByExecutor["foo"].QueueSchedulingContexts["A"],
 	)
 
 	actualSchedulingContextByExecutor, ok = repo.GetMostRecentSchedulingContextByExecutorForQueue("B")
 	require.True(t, ok)
 	assert.Equal(
 		t,
-		SchedulingContextByExecutor{
-			"bar": withUnsuccessfulJobSchedulingContext(testSchedulingContext("bar"), "B", "failureB"),
-		},
-		actualSchedulingContextByExecutor["bar"],
+		withUnsuccessfulJobSchedulingContext(testSchedulingContext("bar"), "B", "failureB").QueueSchedulingContexts["B"],
+		actualSchedulingContextByExecutor["bar"].QueueSchedulingContexts["B"],
 	)
 
 	actualSchedulingContextByExecutor, ok = repo.GetMostRecentSuccessfulSchedulingContextByExecutorForQueue("B")
 	require.True(t, ok)
 	assert.Equal(
 		t,
-		SchedulingContextByExecutor{
-			"bar": withSuccessfulJobSchedulingContext(testSchedulingContext("bar"), "B", "successBarB"),
-		},
-		actualSchedulingContextByExecutor["bar"],
+		withSuccessfulJobSchedulingContext(testSchedulingContext("bar"), "B", "successBarB").QueueSchedulingContexts["B"],
+		actualSchedulingContextByExecutor["bar"].QueueSchedulingContexts["B"],
 	)
 
 	actualSchedulingContextByExecutor, ok = repo.GetMostRecentSchedulingContextByExecutorForQueue("C")
 	require.True(t, ok)
 	assert.Equal(
 		t,
-		SchedulingContextByExecutor{
-			"baz": withPreemptingJobSchedulingContext(testSchedulingContext("baz"), "C", "preempted"),
-		},
-		actualSchedulingContextByExecutor["baz"],
+		withPreemptingJobSchedulingContext(testSchedulingContext("baz"), "C", "preempted").QueueSchedulingContexts["C"],
+		actualSchedulingContextByExecutor["baz"].QueueSchedulingContexts["C"],
 	)
 
 	actualSchedulingContextByExecutor = repo.GetMostRecentSchedulingContextByExecutor()

--- a/internal/scheduler/reports_test.go
+++ b/internal/scheduler/reports_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestExtractQueueAndJobContexts(t *testing.T) {
 	sctx := withUnsuccessfulJobSchedulingContext(withSuccessfulJobSchedulingContext(testSchedulingContext("executor"), "queue", "success"), "queue", "failure")
-	qctxs, jctxs := extractQueueAndJobContexts(sctx)
+	qctxs, jctxs := extractQueueAndJobSchedulingContexts(sctx)
 	queues := util.Map(qctxs, func(qctx *schedulercontext.QueueSchedulingContext) string { return qctx.Queue })
 	slices.Sort(queues)
 	jobIds := util.Map(jctxs, func(jctx *schedulercontext.JobSchedulingContext) string { return jctx.JobId })


### PR DESCRIPTION
Most of the changes here are to the internal bookkeeping; the only visible change to the scheduling reports is that `scheduling-report` will now only print the most recent scheduling report if it is invoked with `--job` (as opposed to "most recent", "most recent successful", and "most recent preempting"), because we only keep the most recent scheduling report for individual jobs.