### PR TITLE
fix: deprecated version of actions - airflow-operator-release-to-pypi, airflow-operator, codeql-analysis.yml workflows

### DIFF
--- a/.github/workflows/airflow-operator-release-to-pypi.yml
+++ b/.github/workflows/airflow-operator-release-to-pypi.yml
@@ -10,10 +10,10 @@ jobs:
       matrix:
         go: [ '1.20' ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/workflows/go-setup
       - name: Install Protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v2
         with:
           version: '3.17.3'
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/airflow-operator.yml
+++ b/.github/workflows/airflow-operator.yml
@@ -55,10 +55,10 @@ jobs:
           - tox-env: 'py310'
             python: '3.10'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/workflows/go-setup
       - name: Install Protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v2
         with:
           version: '3.17.3'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -102,7 +102,7 @@ jobs:
           mkdir -p .kube/external
           go run github.com/magefile/mage@v1.14.0 -v localdev minimal
       - name: Install Protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v2
         with:
           version: '3.17.3'
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,10 +38,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     # The ArmadaProject.Io.Client needs the generated proto files
     - name: Install Protoc
-      uses: arduino/setup-protoc@v1
+      uses: arduino/setup-protoc@v2
       with:
         version: '3.17.3'
         repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

## What type of PR is this?


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2592 

This PR updates the deprecated versions of `actions/checkout@v2` and `arduino/setup-protoc@v1`

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-420) by [Unito](https://www.unito.io)
