### PR TITLE
Add armada-scheduler k8s service to its tls certificate

### DIFF
--- a/deployment/scheduler/templates/scheduler-ingress.yaml
+++ b/deployment/scheduler/templates/scheduler-ingress.yaml
@@ -40,6 +40,7 @@ spec:
   tls:
     - hosts:
       {{- toYaml .Values.scheduler.hostnames  | nindent 6 }}
+      - {{ include "armada-scheduler.name" $root }}.{{ $root.Release.Namespace }}.svc
       {{- $root := . -}}
       {{- range $i := until (int .Values.scheduler.replicas) }}
       - {{ include "armada-scheduler.name" $root }}-{{ $i }}.{{ include "armada-scheduler.name" $root }}.{{ $root.Release.Namespace }}.svc


### PR DESCRIPTION
This allows armada components to talk to the armada-scheduler service directly
 - Without this, they get an error saying the cert is not signed for the service url

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-450) by [Unito](https://www.unito.io)
