### PR TITLE
Fixing CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Unit Tests
         id: unit_test
-        run: go run github.com/magefile/mage@v1.14.0 -v tests
+        run: make tests
 
       - name: Publish JUnit Report
         uses: mikepenz/action-junit-report@v3


### PR DESCRIPTION
Please note that `go run github.com/magefile/mage@v1.14.0 -v tests` and `make tests` run a significantly different number of unit tests. This needs to be fixed ASAP

Hopefully this works for now.