### PR TITLE
Integrate release and release-rc workflows with self hosted runners

### DIFF
--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   validate:
-    if: github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion == 'success'
+    if: github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion == 'success' && github.repository_owner == 'armadaproject'
     name: "Validate revision"
     runs-on: ubuntu-22.04
 
@@ -58,11 +58,11 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v2
 
-      # - name: "Docker login"
-      #   uses: "docker/login-action@v2"
-      #   with:
-      #     username: "${{ secrets.DOCKERHUB_USER }}"
-      #     password: "${{ secrets.DOCKERHUB_PASS }}"
+      - name: "Docker login"
+        uses: "docker/login-action@v2"
+        with:
+          username: "${{ secrets.DOCKERHUB_USER }}"
+          password: "${{ secrets.DOCKERHUB_PASS }}"
 
       - name: "Run GoReleaser"
         uses: "goreleaser/goreleaser-action@v4"

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   validate:
-    if: github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion == 'success' && github.repository_owner == 'armadaproject'
+    if: github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion == 'success'
     name: "Validate revision"
     runs-on: ubuntu-22.04
 
@@ -40,7 +40,7 @@ jobs:
   release:
     name: Release
     needs: validate
-    runs-on: "ubuntu-22.04"
+    runs-on: [self-hosted]
     environment: armada-dockerhub
 
     steps:
@@ -58,11 +58,11 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: "Docker login"
-        uses: "docker/login-action@v2"
-        with:
-          username: "${{ secrets.DOCKERHUB_USER }}"
-          password: "${{ secrets.DOCKERHUB_PASS }}"
+      # - name: "Docker login"
+      #   uses: "docker/login-action@v2"
+      #   with:
+      #     username: "${{ secrets.DOCKERHUB_USER }}"
+      #     password: "${{ secrets.DOCKERHUB_PASS }}"
 
       - name: "Run GoReleaser"
         uses: "goreleaser/goreleaser-action@v4"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   validate:
-    if: github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion == 'success' && github.repository_owner == 'armadaproject'
+    if: github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion == 'success'
     name: "Validate revision"
     runs-on: ubuntu-22.04
 
@@ -40,7 +40,7 @@ jobs:
   release:
     name: "Release"
     needs: validate
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted]
     environment: armada-dockerhub
 
     steps:
@@ -61,14 +61,17 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: "Docker login"
-        uses: "docker/login-action@v2"
-        with:
-          username: "${{ secrets.DOCKERHUB_USER }}"
-          password: "${{ secrets.DOCKERHUB_PASS }}"
+      # - name: "Docker login"
+      #   uses: "docker/login-action@v2"
+      #   with:
+      #     username: "${{ secrets.DOCKERHUB_USER }}"
+      #     password: "${{ secrets.DOCKERHUB_PASS }}"
 
       - name: Set up Syft
-        run: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+        run: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b ${HOME}/bin
+
+      - name: Add to PATH
+        run: echo "${HOME}/bin" >> $GITHUB_PATH      
 
       - name: Set current and previous tag # Workaround, GoReleaser uses 'git-describe' to determine a previous tag.
         run: |
@@ -82,7 +85,7 @@ jobs:
         with:
           distribution: goreleaser
           version: v1.19.2
-          args: "-f ./.goreleaser.yml release --clean"
+          args: "-f ./.goreleaser.yml release --clean --timeout 60m"
         env:
           FULL_RELEASE: true
           DOCKER_REPO: "gresearch"
@@ -90,10 +93,10 @@ jobs:
           DOCKER_BUILDX_BUILDER: "${{ steps.buildx.outputs.name }}"
           DOCKER_BUILDX_CACHE_FROM: "type=gha"
           DOCKER_BUILDX_CACHE_TO: "type=gha,mode=max"
-  invoke-chart-push:
-    name: Invoke Chart push
-    needs: release
-    uses: G-Research/charts/.github/workflows/invoke-push.yaml@master
-    secrets:
-      APP_ID: ${{ secrets.APP_ID }}
-      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+  # invoke-chart-push:
+  #   name: Invoke Chart push
+  #   needs: release
+  #   uses: G-Research/charts/.github/workflows/invoke-push.yaml@master
+  #   secrets:
+  #     APP_ID: ${{ secrets.APP_ID }}
+  #     APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   validate:
-    if: github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion == 'success'
+    if: github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion == 'success' && github.repository_owner == 'armadaproject'
     name: "Validate revision"
     runs-on: ubuntu-22.04
 
@@ -61,11 +61,11 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v2
 
-      # - name: "Docker login"
-      #   uses: "docker/login-action@v2"
-      #   with:
-      #     username: "${{ secrets.DOCKERHUB_USER }}"
-      #     password: "${{ secrets.DOCKERHUB_PASS }}"
+      - name: "Docker login"
+        uses: "docker/login-action@v2"
+        with:
+          username: "${{ secrets.DOCKERHUB_USER }}"
+          password: "${{ secrets.DOCKERHUB_PASS }}"
 
       - name: Set up Syft
         run: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b ${HOME}/bin
@@ -93,10 +93,10 @@ jobs:
           DOCKER_BUILDX_BUILDER: "${{ steps.buildx.outputs.name }}"
           DOCKER_BUILDX_CACHE_FROM: "type=gha"
           DOCKER_BUILDX_CACHE_TO: "type=gha,mode=max"
-  # invoke-chart-push:
-  #   name: Invoke Chart push
-  #   needs: release
-  #   uses: G-Research/charts/.github/workflows/invoke-push.yaml@master
-  #   secrets:
-  #     APP_ID: ${{ secrets.APP_ID }}
-  #     APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+  invoke-chart-push:
+    name: Invoke Chart push
+    needs: release
+    uses: G-Research/charts/.github/workflows/invoke-push.yaml@master
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
#### What type of PR is this?
This is an enhancement PR.

#### What this PR does / why we need it:
This PR integrates `release` and `release-rc` workflows (specific jobs from each), with self hosted runners.

#### Which issue(s) this PR fixes:
Fixes https://github.com/G-Research/gr-oss/issues/419

#### Special notes for your reviewer:
Working examples (please disregard the error message, i don't have permissions to push to dockerhub):
- Release Armada Components RC: https://github.com/pavlovic-ivan/armada/actions/runs/5620950787
- Release Armada Components: https://github.com/pavlovic-ivan/armada/actions/runs/5621336630

There are some prerequisites that need to be done first:

- [ ] Armada AWS DEV and PROD account setup and necessary resources deployed
- [ ] Github App created, installed and configured
- [ ] Armada repo configured with new secrets

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-506) by [Unito](https://www.unito.io)
