### PR TITLE
Use a callback to generate/access grpc credentials for operator use.

### DIFF
--- a/third_party/airflow/armada/operators/grpc.py
+++ b/third_party/airflow/armada/operators/grpc.py
@@ -1,3 +1,4 @@
+import importlib
 from typing import Optional, Sequence, Tuple, Any, TypedDict
 
 import grpc
@@ -9,9 +10,41 @@ class GrpcChannelArgsDict(TypedDict):
     """
 
     target: str
-    credentials: Optional[grpc.ChannelCredentials]
     options: Optional[Sequence[Tuple[str, Any]]]
     compression: Optional[grpc.Compression]
+
+
+class CredentialsCallbackDict(TypedDict):
+    module_name: str
+    function_name: str
+    function_kwargs: dict
+
+
+class CredentialsCallback(object):
+    """
+    Allows the use of an arbitrary callback function to get grpc credentials.
+
+    :param module_name: The fully qualified python module name where the
+        function is located.
+    :param function_name: The name of the function to be called.
+    :param function_kwargs: Keyword arguments to function_name in a dictionary.
+    """
+
+    def __init__(
+        self,
+        module_name: str,
+        function_name: str,
+        function_kwargs: dict,
+    ) -> None:
+        self.module_name = module_name
+        self.function_name = function_name
+        self.function_kwargs = function_kwargs
+
+    def call(self):
+        """Do the callback to get grpc credentials."""
+        module = importlib.import_module(self.module_name)
+        func = getattr(module, self.function_name)
+        return func(**self.function_kwargs)
 
 
 class GrpcChannelArguments(object):
@@ -20,8 +53,8 @@ class GrpcChannelArguments(object):
 
     :param target: Target keyword argument used
         when instantiating a grpc channel.
-    :param credentials: credentials keyword argument used
-        when instantiating a grpc channel.
+    :param credentials_callback_args: Arguments to CredentialsCallback to use
+        when instantiating a grpc channel that takes credentials.
     :param options: options keyword argument used
         when instantiating a grpc channel.
     :param compression: compression keyword argument used
@@ -32,14 +65,15 @@ class GrpcChannelArguments(object):
     def __init__(
         self,
         target: str,
-        credentials: Optional[grpc.ChannelCredentials] = None,
         options: Optional[Sequence[Tuple[str, Any]]] = None,
         compression: Optional[grpc.Compression] = None,
+        credentials_callback_args: CredentialsCallbackDict = None,
     ) -> None:
         self.target = target
-        self.credentials = credentials
         self.options = options
         self.compression = compression
+        if credentials_callback_args is not None:
+            self.credentials_callback = CredentialsCallback(**credentials_callback_args)
 
     def channel(self) -> grpc.Channel:
         """
@@ -49,7 +83,7 @@ class GrpcChannelArguments(object):
             returns grpc.secure_channel.
         """
 
-        if self.credentials is None:
+        if self.credentials_callback is None:
             return grpc.insecure_channel(
                 target=self.target,
                 options=self.options,
@@ -57,7 +91,7 @@ class GrpcChannelArguments(object):
             )
         return grpc.secure_channel(
             target=self.target,
-            credentials=self.credentials,
+            credentials=self.credentials_callback.call(),
             options=self.options,
             compression=self.compression,
         )
@@ -70,7 +104,7 @@ class GrpcChannelArguments(object):
             returns grpc.aio.secure_channel.
         """
 
-        if self.credentials is None:
+        if self.credentials_callback is None:
             return grpc.aio.insecure_channel(
                 target=self.target,
                 options=self.options,
@@ -78,7 +112,7 @@ class GrpcChannelArguments(object):
             )
         return grpc.aio.secure_channel(
             target=self.target,
-            credentials=self.credentials,
+            credentials=self.credentials_callback.call(),
             options=self.options,
             compression=self.compression,
         )
@@ -93,7 +127,7 @@ class GrpcChannelArguments(object):
 
         return {
             "target": self.target,
-            "credentials": self.credentials,
+            "credentials_callback": self.credentials_callback,
             "options": self.options,
             "compression": self.compression,
         }

--- a/third_party/airflow/tests/unit/test_armada_operator.py
+++ b/third_party/airflow/tests/unit/test_armada_operator.py
@@ -1,5 +1,10 @@
-from armada.operators.armada import ArmadaOperator
+import copy
+
+import grpc
 import pytest
+
+from armada.operators.armada import ArmadaOperator
+from armada.operators.grpc import CredentialsCallback
 
 get_lookout_url_test_cases = [
     (
@@ -35,3 +40,94 @@ def test_get_lookout_url(lookout_url_template, job_id, expected_url):
     )
 
     assert operator._get_lookout_url(job_id) == expected_url
+
+
+def test_deepcopy_operator():
+    armada_channel_args = {"target": "127.0.0.1:50051"}
+    job_service_channel_args = {"target": "127.0.0.1:60003"}
+
+    operator = ArmadaOperator(
+        task_id="test_task_id",
+        name="test_task",
+        armada_channel_args=armada_channel_args,
+        job_service_channel_args=job_service_channel_args,
+        armada_queue="test_queue",
+        job_request_items=[],
+        lookout_url_template="http://localhost:8089/jobs?job_id=<job_id>",
+    )
+
+    try:
+        copy.deepcopy(operator)
+    except Exception as e:
+        assert False, f"{e}"
+
+
+@pytest.mark.skip("demonstrates how the old way of passing in credentials fails")
+def test_deepcopy_operator_with_grpc_credentials():
+    armada_channel_args = {
+        "target": "127.0.0.1:50051",
+        "credentials": grpc.composite_channel_credentials(
+            grpc.ssl_channel_credentials(),
+            grpc.metadata_call_credentials(("authorization", "fake_jwt")),
+        ),
+    }
+    job_service_channel_args = {"target": "127.0.0.1:60003"}
+
+    operator = ArmadaOperator(
+        task_id="test_task_id",
+        name="test_task",
+        armada_channel_args=armada_channel_args,
+        job_service_channel_args=job_service_channel_args,
+        armada_queue="test_queue",
+        job_request_items=[],
+        lookout_url_template="http://localhost:8089/jobs?job_id=<job_id>",
+    )
+
+    try:
+        copy.deepcopy(operator)
+    except Exception as e:
+        assert False, f"{e}"
+
+
+def test_deepcopy_operator_with_grpc_credentials_callback():
+    armada_channel_args = {
+        "target": "127.0.0.1:50051",
+        "credentials_callback_args": {
+            "module_name": "tests.unit.test_armada_operator",
+            "function_name": "__example_test_callback",
+            "function_kwargs": {
+                "test_arg": "fake_arg",
+            },
+        },
+    }
+    job_service_channel_args = {"target": "127.0.0.1:60003"}
+
+    operator = ArmadaOperator(
+        task_id="test_task_id",
+        name="test_task",
+        armada_channel_args=armada_channel_args,
+        job_service_channel_args=job_service_channel_args,
+        armada_queue="test_queue",
+        job_request_items=[],
+        lookout_url_template="http://localhost:8089/jobs?job_id=<job_id>",
+    )
+
+    try:
+        copy.deepcopy(operator)
+    except Exception as e:
+        assert False, f"{e}"
+
+
+def __example_test_callback():
+    return "fake_cred"
+
+
+def test_credentials_callback():
+    callback = CredentialsCallback(
+        module_name="tests.unit.test_armada_operator",
+        function_name="__example_test_callback",
+        function_kwargs={},
+    )
+
+    result = callback.call()
+    assert result == "fake_cred"


### PR DESCRIPTION
Hopefully fixes #2786 