### PR TITLE
Fix jobDb job order

### DIFF
--- a/internal/scheduler/jobdb/job.go
+++ b/internal/scheduler/jobdb/job.go
@@ -457,20 +457,16 @@ type JobPriorityComparer struct{}
 // Compare jobs first by priority then by created and finally by id.
 // returns -1 if a should come before b, 1 if a should come after b and 0 if the two jobs are equal
 func (j JobPriorityComparer) Compare(a, b *Job) int {
-	if a == b {
-		return 0
-	}
-
-	// Compare the jobs by priority
+	// Compare the jobs by priority.
 	if a.priority != b.priority {
-		if a.priority > b.priority {
+		if a.priority < b.priority {
 			return -1
 		} else {
 			return 1
 		}
 	}
 
-	// If the jobs have the same priority, compare them by created timestamp
+	// If the jobs have the same priority, compare them by created timestamp.
 	if a.created != b.created {
 		if a.created < b.created {
 			return -1
@@ -479,7 +475,7 @@ func (j JobPriorityComparer) Compare(a, b *Job) int {
 		}
 	}
 
-	// If the jobs have the same priority and created timestamp, compare them by ID
+	// If the jobs have the same priority and created timestamp, compare them by id.
 	if a.id != b.id {
 		if a.id < b.id {
 			return -1
@@ -488,6 +484,6 @@ func (j JobPriorityComparer) Compare(a, b *Job) int {
 		}
 	}
 
-	// If the jobs have the same ID, return 0
+	// Jobs are equal; return 0.
 	return 0
 }

--- a/internal/scheduler/jobdb/job_test.go
+++ b/internal/scheduler/jobdb/job_test.go
@@ -366,8 +366,8 @@ func TestJobPriorityComparer(t *testing.T) {
 	comparer := JobPriorityComparer{}
 
 	assert.Equal(t, 0, comparer.Compare(job1, job1))
-	assert.Equal(t, -1, comparer.Compare(job1, job1.WithPriority(9)))
+	assert.Equal(t, 1, comparer.Compare(job1, job1.WithPriority(9)))
 	assert.Equal(t, -1, comparer.Compare(job1, job1.WithCreated(6)))
-	assert.Equal(t, 1, comparer.Compare(job1, job1.WithPriority(11)))
+	assert.Equal(t, -1, comparer.Compare(job1, job1.WithPriority(11)))
 	assert.Equal(t, 1, comparer.Compare(job1, job1.WithCreated(4)))
 }

--- a/internal/scheduler/jobdb/jobdb_test.go
+++ b/internal/scheduler/jobdb/jobdb_test.go
@@ -92,7 +92,7 @@ func TestJobDb_TestQueuedJobs(t *testing.T) {
 	for i := 0; i < len(jobs); i++ {
 		jobs[i] = newJob().WithQueued(true)
 		jobs[i].priority = 1000
-		jobs[i].created = int64(i) // forces an order
+		jobs[i].created = int64(i) // Ensures jobs are ordered.
 	}
 	shuffledJobs := slices.Clone(jobs)
 	rand.Shuffle(len(shuffledJobs), func(i, j int) { shuffledJobs[i], shuffledJobs[j] = shuffledJobs[j], jobs[i] })

--- a/internal/scheduler/jobdb/jobdb_test.go
+++ b/internal/scheduler/jobdb/jobdb_test.go
@@ -91,6 +91,7 @@ func TestJobDb_TestQueuedJobs(t *testing.T) {
 	jobs := make([]*Job, 10)
 	for i := 0; i < len(jobs); i++ {
 		jobs[i] = newJob().WithQueued(true)
+		jobs[i].priority = 1000
 		jobs[i].created = int64(i) // forces an order
 	}
 	shuffledJobs := slices.Clone(jobs)
@@ -122,7 +123,7 @@ func TestJobDb_TestQueuedJobs(t *testing.T) {
 	assert.Equal(t, []*Job{jobs[0], jobs[2], jobs[6], jobs[8], jobs[9]}, collect())
 
 	// change the priority of a job to put it to the front of the queue
-	updatedJob := jobs[8].WithPriority(100)
+	updatedJob := jobs[8].WithPriority(0)
 	err = jobDb.Upsert(txn, []*Job{updatedJob})
 	require.NoError(t, err)
 	assert.Equal(t, []*Job{updatedJob, jobs[0], jobs[2], jobs[6], jobs[9]}, collect())

--- a/internal/scheduler/queue_scheduler_test.go
+++ b/internal/scheduler/queue_scheduler_test.go
@@ -421,6 +421,17 @@ func TestQueueScheduler(t *testing.T) {
 			PriorityFactorByQueue:    map[string]float64{"A": 1},
 			ExpectedScheduledIndices: []int{1},
 		},
+		"job priority": {
+			SchedulingConfig: testfixtures.TestSchedulingConfig(),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
+			Jobs: armadaslices.Concatenate(
+				testfixtures.WithPriorityJobs(10, testfixtures.N32Cpu256GiJobs("A", testfixtures.PriorityClass0, 1)),
+				testfixtures.WithPriorityJobs(1, testfixtures.N32Cpu256GiJobs("A", testfixtures.PriorityClass0, 1)),
+				testfixtures.WithPriorityJobs(20, testfixtures.N32Cpu256GiJobs("A", testfixtures.PriorityClass0, 1)),
+			),
+			PriorityFactorByQueue:    map[string]float64{"A": 1},
+			ExpectedScheduledIndices: []int{1},
+		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/internal/scheduler/testfixtures/testfixtures.go
+++ b/internal/scheduler/testfixtures/testfixtures.go
@@ -233,6 +233,13 @@ func WithNodeSelectorPodReq(selector map[string]string, req *schedulerobjects.Po
 	return req
 }
 
+func WithPriorityJobs(priority uint32, jobs []*jobdb.Job) []*jobdb.Job {
+	for i, job := range jobs {
+		jobs[i] = job.WithPriority(priority)
+	}
+	return jobs
+}
+
 func WithNodeUniformityLabelAnnotationJobs(label string, jobs []*jobdb.Job) []*jobdb.Job {
 	for _, job := range jobs {
 		req := job.PodRequirements()


### PR DESCRIPTION
Smaller job priority value should indicate higher job priority.

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-673) by [Unito](https://www.unito.io)
