### PR TITLE
Fix Tls Config For Rest Gateway

### DIFF
--- a/cmd/armada/main.go
+++ b/cmd/armada/main.go
@@ -96,7 +96,10 @@ func main() {
 	// register gRPC API handlers in mux
 	// TODO: Run in errgroup
 	shutdownGateway := gateway.CreateGatewayHandler(
-		config.GrpcPort, mux, "/",
+		config.GrpcPort,
+		mux,
+		config.GrpcGatewayPath,
+		config.Grpc.Tls.Enabled,
 		config.CorsAllowedOrigins,
 		api.SwaggerJsonTemplate(),
 		api.RegisterSubmitHandler,

--- a/cmd/binoculars/main.go
+++ b/cmd/binoculars/main.go
@@ -80,7 +80,7 @@ func serveHttp(
 	spec string,
 	handlers ...func(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error,
 ) (shutdown func()) {
-	shutdownGateway := gateway.CreateGatewayHandler(grpcPort, mux, "/", corsAllowedOrigins, spec, handlers...)
+	shutdownGateway := gateway.CreateGatewayHandler(grpcPort, mux, "/", false, corsAllowedOrigins, spec, handlers...)
 	cancel := common.ServeHttp(port, mux)
 
 	return func() {

--- a/cmd/lookout/main.go
+++ b/cmd/lookout/main.go
@@ -98,6 +98,7 @@ func main() {
 		config.GrpcPort,
 		mux,
 		"/api/",
+		config.Grpc.Tls.Enabled,
 		[]string{},
 		lookoutApi.SwaggerJsonTemplate(),
 		lookoutApi.RegisterLookoutHandler)

--- a/config/armada/config.yaml
+++ b/config/armada/config.yaml
@@ -5,6 +5,7 @@ corsAllowedOrigins:
   - http://localhost:3000
   - http://localhost:8089
   - http://localhost:10000
+grpcGatewayPath: "/"
 cancelJobsBatchSize: 1000
 pulsarSchedulerEnabled: false
 probabilityOfUsingPulsarScheduler: 0

--- a/internal/armada/configuration/types.go
+++ b/internal/armada/configuration/types.go
@@ -26,6 +26,7 @@ type ArmadaConfig struct {
 	PprofPort *uint16
 
 	CorsAllowedOrigins []string
+	GrpcGatewayPath    string
 
 	Grpc grpcconfig.GrpcConfig
 

--- a/internal/common/grpc/gateway.go
+++ b/internal/common/grpc/gateway.go
@@ -4,17 +4,16 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"google.golang.org/grpc/credentials"
 	"net/http"
 	"path"
 	"strings"
-
-	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/jcmturner/gokrb5/v8/spnego"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 
 	protoutil "github.com/armadaproject/armada/internal/common/grpc/protoutils"
 	"github.com/armadaproject/armada/internal/common/util"


### PR DESCRIPTION
- Allows the rest gateway to make a TLS connection tot he rest backend
- Allows the armada rest gateway to be available at a configurable path. Default is "/" which was the value hardcoded previously