### PR TITLE
Fixes for routable services

### DIFF
--- a/deployment/armada/templates/deployment.yaml
+++ b/deployment/armada/templates/deployment.yaml
@@ -100,6 +100,7 @@ spec:
             httpGet:
               path: /health
               port: rest
+              scheme: {{ if .Values.applicationConfig.grpc.tls.enabled }}HTTPS{{ else }}HTTP{{ end }}
             initialDelaySeconds: 5
             timeoutSeconds: 5
             failureThreshold: 2
@@ -107,6 +108,7 @@ spec:
             httpGet:
               path: /health
               port: rest
+              scheme: {{ if .Values.applicationConfig.grpc.tls.enabled }}HTTPS{{ else }}HTTP{{ end }}
             initialDelaySeconds: 10
             timeoutSeconds: 10
             failureThreshold: 3

--- a/deployment/armada/templates/routableservice.yaml
+++ b/deployment/armada/templates/routableservice.yaml
@@ -10,14 +10,14 @@ spec:
   type: LoadBalancer
   allocateLoadBalancerNodePorts: false
   {{ if .Values.routableService.grpcLoadBalancerIP }}
-  loadBalancerIP: {{.Values.routableService.grpcloadBalancerIP}}
+  loadBalancerIP: {{.Values.routableService.grpcLoadBalancerIP}}
   {{ end }}
   selector:
     {{- include "armada.labels.identity" . | nindent 4 }}
   ports:
     - name: grpc
       protocol: TCP
-      port: {{ if .Values.applicationConfig.grpc.Tls.enabled }}443{{ else }}80{{ end }}
+      port: {{ if .Values.applicationConfig.grpc.tls.enabled }}443{{ else }}80{{ end }}
       targetPort: {{ .Values.applicationConfig.grpcPort }}
 ---
 apiVersion: v1
@@ -31,13 +31,13 @@ spec:
   type: LoadBalancer
   allocateLoadBalancerNodePorts: false
   {{ if .Values.routableService.restLoadBalancerIP }}
-  loadBalancerIP: {{.Values.routableService.restloadBalancerIP}}
+  loadBalancerIP: {{.Values.routableService.restLoadBalancerIP}}
   {{ end }}
   selector:
     {{- include "armada.labels.identity" . | nindent 4 }}
   ports:
     - name: grpc
       protocol: TCP
-      port: {{ if .Values.applicationConfig.grpc.Tls.enabled }}443{{ else }}80{{ end }}
+      port: {{ if .Values.applicationConfig.grpc.tls.enabled }}443{{ else }}80{{ end }}
       targetPort: {{ .Values.applicationConfig.httpPort }}
 {{ end }}

--- a/deployment/armada/templates/service.yaml
+++ b/deployment/armada/templates/service.yaml
@@ -6,21 +6,11 @@ metadata:
   labels:
     {{- include "armada.labels.all" . | nindent 4 }}
 spec:
-  type: {{ .Values.serviceType }}
+  {{- if .Values.nodePort }}
+  type: NodePort
+  {{- end }}
   selector:
     {{- include "armada.labels.identity" . | nindent 4 }}
-  {{- if .Values.externalTrafficPolicy }}
-  externalTrafficPolicy: {{ .Values.externalTrafficPolicy }}
-  {{- end }}
-  {{- if .Values.internalTrafficPolicy }}
-  internalTrafficPolicy: {{ .Values.internalTrafficPolicy }}
-  {{- end }}
-  {{- with .Values.clusterIP }}
-  clusterIP: {{ . | quote }}
-  {{- end } }
-  {{- with .Values.loadBalancerIP }}
-  loadBalancerIP: {{ . | quote }}
-  {{- end }}
   ports:
     - name: grpc
       protocol: TCP

--- a/deployment/lookout-v2/templates/deployment.yaml
+++ b/deployment/lookout-v2/templates/deployment.yaml
@@ -74,6 +74,7 @@ spec:
             httpGet:
               path: /health
               port: web
+              scheme: {{ if .Values.applicationConfig.tls.enabled }}HTTPS{{ else }}HTTP{{ end }}
             initialDelaySeconds: 10
             timeoutSeconds: 10
             failureThreshold: 3

--- a/deployment/lookout/templates/deployment.yaml
+++ b/deployment/lookout/templates/deployment.yaml
@@ -73,6 +73,7 @@ spec:
             httpGet:
               path: /health
               port: web
+              scheme: {{ if .Values.applicationConfig.grpc.tls.enabled }}HTTPS{{ else }}HTTP{{ end }}
             initialDelaySeconds: 5
             timeoutSeconds: 5
             failureThreshold: 2
@@ -80,6 +81,7 @@ spec:
             httpGet:
               path: /health
               port: web
+              scheme: {{ if .Values.applicationConfig.grpc.tls.enabled }}HTTPS{{ else }}HTTP{{ end }}
             initialDelaySeconds: 10
             timeoutSeconds: 10
             failureThreshold: 3

--- a/deployment/lookout/templates/routableservice.yaml
+++ b/deployment/lookout/templates/routableservice.yaml
@@ -2,27 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "lookout.name" . }}-routable
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "lookout.labels.all" . | nindent 4 }}
-spec:
-  type: LoadBalancer
-  allocateLoadBalancerNodePorts: false
-  {{ if .Values.routableService.grpcLoadBalancerIP }}
-  loadBalancerIP: {{.Values.routableService.grpcloadBalancerIP}}
-  {{ end }}
-  selector:
-    {{- include "armada.labels.identity" . | nindent 4 }}
-  ports:
-    - name: grpc
-      protocol: TCP
-      port: {{ if .Values.applicationConfig.grpc.Tls.enabled }}443{{ else }}80{{ end }}
-      targetPort: {{ .Values.applicationConfig.grpcPort }}
----
-apiVersion: v1
-kind: Service
-metadata:
   name: {{ include "lookout.name" . }}-rest-routable
   namespace: {{ .Release.Namespace }}
   labels:
@@ -30,14 +9,14 @@ metadata:
 spec:
   type: LoadBalancer
   allocateLoadBalancerNodePorts: false
-  {{ if .Values.routableService.restLoadBalancerIP }}
-  loadBalancerIP: {{.Values.routableService.restloadBalancerIP}}
+  {{ if .Values.routableService.loadBalancerIP }}
+  loadBalancerIP: {{.Values.routableService.loadBalancerIP}}
   {{ end }}
   selector:
     {{- include "armada.labels.identity" . | nindent 4 }}
   ports:
     - name: grpc
       protocol: TCP
-      port: {{ if .Values.applicationConfig.grpc.Tls.enabled }}443{{ else }}80{{ end }}
+      port: {{ if .Values.applicationConfig.grpc.tls.enabled }}443{{ else }}80{{ end }}
       targetPort: {{ .Values.applicationConfig.httpPort }}
 {{ end }}


### PR DESCRIPTION
- liveness/readiness probes to use https if we're doing tls termination
- various casing issue
- remove changes to `deployment/armada/templates/service.yaml` that we introduced previously in error
- don't expose the lookout grpc service as routable as it isn't needed
