### PR TITLE
Also print queue and job scheduling reports with `--queue` and `--job`

### DIFF
--- a/internal/scheduler/context/context.go
+++ b/internal/scheduler/context/context.go
@@ -341,7 +341,7 @@ func (qctx *QueueSchedulingContext) String() string {
 	return qctx.ReportString(0)
 }
 
-const maxPrintedJobIdsByReason = 1
+const maxJobIdsToPrint = 1
 
 func (qctx *QueueSchedulingContext) ReportString(verbosity int32) string {
 	var sb strings.Builder
@@ -362,8 +362,8 @@ func (qctx *QueueSchedulingContext) ReportString(verbosity int32) string {
 		fmt.Fprintf(w, "Number of jobs that could not be scheduled:\t%d\n", len(qctx.UnsuccessfulJobSchedulingContexts))
 		if len(qctx.SuccessfulJobSchedulingContexts) > 0 {
 			jobIdsToPrint := maps.Keys(qctx.SuccessfulJobSchedulingContexts)
-			if len(jobIdsToPrint) > maxPrintedJobIdsByReason {
-				jobIdsToPrint = jobIdsToPrint[0:maxPrintedJobIdsByReason]
+			if len(jobIdsToPrint) > maxJobIdsToPrint {
+				jobIdsToPrint = jobIdsToPrint[0:maxJobIdsToPrint]
 			}
 			fmt.Fprintf(w, "Scheduled jobs:\t%v", jobIdsToPrint)
 			if len(jobIdsToPrint) != len(qctx.SuccessfulJobSchedulingContexts) {
@@ -374,8 +374,8 @@ func (qctx *QueueSchedulingContext) ReportString(verbosity int32) string {
 		}
 		if len(qctx.EvictedJobsById) > 0 {
 			jobIdsToPrint := maps.Keys(qctx.EvictedJobsById)
-			if len(jobIdsToPrint) > maxPrintedJobIdsByReason {
-				jobIdsToPrint = jobIdsToPrint[0:maxPrintedJobIdsByReason]
+			if len(jobIdsToPrint) > maxJobIdsToPrint {
+				jobIdsToPrint = jobIdsToPrint[0:maxJobIdsToPrint]
 			}
 			fmt.Fprintf(w, "Preempted jobs:\t%v", jobIdsToPrint)
 			if len(jobIdsToPrint) != len(qctx.EvictedJobsById) {

--- a/internal/scheduler/context/context.go
+++ b/internal/scheduler/context/context.go
@@ -362,7 +362,7 @@ func (qctx *QueueSchedulingContext) ReportString(verbosity int32) string {
 		fmt.Fprintf(w, "Number of jobs that could not be scheduled:\t%d\n", len(qctx.UnsuccessfulJobSchedulingContexts))
 		if len(qctx.SuccessfulJobSchedulingContexts) > 0 {
 			jobIdsToPrint := maps.Keys(qctx.SuccessfulJobSchedulingContexts)
-			if verbosity <= 1 && len(jobIdsToPrint) > maxPrintedJobIdsByReason {
+			if len(jobIdsToPrint) > maxPrintedJobIdsByReason {
 				jobIdsToPrint = jobIdsToPrint[0:maxPrintedJobIdsByReason]
 			}
 			fmt.Fprintf(w, "Scheduled jobs:\t%v", jobIdsToPrint)
@@ -374,7 +374,7 @@ func (qctx *QueueSchedulingContext) ReportString(verbosity int32) string {
 		}
 		if len(qctx.EvictedJobsById) > 0 {
 			jobIdsToPrint := maps.Keys(qctx.EvictedJobsById)
-			if verbosity <= 1 && len(jobIdsToPrint) > maxPrintedJobIdsByReason {
+			if len(jobIdsToPrint) > maxPrintedJobIdsByReason {
 				jobIdsToPrint = jobIdsToPrint[0:maxPrintedJobIdsByReason]
 			}
 			fmt.Fprintf(w, "Preempted jobs:\t%v", jobIdsToPrint)

--- a/internal/scheduler/context/context.go
+++ b/internal/scheduler/context/context.go
@@ -167,7 +167,7 @@ func (sctx *SchedulingContext) ReportString(verbosity int32) string {
 		fmt.Fprint(w, "Scheduled queues:\n")
 		for queueName, qctx := range scheduled {
 			fmt.Fprintf(w, "\t%s:\n", queueName)
-			fmt.Fprintf(w, indent.String("\t\t", qctx.ReportString(verbosity-1)))
+			fmt.Fprintf(w, indent.String("\t\t", qctx.ReportString(verbosity-2)))
 		}
 	}
 	preempted := armadamaps.Filter(
@@ -182,7 +182,7 @@ func (sctx *SchedulingContext) ReportString(verbosity int32) string {
 		fmt.Fprint(w, "Preempted queues:\n")
 		for queueName, qctx := range preempted {
 			fmt.Fprintf(w, "\t%s:\n", queueName)
-			fmt.Fprintf(w, indent.String("\t\t", qctx.ReportString(verbosity-1)))
+			fmt.Fprintf(w, indent.String("\t\t", qctx.ReportString(verbosity-2)))
 		}
 	}
 	w.Flush()
@@ -346,7 +346,7 @@ const maxPrintedJobIdsByReason = 1
 func (qctx *QueueSchedulingContext) ReportString(verbosity int32) string {
 	var sb strings.Builder
 	w := tabwriter.NewWriter(&sb, 1, 1, 1, ' ', 0)
-	if verbosity > 0 {
+	if verbosity >= 0 {
 		fmt.Fprintf(w, "Time:\t%s\n", qctx.Created)
 		fmt.Fprintf(w, "Queue:\t%s\n", qctx.Queue)
 	}
@@ -354,7 +354,7 @@ func (qctx *QueueSchedulingContext) ReportString(verbosity int32) string {
 	fmt.Fprintf(w, "Scheduled resources (by priority):\t%s\n", qctx.ScheduledResourcesByPriority.String())
 	fmt.Fprintf(w, "Preempted resources:\t%s\n", qctx.EvictedResourcesByPriority.AggregateByResource().CompactString())
 	fmt.Fprintf(w, "Preempted resources (by priority):\t%s\n", qctx.EvictedResourcesByPriority.String())
-	if verbosity > 0 {
+	if verbosity >= 0 {
 		fmt.Fprintf(w, "Total allocated resources after scheduling:\t%s\n", qctx.AllocatedByPriority.AggregateByResource().CompactString())
 		fmt.Fprintf(w, "Total allocated resources after scheduling (by priority):\t%s\n", qctx.AllocatedByPriority.String())
 		fmt.Fprintf(w, "Number of jobs scheduled:\t%d\n", len(qctx.SuccessfulJobSchedulingContexts))

--- a/internal/scheduler/context/context.go
+++ b/internal/scheduler/context/context.go
@@ -347,7 +347,8 @@ func (qctx *QueueSchedulingContext) ReportString(verbosity int32) string {
 	var sb strings.Builder
 	w := tabwriter.NewWriter(&sb, 1, 1, 1, ' ', 0)
 	if verbosity > 0 {
-		fmt.Fprintf(w, "Created:\t%s\n", qctx.Created)
+		fmt.Fprintf(w, "Time:\t%s\n", qctx.Created)
+		fmt.Fprintf(w, "Queue:\t%s\n", qctx.Queue)
 	}
 	fmt.Fprintf(w, "Scheduled resources:\t%s\n", qctx.ScheduledResourcesByPriority.AggregateByResource().CompactString())
 	fmt.Fprintf(w, "Scheduled resources (by priority):\t%s\n", qctx.ScheduledResourcesByPriority.String())
@@ -571,7 +572,7 @@ func (jctx *JobSchedulingContext) String() string {
 	var sb strings.Builder
 	w := tabwriter.NewWriter(&sb, 1, 1, 1, ' ', 0)
 	fmt.Fprintf(w, "Time:\t%s\n", jctx.Created)
-	fmt.Fprintf(w, "Job id:\t%s\n", jctx.JobId)
+	fmt.Fprintf(w, "Job ID:\t%s\n", jctx.JobId)
 	fmt.Fprintf(w, "Number of nodes in cluster:\t%d\n", jctx.NumNodes)
 	if jctx.UnschedulableReason != "" {
 		fmt.Fprintf(w, "UnschedulableReason:\t%s\n", jctx.UnschedulableReason)


### PR DESCRIPTION
The main change here is that the `scheduling-report` subcommand of `armadactl` also prints queue and job scheduling reports if invoked with `--queue` or `--job`. That looks something like this:

```console
$ go run cmd/armadactl/main.go scheduling-report --job 01h39z8wt90r1sfh21j4htxqej
executor-01:
 Most recent scheduling round that affected job 01h39z8wt90r1sfh21j4htxqej:
  Overall scheduling report:
   Started:                   2023-03-22 16:34:39.5035361 +0000 GMT
   Finished:                  2023-03-22 16:34:39.5055666 +0000 GMT
   Duration:                  2.0305ms
   Termination reason:        no remaining candidate jobs
   Total capacity:            {cpu: 32, memory: 256Gi}
   Scheduled resources:       {cpu: 16, memory: 128Gi}
   Preempted resources:       {cpu: 16, memory: 128Gi}
   Number of gangs scheduled: 0
   Number of jobs scheduled:  16
   Number of jobs preempted:  16
   Scheduled queues:          [batch-bob]
   Preempted queues:          [batch-alice]
  Scheduling report for queue batch-alice:
   Time:                                                     2023-03-22 16:34:39.5035361 +0000 GMT
   Queue:                                                    batch-alice
   Scheduled resources:                                      {}
   Scheduled resources (by priority):                        {}
   Preempted resources:                                      {cpu: 16, memory: 128Gi}
   Preempted resources (by priority):                        {0: {cpu: 16, memory: 128Gi}}
   Total allocated resources after scheduling:               {cpu: 16, memory: 128Gi}
   Total allocated resources after scheduling (by priority): {0: {cpu: 16, memory: 128Gi}}
   Number of jobs scheduled:                                 0
   Number of jobs preempted:                                 16
   Number of jobs that could not be scheduled:               16
   Preempted jobs:                                           [01h39z8wt90r1sfh21j4htxqej] (and 15 others not shown)
   Unschedulable jobs:
    16: maximum total resources for this queue exceeded (e.g., 01h39z8wt90r1sfh21j5gd0qtt)
  Scheduling report for job 01h39z8wt90r1sfh21j4htxqej:
   Time:                       0001-01-01 00:00:00 +0000 UTC
   Job ID:                     01h39z8wt90r1sfh21j4htxqej
   Number of nodes in cluster: 2
   UnschedulableReason:        maximum total resources for this queue exceeded
```

I've also changed a couple of minor aspects of the scheduling reports that I noticed while working on this.

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-375) by [Unito](https://www.unito.io)
