### PR TITLE
Fix go-integration-tests in Github CI workflow.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   ts-unit-tests:
     name: TypeScript Unit Tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest-4-cores
 
     steps:
       - name: Checkout
@@ -48,7 +48,7 @@ jobs:
 
   go-unit-tests:
     name: Golang Unit Tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest-4-cores
 
     steps:
       - name: Checkout
@@ -87,7 +87,7 @@ jobs:
 
   go-integration-tests:
     name: Golang Integration Tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest-4-cores
 
     env:
       ARMADA_EXECUTOR_INGRESS_URL: "http://localhost"
@@ -159,7 +159,7 @@ jobs:
 
   go-mod-up-to-date:
     name: Golang Mod Up To Date
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest-4-cores
 
     steps:
       - name: Checkout code
@@ -198,7 +198,7 @@ jobs:
 
   proto-up-to-date:
     name: Proto Up To Date
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest-4-cores
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,6 +131,22 @@ jobs:
           path: junit.xml
           if-no-files-found: error
 
+      - name: Store Docker Logs
+        if: always()
+        run: |
+          mkdir -p ./logs
+          docker compose logs --no-color > ./logs/docker-compose.log
+          docker logs pulsar > ./logs/pulsar.log 2>&1
+
+      - name: Upload Docker Compose Logs
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: docker-compose-logs
+          path: |
+            ./logs/
+          if-no-files-found: error
+
       - name: Publish JUnit Report
         uses: mikepenz/action-junit-report@v3
         if: always()

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -65,7 +65,7 @@ services:
     working_dir: /app
     env_file:
       - ./developer/env/server.env
-    command: ./server --config /config/insecure-armada.yaml
+    command: sleep 30 && ./server --config /config/insecure-armada.yaml
 
   server-pulsar:
     container_name: server
@@ -141,8 +141,6 @@ services:
     ports:
       - 9001:9001
       - 4001:4000
-    depends_on:
-      - server
     volumes:
       - ./.kube/internal:/.kube
       - "go-cache:/root/.cache/go-build:rw"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -65,7 +65,7 @@ services:
     working_dir: /app
     env_file:
       - ./developer/env/server.env
-    command: sleep 30 && ./server --config /config/insecure-armada.yaml
+    command: sh -c "sleep 30 && ./server --config /config/insecure-armada.yaml"
 
   server-pulsar:
     container_name: server

--- a/magefiles/ci.go
+++ b/magefiles/ci.go
@@ -25,7 +25,6 @@ func createQueue() error {
 
 // Build images, spin up a test environment, and run the integration tests against it.
 func TestSuite() error {
-	mg.Deps(createQueue)
 	mg.Deps(CheckForArmadaRunning)
 
 	// Only set these if they have not already been set
@@ -52,6 +51,7 @@ func TestSuite() error {
 
 // Checks if Armada is ready to accept jobs.
 func CheckForArmadaRunning() error {
+	time.Sleep(30 * time.Second)
 	mg.Deps(createQueue)
 
 	// Set high to take compile time into account


### PR DESCRIPTION
In `docker-compose.yaml`, remove Armada `server` as dependency for `executor` startup, and have the former wait 30 seconds before starting, so the Executor should be running and healthy before the server expects it.  Also save docker-compose logs and Pulsar container logs to GH artifacts for debugging purposes.