### PR TITLE
Tidy logging in pod_issuer_handler

### DIFF
--- a/config/executor/config.yaml
+++ b/config/executor/config.yaml
@@ -12,7 +12,7 @@ task:
   utilisationReportingInterval: 1s
   missingJobEventReconciliationInterval: 15s
   jobLeaseRenewalInterval: 15s
-  podIssueHandlingInterval: 5s
+  podIssueHandlingInterval: 10s
   podDeletionInterval: 5s
   resourceCleanupInterval: 15s
   allocateSpareClusterCapacityInterval: 5s

--- a/internal/executor/service/pod_issue_handler.go
+++ b/internal/executor/service/pod_issue_handler.go
@@ -125,14 +125,15 @@ func (p *IssueHandler) registerIssue(issue *runIssue) {
 
 	runId := issue.RunId
 	if runId == "" {
-		log.Debugf("Not registering an issue for job %s as run id was empty", issue.JobId)
+		log.Warnf("Not registering an issue for job %s as run id was empty", issue.JobId)
 		return
 	}
 	_, exists := p.knownPodIssues[issue.RunId]
 	if !exists {
+		log.Infof("Issue for job %s run %s is registered", issue.JobId, issue.RunId)
 		p.knownPodIssues[issue.RunId] = issue
 	} else {
-		log.Debugf("Not registering an issue for job %s (runId %s) as it already has an issue set", issue.JobId, issue.RunId)
+		log.Warnf("Not registering an issue for job %s (runId %s) as it already has an issue set", issue.JobId, issue.RunId)
 	}
 }
 
@@ -502,6 +503,9 @@ func (p *IssueHandler) detectReconciliationIssues(pods []*v1.Pod) {
 	for _, run := range runs {
 		_, present := runIdsToPod[run.Meta.RunId]
 		if !present {
+			if p.hasIssue(run.Meta.RunId) {
+				continue
+			}
 			p.registerIssue(&runIssue{
 				JobId: run.Meta.JobId,
 				RunId: run.Meta.RunId,


### PR DESCRIPTION
Primarily the aim here is to reduce logging, but also make it clearer from logs when an issue starts/ends

Currently when there are a lot of issues, we log megabytes a second - due to logging the full issue of every pod - every 5 seconds

 - Skip issue detection again if pod already has issue registered
   - During issue detection we log the full issue
 - Reduce how often we log the full issue
 - Explicitly log issue registered/resolved
 - Perform issue handling slightly less frequently

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-485) by [Unito](https://www.unito.io)
