### PR TITLE
[armada-scheduler] Add separate config for maxJobsLeasedPerCall

### DIFF
--- a/config/scheduler/config.yaml
+++ b/config/scheduler/config.yaml
@@ -1,6 +1,7 @@
 cyclePeriod: 1s
 schedulePeriod: 10s
 maxSchedulingDuration: 5s
+maxJobsLeasedPerCall: 1000
 executorTimeout: 1h
 databaseFetchSize: 1000
 pulsarSendTimeout: 5s

--- a/internal/scheduler/configuration/configuration.go
+++ b/internal/scheduler/configuration/configuration.go
@@ -51,6 +51,8 @@ type Configuration struct {
 	DatabaseFetchSize int `validate:"required"`
 	// Timeout to use when sending messages to pulsar
 	PulsarSendTimeout time.Duration `validate:"required"`
+	// Maximum jobs to return from a single lease call
+	MaxJobsLeasedPerCall uint `validate:"required"`
 }
 
 type LeaderConfig struct {

--- a/internal/scheduler/schedulerapp.go
+++ b/internal/scheduler/schedulerapp.go
@@ -138,7 +138,7 @@ func Run(config schedulerconfig.Configuration) error {
 		executorRepository,
 		legacyExecutorRepository,
 		allowedPcs,
-		config.Scheduling.MaximumJobsToSchedule,
+		config.MaxJobsLeasedPerCall,
 		config.Scheduling.Preemption.NodeIdLabel,
 		config.Scheduling.Preemption.PriorityClassNameOverride,
 		config.Pulsar.MaxAllowedMessageSize,


### PR DESCRIPTION
Currently we use the same config for how many job we scheduler per round and how many jobs we lease per call

This was fine historically, however now we schedule jobs per pool (not per executor) we'd like to increaes the number of jobs we scheduler per round
 - Which will have the unintended impact of increasing how many jobs we send per lease call

Adding separate config, so we can tune these 2 things separately

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-545) by [Unito](https://www.unito.io)
