### PR TITLE
update alpine to 3.17 everywhere

### DIFF
--- a/build/armada-load-tester/Dockerfile
+++ b/build/armada-load-tester/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.14
 
 RUN addgroup -S -g 2000 armada && adduser -S -u 1000 armada -G armada
 

--- a/build/armada-load-tester/Dockerfile
+++ b/build/armada-load-tester/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.17
 
 RUN addgroup -S -g 2000 armada && adduser -S -u 1000 armada -G armada
 

--- a/build/armada/Dockerfile
+++ b/build/armada/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.14
 
 RUN addgroup -S -g 2000 armada && adduser -S -u 1000 armada -G armada
 

--- a/build/armada/Dockerfile
+++ b/build/armada/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.17
 
 RUN addgroup -S -g 2000 armada && adduser -S -u 1000 armada -G armada
 

--- a/build/armadactl/Dockerfile
+++ b/build/armadactl/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.14
 
 RUN addgroup -S -g 2000 armada && adduser -S -u 1000 armada -G armada
 

--- a/build/armadactl/Dockerfile
+++ b/build/armadactl/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.17
 
 RUN addgroup -S -g 2000 armada && adduser -S -u 1000 armada -G armada
 

--- a/build/binoculars/Dockerfile
+++ b/build/binoculars/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.14
 
 RUN addgroup -S -g 2000 armada && adduser -S -u 1000 armada -G armada
 

--- a/build/binoculars/Dockerfile
+++ b/build/binoculars/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.17
 
 RUN addgroup -S -g 2000 armada && adduser -S -u 1000 armada -G armada
 

--- a/build/eventingester/Dockerfile
+++ b/build/eventingester/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.14
 
 RUN addgroup -S -g 2000 armada && adduser -S -u 1000 armada -G armada
 

--- a/build/eventingester/Dockerfile
+++ b/build/eventingester/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.17
 
 RUN addgroup -S -g 2000 armada && adduser -S -u 1000 armada -G armada
 

--- a/build/executor/Dockerfile
+++ b/build/executor/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.14
 
 RUN addgroup -S -g 2000 armada && adduser -S -u 1000 armada -G armada
 

--- a/build/executor/Dockerfile
+++ b/build/executor/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.17
 
 RUN addgroup -S -g 2000 armada && adduser -S -u 1000 armada -G armada
 

--- a/build/fakeexecutor/Dockerfile
+++ b/build/fakeexecutor/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.14
 
 RUN addgroup -S -g 2000 armada && adduser -S -u 1000 armada -G armada
 

--- a/build/fakeexecutor/Dockerfile
+++ b/build/fakeexecutor/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.17
 
 RUN addgroup -S -g 2000 armada && adduser -S -u 1000 armada -G armada
 

--- a/build/jobservice/Dockerfile
+++ b/build/jobservice/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.14
 
 RUN addgroup -S -g 2000 armada && adduser -S -u 1000 armada -G armada
 

--- a/build/jobservice/Dockerfile
+++ b/build/jobservice/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.17
 
 RUN addgroup -S -g 2000 armada && adduser -S -u 1000 armada -G armada
 

--- a/build/lookout/Dockerfile
+++ b/build/lookout/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.14
 
 RUN addgroup -S -g 2000 armada && adduser -S -u 1000 armada -G armada
 

--- a/build/lookout/Dockerfile
+++ b/build/lookout/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.17
 
 RUN addgroup -S -g 2000 armada && adduser -S -u 1000 armada -G armada
 

--- a/build/lookoutingester/Dockerfile
+++ b/build/lookoutingester/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.14
 
 RUN addgroup -S -g 2000 armada && adduser -S -u 1000 armada -G armada
 

--- a/build/lookoutingester/Dockerfile
+++ b/build/lookoutingester/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.17
 
 RUN addgroup -S -g 2000 armada && adduser -S -u 1000 armada -G armada
 

--- a/build/lookoutingesterv2/Dockerfile
+++ b/build/lookoutingesterv2/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.14
 
 RUN addgroup -S -g 2000 armada && adduser -S -u 1000 armada -G armada
 

--- a/build/lookoutingesterv2/Dockerfile
+++ b/build/lookoutingesterv2/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.17
 
 RUN addgroup -S -g 2000 armada && adduser -S -u 1000 armada -G armada
 

--- a/build/lookoutv2/Dockerfile
+++ b/build/lookoutv2/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.14
 
 RUN addgroup -S -g 2000 armada && adduser -S -u 1000 armada -G armada
 

--- a/build/lookoutv2/Dockerfile
+++ b/build/lookoutv2/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.17
 
 RUN addgroup -S -g 2000 armada && adduser -S -u 1000 armada -G armada
 

--- a/build/scheduler/Dockerfile
+++ b/build/scheduler/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.14
 
 RUN addgroup -S -g 2000 armada && adduser -S -u 1000 armada -G armada
 

--- a/build/scheduler/Dockerfile
+++ b/build/scheduler/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.17
 
 RUN addgroup -S -g 2000 armada && adduser -S -u 1000 armada -G armada
 

--- a/build/scheduleringester/Dockerfile
+++ b/build/scheduleringester/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.14
 
 RUN addgroup -S -g 2000 armada && adduser -S -u 1000 armada -G armada
 

--- a/build/scheduleringester/Dockerfile
+++ b/build/scheduleringester/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.17
 
 RUN addgroup -S -g 2000 armada && adduser -S -u 1000 armada -G armada
 

--- a/build/testsuite/Dockerfile
+++ b/build/testsuite/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.14
 
 RUN addgroup -S -g 2000 armada && adduser -S -u 1000 armada -G armada
 

--- a/build/testsuite/Dockerfile
+++ b/build/testsuite/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.17
 
 RUN addgroup -S -g 2000 armada && adduser -S -u 1000 armada -G armada
 

--- a/cmd/armada-load-tester/cmd/loadtest.go
+++ b/cmd/armada-load-tester/cmd/loadtest.go
@@ -52,7 +52,7 @@ var loadtestCmd = &cobra.Command{
 			  containers:
 				- name: sleep
 				  imagePullPolicy: IfNotPresent
-				  image: alpine:3.10
+				  image: alpine:3.14
 				  command:
 					- sh
 				  args:

--- a/cmd/armada-load-tester/cmd/loadtest.go
+++ b/cmd/armada-load-tester/cmd/loadtest.go
@@ -52,7 +52,7 @@ var loadtestCmd = &cobra.Command{
 			  containers:
 				- name: sleep
 				  imagePullPolicy: IfNotPresent
-				  image: alpine:3.14
+				  image: alpine:3.17
 				  command:
 					- sh
 				  args:

--- a/deployment/lookout-migration/templates/job.yaml
+++ b/deployment/lookout-migration/templates/job.yaml
@@ -25,7 +25,7 @@ spec:
       {{- end }}
       initContainers:
         - name: db-wait
-          image: alpine:3.14
+          image: alpine:3.17
           command:
             - /bin/sh
             - -c

--- a/deployment/lookout-migration/templates/job.yaml
+++ b/deployment/lookout-migration/templates/job.yaml
@@ -25,7 +25,7 @@ spec:
       {{- end }}
       initContainers:
         - name: db-wait
-          image: alpine:3.10
+          image: alpine:3.14
           command:
             - /bin/sh
             - -c

--- a/e2e/armadactl_test/armadactl_test.go
+++ b/e2e/armadactl_test/armadactl_test.go
@@ -179,7 +179,7 @@ jobs:
       containers:
         - name: ls
           imagePullPolicy: IfNotPresent
-          image: alpine:3.14
+          image: alpine:3.17
           command:
             - sh
             - -c

--- a/e2e/armadactl_test/armadactl_test.go
+++ b/e2e/armadactl_test/armadactl_test.go
@@ -179,7 +179,7 @@ jobs:
       containers:
         - name: ls
           imagePullPolicy: IfNotPresent
-          image: alpine:3.10
+          image: alpine:3.14
           command:
             - sh
             - -c

--- a/e2e/lookout_ingester_test/lookout_ingester_test.go
+++ b/e2e/lookout_ingester_test/lookout_ingester_test.go
@@ -354,7 +354,7 @@ func createJobRequest(namespace string, args []string) *api.JobSubmitRequest {
 					Containers: []v1.Container{
 						{
 							Name:    "container1",
-							Image:   "alpine:3.10",
+							Image:   "alpine:3.14",
 							Command: []string{"/bin/sh", "-c"},
 							Args:    args,
 							Resources: v1.ResourceRequirements{

--- a/e2e/lookout_ingester_test/lookout_ingester_test.go
+++ b/e2e/lookout_ingester_test/lookout_ingester_test.go
@@ -354,7 +354,7 @@ func createJobRequest(namespace string, args []string) *api.JobSubmitRequest {
 					Containers: []v1.Container{
 						{
 							Name:    "container1",
-							Image:   "alpine:3.14",
+							Image:   "alpine:3.17",
 							Command: []string{"/bin/sh", "-c"},
 							Args:    args,
 							Resources: v1.ResourceRequirements{

--- a/e2e/pulsar_test/pulsar_test.go
+++ b/e2e/pulsar_test/pulsar_test.go
@@ -1012,7 +1012,7 @@ func createJobSubmitRequestWithClientId(numJobs int, clientId string) *api.JobSu
 				Containers: []v1.Container{
 					{
 						Name:  "container1",
-						Image: "alpine:3.10",
+						Image: "alpine:3.14",
 						Args:  []string{"sleep", "5s"},
 						Resources: v1.ResourceRequirements{
 							Requests: v1.ResourceList{"cpu": cpu, "memory": memory},
@@ -1042,7 +1042,7 @@ func createWgetJobRequest(address string) *api.JobSubmitRequest {
 				Containers: []v1.Container{
 					{
 						Name:  "wget",
-						Image: "alpine:3.10",
+						Image: "alpine:3.14",
 						Args:  []string{"wget", address, "--timeout=5"}, // Queried from the k8s services API
 						Resources: v1.ResourceRequirements{
 							Requests: v1.ResourceList{"cpu": cpu, "memory": memory},
@@ -1173,7 +1173,7 @@ func createJobSubmitRequestWithEverything(numJobs int) *api.JobSubmitRequest {
 				Containers: []v1.Container{
 					{
 						Name:  "container1",
-						Image: "alpine:3.10",
+						Image: "alpine:3.14",
 						Args:  []string{"sleep", "5s"},
 						Resources: v1.ResourceRequirements{
 							Requests: v1.ResourceList{"cpu": cpu, "memory": memory},
@@ -1240,7 +1240,7 @@ func createJobSubmitRequestWithError(numJobs int) *api.JobSubmitRequest {
 				Containers: []v1.Container{
 					{
 						Name:  "container1",
-						Image: "alpine:3.10",
+						Image: "alpine:3.14",
 						Args:  []string{"sleep", "5s", "&&", "exit", "1"},
 						Resources: v1.ResourceRequirements{
 							Requests: v1.ResourceList{"cpu": cpu, "memory": memory},

--- a/e2e/pulsar_test/pulsar_test.go
+++ b/e2e/pulsar_test/pulsar_test.go
@@ -1012,7 +1012,7 @@ func createJobSubmitRequestWithClientId(numJobs int, clientId string) *api.JobSu
 				Containers: []v1.Container{
 					{
 						Name:  "container1",
-						Image: "alpine:3.14",
+						Image: "alpine:3.17",
 						Args:  []string{"sleep", "5s"},
 						Resources: v1.ResourceRequirements{
 							Requests: v1.ResourceList{"cpu": cpu, "memory": memory},
@@ -1042,7 +1042,7 @@ func createWgetJobRequest(address string) *api.JobSubmitRequest {
 				Containers: []v1.Container{
 					{
 						Name:  "wget",
-						Image: "alpine:3.14",
+						Image: "alpine:3.17",
 						Args:  []string{"wget", address, "--timeout=5"}, // Queried from the k8s services API
 						Resources: v1.ResourceRequirements{
 							Requests: v1.ResourceList{"cpu": cpu, "memory": memory},
@@ -1173,7 +1173,7 @@ func createJobSubmitRequestWithEverything(numJobs int) *api.JobSubmitRequest {
 				Containers: []v1.Container{
 					{
 						Name:  "container1",
-						Image: "alpine:3.14",
+						Image: "alpine:3.17",
 						Args:  []string{"sleep", "5s"},
 						Resources: v1.ResourceRequirements{
 							Requests: v1.ResourceList{"cpu": cpu, "memory": memory},
@@ -1240,7 +1240,7 @@ func createJobSubmitRequestWithError(numJobs int) *api.JobSubmitRequest {
 				Containers: []v1.Container{
 					{
 						Name:  "container1",
-						Image: "alpine:3.14",
+						Image: "alpine:3.17",
 						Args:  []string{"sleep", "5s", "&&", "exit", "1"},
 						Resources: v1.ResourceRequirements{
 							Requests: v1.ResourceList{"cpu": cpu, "memory": memory},

--- a/e2e/setup/setup_cluster_kind.sh
+++ b/e2e/setup/setup_cluster_kind.sh
@@ -2,4 +2,4 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 
 echo "Setting up cluster1"
 kind create cluster --config ${REPO_ROOT}/e2e/setup/worker-master-config.yaml --name cluster1 --wait 3m
-kind load --name cluster1 docker-image alpine:3.14
+kind load --name cluster1 docker-image alpine:3.17

--- a/e2e/setup/setup_cluster_kind.sh
+++ b/e2e/setup/setup_cluster_kind.sh
@@ -2,4 +2,4 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 
 echo "Setting up cluster1"
 kind create cluster --config ${REPO_ROOT}/e2e/setup/worker-master-config.yaml --name cluster1 --wait 3m
-kind load --name cluster1 docker-image alpine:3.10
+kind load --name cluster1 docker-image alpine:3.14

--- a/internal/common/eventutil/eventutil_test.go
+++ b/internal/common/eventutil/eventutil_test.go
@@ -485,7 +485,7 @@ func testContainer(name string) v1.Container {
 	memory, _ := resource.ParseQuantity("50Mi")
 	return v1.Container{
 		Name:    name,
-		Image:   "alpine:3.10",
+		Image:   "alpine:3.14",
 		Command: []string{"cmd1", "cmd2"},
 		Args:    []string{"sleep", "5s"},
 		Resources: v1.ResourceRequirements{

--- a/internal/common/eventutil/eventutil_test.go
+++ b/internal/common/eventutil/eventutil_test.go
@@ -485,7 +485,7 @@ func testContainer(name string) v1.Container {
 	memory, _ := resource.ParseQuantity("50Mi")
 	return v1.Container{
 		Name:    name,
-		Image:   "alpine:3.14",
+		Image:   "alpine:3.17",
 		Command: []string{"cmd1", "cmd2"},
 		Args:    []string{"sleep", "5s"},
 		Resources: v1.ResourceRequirements{

--- a/magefiles/kind.go
+++ b/magefiles/kind.go
@@ -21,7 +21,7 @@ const (
 
 func getImages() []string {
 	images := []string{
-		"alpine:3.14",
+		"alpine:3.17",
 		"nginx:1.21.6",
 		"registry.k8s.io/ingress-nginx/controller:v1.4.0",
 		"registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20220916-gd32f8c343",

--- a/magefiles/kind.go
+++ b/magefiles/kind.go
@@ -21,7 +21,7 @@ const (
 
 func getImages() []string {
 	images := []string{
-		"alpine:3.10",
+		"alpine:3.14",
 		"nginx:1.21.6",
 		"registry.k8s.io/ingress-nginx/controller:v1.4.0",
 		"registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20220916-gd32f8c343",

--- a/makefile
+++ b/makefile
@@ -446,11 +446,11 @@ setup-cluster:
 	kind create cluster --config e2e/setup/kind.yaml
 
 	# Load images necessary for tests.
-	docker pull "alpine:3.10" # used for e2e tests
+	docker pull "alpine:3.14" # used for e2e tests
 	docker pull "nginx:1.21.6" # used for e2e tests (ingress)
 	docker pull "registry.k8s.io/ingress-nginx/controller:v1.4.0"
 	docker pull "registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20220916-gd32f8c343"
-	kind load docker-image "alpine:3.10" --name armada-test
+	kind load docker-image "alpine:3.14" --name armada-test
 	kind load docker-image "nginx:1.21.6" --name armada-test
 	kind load docker-image "registry.k8s.io/ingress-nginx/controller:v1.4.0" --name armada-test
 	kind load docker-image "registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20220916-gd32f8c343" --name armada-test

--- a/makefile
+++ b/makefile
@@ -446,11 +446,11 @@ setup-cluster:
 	kind create cluster --config e2e/setup/kind.yaml
 
 	# Load images necessary for tests.
-	docker pull "alpine:3.14" # used for e2e tests
+	docker pull "alpine:3.17" # used for e2e tests
 	docker pull "nginx:1.21.6" # used for e2e tests (ingress)
 	docker pull "registry.k8s.io/ingress-nginx/controller:v1.4.0"
 	docker pull "registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20220916-gd32f8c343"
-	kind load docker-image "alpine:3.14" --name armada-test
+	kind load docker-image "alpine:3.17" --name armada-test
 	kind load docker-image "nginx:1.21.6" --name armada-test
 	kind load docker-image "registry.k8s.io/ingress-nginx/controller:v1.4.0" --name armada-test
 	kind load docker-image "registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20220916-gd32f8c343" --name armada-test


### PR DESCRIPTION
Fixes #2740 

Update alpine from 3.10 to 3.14.  Also update tests/kind to use latest alpine image.

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-528) by [Unito](https://www.unito.io)
