### PR TITLE
Feat/improved version checking output

### DIFF
--- a/magefiles/docker.go
+++ b/magefiles/docker.go
@@ -74,13 +74,13 @@ func dockerVersion() (*semver.Version, error) {
 	return version, nil
 }
 
-func constraintCheck(version *semver.Version, versionRequirement string) error {
+func constraintCheck(version *semver.Version, versionRequirement string, dependencyName string) error {
 	constraint, err := semver.NewConstraint(versionRequirement)
 	if err != nil {
 		return errors.Errorf("error parsing constraint: %v", err)
 	}
 	if !constraint.Check(version) {
-		return errors.Errorf("found version %v but it failed constaint %v", version, constraint)
+		return errors.Errorf("found %s version %v but it failed constaint %v", dependencyName, version, constraint)
 	}
 	return nil
 }
@@ -90,7 +90,7 @@ func dockerComposeCheck() error {
 	if err != nil {
 		return errors.Errorf("error getting version: %v", err)
 	}
-	return constraintCheck(version, DOCKER_COMPOSE_VERSION_CONSTRAINT)
+	return constraintCheck(version, DOCKER_COMPOSE_VERSION_CONSTRAINT, "docker-compose")
 }
 
 func dockerBuildxCheck() error {
@@ -98,7 +98,7 @@ func dockerBuildxCheck() error {
 	if err != nil {
 		return errors.Errorf("error getting version: %v", err)
 	}
-	return constraintCheck(version, DOCKER_BUILDX_VERSION_CONSTRAINT)
+	return constraintCheck(version, DOCKER_BUILDX_VERSION_CONSTRAINT, "docker-buildx")
 }
 
 func dockerCheck() error {
@@ -111,7 +111,7 @@ func dockerCheck() error {
 		return errors.Errorf("error parsing constraint: %v", err)
 	}
 	if !constraint.Check(version) {
-		return errors.Errorf("found version %v but it failed constaint %v", version, constraint)
+		return errors.Errorf("found docker version %v but it failed constaint %v", version, constraint)
 	}
 	return nil
 }

--- a/magefiles/go.go
+++ b/magefiles/go.go
@@ -43,14 +43,7 @@ func goCheck() error {
 	if err != nil {
 		return errors.Errorf("error getting version: %v", err)
 	}
-	constraint, err := semver.NewConstraint(GO_VERSION_CONSTRAINT)
-	if err != nil {
-		return errors.Errorf("error parsing constraint: %v", err)
-	}
-	if !constraint.Check(version) {
-		return errors.Errorf("found version %v but it failed constaint %v", version, constraint)
-	}
-	return nil
+	return constraintCheck(version, GO_VERSION_CONSTRAINT, "Go")
 }
 
 func goEnv(name string) (string, error) {

--- a/magefiles/kind.go
+++ b/magefiles/kind.go
@@ -70,14 +70,7 @@ func kindCheck() error {
 	if err != nil {
 		return errors.Errorf("error getting version: %v", err)
 	}
-	constraint, err := semver.NewConstraint(KIND_VERSION_CONSTRAINT)
-	if err != nil {
-		return errors.Errorf("error parsing constraint: %v", err)
-	}
-	if !constraint.Check(version) {
-		return errors.Errorf("found version %v but it failed constaint %v", version, constraint)
-	}
-	return nil
+	return constraintCheck(version, KIND_VERSION_CONSTRAINT, "kind")
 }
 
 // Images that need to be available in the Kind cluster,

--- a/magefiles/kubectl.go
+++ b/magefiles/kubectl.go
@@ -48,12 +48,5 @@ func kubectlCheck() error {
 	if err != nil {
 		return errors.Errorf("error getting version: %v", err)
 	}
-	constraint, err := semver.NewConstraint(KUBECTL_VERSION_CONSTRAINT)
-	if err != nil {
-		return errors.Errorf("error parsing constraint: %v", err)
-	}
-	if !constraint.Check(version) {
-		return errors.Errorf("found version %v but it failed constaint %v", version, constraint)
-	}
-	return nil
+	return constraintCheck(version, KUBECTL_VERSION_CONSTRAINT, "kubectl")
 }

--- a/magefiles/linting.go
+++ b/magefiles/linting.go
@@ -35,14 +35,7 @@ func golangciLintCheck() error {
 	if err != nil {
 		return errors.Errorf("error getting version: %v", err)
 	}
-	constraint, err := semver.NewConstraint(GOLANGCI_LINT_VERSION_CONSTRAINT)
-	if err != nil {
-		return errors.Errorf("error parsing constraint: %v", err)
-	}
-	if !constraint.Check(version) {
-		return errors.Errorf("found version %v but it failed constraint %v", version, constraint)
-	}
-	return nil
+	return constraintCheck(version, GOLANGCI_LINT_VERSION_CONSTRAINT, "golangci-lint")
 }
 
 // Fixing Linting

--- a/magefiles/protoc.go
+++ b/magefiles/protoc.go
@@ -43,12 +43,5 @@ func protocCheck() error {
 	if err != nil {
 		return errors.Errorf("error getting version: %v", err)
 	}
-	constraint, err := semver.NewConstraint(PROTOC_VERSION_CONSTRAINT)
-	if err != nil {
-		return errors.Errorf("error parsing constraint: %v", err)
-	}
-	if !constraint.Check(version) {
-		return errors.Errorf("found version %v but it failed constaint %v", version, constraint)
-	}
-	return nil
+	return constraintCheck(version, PROTOC_VERSION_CONSTRAINT, "protoc")
 }

--- a/magefiles/sqlc.go
+++ b/magefiles/sqlc.go
@@ -37,12 +37,5 @@ func sqlcCheck() error {
 	if err != nil {
 		return errors.Errorf("error getting version: %v", err)
 	}
-	constraint, err := semver.NewConstraint(SQLC_VERSION_CONSTRAINT)
-	if err != nil {
-		return errors.Errorf("error parsing constraint: %v", err)
-	}
-	if !constraint.Check(version) {
-		return errors.Errorf("found version %v but it failed constaint %v", version, constraint)
-	}
-	return nil
+	return constraintCheck(version, SQLC_VERSION_CONSTRAINT, "sqlc")
 }


### PR DESCRIPTION
This PR does two things:
- Refactors the version checking code to use the already written constraintCheck() function
- Expands the Constraint Check function to also output the actual dependency that is out dated.

The current functionality if a constraint is failed for example docker the output is:
"Error: found version xxx but it failed constraint >= xxx"

This PR changes the output to be:
"Error: found **docker** version xxx  but it failed constraint >= xxx"

Other than "docker" it could print out: "kind", "Go", "kubectl", "golangci-lint", "protoc", and "sqlc".

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-649) by [Unito](https://www.unito.io)
