### PR TITLE
Add sleep to testsuite thread spawn

### DIFF
--- a/internal/testsuite/app.go
+++ b/internal/testsuite/app.go
@@ -192,9 +192,9 @@ func (a *App) RunTests(ctx context.Context, testSpecs []*api.TestSpec) (*TestSui
 			rv.TestCaseReports[i] = testRunner.TestCaseReport
 			wg.Done()
 		}()
+		time.Sleep(100 * time.Millisecond)
 	}
 
-	time.Sleep(100 * time.Millisecond)
 	fmt.Fprintf(a.Out, "---\n")
 	g.Go(func() error { return eventLogger.Run(ctx) })
 


### PR DESCRIPTION
To work around issues resulting from Kerberos tokens being generated cocnurrently.

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-356) by [Unito](https://www.unito.io)
