### PR TITLE
Add config to globally disable scheduling 

### DIFF
--- a/internal/armada/configuration/types.go
+++ b/internal/armada/configuration/types.go
@@ -107,6 +107,8 @@ type DatabaseConfig struct {
 }
 
 type SchedulingConfig struct {
+	// Set to true to disable scheduling
+	DisableScheduling bool
 	// Set to true to enable scheduler assertions. This results in some performance loss.
 	EnableAssertions bool
 	// If true, schedule jobs across all executors in the same pool in a unified manner.

--- a/internal/armada/server/lease.go
+++ b/internal/armada/server/lease.go
@@ -456,7 +456,7 @@ func (q *AggregatedQueueServer) getJobs(ctx context.Context, req *api.StreamingL
 	// At this point we've written updated usage information to Redis and are ready to start scheduling.
 	// Exit here if scheduling is disabled.
 	if q.schedulingConfig.DisableScheduling {
-		log.Info("skipping scheduling on %s - scheduling disabled", req.ClusterId)
+		log.Infof("skipping scheduling on %s - scheduling disabled", req.ClusterId)
 		return make([]*api.Job, 0), nil
 	}
 

--- a/internal/armada/server/lease.go
+++ b/internal/armada/server/lease.go
@@ -453,6 +453,13 @@ func (q *AggregatedQueueServer) getJobs(ctx context.Context, req *api.StreamingL
 		log.WithError(err).Warnf("could not store executor details for cluster %s", req.ClusterId)
 	}
 
+	// At this point we've written updated usage information to Redis and are ready to start scheduling.
+	// Exit here if scheduling is disabled.
+	if q.schedulingConfig.DisableScheduling {
+		log.Info("skipping scheduling on %s - scheduling disabled", req.ClusterId)
+		return make([]*api.Job, 0), nil
+	}
+
 	// Give Schedule() a 3 second shorter deadline than ctx to give it a chance to finish up before ctx deadline.
 	if deadline, ok := ctx.Deadline(); ok {
 		var cancel context.CancelFunc

--- a/internal/scheduler/scheduling_algo.go
+++ b/internal/scheduler/scheduling_algo.go
@@ -84,6 +84,17 @@ func (l *FairSchedulingAlgo) Schedule(
 	jobDb *jobdb.JobDb,
 ) (*SchedulerResult, error) {
 	log := ctxlogrus.Extract(ctx)
+
+	overallSchedulerResult := &SchedulerResult{
+		NodeIdByJobId: make(map[string]string),
+	}
+
+	// Exit immediately if scheduling is disabled.
+	if l.schedulingConfig.DisableScheduling {
+		log.Info("skipping scheduling - scheduling disabled")
+		return overallSchedulerResult, nil
+	}
+
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, l.maxSchedulingDuration)
 	defer cancel()
 
@@ -91,9 +102,7 @@ func (l *FairSchedulingAlgo) Schedule(
 	if err != nil {
 		return nil, err
 	}
-	overallSchedulerResult := &SchedulerResult{
-		NodeIdByJobId: make(map[string]string),
-	}
+
 	executorGroups := l.groupExecutors(fsctx.executors)
 	if len(l.executorGroupsToSchedule) == 0 {
 		// Cycle over groups in a consistent order.


### PR DESCRIPTION
This change is largely taken from: https://github.com/armadaproject/armada/pull/2662

It allows scheduling to be disabled globally via config
 - Long term ideally we'd have the ability to "cordon" executors individually - ideally via api (armadactl?)

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-566) by [Unito](https://www.unito.io)
