### PR TITLE
Revert to previous unpinned airflow version spec.

### DIFF
--- a/third_party/airflow/pyproject.toml
+++ b/third_party/airflow/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "armada_airflow"
-version = "0.5.4"
+version = "0.5.5"
 description = "Armada Airflow Operator"
 requires-python = ">=3.7"
 # Note(JayF): This dependency value is not suitable for release. Whatever

--- a/third_party/airflow/pyproject.toml
+++ b/third_party/airflow/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.7"
 # extremely difficult.
 dependencies = [
 	"armada-client",
-	"apache-airflow==2.7.1",
+	"apache-airflow>=2.6.3",
 	"grpcio==1.58.0",
 	"grpcio-tools==1.58.0",
 	"types-protobuf==4.24.0.1"


### PR DESCRIPTION
Revert to previous unpinned version of apache-airflow (use `>=2.6.3`) in Airflow pyproject.toml.