### PR TITLE
NodeDb: consider all nodes within the same bucket

### DIFF
--- a/internal/scheduler/nodedb/encoding.go
+++ b/internal/scheduler/nodedb/encoding.go
@@ -33,10 +33,15 @@ func RoundedNodeIndexKeyFromResourceList(out []byte, nodeTypeId uint64, resource
 	for i, name := range resourceNames {
 		resolution := resourceResolutionMillis[i]
 		q := rl.Get(name)
-		q.SetMilli((q.MilliValue() / resolution) * resolution)
+		q = roundQuantityToResolution(q, resolution)
 		out = EncodeQuantity(out, q)
 	}
 	return out
+}
+
+func roundQuantityToResolution(q resource.Quantity, resolutionMillis int64) resource.Quantity {
+	q.SetMilli((q.MilliValue() / resolutionMillis) * resolutionMillis)
+	return q
 }
 
 // EncodeQuantity returns the canonical byte representation of a resource.Quantity used within the nodeDb.

--- a/internal/scheduler/nodedb/encoding_test.go
+++ b/internal/scheduler/nodedb/encoding_test.go
@@ -100,72 +100,72 @@ func TestEncodeQuantity(t *testing.T) {
 }
 
 func TestNodeIndexKey(t *testing.T) {
-	type v struct {
+	type nodeIndexKeyValues struct {
 		nodeTypeId uint64
 		resources  []resource.Quantity
 	}
 	tests := map[string]struct {
-		a v
-		b v
+		a nodeIndexKeyValues
+		b nodeIndexKeyValues
 	}{
 		"equal nodeTypeId": {
-			a: v{
+			a: nodeIndexKeyValues{
 				nodeTypeId: 10,
 			},
-			b: v{
+			b: nodeIndexKeyValues{
 				nodeTypeId: 10,
 			},
 		},
 		"unequal nodeTypeId": {
-			a: v{
+			a: nodeIndexKeyValues{
 				nodeTypeId: 10,
 			},
-			b: v{
+			b: nodeIndexKeyValues{
 				nodeTypeId: 11,
 			},
 		},
 		"equal nodeTypeId and resources": {
-			a: v{
+			a: nodeIndexKeyValues{
 				nodeTypeId: 10,
 				resources:  []resource.Quantity{resource.MustParse("1"), resource.MustParse("2")},
 			},
-			b: v{
+			b: nodeIndexKeyValues{
 				nodeTypeId: 10,
 				resources:  []resource.Quantity{resource.MustParse("1"), resource.MustParse("2")},
 			},
 		},
 		"equal nodeTypeId and unequal resources": {
-			a: v{
+			a: nodeIndexKeyValues{
 				nodeTypeId: 10,
 				resources:  []resource.Quantity{resource.MustParse("2"), resource.MustParse("1")},
 			},
-			b: v{
+			b: nodeIndexKeyValues{
 				nodeTypeId: 10,
 				resources:  []resource.Quantity{resource.MustParse("1"), resource.MustParse("2")},
 			},
 		},
 		"unequal nodeTypeId and equal resources": {
-			a: v{
+			a: nodeIndexKeyValues{
 				nodeTypeId: 10,
 				resources:  []resource.Quantity{resource.MustParse("1"), resource.MustParse("2")},
 			},
-			b: v{
+			b: nodeIndexKeyValues{
 				nodeTypeId: 11,
 				resources:  []resource.Quantity{resource.MustParse("1"), resource.MustParse("2")},
 			},
 		},
 		"negative resource": {
-			a: v{
+			a: nodeIndexKeyValues{
 				nodeTypeId: 10,
 				resources:  []resource.Quantity{resource.MustParse("1"), resource.MustParse("2")},
 			},
-			b: v{
+			b: nodeIndexKeyValues{
 				nodeTypeId: 10,
 				resources:  []resource.Quantity{resource.MustParse("-1"), resource.MustParse("2")},
 			},
 		},
 	}
-	expectedCmp := func(a, b v) int {
+	expectedCmp := func(a, b nodeIndexKeyValues) int {
 		if a.nodeTypeId < b.nodeTypeId {
 			return -1
 		} else if a.nodeTypeId > b.nodeTypeId {

--- a/internal/scheduler/nodedb/nodedb.go
+++ b/internal/scheduler/nodedb/nodedb.go
@@ -447,6 +447,7 @@ func (nodeDb *NodeDb) selectNodeForPodAtPriority(
 		priority,
 		nodeDb.indexedResources,
 		indexResourceRequests,
+		nodeDb.indexedResourceResolutionMillis,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/scheduler/nodedb/nodeiteration_test.go
+++ b/internal/scheduler/nodedb/nodeiteration_test.go
@@ -447,7 +447,7 @@ func TestNodeTypeIterator(t *testing.T) {
 				}
 			}
 			require.NotEqual(t, -1, keyIndex)
-			it, err := NewNodeTypeIterator(nodeDb.Txn(false), tc.nodeTypeId, nodeIndexName(keyIndex), tc.priority, testfixtures.TestResourceNames, indexedResourceRequests)
+			it, err := NewNodeTypeIterator(nodeDb.Txn(false), tc.nodeTypeId, nodeIndexName(keyIndex), tc.priority, testfixtures.TestResourceNames, indexedResourceRequests, testfixtures.TestIndexedResourceResolutionMillis)
 			require.NoError(t, err)
 
 			// Compare actual with expected order.
@@ -832,6 +832,7 @@ func TestNodeTypesIterator(t *testing.T) {
 				tc.priority,
 				testfixtures.TestResourceNames,
 				indexedResourceRequests,
+				testfixtures.TestIndexedResourceResolutionMillis,
 			)
 			require.NoError(t, err)
 
@@ -902,7 +903,7 @@ func BenchmarkNodeTypeIterator(b *testing.B) {
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		it, err := NewNodeTypeIterator(txn, nodeTypeId, nodeDb.indexNameByPriority[priority], priority, nodeDb.indexedResources, indexedResourceRequests)
+		it, err := NewNodeTypeIterator(txn, nodeTypeId, nodeDb.indexNameByPriority[priority], priority, nodeDb.indexedResources, indexedResourceRequests, testfixtures.TestIndexedResourceResolutionMillis)
 		require.NoError(b, err)
 		for {
 			node, err := it.NextNode()

--- a/internal/scheduler/testfixtures/testfixtures.go
+++ b/internal/scheduler/testfixtures/testfixtures.go
@@ -477,8 +477,8 @@ func Test1GpuPodReqs(queue string, jobId ulid.ULID, priority int32) *schedulerob
 		jobId,
 		priority,
 		v1.ResourceList{
-			"cpu":    resource.MustParse("4"),
-			"memory": resource.MustParse("16Gi"),
+			"cpu":    resource.MustParse("8"),
+			"memory": resource.MustParse("128Gi"),
 			"gpu":    resource.MustParse("1"),
 		},
 	)


### PR DESCRIPTION
This PR fixes a bug where not all nodes rounded to the same amount of allocatable resources were considered.

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-354) by [Unito](https://www.unito.io)
