### PR TITLE
Fix runs getting stuck in non-terminal states

### DIFF
--- a/internal/executor/reporter/job_event_reporter.go
+++ b/internal/executor/reporter/job_event_reporter.go
@@ -169,6 +169,7 @@ func (eventReporter *JobEventReporter) reportStatusUpdate(old *v1.Pod, new *v1.P
 	// Don't report status change for pods Armada is deleting
 	// This prevents reporting JobFailed when we delete a pod - for example due to cancellation
 	if util.IsMarkedForDeletion(new) {
+		log.Warnf("not sending event to report pod %s moving into phase %s as pod is marked for deletion", new.Name, new.Status.Phase)
 		return
 	}
 	eventReporter.reportCurrentStatus(new)

--- a/internal/executor/reporter/job_event_reporter.go
+++ b/internal/executor/reporter/job_event_reporter.go
@@ -169,7 +169,7 @@ func (eventReporter *JobEventReporter) reportStatusUpdate(old *v1.Pod, new *v1.P
 	// Don't report status change for pods Armada is deleting
 	// This prevents reporting JobFailed when we delete a pod - for example due to cancellation
 	if util.IsMarkedForDeletion(new) {
-		log.Warnf("not sending event to report pod %s moving into phase %s as pod is marked for deletion", new.Name, new.Status.Phase)
+		log.Infof("not sending event to report pod %s moving into phase %s as pod is marked for deletion", new.Name, new.Status.Phase)
 		return
 	}
 	eventReporter.reportCurrentStatus(new)

--- a/internal/executor/service/pod_issue_handler_test.go
+++ b/internal/executor/service/pod_issue_handler_test.go
@@ -119,7 +119,7 @@ func TestPodIssueService_DeletesPodAndReportsFailed_IfRetryableStuckPodStartsUpA
 	assert.Len(t, eventsReporter.ReceivedEvents, 0)
 	assert.Len(t, getActivePods(t, fakeClusterContext), 1)
 
-	// Now processes the issue as non-retryable and fails the po
+	// Now processes the issue as non-retryable and fails the pod
 	podIssueService.HandlePodIssues()
 	assert.Len(t, getActivePods(t, fakeClusterContext), 0)
 


### PR DESCRIPTION
There is a very weak form of communication between pod_issue_handler and job_event_reporter
 - Once something marks a pod for deletion, job_event_reporter will stop sending phase change updates for this pod.

The issue is when pod_issue_handler tries to delete a pod, the pod actually runs to completion. So pod_issue_handler stops "handling" this pod but also job_event_reporter also has stopped sending updates

The end result is no events get sent and the pod ends up stuck forever

Now if a pod issue is being handled and delete has been called, pod_issue_handler is responsible for sending the terminal events for that pod

In practice:
 - Don't ever resolve an issue early, if delete has been called
 - If a pod unexpected starts up during deletion, consider the run as failed

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-398) by [Unito](https://www.unito.io)
