### PR TITLE
[armada-scheduler] Fix node selector being nil after JobSchedulingInfo update

### DIFF
--- a/internal/scheduler/jobdb/job.go
+++ b/internal/scheduler/jobdb/job.go
@@ -71,21 +71,7 @@ func NewJob(
 	cancelled bool,
 	created int64,
 ) *Job {
-	// Initialise the annotation and nodeSelector maps if nil.
-	// Since those need to be mutated in-place.
-	if schedulingInfo != nil {
-		for _, req := range schedulingInfo.ObjectRequirements {
-			if podReq := req.GetPodRequirements(); podReq != nil {
-				if podReq.Annotations == nil {
-					podReq.Annotations = make(map[string]string)
-				}
-				if podReq.NodeSelector == nil {
-					podReq.NodeSelector = make(map[string]string)
-				}
-			}
-		}
-	}
-	return &Job{
+	job := &Job{
 		id:                      jobId,
 		jobset:                  jobset,
 		queue:                   queue,
@@ -99,6 +85,25 @@ func NewJob(
 		cancelled:               cancelled,
 		created:                 created,
 		runsById:                map[uuid.UUID]*JobRun{},
+	}
+	job.ensureJobSchedulingInfoFieldsInitialised()
+	return job
+}
+
+func (job *Job) ensureJobSchedulingInfoFieldsInitialised() {
+	// Initialise the annotation and nodeSelector maps if nil.
+	// Since those need to be mutated in-place.
+	if job.jobSchedulingInfo != nil {
+		for _, req := range job.jobSchedulingInfo.ObjectRequirements {
+			if podReq := req.GetPodRequirements(); podReq != nil {
+				if podReq.Annotations == nil {
+					podReq.Annotations = make(map[string]string)
+				}
+				if podReq.NodeSelector == nil {
+					podReq.NodeSelector = make(map[string]string)
+				}
+			}
+		}
 	}
 }
 
@@ -422,6 +427,7 @@ func (job *Job) WithCreated(created int64) *Job {
 func (job *Job) WithJobSchedulingInfo(jobSchedulingInfo *schedulerobjects.JobSchedulingInfo) *Job {
 	j := copyJob(*job)
 	j.jobSchedulingInfo = jobSchedulingInfo
+	// j.ensureJobSchedulingInfoFieldsInitialised()
 	return j
 }
 

--- a/internal/scheduler/jobdb/job.go
+++ b/internal/scheduler/jobdb/job.go
@@ -427,7 +427,7 @@ func (job *Job) WithCreated(created int64) *Job {
 func (job *Job) WithJobSchedulingInfo(jobSchedulingInfo *schedulerobjects.JobSchedulingInfo) *Job {
 	j := copyJob(*job)
 	j.jobSchedulingInfo = jobSchedulingInfo
-	// j.ensureJobSchedulingInfoFieldsInitialised()
+	j.ensureJobSchedulingInfoFieldsInitialised()
 	return j
 }
 

--- a/internal/scheduler/jobdb/job_test.go
+++ b/internal/scheduler/jobdb/job_test.go
@@ -3,6 +3,7 @@ package jobdb
 import (
 	"testing"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 
@@ -319,15 +320,18 @@ func TestJobSchedulingInfoFieldsInitialised(t *testing.T) {
 		},
 	}
 
+	infoWithNilFieldsCopy := proto.Clone(infoWithNilFields).(*schedulerobjects.JobSchedulingInfo)
 	assert.NotNil(t, infoWithNilFields.GetPodRequirements())
 	assert.Nil(t, infoWithNilFields.GetPodRequirements().NodeSelector)
 	assert.Nil(t, infoWithNilFields.GetPodRequirements().Annotations)
 
-	job := NewJob("test-job", "test-jobset", "test-queue", 2, infoWithNilFields, true, 0, false, false, false, 3)
+	job := NewJob("test-job", "test-jobset", "test-queue", 2, infoWithNilFieldsCopy, true, 0, false, false, false, 3)
 	assert.NotNil(t, job.GetNodeSelector())
 	assert.NotNil(t, job.GetAnnotations())
 
-	updatedJob := baseJob.WithJobSchedulingInfo(infoWithNilFields)
+	// Copy again here, as the fields get mutated so we want a clean copy
+	infoWithNilFieldsCopy2 := proto.Clone(infoWithNilFields).(*schedulerobjects.JobSchedulingInfo)
+	updatedJob := baseJob.WithJobSchedulingInfo(infoWithNilFieldsCopy2)
 	assert.NotNil(t, updatedJob.GetNodeSelector())
 	assert.NotNil(t, updatedJob.GetAnnotations())
 }

--- a/internal/scheduler/jobdb/job_test.go
+++ b/internal/scheduler/jobdb/job_test.go
@@ -308,6 +308,30 @@ func TestJob_TestWithJobSchedulingInfo(t *testing.T) {
 	assert.Equal(t, newSchedInfo, newJob.JobSchedulingInfo())
 }
 
+func TestJobSchedulingInfoFieldsInitialised(t *testing.T) {
+	infoWithNilFields := &schedulerobjects.JobSchedulingInfo{
+		ObjectRequirements: []*schedulerobjects.ObjectRequirements{
+			{
+				Requirements: &schedulerobjects.ObjectRequirements_PodRequirements{
+					PodRequirements: &schedulerobjects.PodRequirements{},
+				},
+			},
+		},
+	}
+
+	assert.NotNil(t, infoWithNilFields.GetPodRequirements())
+	assert.Nil(t, infoWithNilFields.GetPodRequirements().NodeSelector)
+	assert.Nil(t, infoWithNilFields.GetPodRequirements().Annotations)
+
+	job := NewJob("test-job", "test-jobset", "test-queue", 2, infoWithNilFields, true, 0, false, false, false, 3)
+	assert.NotNil(t, job.GetNodeSelector())
+	assert.NotNil(t, job.GetAnnotations())
+
+	updatedJob := baseJob.WithJobSchedulingInfo(infoWithNilFields)
+	assert.NotNil(t, updatedJob.GetNodeSelector())
+	assert.NotNil(t, updatedJob.GetAnnotations())
+}
+
 func TestJobPriorityComparer(t *testing.T) {
 	job1 := &Job{
 		id:       "a",


### PR DESCRIPTION
Currently we rely on nodeSelector and annotations never being nil
 - If they are, we can't evict the job

As the object is a proto object it is hard to ensure its never created with nil values

For now just make sure any updates to job.JobSchedulingInfo result in a valid configuration

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-481) by [Unito](https://www.unito.io)
