### PR TITLE
Add basic health endpoint and readiness check to scheduler

### DIFF
--- a/config/scheduler/config.yaml
+++ b/config/scheduler/config.yaml
@@ -37,6 +37,8 @@ leader:
   renewDeadline: 10s
   retryPeriod: 2s
   podName: "" # This must be set so viper allows env vars to overwrite it
+http:
+  port: 8080
 grpc:
   port: 50052
   keepaliveParams:

--- a/deployment/scheduler/templates/scheduler-statefulset.yaml
+++ b/deployment/scheduler/templates/scheduler-statefulset.yaml
@@ -55,6 +55,9 @@ spec:
           resources:
             {{- toYaml .Values.scheduler.resources | nindent 12 }}
           ports:
+            - containerPort: { { .Values.scheduler.applicationConfig.http.port } }
+              protocol: TCP
+              name: http
             - containerPort:  {{ .Values.scheduler.applicationConfig.grpc.port }}
               protocol: TCP
               name: grpc
@@ -79,6 +82,13 @@ spec:
             {{- if .Values.scheduler.additionalVolumeMounts }}
             {{- toYaml .Values.scheduler.additionalVolumeMounts | nindent 12 -}}
             {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 2
           securityContext:
             allowPrivilegeEscalation: false
       affinity:

--- a/deployment/scheduler/values.yaml
+++ b/deployment/scheduler/values.yaml
@@ -19,6 +19,8 @@ scheduler:
       port: 50051
     metrics:
       port: 9001
+    http:
+      port: 8080
     pulsar: {}
   updateStrategy:
     rollingUpdate:

--- a/internal/scheduler/configuration/configuration.go
+++ b/internal/scheduler/configuration/configuration.go
@@ -33,6 +33,7 @@ type Configuration struct {
 	Scheduling configuration.SchedulingConfig
 	Auth       authconfig.AuthConfig
 	Grpc       grpcconfig.GrpcConfig
+	Http       HttpConfig
 	// Maximum number of strings that should be cached at any one time
 	InternedStringsCacheSize uint32 `validate:"required"`
 	// How often the scheduling cycle should run
@@ -67,4 +68,8 @@ type LeaderConfig struct {
 	RenewDeadline time.Duration
 	// RetryPeriod is the duration the LeaderElector clients should waite between tries of actions.
 	RetryPeriod time.Duration
+}
+
+type HttpConfig struct {
+	Port int `validate:"required"`
 }

--- a/internal/scheduler/schedulerapp.go
+++ b/internal/scheduler/schedulerapp.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/apache/pulsar-client-go/pulsar"
-	"github.com/armadaproject/armada/internal/common/health"
 	"github.com/go-redis/redis"
 	"github.com/google/uuid"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus/ctxlogrus"
@@ -25,6 +24,7 @@ import (
 	"github.com/armadaproject/armada/internal/common/auth"
 	dbcommon "github.com/armadaproject/armada/internal/common/database"
 	grpcCommon "github.com/armadaproject/armada/internal/common/grpc"
+	"github.com/armadaproject/armada/internal/common/health"
 	"github.com/armadaproject/armada/internal/common/pulsarutils"
 	"github.com/armadaproject/armada/internal/common/stringinterner"
 	schedulerconfig "github.com/armadaproject/armada/internal/scheduler/configuration"


### PR DESCRIPTION
This is currently the most basic check - to confirm the application has started up successfully
 - Longer term we'll make this check more comprehensive

This should prevent a bad config rollout from taking down all scheduler replicas
 - As now we the scheduler pod doesn't report "Ready" until after it has read the config + reconnected to all databases

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-423) by [Unito](https://www.unito.io)
