### PR TITLE
Change format of the "Unschedulable jobs:" scheduling report section

### DIFF
--- a/internal/scheduler/context/context.go
+++ b/internal/scheduler/context/context.go
@@ -356,8 +356,8 @@ func (qctx *QueueSchedulingContext) ReportString(verbosity int32) string {
 		fmt.Fprintf(w, "Total allocated resources after scheduling:\t%s\n", qctx.AllocatedByPriority.AggregateByResource().CompactString())
 		fmt.Fprintf(w, "Total allocated resources after scheduling (by priority):\t%s\n", qctx.AllocatedByPriority.String())
 		fmt.Fprintf(w, "Number of jobs scheduled:\t%d\n", len(qctx.SuccessfulJobSchedulingContexts))
-		fmt.Fprintf(w, "Number of jobs that could not be scheduled:\t%d\n", len(qctx.UnsuccessfulJobSchedulingContexts))
 		fmt.Fprintf(w, "Number of jobs preempted:\t%d\n", len(qctx.EvictedJobsById))
+		fmt.Fprintf(w, "Number of jobs that could not be scheduled:\t%d\n", len(qctx.UnsuccessfulJobSchedulingContexts))
 		if len(qctx.SuccessfulJobSchedulingContexts) > 0 {
 			jobIdsToPrint := maps.Keys(qctx.SuccessfulJobSchedulingContexts)
 			if verbosity <= 1 && len(jobIdsToPrint) > maxPrintedJobIdsByReason {
@@ -366,6 +366,18 @@ func (qctx *QueueSchedulingContext) ReportString(verbosity int32) string {
 			fmt.Fprintf(w, "Scheduled jobs:\t%v", jobIdsToPrint)
 			if len(jobIdsToPrint) != len(qctx.SuccessfulJobSchedulingContexts) {
 				fmt.Fprintf(w, " (and %d others not shown)\n", len(qctx.SuccessfulJobSchedulingContexts)-len(jobIdsToPrint))
+			} else {
+				fmt.Fprint(w, "\n")
+			}
+		}
+		if len(qctx.EvictedJobsById) > 0 {
+			jobIdsToPrint := maps.Keys(qctx.EvictedJobsById)
+			if verbosity <= 1 && len(jobIdsToPrint) > maxPrintedJobIdsByReason {
+				jobIdsToPrint = jobIdsToPrint[0:maxPrintedJobIdsByReason]
+			}
+			fmt.Fprintf(w, "Preempted jobs:\t%v", jobIdsToPrint)
+			if len(jobIdsToPrint) != len(qctx.EvictedJobsById) {
+				fmt.Fprintf(w, " (and %d others not shown)\n", len(qctx.EvictedJobsById)-len(jobIdsToPrint))
 			} else {
 				fmt.Fprint(w, "\n")
 			}
@@ -391,18 +403,6 @@ func (qctx *QueueSchedulingContext) ReportString(verbosity int32) string {
 				} else {
 					fmt.Fprint(w, "\n")
 				}
-			}
-		}
-		if len(qctx.EvictedJobsById) > 0 {
-			jobIdsToPrint := maps.Keys(qctx.EvictedJobsById)
-			if verbosity <= 1 && len(jobIdsToPrint) > maxPrintedJobIdsByReason {
-				jobIdsToPrint = jobIdsToPrint[0:maxPrintedJobIdsByReason]
-			}
-			fmt.Fprintf(w, "Preempted jobs:\t%v", jobIdsToPrint)
-			if len(jobIdsToPrint) != len(qctx.EvictedJobsById) {
-				fmt.Fprintf(w, " (and %d others not shown)\n", len(qctx.EvictedJobsById)-len(jobIdsToPrint))
-			} else {
-				fmt.Fprint(w, "\n")
 			}
 		}
 	}

--- a/internal/scheduler/context/context.go
+++ b/internal/scheduler/context/context.go
@@ -397,7 +397,7 @@ func (qctx *QueueSchedulingContext) ReportString(verbosity int32) string {
 				if verbosity <= 1 && len(jobIdsToPrint) > maxPrintedJobIdsByReason {
 					jobIdsToPrint = jobIds[0:maxPrintedJobIdsByReason]
 				}
-				fmt.Fprintf(w, "\t%d:\t%s jobs\t%v", len(qctx.UnsuccessfulJobSchedulingContexts), reason, jobIdsToPrint)
+				fmt.Fprintf(w, "\t%s:\t%v", reason, jobIdsToPrint)
 				if len(jobIdsToPrint) != len(jobIds) {
 					fmt.Fprintf(w, " (and %d others not shown)\n", len(jobIds)-len(jobIdsToPrint))
 				} else {

--- a/internal/scheduler/context/context.go
+++ b/internal/scheduler/context/context.go
@@ -399,7 +399,7 @@ func (qctx *QueueSchedulingContext) ReportString(verbosity int32) string {
 			for i := len(reasons) - 1; i >= 0; i-- {
 				reason := reasons[i]
 				jobIds := jobIdsByReason[reason]
-				if jobIds == nil || len(jobIds) <= 0 {
+				if len(jobIds) <= 0 {
 					continue
 				}
 				fmt.Fprintf(w, "\t%d:\t%s (e.g., %s)\n", len(jobIds), reason, jobIds[0])


### PR DESCRIPTION
Before c84494aed68304bec6d89b908c31b7809d0dcb0a:

```console
$ go run cmd/armadactl/main.go scheduling-report --job 01h39j8x5ds23jnp8a7sxtttwe -vv
executor-01:
 Most recent attempt:
  …
  Scheduled queues:
   queue-bob:
    …
  Preempted queues:
   queue-alice:
    Created:                                                  2023-03-22 16:34:39.5035361 +0000 GMT
    Scheduled resources:                                      {}
    Scheduled resources (by priority):                        {}
    Preempted resources:                                      {cpu: 16, memory: 128Gi}
    Preempted resources (by priority):                        {0: {cpu: 16, memory: 128Gi}}
    Total allocated resources after scheduling:               {memory: 128Gi, cpu: 16}
    Total allocated resources after scheduling (by priority): {0: {cpu: 16, memory: 128Gi}}
    Number of jobs scheduled:                                 0
    Number of jobs preempted:                                 16
    Number of jobs that could not be scheduled:               16
    Preempted jobs:                                           [01h39jgp1jgcx77bywmscsv8mr] (and 15 others not shown)
    Unschedulable jobs:
     16: maximum total resources for this queue exceeded jobs [01h39jgp1kv6bztq2nfpckky17] (and 11 others not shown)
     16: some other reason jobs                               [01h39jgp1jgcx77bywmrzn6dwj] (and 3 others not shown)
 …
```

It looks to me like the counts on the left-hand side have always been wrong: https://github.com/armadaproject/armada/blame/725845e5bd1fc63db020985cec58f6c231f71305/internal/scheduler/context/context.go#L323

After af51a381bd4a5c0ae00ebe12dd61e23f349c464a:

```console
$ go run cmd/armadactl/main.go scheduling-report --job 01h39jkf83p479zvc62rqzf5ra -vv
executor-01:
 Most recent attempt:
  …
  Scheduled queues:
   queue-bob:
    …
  Preempted queues:
   queue-alice:
    Created:                                                  2023-03-22 16:34:39.5035361 +0000 GMT
    Scheduled resources:                                      {}
    Scheduled resources (by priority):                        {}
    Preempted resources:                                      {cpu: 16, memory: 128Gi}
    Preempted resources (by priority):                        {0: {cpu: 16, memory: 128Gi}}
    Total allocated resources after scheduling:               {cpu: 16, memory: 128Gi}
    Total allocated resources after scheduling (by priority): {0: {cpu: 16, memory: 128Gi}}
    Number of jobs scheduled:                                 0
    Number of jobs preempted:                                 16
    Number of jobs that could not be scheduled:               16
    Preempted jobs:                                           [01h39jkf83p479zvc6348zm1sp] (and 15 others not shown)
    Unschedulable jobs:
     12: maximum total resources for this queue exceeded (e.g., 01h39jkf83p479zvc639q0x9pw)
     4:  some other reason (e.g., 01h39jkf83p479zvc62w8cnc3g)
 …
```