### PR TITLE
Set default executorTimeout in armada config

### DIFF
--- a/config/armada/config.yaml
+++ b/config/armada/config.yaml
@@ -61,6 +61,7 @@ scheduling:
         preemptible: true
     defaultPriorityClass: armada-default
     priorityClassNameOverride: armada-default
+  executorTimeout: 60m
   maxQueueLookback: 1000
   maxExtraNodesToConsider: 1
   maximumResourceFractionToSchedule:


### PR DESCRIPTION
This is currently defaulting to having an infinite timeout

Which if a cluster dies, any jobs on it when it died forever contribute to fair share calculations, which isn't an ideal default

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-484) by [Unito](https://www.unito.io)
