### PR TITLE
CodeQL: Run once daily on a schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,6 @@ permissions:
 jobs:
   lint:
     uses: ./.github/workflows/lint.yml
-  codeql:
-    uses: ./.github/workflows/codeql-analysis.yml
   test:
     uses: ./.github/workflows/test.yml
   # Virtual job that can be configured as a required check before a PR can be merged.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,7 +12,8 @@
 name: "CodeQL"
 
 on:
-  workflow_call:
+  schedule:
+    - cron: "0 9 * * *"
 
 permissions:
   actions: read


### PR DESCRIPTION
CodeQL is taking much time running on each pull request and push. I converted it to a cron job to run once daily at 9 am.