### PR TITLE
Clean up `nodedb` tests

### DIFF
--- a/internal/scheduler/nodedb/nodedb.go
+++ b/internal/scheduler/nodedb/nodedb.go
@@ -42,7 +42,7 @@ type Node struct {
 
 	TotalResources schedulerobjects.ResourceList
 
-	// This field is set when inserting the Node into the node database.
+	// This field is set when inserting the Node into a NodeDb.
 	Keys [][]byte
 
 	NodeTypeId uint64

--- a/internal/scheduler/nodedb/nodedb_test.go
+++ b/internal/scheduler/nodedb/nodedb_test.go
@@ -26,7 +26,7 @@ func TestNodeDbSchema(t *testing.T) {
 
 // Test the accounting of total resources across all nodes.
 func TestTotalResources(t *testing.T) {
-	nodeDb, err := createNodeDb([]*schedulerobjects.Node{})
+	nodeDb, err := newNodeDbWithNodes([]*schedulerobjects.Node{})
 	require.NoError(t, err)
 
 	expected := schedulerobjects.ResourceList{Resources: make(map[string]resource.Quantity)}
@@ -65,7 +65,7 @@ func TestSelectNodeForPod_NodeIdLabel_Success(t *testing.T) {
 	nodes := testfixtures.N32CpuNodes(2, testfixtures.TestPriorities)
 	nodeId := nodes[1].Id
 	require.NotEmpty(t, nodeId)
-	db, err := createNodeDb(nodes)
+	db, err := newNodeDbWithNodes(nodes)
 	require.NoError(t, err)
 	jobs := testfixtures.WithNodeSelectorJobs(
 		map[string]string{schedulerconfig.NodeIdLabel: nodeId},
@@ -94,7 +94,7 @@ func TestSelectNodeForPod_NodeIdLabel_Failure(t *testing.T) {
 	nodes := testfixtures.N32CpuNodes(1, testfixtures.TestPriorities)
 	nodeId := nodes[0].Id
 	require.NotEmpty(t, nodeId)
-	db, err := createNodeDb(nodes)
+	db, err := newNodeDbWithNodes(nodes)
 	require.NoError(t, err)
 	jobs := testfixtures.WithNodeSelectorJobs(
 		map[string]string{schedulerconfig.NodeIdLabel: "this node does not exist"},
@@ -119,7 +119,7 @@ func TestSelectNodeForPod_NodeIdLabel_Failure(t *testing.T) {
 
 func TestNodeBindingEvictionUnbinding(t *testing.T) {
 	node := testfixtures.Test8GpuNode(testfixtures.TestPriorities)
-	nodeDb, err := createNodeDb([]*schedulerobjects.Node{node})
+	nodeDb, err := newNodeDbWithNodes([]*schedulerobjects.Node{node})
 	require.NoError(t, err)
 	entry, err := nodeDb.GetNode(node.Id)
 	require.NoError(t, err)
@@ -276,7 +276,7 @@ func TestEviction(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			nodeDb, err := createNodeDb([]*schedulerobjects.Node{})
+			nodeDb, err := newNodeDbWithNodes([]*schedulerobjects.Node{})
 			require.NoError(t, err)
 			txn := nodeDb.Txn(true)
 			jobs := []*jobdb.Job{
@@ -432,7 +432,7 @@ func TestScheduleIndividually(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			nodeDb, err := createNodeDb(tc.Nodes)
+			nodeDb, err := newNodeDbWithNodes(tc.Nodes)
 			require.NoError(t, err)
 
 			jctxs := schedulercontext.JobSchedulingContextsFromJobs(testfixtures.TestPriorityClasses, tc.Jobs)
@@ -516,7 +516,7 @@ func TestScheduleMany(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			nodeDb, err := createNodeDb(tc.Nodes)
+			nodeDb, err := newNodeDbWithNodes(tc.Nodes)
 			require.NoError(t, err)
 			for i, jobs := range tc.Jobs {
 				jctxs := schedulercontext.JobSchedulingContextsFromJobs(testfixtures.TestPriorityClasses, jobs)
@@ -696,7 +696,7 @@ func BenchmarkScheduleManyResourceConstrained(b *testing.B) {
 	)
 }
 
-func createNodeDb(nodes []*schedulerobjects.Node) (*NodeDb, error) {
+func newNodeDbWithNodes(nodes []*schedulerobjects.Node) (*NodeDb, error) {
 	nodeDb, err := NewNodeDb(
 		testfixtures.TestPriorityClasses,
 		testfixtures.TestMaxExtraNodesToConsider,

--- a/internal/scheduler/nodedb/nodeiteration_test.go
+++ b/internal/scheduler/nodedb/nodeiteration_test.go
@@ -35,7 +35,7 @@ func TestNodesIterator(t *testing.T) {
 			for i, node := range tc.Nodes {
 				indexById[node.Id] = i
 			}
-			nodeDb, err := createNodeDb(tc.Nodes)
+			nodeDb, err := newNodeDbWithNodes(tc.Nodes)
 			if !assert.NoError(t, err) {
 				return
 			}
@@ -66,7 +66,7 @@ func TestNodePairIterator(t *testing.T) {
 	for i, nodeId := range []string{"A", "B", "C"} {
 		nodes[i].Id = nodeId
 	}
-	nodeDb, err := createAndPopulateNodeDb(nodes)
+	nodeDb, err := newNodeDbWithNodes(nodes)
 	require.NoError(t, err)
 	entries := make([]*Node, len(nodes))
 	for i, node := range nodes {
@@ -409,7 +409,7 @@ func TestNodeTypeIterator(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			nodeDb, err := createNodeDb(nil)
+			nodeDb, err := newNodeDbWithNodes(nil)
 			require.NoError(t, err)
 
 			entries := make([]*Node, len(tc.nodes))
@@ -799,7 +799,7 @@ func TestNodeTypesIterator(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			nodeDb, err := createNodeDb(nil)
+			nodeDb, err := newNodeDbWithNodes(nil)
 			require.NoError(t, err)
 
 			entries := make([]*Node, len(tc.nodes))
@@ -873,7 +873,7 @@ func BenchmarkNodeTypeIterator(b *testing.B) {
 			[]*schedulerobjects.Node{node},
 		)
 	}
-	nodeDb, err := createNodeDb(nodes)
+	nodeDb, err := newNodeDbWithNodes(nodes)
 	require.NoError(b, err)
 
 	// Create iterator for 0 CPU required and an unfeasible memory request,

--- a/internal/scheduler/nodedb/nodeiteration_test.go
+++ b/internal/scheduler/nodedb/nodeiteration_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/go-memdb"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
@@ -64,30 +62,21 @@ func TestNodesIterator(t *testing.T) {
 }
 
 func TestNodePairIterator(t *testing.T) {
-	nodeDb, err := createNodeDb(nil)
-	require.NoError(t, err)
-
 	nodes := testfixtures.TestCluster()
-	for i, c := range []string{"A", "B", "C"} {
-		nodes[i].Id = c
+	for i, nodeId := range []string{"A", "B", "C"} {
+		nodes[i].Id = nodeId
 	}
+	nodeDb, err := createAndPopulateNodeDb(nodes)
+	require.NoError(t, err)
 	entries := make([]*Node, len(nodes))
 	for i, node := range nodes {
-		entry, err := nodeDb.create(node)
+		entry, err := nodeDb.GetNode(node.Id)
 		require.NoError(t, err)
 		entries[i] = entry
 	}
 
-	for _, node := range entries {
-		node.Keys = make([][]byte, len(nodeDb.prioritiesToTryAssigningAt))
-		for i, p := range nodeDb.prioritiesToTryAssigningAt {
-			node.Keys[i] = nodeDb.nodeDbKey(node.Keys[i], node.NodeTypeId, node.AllocatableByPriority[p])
-		}
-	}
-
 	txn := nodeDb.Txn(true)
-	require.NoError(t, txn.Insert("nodes", entries[0]))
-	require.NoError(t, txn.Insert("nodes", entries[1]))
+	require.NoError(t, txn.Delete("nodes", entries[2]))
 	txn.Commit()
 	txnA := nodeDb.Txn(false)
 
@@ -423,34 +412,21 @@ func TestNodeTypeIterator(t *testing.T) {
 			nodeDb, err := createNodeDb(nil)
 			require.NoError(t, err)
 
-			// Set monotonically increaseing node ids to ensure nodes appear in predictable order.
-			for i, node := range tc.nodes {
-				node.Id = fmt.Sprintf("%d", i)
-			}
-			indexByNodeId := make(map[string]int)
-			for i, node := range tc.nodes {
-				indexByNodeId[node.Id] = i
-			}
-
 			entries := make([]*Node, len(tc.nodes))
 			for i, node := range tc.nodes {
+				// Set monotonically increasing node IDs to ensure nodes appear in predictable order.
+				node.Id = fmt.Sprintf("%d", i)
+
 				entry, err := nodeDb.create(node)
 				require.NoError(t, err)
+
+				// We can safely override NodeTypeId, because Keys is recomputed upon insertion.
 				entry.NodeTypeId = node.NodeTypeId
+
 				entries[i] = entry
 			}
+			require.NoError(t, nodeDb.UpsertMany(entries))
 
-			// Compute the keys necessary to efficiently iterate over nodes
-			// and populate the database. We do this manually instead of using nodeDb.Upsert to control the nodeTypeId.
-			for _, node := range entries {
-				node.Keys = make([][]byte, len(nodeDb.prioritiesToTryAssigningAt))
-				for i, p := range nodeDb.prioritiesToTryAssigningAt {
-					node.Keys[i] = nodeDb.nodeDbKey(node.Keys[i], node.NodeTypeId, node.AllocatableByPriority[p])
-				}
-			}
-			require.NoError(t, populateDatabase(nodeDb.db, entries))
-
-			// Create iterator.
 			indexedResourceRequests := make([]resource.Quantity, len(testfixtures.TestResources))
 			for i, t := range nodeDb.indexedResources {
 				indexedResourceRequests[i] = tc.resourceRequests.Get(t)
@@ -462,22 +438,31 @@ func TestNodeTypeIterator(t *testing.T) {
 				}
 			}
 			require.NotEqual(t, -1, keyIndex)
-			it, err := NewNodeTypeIterator(nodeDb.Txn(false), tc.nodeTypeId, nodeIndexName(keyIndex), tc.priority, testfixtures.TestResourceNames, indexedResourceRequests, testfixtures.TestIndexedResourceResolutionMillis)
+			it, err := NewNodeTypeIterator(
+				nodeDb.Txn(false),
+				tc.nodeTypeId,
+				nodeIndexName(keyIndex),
+				tc.priority,
+				testfixtures.TestResourceNames,
+				indexedResourceRequests,
+				testfixtures.TestIndexedResourceResolutionMillis,
+			)
 			require.NoError(t, err)
 
-			// Compare actual with expected order.
-			actual := make([]int, 0)
+			expected := make([]string, len(tc.expected))
+			for i, nodeId := range tc.expected {
+				expected[i] = fmt.Sprintf("%d", nodeId)
+			}
+			actual := make([]string, 0)
 			for {
 				node, err := it.NextNode()
 				require.NoError(t, err)
 				if node == nil {
 					break
 				}
-				i, ok := indexByNodeId[node.Id]
-				require.True(t, ok)
-				actual = append(actual, i)
+				actual = append(actual, node.Id)
 			}
-			assert.Equal(t, tc.expected, actual)
+			assert.Equal(t, expected, actual)
 
 			// Calling next should always return nil from now on.
 			for i := 0; i < 100; i++ {
@@ -817,32 +802,20 @@ func TestNodeTypesIterator(t *testing.T) {
 			nodeDb, err := createNodeDb(nil)
 			require.NoError(t, err)
 
-			// Set monotonically increaseing node ids to ensure nodes appear in predictable order.
-			for i, node := range tc.nodes {
-				node.Id = fmt.Sprintf("%d", i)
-			}
-			indexByNodeId := make(map[string]int)
-			for i, node := range tc.nodes {
-				indexByNodeId[node.Id] = i
-			}
-
 			entries := make([]*Node, len(tc.nodes))
 			for i, node := range tc.nodes {
+				// Set monotonically increasing node IDs to ensure nodes appear in predictable order.
+				node.Id = fmt.Sprintf("%d", i)
+
 				entry, err := nodeDb.create(node)
 				require.NoError(t, err)
+
+				// We can safely override NodeTypeId, because Keys is recomputed upon insertion.
 				entry.NodeTypeId = node.NodeTypeId
+
 				entries[i] = entry
 			}
-
-			// Compute the keys necessary to efficiently iterate over nodes
-			// and populate the database. We do this manually instead of using nodeDb.Upsert to control the nodeTypeId.
-			for _, node := range entries {
-				node.Keys = make([][]byte, len(nodeDb.prioritiesToTryAssigningAt))
-				for i, p := range nodeDb.prioritiesToTryAssigningAt {
-					node.Keys[i] = nodeDb.nodeDbKey(node.Keys[i], node.NodeTypeId, node.AllocatableByPriority[p])
-				}
-			}
-			require.NoError(t, populateDatabase(nodeDb.db, entries))
+			require.NoError(t, nodeDb.UpsertMany(entries))
 
 			indexedResourceRequests := make([]resource.Quantity, len(testfixtures.TestResources))
 			for i, t := range testfixtures.TestResourceNames {
@@ -859,19 +832,20 @@ func TestNodeTypesIterator(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			// Compare actual with expected order.
-			actual := make([]int, 0)
+			expected := make([]string, len(tc.expected))
+			for i, nodeId := range tc.expected {
+				expected[i] = fmt.Sprintf("%d", nodeId)
+			}
+			actual := make([]string, 0)
 			for {
 				node, err := it.NextNode()
 				require.NoError(t, err)
 				if node == nil {
 					break
 				}
-				i, ok := indexByNodeId[node.Id]
-				require.True(t, ok)
-				actual = append(actual, i)
+				actual = append(actual, node.Id)
 			}
-			assert.Equal(t, tc.expected, actual)
+			assert.Equal(t, expected, actual)
 
 			// Calling next again should still return nil.
 			node, err := it.NextNode()
@@ -879,19 +853,6 @@ func TestNodeTypesIterator(t *testing.T) {
 			require.Nil(t, node)
 		})
 	}
-}
-
-func populateDatabase(db *memdb.MemDB, nodes []*Node) error {
-	txn := db.Txn(true)
-	defer txn.Abort()
-	for _, node := range nodes {
-		err := txn.Insert("nodes", node)
-		if err != nil {
-			return errors.WithStack(err)
-		}
-	}
-	txn.Commit()
-	return nil
 }
 
 func BenchmarkNodeTypeIterator(b *testing.B) {


### PR DESCRIPTION
A small follow-up to #2625 that removes a couple of calls to internal functions from the `nodedb` tests.

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-422) by [Unito](https://www.unito.io)
