### PR TITLE
F/owentho957 add priorityclass to executor chart

### DIFF
--- a/deployment/executor/templates/deployment.yaml
+++ b/deployment/executor/templates/deployment.yaml
@@ -80,8 +80,8 @@ spec:
           {{- end }}
       nodeSelector:
         {{- toYaml .Values.nodeSelector | nindent 8 }}
-      {{- if .Values.priorityClass }}
-      priorityClassName: {{- .Values.priorityClass }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{- .Values.priorityClassName }}
       {{- end }}
       tolerations:
         {{- toYaml .Values.tolerations | nindent 8 }}

--- a/deployment/executor/templates/deployment.yaml
+++ b/deployment/executor/templates/deployment.yaml
@@ -80,6 +80,9 @@ spec:
           {{- end }}
       nodeSelector:
         {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- if .Values.priorityClass }}
+      priorityClassName: {{- .Values.priorityClass }}
+      {{- end }}
       tolerations:
         {{- toYaml .Values.tolerations | nindent 8 }}
       volumes:

--- a/deployment/executor/values.yaml
+++ b/deployment/executor/values.yaml
@@ -18,6 +18,7 @@ nodeSelector: {}
 tolerations: []
 customServiceAccount: null
 serviceAccount: null
+priorityClassName: ""
 
 healthcheck:
   enabled: false


### PR DESCRIPTION
At the moment the helm chart for the executor doesn't include priorityClass even though one is created in the chart. This means that the executor deployment is unable to set the priorityClass.

