### PR TITLE
Expose scheduler context to scheduler.go

### DIFF
--- a/internal/scheduler/common.go
+++ b/internal/scheduler/common.go
@@ -11,6 +11,7 @@ import (
 	armadamaps "github.com/armadaproject/armada/internal/common/maps"
 	armadaslices "github.com/armadaproject/armada/internal/common/slices"
 	schedulerconfig "github.com/armadaproject/armada/internal/scheduler/configuration"
+	schedulercontext "github.com/armadaproject/armada/internal/scheduler/context"
 	"github.com/armadaproject/armada/internal/scheduler/interfaces"
 	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
 )
@@ -24,6 +25,9 @@ type SchedulerResult struct {
 	// For each preempted job, maps the job id to the id of the node on which the job was running.
 	// For each scheduled job, maps the job id to the id of the node on which the job should be scheduled.
 	NodeIdByJobId map[string]string
+	// The Scheduling Context. Being passed up for metrics decisions made in scheduler.go and scheduler_metrics.go.
+	// Passing a pointer as the structure is enormous
+	SchedulingContext *schedulercontext.SchedulingContext
 }
 
 func NewSchedulerResult[S ~[]T, T interfaces.LegacySchedulerJob](

--- a/internal/scheduler/common.go
+++ b/internal/scheduler/common.go
@@ -27,7 +27,7 @@ type SchedulerResult struct {
 	NodeIdByJobId map[string]string
 	// The Scheduling Context. Being passed up for metrics decisions made in scheduler.go and scheduler_metrics.go.
 	// Passing a pointer as the structure is enormous
-	SchedulingContext *schedulercontext.SchedulingContext
+	SchedulingContextList []*schedulercontext.SchedulingContext
 }
 
 func NewSchedulerResult[S ~[]T, T interfaces.LegacySchedulerJob](

--- a/internal/scheduler/common.go
+++ b/internal/scheduler/common.go
@@ -27,7 +27,7 @@ type SchedulerResult struct {
 	NodeIdByJobId map[string]string
 	// The Scheduling Context. Being passed up for metrics decisions made in scheduler.go and scheduler_metrics.go.
 	// Passing a pointer as the structure is enormous
-	SchedulingContextList []*schedulercontext.SchedulingContext
+	SchedulingContexts []*schedulercontext.SchedulingContext
 }
 
 func NewSchedulerResult[S ~[]T, T interfaces.LegacySchedulerJob](

--- a/internal/scheduler/preempting_queue_scheduler.go
+++ b/internal/scheduler/preempting_queue_scheduler.go
@@ -287,9 +287,10 @@ func (sch *PreemptingQueueScheduler) Schedule(ctx context.Context) (*SchedulerRe
 		}
 	}
 	return &SchedulerResult{
-		PreemptedJobs: preemptedJobs,
-		ScheduledJobs: scheduledJobs,
-		NodeIdByJobId: sch.nodeIdByJobId,
+		PreemptedJobs:     preemptedJobs,
+		ScheduledJobs:     scheduledJobs,
+		NodeIdByJobId:     sch.nodeIdByJobId,
+		SchedulingContext: sch.schedulingContext,
 	}, nil
 }
 

--- a/internal/scheduler/preempting_queue_scheduler.go
+++ b/internal/scheduler/preempting_queue_scheduler.go
@@ -287,10 +287,10 @@ func (sch *PreemptingQueueScheduler) Schedule(ctx context.Context) (*SchedulerRe
 		}
 	}
 	return &SchedulerResult{
-		PreemptedJobs:     preemptedJobs,
-		ScheduledJobs:     scheduledJobs,
-		NodeIdByJobId:     sch.nodeIdByJobId,
-		SchedulingContext: sch.schedulingContext,
+		PreemptedJobs:         preemptedJobs,
+		ScheduledJobs:         scheduledJobs,
+		NodeIdByJobId:         sch.nodeIdByJobId,
+		SchedulingContextList: []*schedulercontext.SchedulingContext{sch.schedulingContext},
 	}, nil
 }
 

--- a/internal/scheduler/preempting_queue_scheduler.go
+++ b/internal/scheduler/preempting_queue_scheduler.go
@@ -287,10 +287,10 @@ func (sch *PreemptingQueueScheduler) Schedule(ctx context.Context) (*SchedulerRe
 		}
 	}
 	return &SchedulerResult{
-		PreemptedJobs:         preemptedJobs,
-		ScheduledJobs:         scheduledJobs,
-		NodeIdByJobId:         sch.nodeIdByJobId,
-		SchedulingContextList: []*schedulercontext.SchedulingContext{sch.schedulingContext},
+		PreemptedJobs:      preemptedJobs,
+		ScheduledJobs:      scheduledJobs,
+		NodeIdByJobId:      sch.nodeIdByJobId,
+		SchedulingContexts: []*schedulercontext.SchedulingContext{sch.schedulingContext},
 	}, nil
 }
 

--- a/internal/scheduler/queue_scheduler.go
+++ b/internal/scheduler/queue_scheduler.go
@@ -134,10 +134,10 @@ func (sch *QueueScheduler) Schedule(ctx context.Context) (*SchedulerResult, erro
 		return nil, errors.Errorf("only %d out of %d jobs mapped to a node", len(nodeIdByJobId), len(scheduledJobs))
 	}
 	return &SchedulerResult{
-		PreemptedJobs:         nil,
-		ScheduledJobs:         scheduledJobs,
-		NodeIdByJobId:         nodeIdByJobId,
-		SchedulingContextList: []*schedulercontext.SchedulingContext{sch.schedulingContext},
+		PreemptedJobs:      nil,
+		ScheduledJobs:      scheduledJobs,
+		NodeIdByJobId:      nodeIdByJobId,
+		SchedulingContexts: []*schedulercontext.SchedulingContext{sch.schedulingContext},
 	}, nil
 }
 

--- a/internal/scheduler/queue_scheduler.go
+++ b/internal/scheduler/queue_scheduler.go
@@ -134,10 +134,10 @@ func (sch *QueueScheduler) Schedule(ctx context.Context) (*SchedulerResult, erro
 		return nil, errors.Errorf("only %d out of %d jobs mapped to a node", len(nodeIdByJobId), len(scheduledJobs))
 	}
 	return &SchedulerResult{
-		PreemptedJobs:     nil,
-		ScheduledJobs:     scheduledJobs,
-		NodeIdByJobId:     nodeIdByJobId,
-		SchedulingContext: sch.schedulingContext,
+		PreemptedJobs:         nil,
+		ScheduledJobs:         scheduledJobs,
+		NodeIdByJobId:         nodeIdByJobId,
+		SchedulingContextList: []*schedulercontext.SchedulingContext{sch.schedulingContext},
 	}, nil
 }
 

--- a/internal/scheduler/queue_scheduler.go
+++ b/internal/scheduler/queue_scheduler.go
@@ -134,9 +134,10 @@ func (sch *QueueScheduler) Schedule(ctx context.Context) (*SchedulerResult, erro
 		return nil, errors.Errorf("only %d out of %d jobs mapped to a node", len(nodeIdByJobId), len(scheduledJobs))
 	}
 	return &SchedulerResult{
-		PreemptedJobs: nil,
-		ScheduledJobs: scheduledJobs,
-		NodeIdByJobId: nodeIdByJobId,
+		PreemptedJobs:     nil,
+		ScheduledJobs:     scheduledJobs,
+		NodeIdByJobId:     nodeIdByJobId,
+		SchedulingContext: sch.schedulingContext,
 	}, nil
 }
 

--- a/internal/scheduler/scheduling_algo.go
+++ b/internal/scheduler/scheduling_algo.go
@@ -86,7 +86,8 @@ func (l *FairSchedulingAlgo) Schedule(
 	log := ctxlogrus.Extract(ctx)
 
 	overallSchedulerResult := &SchedulerResult{
-		NodeIdByJobId: make(map[string]string),
+		NodeIdByJobId:         make(map[string]string),
+		SchedulingContextList: make([]*schedulercontext.SchedulingContext, 0, 0),
 	}
 
 	// Exit immediately if scheduling is disabled.
@@ -169,6 +170,7 @@ func (l *FairSchedulingAlgo) Schedule(
 		// Aggregate changes across executors.
 		overallSchedulerResult.PreemptedJobs = append(overallSchedulerResult.PreemptedJobs, schedulerResult.PreemptedJobs...)
 		overallSchedulerResult.ScheduledJobs = append(overallSchedulerResult.ScheduledJobs, schedulerResult.ScheduledJobs...)
+		overallSchedulerResult.SchedulingContextList = append(overallSchedulerResult.SchedulingContextList, schedulerResult.SchedulingContextList...)
 		maps.Copy(overallSchedulerResult.NodeIdByJobId, schedulerResult.NodeIdByJobId)
 
 		// Update fsctx.

--- a/internal/scheduler/scheduling_algo.go
+++ b/internal/scheduler/scheduling_algo.go
@@ -86,8 +86,8 @@ func (l *FairSchedulingAlgo) Schedule(
 	log := ctxlogrus.Extract(ctx)
 
 	overallSchedulerResult := &SchedulerResult{
-		NodeIdByJobId:         make(map[string]string),
-		SchedulingContextList: make([]*schedulercontext.SchedulingContext, 0, 0),
+		NodeIdByJobId:      make(map[string]string),
+		SchedulingContexts: make([]*schedulercontext.SchedulingContext, 0, 0),
 	}
 
 	// Exit immediately if scheduling is disabled.
@@ -170,7 +170,7 @@ func (l *FairSchedulingAlgo) Schedule(
 		// Aggregate changes across executors.
 		overallSchedulerResult.PreemptedJobs = append(overallSchedulerResult.PreemptedJobs, schedulerResult.PreemptedJobs...)
 		overallSchedulerResult.ScheduledJobs = append(overallSchedulerResult.ScheduledJobs, schedulerResult.ScheduledJobs...)
-		overallSchedulerResult.SchedulingContextList = append(overallSchedulerResult.SchedulingContextList, schedulerResult.SchedulingContextList...)
+		overallSchedulerResult.SchedulingContexts = append(overallSchedulerResult.SchedulingContexts, schedulerResult.SchedulingContexts...)
 		maps.Copy(overallSchedulerResult.NodeIdByJobId, schedulerResult.NodeIdByJobId)
 
 		// Update fsctx.

--- a/third_party/airflow/README.md
+++ b/third_party/airflow/README.md
@@ -36,12 +36,10 @@ python3.8 -m pip install armada-airflow
 
 From the top level of the repo, you should run `make airflow-operator`.  This will generate proto/grpc files in the jobservice folder.
 
-Airflow with the Armada operator can be run alongside the other Armada services via the localdev docker-compose 
-environment. It is manually started in this way:
+Airflow with the Armada operator can be run alongside the other Armada services via the docker-compose environment. It is manually started in this way:
 
 ```
-cd localdev
-docker-compose up -d airflow
+mage airflow start
 ```
 
 Airflow's web UI will then be accessible at http://localhost:8081 (login with admin/admin).


### PR DESCRIPTION
Passes up the schedeuling context as a return value. This allows us to start considering scheduling decisions as the basis for metrics.

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-669) by [Unito](https://www.unito.io)
