### PR TITLE
Log Call Site

### DIFF
--- a/internal/common/startup.go
+++ b/internal/common/startup.go
@@ -111,7 +111,8 @@ func readEnvironmentLogFormat() log.Formatter {
 		CallerPrettyfier: func(frame *runtime.Frame) (function string, file string) {
 			fileName := path.Base(frame.File) + ":" + strconv.Itoa(frame.Line)
 			return "", fileName
-		}}
+		},
+	}
 
 	switch strings.ToLower(formatStr) {
 	case "json":

--- a/internal/common/startup.go
+++ b/internal/common/startup.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -80,6 +81,7 @@ func ConfigureCommandLineLogging() {
 func ConfigureLogging() {
 	log.SetLevel(readEnvironmentLogLevel())
 	log.SetFormatter(readEnvironmentLogFormat())
+	log.SetReportCaller(readEnvironmentLogCallSite())
 	log.SetOutput(os.Stdout)
 }
 
@@ -92,6 +94,17 @@ func readEnvironmentLogLevel() log.Level {
 		}
 	}
 	return log.InfoLevel
+}
+
+func readEnvironmentLogCallSite() bool {
+	level, ok := os.LookupEnv("LOG_REPORT_CALLER")
+	if ok {
+		logCallSite, err := strconv.ParseBool(level)
+		if err == nil {
+			return logCallSite
+		}
+	}
+	return false
 }
 
 func readEnvironmentLogFormat() log.Formatter {


### PR DESCRIPTION
Adds the call site to every log line via logrus's `log.SetReportCaller(true)` mechanism.  For the json logger we log as is, but for the text logger we use a `CallerPrettyfier` to log only the file as otherwise the log line can get quite cluttered. Examples:

**Text**
```
INFO[2023-08-23T07:44:46.42+01:00]startup.go:47 Read base config from /Users/chris/GolandProjects/armada/config/scheduler/config.yaml 
ERRO[2023-08-23T07:44:46.42+01:00]startup.go:53 Error reading config from localdev/config/armada/config.yaml: open localdev/config/armada/config.yaml: no such file or directory 
```

**Json**
```
{"file":"/Users/chris/GolandProjects/armada/internal/common/startup.go:47","func":"github.com/armadaproject/armada/internal/common.LoadConfig","level":"info","msg":"Read base config from /Users/chris/GolandProjects/armada/config/scheduler/config.yaml","time":"2023-08-23T07:54:19.633+01:00"}
{"file":"/Users/chris/GolandProjects/armada/internal/common/startup.go:53","func":"github.com/armadaproject/armada/internal/common.LoadConfig","level":"error","msg":"Error reading config from localdev/config/armada/config.yaml: open localdev/config/armada/config.yaml: no such file or directory","time":"2023-08-23T07:54:19.633+01:00"}
```

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-694) by [Unito](https://www.unito.io)
