### PR TITLE
Fixing docs-check builds by limiting pkg version

### DIFF
--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -10,7 +10,8 @@ authors = [{ name = "G-Research Open Source Software", email = "armada@armadapro
 
 [project.optional-dependencies]
 format = ["black==23.3.0", "flake8==6.0.0", "pylint==2.17.4"]
-docs = ["sphinx", "sphinx-jekyll-builder", "sphinx-toolbox==3.2.0b1"]
+# note(JayF): sphinx-jekyll-builder was broken by sphinx-markdown-builder 0.6 -- so exclude it
+docs = ["sphinx", "sphinx-jekyll-builder", "sphinx-toolbox==3.2.0b1", "sphinx-markdown-builder<0.6"]
 test = ["pytest==7.3.1", "coverage>=6.5.0", "pytest-asyncio==0.21.0"]
 
 [build-system]

--- a/third_party/airflow/pyproject.toml
+++ b/third_party/airflow/pyproject.toml
@@ -21,7 +21,8 @@ readme = "README.md"
 [project.optional-dependencies]
 format = ["black==23.3.0", "flake8==6.0.0", "pylint==2.17.4"]
 test = ["pytest==7.3.1", "coverage>=6.5.0", "pytest-asyncio==0.21.0"]
-docs = ["sphinx", "sphinx-jekyll-builder"]
+# note(JayF): sphinx-jekyll-builder was broken by sphinx-markdown-builder 0.6 -- so exclude it
+docs = ["sphinx", "sphinx-jekyll-builder", "sphinx-markdown-builder<0.6"]
 
 [build-system]
 requires = ["setuptools"]


### PR DESCRIPTION
sphinx-markdown-builder released on 6/23, breaking the docs build. We won't install the new version now, working around the failure.

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-408) by [Unito](https://www.unito.io)
