### PR TITLE
Separate node id and name in job runs

### DIFF
--- a/internal/scheduler/jobdb/job.go
+++ b/internal/scheduler/jobdb/job.go
@@ -333,13 +333,14 @@ func (job *Job) HasRuns() bool {
 }
 
 // WithNewRun creates a copy of the job with a new run on the given executor.
-func (job *Job) WithNewRun(executor string, nodeId string) *Job {
+func (job *Job) WithNewRun(executor string, nodeId, nodeName string) *Job {
 	run := &JobRun{
 		id:       uuid.New(),
 		jobId:    job.id,
 		created:  time.Now().UnixNano(),
 		executor: executor,
 		nodeId:   nodeId,
+		nodeName: nodeName,
 	}
 	return job.WithUpdatedRun(run)
 }

--- a/internal/scheduler/jobdb/job_run.go
+++ b/internal/scheduler/jobdb/job_run.go
@@ -15,7 +15,11 @@ type JobRun struct {
 	// The name of the executor this run has been leased to.
 	executor string
 	// The id of the node this run has been leased to.
+	// Identifies the node within the Armada scheduler.
 	nodeId string
+	// The name of the node this run has been leased to.
+	// Identifies the node within the target executor cluster.
+	nodeName string
 	// True if the job has been reported as running by the executor.
 	running bool
 	// True if the job has been reported as succeeded by the executor.
@@ -81,9 +85,14 @@ func (run *JobRun) Executor() string {
 	return run.executor
 }
 
-// Node returns the nodeId to which the JobRun is assigned.
-func (run *JobRun) Node() string {
+// NodeId returns the id of the node to which the JobRun is assigned.
+func (run *JobRun) NodeId() string {
 	return run.nodeId
+}
+
+// NodeId returns the name of the node to which the JobRun is assigned.
+func (run *JobRun) NodeName() string {
+	return run.nodeName
 }
 
 // Succeeded Returns true if the executor has reported the job run as successful

--- a/internal/scheduler/jobdb/job_run_test.go
+++ b/internal/scheduler/jobdb/job_run_test.go
@@ -26,7 +26,7 @@ func TestJobRun_TestGetter(t *testing.T) {
 	assert.Equal(t, baseJobRun.id, baseJobRun.Id())
 	assert.Equal(t, baseJobRun.created, baseJobRun.Created())
 	assert.Equal(t, baseJobRun.executor, baseJobRun.Executor())
-	assert.Equal(t, baseJobRun.nodeId, baseJobRun.Node())
+	assert.Equal(t, baseJobRun.nodeId, baseJobRun.NodeId())
 }
 
 func TestJobRun_TestRunning(t *testing.T) {

--- a/internal/scheduler/jobdb/job_test.go
+++ b/internal/scheduler/jobdb/job_test.go
@@ -123,11 +123,11 @@ func TestJob_TestInTerminalState(t *testing.T) {
 
 func TestJob_TestHasRuns(t *testing.T) {
 	assert.Equal(t, false, baseJob.HasRuns())
-	assert.Equal(t, true, baseJob.WithNewRun("test-executor", "test-nodeId").HasRuns())
+	assert.Equal(t, true, baseJob.WithNewRun("test-executor", "test-nodeId", "nodeId").HasRuns())
 }
 
 func TestJob_TestWithNewRun(t *testing.T) {
-	jobWithRun := baseJob.WithNewRun("test-executor", "test-nodeId")
+	jobWithRun := baseJob.WithNewRun("test-executor", "test-nodeId", "nodeId")
 	assert.Equal(t, true, jobWithRun.HasRuns())
 	run := jobWithRun.LatestRun()
 	assert.NotNil(t, run)
@@ -137,6 +137,7 @@ func TestJob_TestWithNewRun(t *testing.T) {
 		created:  run.created,
 		executor: "test-executor",
 		nodeId:   "test-nodeId",
+		nodeName: "nodeId",
 	}, run)
 }
 

--- a/internal/scheduler/jobdb/jobdb_test.go
+++ b/internal/scheduler/jobdb/jobdb_test.go
@@ -54,8 +54,8 @@ func TestJobDb_TestGetById(t *testing.T) {
 
 func TestJobDb_TestGetByRunId(t *testing.T) {
 	jobDb := NewJobDb()
-	job1 := newJob().WithNewRun("executor", "nodeId")
-	job2 := newJob().WithNewRun("executor", "nodeId")
+	job1 := newJob().WithNewRun("executor", "nodeId", "nodeName")
+	job2 := newJob().WithNewRun("executor", "nodeId", "nodeName")
 	txn := jobDb.WriteTxn()
 
 	err := jobDb.Upsert(txn, []*Job{job1, job2})
@@ -71,8 +71,8 @@ func TestJobDb_TestGetByRunId(t *testing.T) {
 
 func TestJobDb_TestHasQueuedJobs(t *testing.T) {
 	jobDb := NewJobDb()
-	job1 := newJob().WithNewRun("executor", "nodeId")
-	job2 := newJob().WithNewRun("executor", "nodeId")
+	job1 := newJob().WithNewRun("executor", "nodeId", "nodeName")
+	job2 := newJob().WithNewRun("executor", "nodeId", "nodeName")
 	txn := jobDb.WriteTxn()
 
 	err := jobDb.Upsert(txn, []*Job{job1, job2})
@@ -141,8 +141,8 @@ func TestJobDb_TestQueuedJobs(t *testing.T) {
 
 func TestJobDb_TestGetAll(t *testing.T) {
 	jobDb := NewJobDb()
-	job1 := newJob().WithNewRun("executor", "nodeId")
-	job2 := newJob().WithNewRun("executor", "nodeId")
+	job1 := newJob().WithNewRun("executor", "nodeId", "nodeName")
+	job2 := newJob().WithNewRun("executor", "nodeId", "nodeName")
 	txn := jobDb.WriteTxn()
 	assert.Equal(t, []*Job{}, jobDb.GetAll(txn))
 
@@ -180,8 +180,8 @@ func TestJobDb_TestTransactions(t *testing.T) {
 
 func TestJobDb_TestBatchDelete(t *testing.T) {
 	jobDb := NewJobDb()
-	job1 := newJob().WithQueued(true).WithNewRun("executor", "nodeId")
-	job2 := newJob().WithQueued(true).WithNewRun("executor", "nodeId")
+	job1 := newJob().WithQueued(true).WithNewRun("executor", "nodeId", "nodeName")
+	job2 := newJob().WithQueued(true).WithNewRun("executor", "nodeId", "nodeName")
 	txn := jobDb.WriteTxn()
 
 	// Insert Job

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -337,7 +337,7 @@ func (s *Scheduler) createSchedulingInfoWithNodeAntiAffinityForAttemptedRuns(job
 
 	for _, run := range job.AllRuns() {
 		if run.RunAttempted() {
-			err := affinity.AddNodeAntiAffinity(newAffinity, s.nodeIdLabel, run.Node())
+			err := affinity.AddNodeAntiAffinity(newAffinity, s.nodeIdLabel, run.NodeName())
 			if err != nil {
 				return nil, err
 			}
@@ -440,10 +440,12 @@ func (s *Scheduler) eventsFromSchedulerResult(txn *jobdb.Txn, result *SchedulerR
 						Created: s.now(),
 						Event: &armadaevents.EventSequence_Event_JobRunLeased{
 							JobRunLeased: &armadaevents.JobRunLeased{
-								RunId:                armadaevents.ProtoUuidFromUuid(job.LatestRun().Id()),
-								JobId:                jobId,
-								ExecutorId:           job.LatestRun().Executor(),
-								NodeId:               job.LatestRun().Node(),
+								RunId:      armadaevents.ProtoUuidFromUuid(job.LatestRun().Id()),
+								JobId:      jobId,
+								ExecutorId: job.LatestRun().Executor(),
+								// NodeId here refers to the unique identifier of the node in an executor cluster,
+								// which is referred to as the NodeName within the scheduler.
+								NodeId:               job.LatestRun().NodeName(),
 								UpdateSequenceNumber: job.QueuedVersion(),
 							},
 						},

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -86,7 +86,7 @@ var leasedJob = jobdb.NewJob(
 	false,
 	false,
 	false,
-	1).WithQueued(false).WithNewRun("testExecutor", "test-node")
+	1).WithQueued(false).WithNewRun("testExecutor", "test-node", "node")
 
 var (
 	requeuedJobId = util.NewULID()
@@ -216,7 +216,7 @@ func TestScheduler_TestCycle(t *testing.T) {
 			expectedQueued:   []string{leasedJob.Id()},
 			expectedRequeued: []string{leasedJob.Id()},
 			// Should add node anti affinities for nodes of any attempted runs
-			expectedNodeAntiAffinities:       []string{leasedJob.LatestRun().Node()},
+			expectedNodeAntiAffinities:       []string{leasedJob.LatestRun().NodeId()},
 			expectedJobSchedulingInfoVersion: 2,
 			expectedQueuedVersion:            leasedJob.QueuedVersion() + 1,
 		},
@@ -933,7 +933,7 @@ func (t *testSchedulingAlgo) Schedule(ctx context.Context, txn *jobdb.Txn, jobDb
 		if !job.Queued() {
 			return nil, errors.Errorf("was asked to lease %s but job was already leased", job.Id())
 		}
-		job = job.WithQueued(false).WithNewRun("test-executor", "test-node")
+		job = job.WithQueued(false).WithNewRun("test-executor", "test-node", "node")
 		scheduledJobs = append(scheduledJobs, job)
 	}
 	if err := jobDb.Upsert(txn, preemptedJobs); err != nil {

--- a/internal/scheduler/scheduling_algo_test.go
+++ b/internal/scheduler/scheduling_algo_test.go
@@ -373,7 +373,7 @@ func TestSchedule(t *testing.T) {
 				for nodeIndex, existingJobs := range existingJobsByExecutorNodeIndex {
 					node := executor.Nodes[nodeIndex]
 					for jobIndex, job := range existingJobs.jobs {
-						job = job.WithQueued(false).WithNewRun(executor.Id, node.Id)
+						job = job.WithQueued(false).WithNewRun(executor.Id, node.Id, node.Name)
 						if existingJobs.acknowledged {
 							run := job.LatestRun()
 							node.StateByJobRunId[run.Id().String()] = schedulerobjects.JobRunState_RUNNING
@@ -448,7 +448,8 @@ func TestSchedule(t *testing.T) {
 				assert.False(t, dbJob.Queued())
 				dbRun := dbJob.LatestRun()
 				assert.False(t, dbRun.Failed())
-				assert.Equal(t, schedulerResult.NodeIdByJobId[dbJob.Id()], dbRun.Node())
+				assert.Equal(t, schedulerResult.NodeIdByJobId[dbJob.Id()], dbRun.NodeId())
+				assert.NotEmpty(t, dbRun.NodeName())
 			}
 
 			// Check that jobDb was updated correctly.
@@ -473,7 +474,7 @@ func BenchmarkNodeDbConstruction(b *testing.B) {
 			nodes := testfixtures.N32CpuNodes(numNodes, testfixtures.TestPriorities)
 			for i, node := range nodes {
 				for j := 32 * i; j < 32*(i+1); j++ {
-					jobs[j] = jobs[j].WithNewRun("executor-01", node.Name)
+					jobs[j] = jobs[j].WithNewRun("executor-01", node.Id, node.Name)
 				}
 			}
 			armadaslices.Shuffle(jobs)


### PR DESCRIPTION


┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-452) by [Unito](https://www.unito.io)
