### PR TITLE
fix: update url of Design

### DIFF
--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -32,7 +32,7 @@ blog_settings:
 menu_settings:
   menu_items:
     - title: 'Design'
-      url: '/design'    
+      url: '/design/'
     - title: 'Documentation'
       submenu_items:
       - title: 'Development'


### PR DESCRIPTION
This PR fixes: #2529

This PR changes the URL of Design page so it can navigate to the correct one. After successful merging of this PR, the below change is expected.

https://github.com/armadaproject/armada/assets/101946115/802a6d00-17f5-4840-bcdb-42ca2983abbc
