### PR TITLE
Stop serving version 1 of the Lookout UI

### DIFF
--- a/internal/lookout/ui/src/App.tsx
+++ b/internal/lookout/ui/src/App.tsx
@@ -5,15 +5,13 @@ import { createGenerateClassName } from "@material-ui/core/styles"
 import { ThemeProvider as ThemeProviderV5, createTheme as createThemeV5 } from "@mui/material/styles"
 import { JobsTableContainer } from "containers/lookoutV2/JobsTableContainer"
 import { SnackbarProvider } from "notistack"
-import { Route, BrowserRouter, Routes } from "react-router-dom"
+import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom"
 import { IGetJobsService } from "services/lookoutV2/GetJobsService"
 import { IGroupJobsService } from "services/lookoutV2/GroupJobsService"
 import { UpdateJobsService } from "services/lookoutV2/UpdateJobsService"
+import { withRouter } from "utils"
 
 import NavBar from "./components/NavBar"
-import JobSetsContainer from "./containers/JobSetsContainer"
-import JobsContainer from "./containers/JobsContainer"
-import OverviewContainer from "./containers/OverviewContainer"
 import { JobService } from "./services/JobService"
 import LogService from "./services/LogService"
 import { ICordonService } from "./services/lookoutV2/CordonService"
@@ -78,6 +76,10 @@ type AppProps = {
   debugEnabled: boolean
 }
 
+// Version 2 of the Lookout UI used to be hosted under /v2, so we try our best
+// to redirect users to the new location while preserving the rest of the URL.
+const V2Redirect = withRouter(({ router }) => <Navigate to={{ ...router.location, pathname: "/" }} />)
+
 export function App(props: AppProps) {
   useEffect(() => {
     if (props.customTitle) {
@@ -98,11 +100,8 @@ export function App(props: AppProps) {
                 <NavBar customTitle={props.customTitle} />
                 <div className="app-content">
                   <Routes>
-                    <Route path="/" element={<OverviewContainer {...props} />} />
-                    <Route path="/job-sets" element={<JobSetsContainer {...props} />} />
-                    <Route path="/jobs" element={<JobsContainer {...props} />} />
                     <Route
-                      path="/v2"
+                      path="/"
                       element={
                         <JobsTableContainer
                           getJobsService={props.v2GetJobsService}
@@ -114,6 +113,16 @@ export function App(props: AppProps) {
                           cordonService={props.v2CordonService}
                           debug={props.debugEnabled}
                         />
+                      }
+                    />
+                    <Route path="/v2" element={<V2Redirect />} />
+                    <Route
+                      path="*"
+                      element={
+                        // This wildcard route ensures that users who follow old
+                        // links to /job-sets or /jobs see something other than
+                        // a blank page.
+                        <Navigate to="/" />
                       }
                     />
                   </Routes>

--- a/internal/lookout/ui/src/components/NavBar.tsx
+++ b/internal/lookout/ui/src/components/NavBar.tsx
@@ -1,62 +1,14 @@
 import React from "react"
 
-import { AppBar, Tab, Tabs, Toolbar, Typography } from "@material-ui/core"
-import { Link } from "react-router-dom"
-
-import { Router, withRouter } from "../utils"
+import { AppBar, Toolbar, Typography } from "@material-ui/core"
 
 import "./NavBar.css"
 
-interface Page {
-  title: string
-  location: string
-}
-
-const PAGES: Page[] = [
-  {
-    title: "Overview",
-    location: "/",
-  },
-  {
-    title: "Job Sets",
-    location: "/job-sets",
-  },
-  {
-    title: "Jobs",
-    location: "/jobs",
-  },
-  {
-    title: "V2",
-    location: "/v2",
-  },
-]
-
-// Creates mapping from location to index of element in ordered navbar
-function getLocationMap(pages: Page[]): Map<string, number> {
-  const locationMap = new Map<string, number>()
-  pages.forEach((page, index) => {
-    locationMap.set(page.location, index)
-  })
-  return locationMap
-}
-
-const locationMap = getLocationMap(PAGES)
-
-function locationFromIndex(pages: Page[], index: number): string {
-  if (pages[index]) {
-    return pages[index].location
-  }
-  return "/"
-}
-
 interface NavBarProps {
   customTitle: string
-  router: Router
 }
 
-function NavBar({ customTitle, router }: NavBarProps) {
-  const currentLocation = router.location.pathname
-  const currentValue = locationMap.has(currentLocation) ? locationMap.get(currentLocation) : 0
+export default function NavBar({ customTitle }: NavBarProps) {
   return (
     <AppBar position="static">
       <Toolbar className="toolbar">
@@ -71,22 +23,7 @@ function NavBar({ customTitle, router }: NavBarProps) {
             </Typography>
           )}
         </a>
-        <div className="nav-items">
-          <Tabs
-            value={currentValue}
-            onChange={(event, newIndex) => {
-              const newLocation = locationFromIndex(PAGES, newIndex)
-              router.navigate(newLocation)
-            }}
-          >
-            {PAGES.map((page, idx) => (
-              <Tab key={idx} label={page.title} component={Link} to={page.location} />
-            ))}
-          </Tabs>
-        </div>
       </Toolbar>
     </AppBar>
   )
 }
-
-export default withRouter(NavBar)


### PR DESCRIPTION
This is the part of #3038 that only touches the Lookout UI, without changing either of the Lookout REST APIs.

On `master`, the Lookout UI has a navigation bar with four tabs, and `/` is routed to the "overview" tab:

<img width="1151" alt="lookout_v1" src="https://github.com/armadaproject/armada/assets/41909795/7ea6a951-017b-48bb-86f2-f61eb7a26bf1">

This PR removes the tabs and routes `/` to version 2 of the Lookout UI (which is accessible via the "v2" tab on `master`):

<img width="1062" alt="lookout_v2" src="https://github.com/armadaproject/armada/assets/41909795/e6a18a47-be09-461a-bfd5-d119bad9adde">

This means that version 1 of the Lookout UI won't be accessible anymore, but I'm not deleting its code just yet.

In order to make the migration easier for our users, I'm redirecting `/v2` to `/` (being careful to preserve the query string), which means that existing links to version 2 of the Lookout UI will continue to work; I'm also adding a wildcard route (it just redirects to `/`), so that links to `/job-sets` or `/jobs` (corresponding to the "job sets" and "jobs" tabs) don't just show a mostly blank page.