### PR TITLE
add mage tests instead of make tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Unit Tests
         id: unit_test
-        run: make tests
+        run: go run github.com/magefile/mage@v1.14.0 -v tests
 
       - name: Publish JUnit Report
         uses: mikepenz/action-junit-report@v3


### PR DESCRIPTION
Add `mage tests` instead of `make tests`.  

Verify codecov works correctly in new path.

And also fix any tests that this added.

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-648) by [Unito](https://www.unito.io)
