### PR TITLE
Upgrade to ci-alerts to v2

### DIFF
--- a/.github/workflows/slack-alerts.yml
+++ b/.github/workflows/slack-alerts.yml
@@ -2,38 +2,18 @@ name: Slack CI Alerts
 
 on:
   workflow_run:
-    workflows: [CI, Python Airflow Operator, Build Release Images]
+    workflows: [CI, Python Airflow Operator, Build Release Images, Release Armada components, Release Armada components - RC]
     types: [completed]
 
 jobs:
-  on_push_failure:
+  on-failure:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'master'
-    steps:
-      - name: "Master Notification"
-        uses: Mo-Fatah/ci-alerts@v1
-        env: 
-          webhook: ${{ secrets.SLACK_WEBHOOK }}
-          event: push
-          commit: ${{ github.sha }}
-          commit_url: https://github.com/armadaproject/armada/commit/${{ github.sha }}
-          author: ${{ github.actor }}
-          workflow_name: ${{ github.event.workflow_run.name }}
-          workflow_url: ${{ github.event.workflow_run.html_url}}
-
-  on_pull_request_failure:
-    runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.event == 'pull_request'
+    if: github.event.workflow_run.conclusion == 'failure' 
     steps:
       - uses: actions/checkout@v3.3.0
-      - name: "Pull Request Notification"
-        uses: Mo-Fatah/ci-alerts@v1
+      - name: "Send Notification"
+        uses: Mo-Fatah/ci-alerts@v2
         env: 
           webhook: ${{ secrets.SLACK_WEBHOOK }}
-          event: pr
-          commit: ${{ github.sha }}
-          commit_url: https://github.com/armadaproject/armada/commit/${{ github.sha }}
-          author: ${{ github.actor }}
-          workflow_name: ${{ github.event.workflow_run.name }}
-          workflow_url: ${{ github.event.workflow_run.html_url}}
+          github_context: ${{ toJSON(github) }}
           users_path: ${{github.workspace}}/.github/gh-to-slackid


### PR DESCRIPTION
I push [ci-alerts](https://github.com/Mo-Fatah/ci-alerts/tree/v2) forward to `v2` . `v2` just needs the `github` context, the `webhook` and the `users_path` mentioning on slack. 
It tells which branch had the failure and which exact job failed. 

![Screenshot from 2023-08-09 16-17-29](https://github.com/armadaproject/armada/assets/39927413/f23a2892-3e2b-4513-90e8-ed741e3432be)

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-646) by [Unito](https://www.unito.io)
