### PR TITLE
Order leased jobs by serial

### DIFF
--- a/internal/scheduler/database/job_repository.go
+++ b/internal/scheduler/database/job_repository.go
@@ -244,6 +244,7 @@ func (r *PostgresJobRepository) FetchJobRunLeases(ctx context.Context, executor 
 				AND jr.succeeded = false
 				AND jr.failed = false
 				AND jr.cancelled = false
+				ORDER BY jr.serial
 				LIMIT %d;
 `
 


### PR DESCRIPTION
This will ensure the job leased first, gets send to the cluster first

Currently we just order by postgres default sorting - which often picks the most recently leased - causing the first lease jobs to get stuck
 - This only occurs when scheduling is faster than leasing

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-697) by [Unito](https://www.unito.io)
