### PR TITLE
fix typo: constaint -> constraint

### DIFF
--- a/magefiles/docker.go
+++ b/magefiles/docker.go
@@ -80,7 +80,7 @@ func constraintCheck(version *semver.Version, versionRequirement string) error {
 		return errors.Errorf("error parsing constraint: %v", err)
 	}
 	if !constraint.Check(version) {
-		return errors.Errorf("found version %v but it failed constaint %v", version, constraint)
+		return errors.Errorf("found version %v but it failed constraint %v", version, constraint)
 	}
 	return nil
 }
@@ -111,7 +111,7 @@ func dockerCheck() error {
 		return errors.Errorf("error parsing constraint: %v", err)
 	}
 	if !constraint.Check(version) {
-		return errors.Errorf("found version %v but it failed constaint %v", version, constraint)
+		return errors.Errorf("found version %v but it failed constraint %v", version, constraint)
 	}
 	return nil
 }

--- a/magefiles/go.go
+++ b/magefiles/go.go
@@ -48,7 +48,7 @@ func goCheck() error {
 		return errors.Errorf("error parsing constraint: %v", err)
 	}
 	if !constraint.Check(version) {
-		return errors.Errorf("found version %v but it failed constaint %v", version, constraint)
+		return errors.Errorf("found version %v but it failed constraint %v", version, constraint)
 	}
 	return nil
 }

--- a/magefiles/kind.go
+++ b/magefiles/kind.go
@@ -75,7 +75,7 @@ func kindCheck() error {
 		return errors.Errorf("error parsing constraint: %v", err)
 	}
 	if !constraint.Check(version) {
-		return errors.Errorf("found version %v but it failed constaint %v", version, constraint)
+		return errors.Errorf("found version %v but it failed constraint %v", version, constraint)
 	}
 	return nil
 }

--- a/magefiles/kubectl.go
+++ b/magefiles/kubectl.go
@@ -53,7 +53,7 @@ func kubectlCheck() error {
 		return errors.Errorf("error parsing constraint: %v", err)
 	}
 	if !constraint.Check(version) {
-		return errors.Errorf("found version %v but it failed constaint %v", version, constraint)
+		return errors.Errorf("found version %v but it failed constraint %v", version, constraint)
 	}
 	return nil
 }

--- a/magefiles/protoc.go
+++ b/magefiles/protoc.go
@@ -48,7 +48,7 @@ func protocCheck() error {
 		return errors.Errorf("error parsing constraint: %v", err)
 	}
 	if !constraint.Check(version) {
-		return errors.Errorf("found version %v but it failed constaint %v", version, constraint)
+		return errors.Errorf("found version %v but it failed constraint %v", version, constraint)
 	}
 	return nil
 }

--- a/magefiles/sqlc.go
+++ b/magefiles/sqlc.go
@@ -42,7 +42,7 @@ func sqlcCheck() error {
 		return errors.Errorf("error parsing constraint: %v", err)
 	}
 	if !constraint.Check(version) {
-		return errors.Errorf("found version %v but it failed constaint %v", version, constraint)
+		return errors.Errorf("found version %v but it failed constraint %v", version, constraint)
 	}
 	return nil
 }


### PR DESCRIPTION
#### What type of PR is this?
This PR corrects a spelling error seen when running any of the mage build scripts such as "mage localdev full"


#### Which issue(s) this PR fixes:
No known issue however here is a screenshot of the error occurring:

![image](https://github.com/armadaproject/armada/assets/41763998/ce442415-9d8e-4f51-9d5a-db52219702e1)

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-624) by [Unito](https://www.unito.io)
