### PR TITLE
Stop serving version 1 of the Lookout UI

### DIFF
--- a/cmd/lookout/main.go
+++ b/cmd/lookout/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -15,7 +14,6 @@ import (
 	"github.com/armadaproject/armada/internal/common"
 	"github.com/armadaproject/armada/internal/common/grpc"
 	"github.com/armadaproject/armada/internal/common/health"
-	"github.com/armadaproject/armada/internal/common/serve"
 	"github.com/armadaproject/armada/internal/lookout"
 	"github.com/armadaproject/armada/internal/lookout/configuration"
 	"github.com/armadaproject/armada/internal/lookout/postgres"
@@ -102,15 +100,8 @@ func main() {
 		config.Grpc.Tls.Enabled,
 		[]string{},
 		lookoutApi.SwaggerJsonTemplate(),
-		lookoutApi.RegisterLookoutHandler)
-
-	// UI config
-	mux.HandleFunc("/config", func(w http.ResponseWriter, r *http.Request) {
-		configHandler(config.UIConfig, w)
-	})
-
-	// server static UI files
-	mux.Handle("/", http.FileServer(serve.CreateDirWithIndexFallback("./internal/lookout/ui/build")))
+		lookoutApi.RegisterLookoutHandler,
+	)
 
 	var shutdownServer func() = nil
 	if config.Grpc.Tls.Enabled {
@@ -130,13 +121,4 @@ func main() {
 	startupCompleteCheck.MarkComplete()
 
 	wg.Wait()
-}
-
-func configHandler(config configuration.LookoutUIConfig, w http.ResponseWriter) {
-	w.Header().Set("Content-Type", "application/json")
-
-	err := json.NewEncoder(w).Encode(config)
-	if err != nil {
-		w.WriteHeader(500)
-	}
 }

--- a/cmd/lookoutv2/main.go
+++ b/cmd/lookoutv2/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/armadaproject/armada/internal/common/database"
 	"github.com/armadaproject/armada/internal/lookoutv2"
 	"github.com/armadaproject/armada/internal/lookoutv2/configuration"
+	"github.com/armadaproject/armada/internal/lookoutv2/gen/restapi"
 	"github.com/armadaproject/armada/internal/lookoutv2/pruner"
 	"github.com/armadaproject/armada/internal/lookoutv2/schema"
 )
@@ -57,7 +58,7 @@ func makeContext() (*armadacontext.Context, func()) {
 	}
 }
 
-func migrate(ctx *armadacontext.Context, config configuration.LookoutV2Configuration) {
+func migrate(ctx *armadacontext.Context, config configuration.LookoutV2Config) {
 	db, err := database.OpenPgxPool(config.Postgres)
 	if err != nil {
 		panic(err)
@@ -74,7 +75,7 @@ func migrate(ctx *armadacontext.Context, config configuration.LookoutV2Configura
 	}
 }
 
-func prune(ctx *armadacontext.Context, config configuration.LookoutV2Configuration) {
+func prune(ctx *armadacontext.Context, config configuration.LookoutV2Config) {
 	db, err := database.OpenPgxConn(config.Postgres)
 	if err != nil {
 		panic(err)
@@ -104,7 +105,7 @@ func main() {
 	common.ConfigureLogging()
 	common.BindCommandlineArguments()
 
-	var config configuration.LookoutV2Configuration
+	var config configuration.LookoutV2Config
 	userSpecifiedConfigs := viper.GetStringSlice(CustomConfigLocation)
 	common.LoadConfig(&config, "./config/lookoutv2", userSpecifiedConfigs)
 
@@ -125,8 +126,9 @@ func main() {
 		return
 	}
 
-	err := lookoutv2.Serve(config)
-	if err != nil {
+	restapi.UIConfig = config.UIConfig
+
+	if err := lookoutv2.Serve(config); err != nil {
 		log.Error(err)
 		os.Exit(1)
 	}

--- a/config/lookout/config.yaml
+++ b/config/lookout/config.yaml
@@ -13,15 +13,6 @@ grpc:
   keepaliveEnforcementPolicy:
     minTime: 5m
     permitWithoutStream: false
-uiConfig:
-  armadaApiBaseUrl: "http://armada-server:8080"
-  userAnnotationPrefix: "armadaproject.io/"
-  binocularsEnabled: true
-  binocularsBaseUrlPattern: "http://armada-binoculars:8080"
-  overviewAutoRefreshMs: 15000
-  jobSetsAutoRefreshMs: 15000
-  jobsAutoRefreshMs: 30000
-  lookoutV2ApiBaseUrl: "http://armada-lookout-v2:10000"
 postgres:
   maxOpenConns: 100
   maxIdleConns: 25
@@ -33,7 +24,6 @@ postgres:
     password: psw
     dbname: postgres
     sslmode: disable
-
 prunerConfig:
   daysToKeep: 42
   batchSize: 1000

--- a/config/lookoutv2/config.yaml
+++ b/config/lookoutv2/config.yaml
@@ -22,3 +22,11 @@ prunerConfig:
   expireAfter: 1008h  # 42 days, 6 weeks
   timeout: 1h
   batchSize: 1000
+uiConfig:
+  armadaApiBaseUrl: "http://armada-server:8080"
+  userAnnotationPrefix: "armadaproject.io/"
+  binocularsEnabled: true
+  binocularsBaseUrlPattern: "http://armada-binoculars:8080"
+  overviewAutoRefreshMs: 15000
+  jobSetsAutoRefreshMs: 15000
+  jobsAutoRefreshMs: 30000

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -241,6 +241,7 @@ services:
       - server
       - lookoutingesterv2
     volumes:
+      - ./internal/lookout/ui/build:/app/internal/lookout/ui/build
       - "go-cache:/root/.cache/go-build:rw"
       - "gomod-cache:/go/pkg/mod:rw"
     env_file:

--- a/internal/lookout/configuration/types.go
+++ b/internal/lookout/configuration/types.go
@@ -7,21 +7,6 @@ import (
 	grpcconfig "github.com/armadaproject/armada/internal/common/grpc/configuration"
 )
 
-type LookoutUIConfig struct {
-	CustomTitle string
-
-	ArmadaApiBaseUrl         string
-	UserAnnotationPrefix     string
-	BinocularsEnabled        bool
-	BinocularsBaseUrlPattern string
-
-	OverviewAutoRefreshMs int
-	JobSetsAutoRefreshMs  int
-	JobsAutoRefreshMs     int
-
-	LookoutV2ApiBaseUrl string
-}
-
 type PrunerConfig struct {
 	DaysToKeep int
 	BatchSize  int
@@ -33,8 +18,6 @@ type LookoutConfiguration struct {
 	MetricsPort uint16
 
 	Grpc grpcconfig.GrpcConfig
-
-	UIConfig LookoutUIConfig
 
 	Postgres     configuration.PostgresConfig
 	PrunerConfig PrunerConfig

--- a/internal/lookout/ui/src/App.tsx
+++ b/internal/lookout/ui/src/App.tsx
@@ -11,9 +11,6 @@ import { IGroupJobsService } from "services/lookoutV2/GroupJobsService"
 import { UpdateJobsService } from "services/lookoutV2/UpdateJobsService"
 
 import NavBar from "./components/NavBar"
-import JobSetsContainer from "./containers/JobSetsContainer"
-import JobsContainer from "./containers/JobsContainer"
-import OverviewContainer from "./containers/OverviewContainer"
 import { JobService } from "./services/JobService"
 import LogService from "./services/LogService"
 import { ICordonService } from "./services/lookoutV2/CordonService"
@@ -98,11 +95,8 @@ export function App(props: AppProps) {
                 <NavBar customTitle={props.customTitle} />
                 <div className="app-content">
                   <Routes>
-                    <Route path="/" element={<OverviewContainer {...props} />} />
-                    <Route path="/job-sets" element={<JobSetsContainer {...props} />} />
-                    <Route path="/jobs" element={<JobsContainer {...props} />} />
                     <Route
-                      path="/v2"
+                      path="/"
                       element={
                         <JobsTableContainer
                           getJobsService={props.v2GetJobsService}

--- a/internal/lookout/ui/src/App.tsx
+++ b/internal/lookout/ui/src/App.tsx
@@ -116,6 +116,15 @@ export function App(props: AppProps) {
                       }
                     />
                     <Route path="/v2" element={<V2Redirect />} />
+                    <Route
+                      path="*"
+                      element={
+                        // This wildcard route ensures that users who follow old
+                        // links to /job-sets or /jobs see something other than
+                        // a blank page.
+                        <Navigate to="/" />
+                      }
+                    />
                   </Routes>
                 </div>
               </div>

--- a/internal/lookout/ui/src/App.tsx
+++ b/internal/lookout/ui/src/App.tsx
@@ -5,10 +5,11 @@ import { createGenerateClassName } from "@material-ui/core/styles"
 import { ThemeProvider as ThemeProviderV5, createTheme as createThemeV5 } from "@mui/material/styles"
 import { JobsTableContainer } from "containers/lookoutV2/JobsTableContainer"
 import { SnackbarProvider } from "notistack"
-import { Route, BrowserRouter, Routes } from "react-router-dom"
+import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom"
 import { IGetJobsService } from "services/lookoutV2/GetJobsService"
 import { IGroupJobsService } from "services/lookoutV2/GroupJobsService"
 import { UpdateJobsService } from "services/lookoutV2/UpdateJobsService"
+import { withRouter } from "utils"
 
 import NavBar from "./components/NavBar"
 import { JobService } from "./services/JobService"
@@ -75,6 +76,10 @@ type AppProps = {
   debugEnabled: boolean
 }
 
+// Version 2 of the Lookout UI used to be hosted under /v2, so we try our best
+// to redirect users to the new location while preserving the rest of the URL.
+const V2Redirect = withRouter(({ router }) => <Navigate to={{ ...router.location, pathname: "/" }} />)
+
 export function App(props: AppProps) {
   useEffect(() => {
     if (props.customTitle) {
@@ -110,6 +115,7 @@ export function App(props: AppProps) {
                         />
                       }
                     />
+                    <Route path="/v2" element={<V2Redirect />} />
                   </Routes>
                 </div>
               </div>

--- a/internal/lookout/ui/src/components/NavBar.tsx
+++ b/internal/lookout/ui/src/components/NavBar.tsx
@@ -11,7 +11,7 @@ interface NavBarProps {
   router: Router
 }
 
-function NavBar({ customTitle, router }: NavBarProps) {
+function NavBar({ customTitle }: NavBarProps) {
   return (
     <AppBar position="static">
       <Toolbar className="toolbar">

--- a/internal/lookout/ui/src/components/NavBar.tsx
+++ b/internal/lookout/ui/src/components/NavBar.tsx
@@ -2,16 +2,13 @@ import React from "react"
 
 import { AppBar, Toolbar, Typography } from "@material-ui/core"
 
-import { Router, withRouter } from "../utils"
-
 import "./NavBar.css"
 
 interface NavBarProps {
   customTitle: string
-  router: Router
 }
 
-function NavBar({ customTitle }: NavBarProps) {
+export default function NavBar({ customTitle }: NavBarProps) {
   return (
     <AppBar position="static">
       <Toolbar className="toolbar">
@@ -30,5 +27,3 @@ function NavBar({ customTitle }: NavBarProps) {
     </AppBar>
   )
 }
-
-export default withRouter(NavBar)

--- a/internal/lookout/ui/src/components/NavBar.tsx
+++ b/internal/lookout/ui/src/components/NavBar.tsx
@@ -1,53 +1,10 @@
 import React from "react"
 
-import { AppBar, Tab, Tabs, Toolbar, Typography } from "@material-ui/core"
-import { Link } from "react-router-dom"
+import { AppBar, Toolbar, Typography } from "@material-ui/core"
 
 import { Router, withRouter } from "../utils"
 
 import "./NavBar.css"
-
-interface Page {
-  title: string
-  location: string
-}
-
-const PAGES: Page[] = [
-  {
-    title: "Overview",
-    location: "/",
-  },
-  {
-    title: "Job Sets",
-    location: "/job-sets",
-  },
-  {
-    title: "Jobs",
-    location: "/jobs",
-  },
-  {
-    title: "V2",
-    location: "/v2",
-  },
-]
-
-// Creates mapping from location to index of element in ordered navbar
-function getLocationMap(pages: Page[]): Map<string, number> {
-  const locationMap = new Map<string, number>()
-  pages.forEach((page, index) => {
-    locationMap.set(page.location, index)
-  })
-  return locationMap
-}
-
-const locationMap = getLocationMap(PAGES)
-
-function locationFromIndex(pages: Page[], index: number): string {
-  if (pages[index]) {
-    return pages[index].location
-  }
-  return "/"
-}
 
 interface NavBarProps {
   customTitle: string
@@ -55,8 +12,6 @@ interface NavBarProps {
 }
 
 function NavBar({ customTitle, router }: NavBarProps) {
-  const currentLocation = router.location.pathname
-  const currentValue = locationMap.has(currentLocation) ? locationMap.get(currentLocation) : 0
   return (
     <AppBar position="static">
       <Toolbar className="toolbar">
@@ -71,19 +26,6 @@ function NavBar({ customTitle, router }: NavBarProps) {
             </Typography>
           )}
         </a>
-        <div className="nav-items">
-          <Tabs
-            value={currentValue}
-            onChange={(event, newIndex) => {
-              const newLocation = locationFromIndex(PAGES, newIndex)
-              router.navigate(newLocation)
-            }}
-          >
-            {PAGES.map((page, idx) => (
-              <Tab key={idx} label={page.title} component={Link} to={page.location} />
-            ))}
-          </Tabs>
-        </div>
       </Toolbar>
     </AppBar>
   )

--- a/internal/lookout/ui/src/index.tsx
+++ b/internal/lookout/ui/src/index.tsx
@@ -47,18 +47,15 @@ import "./index.css"
   )
 
   const fakeDataEnabled = uiConfig.fakeDataEnabled
-  const lookoutV2BaseUrl = uiConfig.lookoutV2ApiBaseUrl
 
   const v2TestJobs = fakeDataEnabled ? makeRandomJobs(10000, 42) : []
-  const v2GetJobsService = fakeDataEnabled ? new FakeGetJobsService(v2TestJobs) : new GetJobsService(lookoutV2BaseUrl)
-  const v2GroupJobsService = fakeDataEnabled
-    ? new FakeGroupJobsService(v2TestJobs)
-    : new GroupJobsService(lookoutV2BaseUrl)
-  const v2RunErrorService = fakeDataEnabled ? new FakeGetRunErrorService() : new GetRunErrorService(lookoutV2BaseUrl)
+  const v2GetJobsService = fakeDataEnabled ? new FakeGetJobsService(v2TestJobs) : new GetJobsService()
+  const v2GroupJobsService = fakeDataEnabled ? new FakeGroupJobsService(v2TestJobs) : new GroupJobsService()
+  const v2RunErrorService = fakeDataEnabled ? new FakeGetRunErrorService() : new GetRunErrorService()
   const v2LogService = fakeDataEnabled
     ? new FakeLogService()
     : new V2LogService({ credentials: "include" }, uiConfig.binocularsBaseUrlPattern)
-  const v2JobSpecService = fakeDataEnabled ? new FakeGetJobSpecService() : new GetJobSpecService(lookoutV2BaseUrl)
+  const v2JobSpecService = fakeDataEnabled ? new FakeGetJobSpecService() : new GetJobSpecService()
   const v2UpdateJobsService = new UpdateJobsService(submitApi)
   const v2CordonService = fakeDataEnabled
     ? new FakeCordonService()

--- a/internal/lookout/ui/src/services/lookoutV2/GetJobSpecService.ts
+++ b/internal/lookout/ui/src/services/lookoutV2/GetJobSpecService.ts
@@ -3,10 +3,8 @@ export interface IGetJobSpecService {
 }
 
 export class GetJobSpecService implements IGetJobSpecService {
-  constructor(private apiBase: string) {}
-
   async getJobSpec(jobId: string, abortSignal: AbortSignal | undefined): Promise<Record<string, any>> {
-    const response = await fetch(this.apiBase + "/api/v1/jobSpec", {
+    const response = await fetch("/api/v1/jobSpec", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({

--- a/internal/lookout/ui/src/services/lookoutV2/GetJobsService.ts
+++ b/internal/lookout/ui/src/services/lookoutV2/GetJobsService.ts
@@ -17,8 +17,6 @@ export type GetJobsResponse = {
 }
 
 export class GetJobsService implements IGetJobsService {
-  constructor(private apiBase: string) {}
-
   async getJobs(
     filters: JobFilter[],
     activeJobSets: boolean,
@@ -27,7 +25,7 @@ export class GetJobsService implements IGetJobsService {
     take: number,
     abortSignal: AbortSignal | undefined,
   ): Promise<GetJobsResponse> {
-    const response = await fetch(this.apiBase + "/api/v1/jobs", {
+    const response = await fetch("/api/v1/jobs", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({

--- a/internal/lookout/ui/src/services/lookoutV2/GetRunErrorService.ts
+++ b/internal/lookout/ui/src/services/lookoutV2/GetRunErrorService.ts
@@ -3,10 +3,8 @@ export interface IGetRunErrorService {
 }
 
 export class GetRunErrorService implements IGetRunErrorService {
-  constructor(private apiBase: string) {}
-
   async getRunError(runId: string, abortSignal: AbortSignal | undefined): Promise<string> {
-    const response = await fetch(this.apiBase + "/api/v1/jobRunError", {
+    const response = await fetch("/api/v1/jobRunError", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({

--- a/internal/lookout/ui/src/services/lookoutV2/GroupJobsService.ts
+++ b/internal/lookout/ui/src/services/lookoutV2/GroupJobsService.ts
@@ -24,8 +24,6 @@ export type GroupJobsResponse = {
 }
 
 export class GroupJobsService implements IGroupJobsService {
-  constructor(private apiBase: string) {}
-
   async groupJobs(
     filters: JobFilter[],
     activeJobSets: boolean,
@@ -36,7 +34,7 @@ export class GroupJobsService implements IGroupJobsService {
     take: number,
     abortSignal: AbortSignal | undefined,
   ): Promise<GroupJobsResponse> {
-    const response = await fetch(this.apiBase + "/api/v1/jobGroups", {
+    const response = await fetch("/api/v1/jobGroups", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({

--- a/internal/lookoutv2/application.go
+++ b/internal/lookoutv2/application.go
@@ -20,7 +20,7 @@ import (
 	"github.com/armadaproject/armada/internal/lookoutv2/repository"
 )
 
-func Serve(configuration configuration.LookoutV2Configuration) error {
+func Serve(configuration configuration.LookoutV2Config) error {
 	// load embedded swagger file
 	swaggerSpec, err := loads.Analyzed(restapi.SwaggerJSON, "")
 	if err != nil {

--- a/internal/lookoutv2/configuration/types.go
+++ b/internal/lookoutv2/configuration/types.go
@@ -6,7 +6,7 @@ import (
 	"github.com/armadaproject/armada/internal/armada/configuration"
 )
 
-type LookoutV2Configuration struct {
+type LookoutV2Config struct {
 	ApiPort            int
 	CorsAllowedOrigins []string
 	Tls                TlsConfig
@@ -14,6 +14,8 @@ type LookoutV2Configuration struct {
 	Postgres configuration.PostgresConfig
 
 	PrunerConfig PrunerConfig
+
+	UIConfig
 }
 
 type TlsConfig struct {
@@ -26,4 +28,17 @@ type PrunerConfig struct {
 	ExpireAfter time.Duration
 	Timeout     time.Duration
 	BatchSize   int
+}
+
+type UIConfig struct {
+	CustomTitle string
+
+	ArmadaApiBaseUrl         string
+	UserAnnotationPrefix     string
+	BinocularsEnabled        bool
+	BinocularsBaseUrlPattern string
+
+	OverviewAutoRefreshMs int
+	JobSetsAutoRefreshMs  int
+	JobsAutoRefreshMs     int
 }

--- a/internal/lookoutv2/gen/restapi/configure_lookout.go
+++ b/internal/lookoutv2/gen/restapi/configure_lookout.go
@@ -5,7 +5,6 @@ package restapi
 import (
 	"crypto/tls"
 	"encoding/json"
-	"github.com/armadaproject/armada/internal/common/health"
 	"net/http"
 	"strings"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 
+	"github.com/armadaproject/armada/internal/common/health"
 	"github.com/armadaproject/armada/internal/common/serve"
 	"github.com/armadaproject/armada/internal/common/util"
 	"github.com/armadaproject/armada/internal/lookoutv2/configuration"

--- a/internal/lookoutv2/gen/restapi/configure_lookout.go
+++ b/internal/lookoutv2/gen/restapi/configure_lookout.go
@@ -4,6 +4,8 @@ package restapi
 
 import (
 	"crypto/tls"
+	"encoding/json"
+	"github.com/armadaproject/armada/internal/common/health"
 	"net/http"
 	"strings"
 
@@ -11,7 +13,9 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 
+	"github.com/armadaproject/armada/internal/common/serve"
 	"github.com/armadaproject/armada/internal/common/util"
+	"github.com/armadaproject/armada/internal/lookoutv2/configuration"
 	"github.com/armadaproject/armada/internal/lookoutv2/gen/restapi/operations"
 )
 
@@ -81,13 +85,35 @@ func setupMiddlewares(handler http.Handler) http.Handler {
 	return handler
 }
 
+var UIConfig configuration.UIConfig
+
+var HealthChecker = health.NewMultiChecker()
+
 // The middleware configuration happens before anything, this middleware also applies to serving the swagger.json document.
 // So this is a good place to plug in a panic handling middleware, logging and metrics.
-func setupGlobalMiddleware(handler http.Handler) http.Handler {
-	return allowCORS(handler, corsAllowedOrigins)
+func setupGlobalMiddleware(apiHandler http.Handler) http.Handler {
+	return allowCORS(uiHandler(apiHandler), corsAllowedOrigins)
 }
 
-func allowCORS(h http.Handler, corsAllowedOrigins []string) http.Handler {
+func uiHandler(apiHandler http.Handler) http.Handler {
+	mux := http.NewServeMux()
+
+	mux.Handle("/", http.FileServer(serve.CreateDirWithIndexFallback("./internal/lookout/ui/build")))
+
+	mux.HandleFunc("/config", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(UIConfig); err != nil {
+			w.WriteHeader(500)
+		}
+	})
+
+	mux.Handle("/api/", apiHandler)
+	mux.Handle("/health", apiHandler)
+
+	return mux
+}
+
+func allowCORS(handler http.Handler, corsAllowedOrigins []string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if origin := r.Header.Get("Origin"); origin != "" && util.ContainsString(corsAllowedOrigins, origin) {
 			w.Header().Set("Access-Control-Allow-Origin", origin)
@@ -97,7 +123,7 @@ func allowCORS(h http.Handler, corsAllowedOrigins []string) http.Handler {
 				return
 			}
 		}
-		h.ServeHTTP(w, r)
+		handler.ServeHTTP(w, r)
 	})
 }
 

--- a/internal/lookoutv2/gen/restapi/configure_lookout.go
+++ b/internal/lookoutv2/gen/restapi/configure_lookout.go
@@ -12,7 +12,6 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 
-	"github.com/armadaproject/armada/internal/common/health"
 	"github.com/armadaproject/armada/internal/common/serve"
 	"github.com/armadaproject/armada/internal/common/util"
 	"github.com/armadaproject/armada/internal/lookoutv2/configuration"
@@ -86,8 +85,6 @@ func setupMiddlewares(handler http.Handler) http.Handler {
 }
 
 var UIConfig configuration.UIConfig
-
-var HealthChecker = health.NewMultiChecker()
 
 // The middleware configuration happens before anything, this middleware also applies to serving the swagger.json document.
 // So this is a good place to plug in a panic handling middleware, logging and metrics.


### PR DESCRIPTION
This is a quick-and-dirty change to stop serving version 1 of the Lookout UI (keeping its API around for now); version 2 of the Lookout UI, which is currently served by `lookout` in tandem with version 1, is served by `lookoutv2` instead (together with the corresponding API).

Concretely, after running a sequence of commands like the following I end up with version 2 of the Lookout UI running on `localhost:10000`, and the API corresponding to version 1 of the Lookout UI running on `localhost:8089`:

```bash
mage ui
mage builddockers bundle,lookout-bundle
mage kind
docker compose up --detach postgres pulsar redis
# Before running this, wait for the containers from the preceding command to start.
docker compose up --detach executor lookout lookoutv2
```

I have only tested this change on my machine; there is likely a bit more work to do before this can be deployed.