### PR TITLE
add `kubectl-armadactl` to goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -169,15 +169,12 @@ archives:
   - id: kubectl-armadactl
     builds:
       - armadactl
+    binary: kubectl-armadactl
     allow_different_binary_count: true
     name_template: 'kubectl-armadactl_{{ replace .Version "-" "_" }}_{{ .Os }}_{{ .Arch }}'
     format_overrides:
       - goos: windows
         format: zip
-    rename:
-      # Here, we specify the desired filename for the new archive.
-      - binary: armadactl
-        to: kubectl-armadactl
     files:
       - LICENSE
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -166,6 +166,17 @@ archives:
     files:
       - LICENSE
 
+  - id: kubectl-armadactl
+    builds:
+      - armadactl
+    allow_different_binary_count: true
+    name_template: 'kubectl-armadactl_{{ replace .Version "-" "_" }}_{{ .Os }}_{{ .Arch }}'
+    format_overrides:
+      - goos: windows
+        format: zip
+    files:
+      - LICENSE
+
 # macOS Universal Binaries-*
 universal_binaries:
   - replace: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -174,6 +174,10 @@ archives:
     format_overrides:
       - goos: windows
         format: zip
+    rename:
+      # Here, we specify the desired filename for the new archive.
+      - binary: armadactl
+        to: kubectl-armadactl
     files:
       - LICENSE
 


### PR DESCRIPTION
This PR builds another archive named `kubectl-armadactl` in our Armada project which will be later used to integrate `armadactl` with `kubectl`.

The contents of the new archive are exactly same as that of `armadactl`.

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-516) by [Unito](https://www.unito.io)
