### PR TITLE
Bring back `/job-sets`

### DIFF
--- a/internal/lookout/ui/src/App.tsx
+++ b/internal/lookout/ui/src/App.tsx
@@ -8,6 +8,7 @@ import { SnackbarProvider } from "notistack"
 import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom"
 import { IGetJobsService } from "services/lookoutV2/GetJobsService"
 import { IGroupJobsService } from "services/lookoutV2/GroupJobsService"
+import { UpdateJobSetsService } from "services/lookoutV2/UpdateJobSetsService"
 import { UpdateJobsService } from "services/lookoutV2/UpdateJobsService"
 import { withRouter } from "utils"
 
@@ -69,6 +70,7 @@ type AppProps = {
   v2JobSpecService: IGetJobSpecService
   v2LogService: ILogService
   v2UpdateJobsService: UpdateJobsService
+  v2UpdateJobSetsService: UpdateJobSetsService
   v2CordonService: ICordonService
   logService: LogService
   overviewAutoRefreshMs: number

--- a/internal/lookout/ui/src/App.tsx
+++ b/internal/lookout/ui/src/App.tsx
@@ -12,6 +12,7 @@ import { UpdateJobsService } from "services/lookoutV2/UpdateJobsService"
 import { withRouter } from "utils"
 
 import NavBar from "./components/NavBar"
+import JobSetsContainer from "./containers/JobSetsContainer"
 import { JobService } from "./services/JobService"
 import LogService from "./services/LogService"
 import { ICordonService } from "./services/lookoutV2/CordonService"
@@ -115,6 +116,7 @@ export function App(props: AppProps) {
                         />
                       }
                     />
+                    <Route path="/job-sets" element={<JobSetsContainer {...props} />} />
                     <Route path="/v2" element={<V2Redirect />} />
                     <Route
                       path="*"

--- a/internal/lookout/ui/src/components/NavBar.tsx
+++ b/internal/lookout/ui/src/components/NavBar.tsx
@@ -1,14 +1,54 @@
 import React from "react"
 
-import { AppBar, Toolbar, Typography } from "@material-ui/core"
+import { AppBar, Tab, Tabs, Toolbar, Typography } from "@material-ui/core"
+import { Link } from "react-router-dom"
+
+import { Router, withRouter } from "../utils"
 
 import "./NavBar.css"
 
-interface NavBarProps {
-  customTitle: string
+interface Page {
+  title: string
+  location: string
 }
 
-export default function NavBar({ customTitle }: NavBarProps) {
+const PAGES: Page[] = [
+  {
+    title: "Jobs",
+    location: "/",
+  },
+  {
+    title: "Job Sets",
+    location: "/job-sets",
+  },
+]
+
+// Creates mapping from location to index of element in ordered navbar
+function getLocationMap(pages: Page[]): Map<string, number> {
+  const locationMap = new Map<string, number>()
+  pages.forEach((page, index) => {
+    locationMap.set(page.location, index)
+  })
+  return locationMap
+}
+
+const locationMap = getLocationMap(PAGES)
+
+function locationFromIndex(pages: Page[], index: number): string {
+  if (pages[index]) {
+    return pages[index].location
+  }
+  return "/"
+}
+
+interface NavBarProps {
+  customTitle: string
+  router: Router
+}
+
+function NavBar({ customTitle, router }: NavBarProps) {
+  const currentLocation = router.location.pathname
+  const currentValue = locationMap.has(currentLocation) ? locationMap.get(currentLocation) : 0
   return (
     <AppBar position="static">
       <Toolbar className="toolbar">
@@ -23,7 +63,22 @@ export default function NavBar({ customTitle }: NavBarProps) {
             </Typography>
           )}
         </a>
+        <div className="nav-items">
+          <Tabs
+            value={currentValue}
+            onChange={(event, newIndex) => {
+              const newLocation = locationFromIndex(PAGES, newIndex)
+              router.navigate(newLocation)
+            }}
+          >
+            {PAGES.map((page, idx) => (
+              <Tab key={idx} label={page.title} component={Link} to={page.location} />
+            ))}
+          </Tabs>
+        </div>
       </Toolbar>
     </AppBar>
   )
 }
+
+export default withRouter(NavBar)

--- a/internal/lookout/ui/src/components/job-sets/JobSetTable.tsx
+++ b/internal/lookout/ui/src/components/job-sets/JobSetTable.tsx
@@ -7,7 +7,6 @@ import { Column, defaultTableCellRenderer } from "react-virtualized"
 import { JobSet } from "../../services/JobService"
 import CheckboxHeaderRow from "../CheckboxHeaderRow"
 import CheckboxRow from "../CheckboxRow"
-import LinkCell from "../LinkCell"
 import SortableHeaderCell from "../SortableHeaderCell"
 
 import "./JobSetTable.css"
@@ -18,7 +17,6 @@ interface JobSetTableProps {
   jobSets: JobSet[]
   selectedJobSets: Map<string, JobSet>
   newestFirst: boolean
-  onJobSetClick: (jobSet: string, state: string) => void
   onSelectJobSet: (index: number, selected: boolean) => void
   onShiftSelectJobSet: (index: number, selected: boolean) => void
   onDeselectAllClick: () => void
@@ -26,13 +24,9 @@ interface JobSetTableProps {
   onOrderChange: (newestFirst: boolean) => void
 }
 
-function cellRendererForState(
-  cellProps: TableCellProps,
-  onJobSetClick: (jobSet: string, state: string) => void,
-  state: string,
-) {
+function cellRendererForState(cellProps: TableCellProps) {
   if (cellProps.cellData) {
-    return <LinkCell onClick={() => onJobSetClick((cellProps.rowData as JobSet).jobSetId, state)} {...cellProps} />
+    return cellProps.cellData
   }
   return defaultTableCellRenderer(cellProps)
 }
@@ -111,42 +105,42 @@ export default function JobSetTable(props: JobSetTableProps) {
           width={0.06 * props.width}
           label="Queued"
           className="job-set-table-number-cell"
-          cellRenderer={(cellProps) => cellRendererForState(cellProps, props.onJobSetClick, "Queued")}
+          cellRenderer={(cellProps) => cellRendererForState(cellProps)}
         />
         <Column
           dataKey="jobsPending"
           width={0.06 * props.width}
           label="Pending"
           className="job-set-table-number-cell"
-          cellRenderer={(cellProps) => cellRendererForState(cellProps, props.onJobSetClick, "Pending")}
+          cellRenderer={(cellProps) => cellRendererForState(cellProps)}
         />
         <Column
           dataKey="jobsRunning"
           width={0.06 * props.width}
           label="Running"
           className="job-set-table-number-cell"
-          cellRenderer={(cellProps) => cellRendererForState(cellProps, props.onJobSetClick, "Running")}
+          cellRenderer={(cellProps) => cellRendererForState(cellProps)}
         />
         <Column
           dataKey="jobsSucceeded"
           width={0.06 * props.width}
           label="Succeeded"
           className="job-set-table-number-cell"
-          cellRenderer={(cellProps) => cellRendererForState(cellProps, props.onJobSetClick, "Succeeded")}
+          cellRenderer={(cellProps) => cellRendererForState(cellProps)}
         />
         <Column
           dataKey="jobsFailed"
           width={0.06 * props.width}
           label="Failed"
           className="job-set-table-number-cell"
-          cellRenderer={(cellProps) => cellRendererForState(cellProps, props.onJobSetClick, "Failed")}
+          cellRenderer={(cellProps) => cellRendererForState(cellProps)}
         />
         <Column
           dataKey="jobsCancelled"
           width={0.06 * props.width}
           label="Cancelled"
           className="job-set-table-number-cell"
-          cellRenderer={(cellProps) => cellRendererForState(cellProps, props.onJobSetClick, "Cancelled")}
+          cellRenderer={(cellProps) => cellRendererForState(cellProps)}
         />
       </VirtualizedTable>
     </div>

--- a/internal/lookout/ui/src/components/job-sets/JobSets.tsx
+++ b/internal/lookout/ui/src/components/job-sets/JobSets.tsx
@@ -1,26 +1,12 @@
 import React from "react"
 
-import {
-  Button,
-  Container,
-  FormControl,
-  InputLabel,
-  MenuItem,
-  MenuProps,
-  Select,
-  TextField,
-  FormControlLabel,
-  Checkbox,
-  Tooltip,
-} from "@material-ui/core"
+import { Button, Container, TextField, FormControlLabel, Checkbox, Tooltip } from "@material-ui/core"
 import CancelIcon from "@material-ui/icons/Cancel"
 import LowPriority from "@material-ui/icons/LowPriority"
 import { AutoSizer } from "react-virtualized"
 
-import DurationPlotsTable from "./DurationPlotsTable"
 import JobSetTable from "./JobSetTable"
-import { JobSetsView, isJobSetsView } from "../../containers/JobSetsContainer"
-import { DurationStats, JobSet } from "../../services/JobService"
+import { JobSet } from "../../services/JobService"
 import { RequestStatus } from "../../utils"
 import AutoRefreshToggle from "../AutoRefreshToggle"
 import RefreshButton from "../RefreshButton"
@@ -29,7 +15,6 @@ import "./JobSets.css"
 
 interface JobSetsProps {
   queue: string
-  view: JobSetsView
   jobSets: JobSet[]
   selectedJobSets: Map<string, JobSet>
   canCancel: boolean
@@ -39,9 +24,7 @@ interface JobSetsProps {
   newestFirst: boolean
   activeOnly: boolean
   onQueueChange: (queue: string) => void
-  onViewChange: (view: JobSetsView) => void
   onRefresh: () => void
-  onJobSetClick: (jobSet: string, jobState: string) => void
   onSelectJobSet: (index: number, selected: boolean) => void
   onShiftSelectJobSet: (index: number, selected: boolean) => void
   onDeselectAllClick: () => void
@@ -53,27 +36,14 @@ interface JobSetsProps {
   onActiveOnlyChange: (activeOnly: boolean) => void
 }
 
-const menuProps: Partial<MenuProps> = {
-  anchorOrigin: {
-    vertical: "bottom",
-    horizontal: "left",
-  },
-  transformOrigin: {
-    vertical: "top",
-    horizontal: "left",
-  },
-  getContentAnchorEl: null,
-}
-
 export default function JobSets(props: JobSetsProps) {
-  let content = (height: number, width: number) => (
+  const content = (height: number, width: number) => (
     <JobSetTable
       height={height}
       width={width}
       jobSets={props.jobSets}
       selectedJobSets={props.selectedJobSets}
       newestFirst={props.newestFirst}
-      onJobSetClick={props.onJobSetClick}
       onSelectJobSet={props.onSelectJobSet}
       onShiftSelectJobSet={props.onShiftSelectJobSet}
       onDeselectAllClick={props.onDeselectAllClick}
@@ -81,34 +51,6 @@ export default function JobSets(props: JobSetsProps) {
       onOrderChange={props.onOrderChange}
     />
   )
-  if (props.view === "queued-time") {
-    const filtered = props.jobSets.filter((js) => js.queuedStats)
-    content = (height: number, width: number) => (
-      <DurationPlotsTable
-        height={height}
-        width={width}
-        names={filtered.map((js) => js.jobSetId)}
-        durations={filtered.map((js) => js.queuedStats as DurationStats)}
-        primaryColor={"#00bcd4"}
-        secondaryColor={"#673ab7"}
-        percentagePlotWidth={0.7}
-      />
-    )
-  }
-  if (props.view === "runtime") {
-    const filtered = props.jobSets.filter((js) => js.runningStats)
-    content = (height: number, width: number) => (
-      <DurationPlotsTable
-        height={height}
-        width={width}
-        names={filtered.map((js) => js.jobSetId)}
-        durations={filtered.map((js) => js.runningStats as DurationStats)}
-        primaryColor={"#4caf50"}
-        secondaryColor={"#3f51b5"}
-        percentagePlotWidth={0.7}
-      />
-    )
-  }
 
   return (
     <Container className="job-sets" maxWidth={false}>
@@ -125,25 +67,6 @@ export default function JobSets(props: JobSetsProps) {
               label="Queue"
               variant="outlined"
             />
-          </div>
-          <div className="job-sets-field">
-            <FormControl className="job-sets-field">
-              <InputLabel>View</InputLabel>
-              <Select
-                value={props.view}
-                onChange={(event) => {
-                  const value = event.target.value
-                  if (typeof value === "string" && isJobSetsView(value)) {
-                    props.onViewChange(value)
-                  }
-                }}
-                MenuProps={menuProps}
-              >
-                <MenuItem value={"job-counts"}>Job counts</MenuItem>
-                <MenuItem value={"runtime"}>Runtime</MenuItem>
-                <MenuItem value={"queued-time"}>Queued time</MenuItem>
-              </Select>
-            </FormControl>
           </div>
           <div className="job-sets-field">
             <Tooltip title="Only display Queued, Pending or Running">

--- a/internal/lookout/ui/src/components/job-sets/cancel-job-sets/CancelJobSetsOutcome.tsx
+++ b/internal/lookout/ui/src/components/job-sets/cancel-job-sets/CancelJobSetsOutcome.tsx
@@ -14,7 +14,7 @@ import {
   TableRow,
 } from "@material-ui/core"
 
-import { CancelJobSetsResponse } from "../../../services/JobService"
+import { CancelJobSetsResponse } from "../../../services/lookoutV2/UpdateJobSetsService"
 import LoadingButton from "../../jobs/LoadingButton"
 
 import "./CancelJobSets.css"

--- a/internal/lookout/ui/src/components/job-sets/reprioritize-job-sets/ReprioritizeJobSetsOutcome.tsx
+++ b/internal/lookout/ui/src/components/job-sets/reprioritize-job-sets/ReprioritizeJobSetsOutcome.tsx
@@ -13,7 +13,7 @@ import {
   TableRow,
 } from "@material-ui/core"
 
-import { ReprioritizeJobSetsResponse } from "../../../services/JobService"
+import { ReprioritizeJobSetsResponse } from "../../../services/lookoutV2/UpdateJobSetsService"
 import LoadingButton from "../../jobs/LoadingButton"
 
 import "./ReprioritizeJobSets.css"

--- a/internal/lookout/ui/src/containers/CancelJobSetsDialog.tsx
+++ b/internal/lookout/ui/src/containers/CancelJobSetsDialog.tsx
@@ -5,7 +5,8 @@ import { Dialog, DialogContent, DialogTitle } from "@material-ui/core"
 import CancelJobSets from "../components/job-sets/cancel-job-sets/CancelJobSets"
 import CancelJobSetsOutcome from "../components/job-sets/cancel-job-sets/CancelJobSetsOutcome"
 import { ApiJobState } from "../openapi/armada"
-import { JobService, CancelJobSetsResponse, JobSet } from "../services/JobService"
+import { JobSet } from "../services/JobService"
+import { CancelJobSetsResponse, UpdateJobSetsService } from "../services/lookoutV2/UpdateJobSetsService"
 import { ApiResult, PlatformCancelReason, RequestStatus } from "../utils"
 
 export type CancelJobSetsDialogState = "CancelJobSets" | "CancelJobSetsResult"
@@ -14,7 +15,7 @@ type CancelJobSetsDialogProps = {
   isOpen: boolean
   queue: string
   selectedJobSets: JobSet[]
-  jobService: JobService
+  updateJobSetsService: UpdateJobSetsService
   onResult: (result: ApiResult) => void
   onClose: () => void
 }
@@ -57,7 +58,7 @@ export default function CancelJobSetsDialog(props: CancelJobSetsDialogProps) {
 
     setRequestStatus("Loading")
     const reason = isPlatformCancel ? PlatformCancelReason : ""
-    const cancelJobSetsResponse = await props.jobService.cancelJobSets(
+    const cancelJobSetsResponse = await props.updateJobSetsService.cancelJobSets(
       props.queue,
       jobSetsToCancel,
       statesToCancel,

--- a/internal/lookout/ui/src/containers/JobSetsContainer.tsx
+++ b/internal/lookout/ui/src/containers/JobSetsContainer.tsx
@@ -3,20 +3,23 @@ import React from "react"
 import CancelJobSetsDialog, { getCancellableJobSets } from "./CancelJobSetsDialog"
 import ReprioritizeJobSetsDialog, { getReprioritizeableJobSets } from "./ReprioritizeJobSetsDialog"
 import JobSets from "../components/job-sets/JobSets"
+import { JobState, Match } from "../models/lookoutV2Models"
 import IntervalService from "../services/IntervalService"
-import { JobService, GetJobSetsRequest, JobSet } from "../services/JobService"
+import { GetJobSetsRequest, JobSet } from "../services/JobService"
 import JobSetsLocalStorageService from "../services/JobSetsLocalStorageService"
 import JobSetsQueryParamsService from "../services/JobSetsQueryParamsService"
+import { IGroupJobsService } from "../services/lookoutV2/GroupJobsService"
+import { UpdateJobSetsService } from "../services/lookoutV2/UpdateJobSetsService"
 import { ApiResult, debounced, PropsWithRouter, RequestStatus, selectItem, setStateAsync, withRouter } from "../utils"
 
 interface JobSetsContainerProps extends PropsWithRouter {
-  jobService: JobService
+  v2GroupJobsService: IGroupJobsService
+  v2UpdateJobSetsService: UpdateJobSetsService
   jobSetsAutoRefreshMs: number
 }
 
 type JobSetsContainerParams = {
   queue: string
-  currentView: JobSetsView
 }
 
 export type JobSetsContainerState = {
@@ -30,12 +33,6 @@ export type JobSetsContainerState = {
   cancelJobSetsIsOpen: boolean
   reprioritizeJobSetsIsOpen: boolean
 } & JobSetsContainerParams
-
-export type JobSetsView = "job-counts" | "runtime" | "queued-time"
-
-export function isJobSetsView(val: string): val is JobSetsView {
-  return ["job-counts", "runtime", "queued-time"].includes(val)
-}
 
 class JobSetsContainer extends React.Component<JobSetsContainerProps, JobSetsContainerState> {
   autoRefreshService: IntervalService
@@ -52,7 +49,6 @@ class JobSetsContainer extends React.Component<JobSetsContainerProps, JobSetsCon
     this.state = {
       queue: "",
       jobSets: [],
-      currentView: "job-counts",
       selectedJobSets: new Map<string, JobSet>(),
       getJobSetsRequestStatus: "Idle",
       autoRefresh: true,
@@ -64,10 +60,8 @@ class JobSetsContainer extends React.Component<JobSetsContainerProps, JobSetsCon
     }
 
     this.setQueue = this.setQueue.bind(this)
-    this.setView = this.setView.bind(this)
     this.orderChange = this.orderChange.bind(this)
     this.activeOnlyChange = this.activeOnlyChange.bind(this)
-    this.navigateToJobSetForState = this.navigateToJobSetForState.bind(this)
     this.selectJobSet = this.selectJobSet.bind(this)
     this.shiftSelectJobSet = this.shiftSelectJobSet.bind(this)
     this.deselectAll = this.deselectAll.bind(this)
@@ -212,21 +206,6 @@ class JobSetsContainer extends React.Component<JobSetsContainerProps, JobSetsCon
     }
   }
 
-  setView(view: JobSetsView) {
-    this.updateState({
-      ...this.state,
-      currentView: view,
-      selectedJobSets: new Map<string, JobSet>(),
-    })
-  }
-
-  navigateToJobSetForState(jobSet: string, jobState: string) {
-    this.props.router.navigate({
-      pathname: "/jobs",
-      search: `queue=${this.state.queue}&job_set=${jobSet}&job_states=${jobState}`,
-    })
-  }
-
   async toggleAutoRefresh(autoRefresh: boolean) {
     await this.updateState({
       ...this.state,
@@ -266,8 +245,44 @@ class JobSetsContainer extends React.Component<JobSetsContainerProps, JobSetsCon
     })
   }
 
-  private fetchJobSets(getJobSetsRequest: GetJobSetsRequest): Promise<JobSet[]> {
-    return this.props.jobService.getJobSets(getJobSetsRequest)
+  private async fetchJobSets(getJobSetsRequest: GetJobSetsRequest): Promise<JobSet[]> {
+    const response = await this.props.v2GroupJobsService.groupJobs(
+      [
+        {
+          isAnnotation: false,
+          field: "queue",
+          value: getJobSetsRequest.queue,
+          match: Match.Exact,
+        },
+      ],
+      getJobSetsRequest.activeOnly,
+      {
+        field: "submitted",
+        direction: getJobSetsRequest.newestFirst ? "DESC" : "ASC",
+      },
+      {
+        field: "jobSet",
+        isAnnotation: false,
+      },
+      ["state", "submitted"],
+      0,
+      0,
+    )
+
+    return response.groups.map((group) => {
+      const state = group.aggregates.state as Record<string, number>
+      return {
+        jobSetId: group.name,
+        queue: getJobSetsRequest.queue,
+        jobsQueued: state[JobState.Queued] || 0,
+        jobsPending: state[JobState.Pending] || 0,
+        jobsRunning: state[JobState.Running] || 0,
+        jobsSucceeded: state[JobState.Succeeded] || 0,
+        jobsFailed: state[JobState.Failed] || 0,
+        jobsCancelled: state[JobState.Cancelled] || 0,
+        latestSubmissionTime: group.aggregates.submitted as string,
+      }
+    })
   }
 
   render() {
@@ -278,7 +293,7 @@ class JobSetsContainer extends React.Component<JobSetsContainerProps, JobSetsCon
           isOpen={this.state.cancelJobSetsIsOpen}
           queue={this.state.queue}
           selectedJobSets={selectedJobSets}
-          jobService={this.props.jobService}
+          updateJobSetsService={this.props.v2UpdateJobSetsService}
           onResult={this.handleApiResult}
           onClose={() => this.openCancelJobSets(false)}
         />
@@ -286,17 +301,14 @@ class JobSetsContainer extends React.Component<JobSetsContainerProps, JobSetsCon
           isOpen={this.state.reprioritizeJobSetsIsOpen}
           queue={this.state.queue}
           selectedJobSets={selectedJobSets}
-          jobService={this.props.jobService}
+          updateJobSetsService={this.props.v2UpdateJobSetsService}
           onResult={this.handleApiResult}
           onClose={() => this.openReprioritizeJobSets(false)}
         />
         <JobSets
-          canCancel={this.state.currentView === "job-counts" && getCancellableJobSets(selectedJobSets).length > 0}
-          canReprioritize={
-            this.state.currentView === "job-counts" && getReprioritizeableJobSets(selectedJobSets).length > 0
-          }
+          canCancel={getCancellableJobSets(selectedJobSets).length > 0}
+          canReprioritize={getReprioritizeableJobSets(selectedJobSets).length > 0}
           queue={this.state.queue}
-          view={this.state.currentView}
           jobSets={this.state.jobSets}
           selectedJobSets={this.state.selectedJobSets}
           getJobSetsRequestStatus={this.state.getJobSetsRequestStatus}
@@ -304,11 +316,9 @@ class JobSetsContainer extends React.Component<JobSetsContainerProps, JobSetsCon
           newestFirst={this.state.newestFirst}
           activeOnly={this.state.activeOnly}
           onQueueChange={this.setQueue}
-          onViewChange={this.setView}
           onOrderChange={this.orderChange}
           onActiveOnlyChange={this.activeOnlyChange}
           onRefresh={this.loadJobSets}
-          onJobSetClick={this.navigateToJobSetForState}
           onSelectJobSet={this.selectJobSet}
           onShiftSelectJobSet={this.shiftSelectJobSet}
           onDeselectAllClick={this.deselectAll}

--- a/internal/lookout/ui/src/containers/ReprioritizeJobSetsDialog.tsx
+++ b/internal/lookout/ui/src/containers/ReprioritizeJobSetsDialog.tsx
@@ -4,7 +4,8 @@ import { Dialog, DialogContent, DialogTitle } from "@material-ui/core"
 
 import ReprioritizeJobSets from "../components/job-sets/reprioritize-job-sets/ReprioritizeJobSets"
 import ReprioritizeJobSetsOutcome from "../components/job-sets/reprioritize-job-sets/ReprioritizeJobSetsOutcome"
-import { JobService, JobSet, ReprioritizeJobSetsResponse } from "../services/JobService"
+import { JobSet } from "../services/JobService"
+import { ReprioritizeJobSetsResponse, UpdateJobSetsService } from "../services/lookoutV2/UpdateJobSetsService"
 import { ApiResult, priorityIsValid, RequestStatus } from "../utils"
 
 import "../components/Dialog.css"
@@ -15,7 +16,7 @@ type ReprioritizeJobSetsDialogProps = {
   isOpen: boolean
   queue: string
   selectedJobSets: JobSet[]
-  jobService: JobService
+  updateJobSetsService: UpdateJobSetsService
   onResult: (result: ApiResult) => void
   onClose: () => void
 }
@@ -41,7 +42,7 @@ export default function ReprioritizeJobSetsDialog(props: ReprioritizeJobSetsDial
     }
 
     setRequestStatus("Loading")
-    const reprioritizeJobSetsResponse = await props.jobService.reprioritizeJobSets(
+    const reprioritizeJobSetsResponse = await props.updateJobSetsService.reprioritizeJobSets(
       props.queue,
       jobSetsToReprioritize,
       Number(priority),

--- a/internal/lookout/ui/src/index.tsx
+++ b/internal/lookout/ui/src/index.tsx
@@ -1,6 +1,7 @@
 import ReactDOM from "react-dom"
 import { GetJobsService } from "services/lookoutV2/GetJobsService"
 import { GroupJobsService } from "services/lookoutV2/GroupJobsService"
+import { UpdateJobSetsService } from "services/lookoutV2/UpdateJobSetsService"
 import { UpdateJobsService } from "services/lookoutV2/UpdateJobsService"
 import FakeGetJobsService from "services/lookoutV2/mocks/FakeGetJobsService"
 import FakeGroupJobsService from "services/lookoutV2/mocks/FakeGroupJobsService"
@@ -60,6 +61,7 @@ import "./index.css"
     : new V2LogService({ credentials: "include" }, uiConfig.binocularsBaseUrlPattern)
   const v2JobSpecService = fakeDataEnabled ? new FakeGetJobSpecService() : new GetJobSpecService(lookoutV2BaseUrl)
   const v2UpdateJobsService = new UpdateJobsService(submitApi)
+  const v2UpdateJobSetsService = new UpdateJobSetsService(submitApi)
   const v2CordonService = fakeDataEnabled
     ? new FakeCordonService()
     : new CordonService({ credentials: "include" }, uiConfig.binocularsBaseUrlPattern)
@@ -71,6 +73,7 @@ import "./index.css"
       v2GetJobsService={v2GetJobsService}
       v2GroupJobsService={v2GroupJobsService}
       v2UpdateJobsService={v2UpdateJobsService}
+      v2UpdateJobSetsService={v2UpdateJobSetsService}
       v2RunErrorService={v2RunErrorService}
       v2JobSpecService={v2JobSpecService}
       v2LogService={v2LogService}

--- a/internal/lookout/ui/src/models/lookoutV2Models.ts
+++ b/internal/lookout/ui/src/models/lookoutV2Models.ts
@@ -139,3 +139,8 @@ export type JobOrder = {
   field: string
   direction: SortDirection
 }
+
+export interface JobSet {
+  queue: string
+  jobSetId: string
+}

--- a/internal/lookout/ui/src/services/JobSetsLocalStorageService.ts
+++ b/internal/lookout/ui/src/services/JobSetsLocalStorageService.ts
@@ -1,4 +1,4 @@
-import { isJobSetsView, JobSetsContainerState } from "../containers/JobSetsContainer"
+import { JobSetsContainerState } from "../containers/JobSetsContainer"
 import { tryParseJson } from "../utils"
 
 const LOCAL_STORAGE_KEY = "armada_lookout_job_sets_user_settings"
@@ -20,13 +20,6 @@ function convertToLocalStorageState(loadedData: Record<string, unknown>): JobSet
   if (loadedData.queue != undefined && typeof loadedData.queue == "string") {
     state.queue = loadedData.queue
   }
-  if (
-    loadedData.currentView != undefined &&
-    typeof loadedData.currentView == "string" &&
-    isJobSetsView(loadedData.currentView)
-  ) {
-    state.currentView = loadedData.currentView
-  }
   if (loadedData.newestFirst != undefined && typeof loadedData.newestFirst == "boolean") {
     state.newestFirst = loadedData.newestFirst
   }
@@ -42,7 +35,6 @@ export default class JobSetsLocalStorageService {
     const localStorageState = {
       autoRefresh: state.autoRefresh,
       queue: state.queue,
-      currentView: state.currentView,
       newestFirst: state.newestFirst,
       activeOnly: state.activeOnly,
     }
@@ -63,7 +55,6 @@ export default class JobSetsLocalStorageService {
     const loadedState = convertToLocalStorageState(loadedData as Record<string, unknown>)
     if (loadedState.autoRefresh != undefined) state.autoRefresh = loadedState.autoRefresh
     if (loadedState.queue) state.queue = loadedState.queue
-    if (loadedState.currentView && isJobSetsView(loadedState.currentView)) state.currentView = loadedState.currentView
     if (loadedState.newestFirst != undefined) state.newestFirst = loadedState.newestFirst
     if (loadedState.activeOnly != undefined) state.activeOnly = loadedState.activeOnly
   }

--- a/internal/lookout/ui/src/services/JobSetsQueryParamsService.ts
+++ b/internal/lookout/ui/src/services/JobSetsQueryParamsService.ts
@@ -1,6 +1,6 @@
 import queryString, { ParseOptions, StringifyOptions } from "query-string"
 
-import { isJobSetsView, JobSetsContainerState } from "../containers/JobSetsContainer"
+import { JobSetsContainerState } from "../containers/JobSetsContainer"
 import { Router } from "../utils"
 
 const QUERY_STRING_OPTIONS: ParseOptions | StringifyOptions = {
@@ -21,7 +21,6 @@ function makeQueryString(state: JobSetsContainerState): string {
   if (state.queue) {
     queryObject.queue = state.queue
   }
-  queryObject.view = state.currentView
   queryObject.newest_first = state.newestFirst
   queryObject.active_only = state.activeOnly
 
@@ -42,7 +41,6 @@ export default class JobSetsQueryParamsService {
     const params = queryString.parse(this.router.location.search, QUERY_STRING_OPTIONS) as JobSetsQueryParams
 
     if (params.queue) state.queue = params.queue
-    if (params.view && isJobSetsView(params.view)) state.currentView = params.view
     if (params.newest_first != undefined) state.newestFirst = params.newest_first
     if (params.active_only != undefined) state.activeOnly = params.active_only
   }

--- a/internal/lookout/ui/src/services/MockJobService.ts
+++ b/internal/lookout/ui/src/services/MockJobService.ts
@@ -1,7 +1,6 @@
 import { v4 as uuidv4 } from "uuid"
 
 import {
-  CancelJobSetsResponse,
   CancelJobsResponse,
   GetJobSetsRequest,
   GetJobsRequest,
@@ -9,10 +8,8 @@ import {
   JobService,
   JobSet,
   QueueInfo,
-  ReprioritizeJobSetsResponse,
   ReprioritizeJobsResponse,
 } from "./JobService"
-import { ApiJobState } from "../openapi/armada"
 
 type MockJobServiceConfig = {
   getJobs: {
@@ -64,26 +61,10 @@ export class MockJobService implements JobService {
   }
 
   // eslint-disable-next-line
-  cancelJobSets(queue: string, jobSets: JobSet[], states: ApiJobState[]): Promise<CancelJobSetsResponse> {
-    return Promise.resolve({
-      cancelledJobSets: [],
-      failedJobSetCancellations: [],
-    })
-  }
-
-  // eslint-disable-next-line
   reprioritizeJobs(jobs: Job[], newPriority: number): Promise<ReprioritizeJobsResponse> {
     return Promise.resolve({
       reprioritizedJobs: [],
       failedJobReprioritizations: [],
-    })
-  }
-
-  // eslint-disable-next-line
-  reprioritizeJobSets(queue: string, jobSets: JobSet[], newPriority: number): Promise<ReprioritizeJobSetsResponse> {
-    return Promise.resolve({
-      reprioritizedJobSets: [],
-      failedJobSetReprioritizations: [],
     })
   }
 }

--- a/internal/lookout/ui/src/services/lookoutV2/GetJobsService.ts
+++ b/internal/lookout/ui/src/services/lookoutV2/GetJobsService.ts
@@ -7,7 +7,7 @@ export interface IGetJobsService {
     order: JobOrder,
     skip: number,
     take: number,
-    abortSignal: AbortSignal | undefined,
+    abortSignal?: AbortSignal,
   ): Promise<GetJobsResponse>
 }
 
@@ -25,7 +25,7 @@ export class GetJobsService implements IGetJobsService {
     order: JobOrder,
     skip: number,
     take: number,
-    abortSignal: AbortSignal | undefined,
+    abortSignal?: AbortSignal,
   ): Promise<GetJobsResponse> {
     const response = await fetch(this.apiBase + "/api/v1/jobs", {
       method: "POST",

--- a/internal/lookout/ui/src/services/lookoutV2/GroupJobsService.ts
+++ b/internal/lookout/ui/src/services/lookoutV2/GroupJobsService.ts
@@ -9,7 +9,7 @@ export interface IGroupJobsService {
     aggregates: string[],
     skip: number,
     take: number,
-    abortSignal: AbortSignal | undefined,
+    abortSignal?: AbortSignal,
   ): Promise<GroupJobsResponse>
 }
 
@@ -34,7 +34,7 @@ export class GroupJobsService implements IGroupJobsService {
     aggregates: string[],
     skip: number,
     take: number,
-    abortSignal: AbortSignal | undefined,
+    abortSignal?: AbortSignal,
   ): Promise<GroupJobsResponse> {
     const response = await fetch(this.apiBase + "/api/v1/jobGroups", {
       method: "POST",

--- a/internal/lookout/ui/src/services/lookoutV2/UpdateJobSetsService.ts
+++ b/internal/lookout/ui/src/services/lookoutV2/UpdateJobSetsService.ts
@@ -1,0 +1,104 @@
+import { JobSet } from "models/lookoutV2Models"
+import { ApiJobState, SubmitApi } from "openapi/armada"
+import { getErrorMessage } from "utils"
+
+export interface CancelJobSetsResponse {
+  cancelledJobSets: JobSet[]
+  failedJobSetCancellations: {
+    jobSet: JobSet
+    error: string
+  }[]
+}
+
+export interface ReprioritizeJobSetsResponse {
+  reprioritizedJobSets: JobSet[]
+  failedJobSetReprioritizations: {
+    jobSet: JobSet
+    error: string
+  }[]
+}
+
+export class UpdateJobSetsService {
+  constructor(private submitApi: SubmitApi) {}
+
+  async cancelJobSets(
+    queue: string,
+    jobSets: JobSet[],
+    states: ApiJobState[],
+    reason: string,
+  ): Promise<CancelJobSetsResponse> {
+    const response: CancelJobSetsResponse = { cancelledJobSets: [], failedJobSetCancellations: [] }
+    for (const jobSet of jobSets) {
+      try {
+        await this.submitApi.cancelJobSet({
+          body: {
+            queue: queue,
+            jobSetId: jobSet.jobSetId,
+            filter: {
+              states: states,
+            },
+            reason: reason,
+          },
+        })
+        response.cancelledJobSets.push(jobSet)
+      } catch (e) {
+        console.error(e)
+        const text = await getErrorMessage(e)
+        response.failedJobSetCancellations.push({ jobSet: jobSet, error: text })
+      }
+    }
+    return response
+  }
+
+  async reprioritizeJobSets(
+    queue: string,
+    jobSets: JobSet[],
+    newPriority: number,
+  ): Promise<ReprioritizeJobSetsResponse> {
+    const response: ReprioritizeJobSetsResponse = { reprioritizedJobSets: [], failedJobSetReprioritizations: [] }
+
+    for (const jobSet of jobSets) {
+      try {
+        const apiResponse = await this.submitApi.reprioritizeJobs({
+          body: {
+            queue: queue,
+            jobSetId: jobSet.jobSetId,
+            newPriority: newPriority,
+          },
+        })
+        if (apiResponse == null || apiResponse.reprioritizationResults == null) {
+          const errorMessage = "No reprioritizationResults found in response body"
+          console.error(errorMessage)
+          response.failedJobSetReprioritizations.push({
+            jobSet: jobSet,
+            error: "No reprioritizationResults found in response body",
+          })
+          continue
+        }
+
+        let errorCount = 0
+        let successCount = 0
+        let error = ""
+        for (const e of Object.values(apiResponse.reprioritizationResults)) {
+          if (e !== "") {
+            errorCount++
+            error = e
+          } else {
+            successCount++
+          }
+        }
+        if (errorCount === 0) {
+          response.reprioritizedJobSets.push(jobSet)
+        } else {
+          const message = `Reprioritized: ${successCount}  Failed: ${errorCount}  Reason: ${error}`
+          response.failedJobSetReprioritizations.push({ jobSet: jobSet, error: message })
+        }
+      } catch (e) {
+        console.error(e)
+        const text = await getErrorMessage(e)
+        response.failedJobSetReprioritizations.push({ jobSet: jobSet, error: text })
+      }
+    }
+    return response
+  }
+}

--- a/internal/lookoutv2/application.go
+++ b/internal/lookoutv2/application.go
@@ -53,17 +53,14 @@ func Serve(configuration configuration.LookoutV2Configuration) error {
 		func(params operations.GetJobsParams) middleware.Responder {
 			filters := util.Map(params.GetJobsRequest.Filters, conversions.FromSwaggerFilter)
 			order := conversions.FromSwaggerOrder(params.GetJobsRequest.Order)
-			skip := 0
-			if params.GetJobsRequest.Skip != nil {
-				skip = int(*params.GetJobsRequest.Skip)
-			}
 			result, err := getJobsRepo.GetJobs(
 				armadacontext.New(params.HTTPRequest.Context(), logger),
 				filters,
 				params.GetJobsRequest.ActiveJobSets,
 				order,
-				skip,
-				int(params.GetJobsRequest.Take))
+				int(params.GetJobsRequest.Skip),
+				int(params.GetJobsRequest.Take),
+			)
 			if err != nil {
 				return operations.NewGetJobsBadRequest().WithPayload(conversions.ToSwaggerError(err.Error()))
 			}
@@ -78,10 +75,6 @@ func Serve(configuration configuration.LookoutV2Configuration) error {
 		func(params operations.GroupJobsParams) middleware.Responder {
 			filters := util.Map(params.GroupJobsRequest.Filters, conversions.FromSwaggerFilter)
 			order := conversions.FromSwaggerOrder(params.GroupJobsRequest.Order)
-			skip := 0
-			if params.GroupJobsRequest.Skip != nil {
-				skip = int(*params.GroupJobsRequest.Skip)
-			}
 			result, err := groupJobsRepo.GroupBy(
 				armadacontext.New(params.HTTPRequest.Context(), logger),
 				filters,
@@ -89,8 +82,9 @@ func Serve(configuration configuration.LookoutV2Configuration) error {
 				order,
 				conversions.FromSwaggerGroupedField(params.GroupJobsRequest.GroupedField),
 				params.GroupJobsRequest.Aggregates,
-				skip,
-				int(params.GroupJobsRequest.Take))
+				int(params.GroupJobsRequest.Skip),
+				int(params.GroupJobsRequest.Take),
+			)
 			if err != nil {
 				return operations.NewGroupJobsBadRequest().WithPayload(conversions.ToSwaggerError(err.Error()))
 			}

--- a/internal/lookoutv2/gen/restapi/embedded_spec.go
+++ b/internal/lookoutv2/gen/restapi/embedded_spec.go
@@ -47,9 +47,7 @@ func init() {
                 "filters",
                 "order",
                 "groupedField",
-                "aggregates",
-                "skip",
-                "take"
+                "aggregates"
               ],
               "properties": {
                 "activeJobSets": {
@@ -279,9 +277,7 @@ func init() {
               "type": "object",
               "required": [
                 "filters",
-                "order",
-                "skip",
-                "take"
+                "order"
               ],
               "properties": {
                 "activeJobSets": {
@@ -699,9 +695,7 @@ func init() {
                 "filters",
                 "order",
                 "groupedField",
-                "aggregates",
-                "skip",
-                "take"
+                "aggregates"
               ],
               "properties": {
                 "activeJobSets": {
@@ -931,9 +925,7 @@ func init() {
               "type": "object",
               "required": [
                 "filters",
-                "order",
-                "skip",
-                "take"
+                "order"
               ],
               "properties": {
                 "activeJobSets": {

--- a/internal/lookoutv2/gen/restapi/operations/get_jobs.go
+++ b/internal/lookoutv2/gen/restapi/operations/get_jobs.go
@@ -80,12 +80,10 @@ type GetJobsBody struct {
 	Order *models.Order `json:"order"`
 
 	// First elements to ignore from the full set of results. Used for pagination.
-	// Required: true
-	Skip *int64 `json:"skip"`
+	Skip int64 `json:"skip,omitempty"`
 
 	// Number of jobs to fetch.
-	// Required: true
-	Take int64 `json:"take"`
+	Take int64 `json:"take,omitempty"`
 }
 
 // Validate validates this get jobs body
@@ -97,14 +95,6 @@ func (o *GetJobsBody) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := o.validateOrder(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := o.validateSkip(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := o.validateTake(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -156,24 +146,6 @@ func (o *GetJobsBody) validateOrder(formats strfmt.Registry) error {
 			}
 			return err
 		}
-	}
-
-	return nil
-}
-
-func (o *GetJobsBody) validateSkip(formats strfmt.Registry) error {
-
-	if err := validate.Required("getJobsRequest"+"."+"skip", "body", o.Skip); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (o *GetJobsBody) validateTake(formats strfmt.Registry) error {
-
-	if err := validate.Required("getJobsRequest"+"."+"take", "body", int64(o.Take)); err != nil {
-		return err
 	}
 
 	return nil

--- a/internal/lookoutv2/gen/restapi/operations/group_jobs.go
+++ b/internal/lookoutv2/gen/restapi/operations/group_jobs.go
@@ -88,12 +88,10 @@ type GroupJobsBody struct {
 	Order *models.Order `json:"order"`
 
 	// First elements to ignore from the full set of results. Used for pagination.
-	// Required: true
-	Skip *int64 `json:"skip"`
+	Skip int64 `json:"skip,omitempty"`
 
 	// Number of job groups to fetch.
-	// Required: true
-	Take int64 `json:"take"`
+	Take int64 `json:"take,omitempty"`
 }
 
 // Validate validates this group jobs body
@@ -113,14 +111,6 @@ func (o *GroupJobsBody) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := o.validateOrder(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := o.validateSkip(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := o.validateTake(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -201,24 +191,6 @@ func (o *GroupJobsBody) validateOrder(formats strfmt.Registry) error {
 			}
 			return err
 		}
-	}
-
-	return nil
-}
-
-func (o *GroupJobsBody) validateSkip(formats strfmt.Registry) error {
-
-	if err := validate.Required("groupJobsRequest"+"."+"skip", "body", o.Skip); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (o *GroupJobsBody) validateTake(formats strfmt.Registry) error {
-
-	if err := validate.Required("groupJobsRequest"+"."+"take", "body", int64(o.Take)); err != nil {
-		return err
 	}
 
 	return nil

--- a/internal/lookoutv2/repository/querybuilder.go
+++ b/internal/lookoutv2/repository/querybuilder.go
@@ -989,6 +989,14 @@ func (qb *QueryBuilder) getQueryColumn(col string, queryTables map[string]bool) 
 }
 
 func limitOffsetSql(skip, take int) string {
+	// Asking for zero rows is not useful to us, so we take a value of zero to
+	// mean "no limit"; this is consistent with go-swagger, which uses zero as
+	// the default value for optional integers:
+	//
+	//     https://github.com/go-swagger/go-swagger/issues/1707
+	if take == 0 {
+		return fmt.Sprintf("OFFSET %d", skip)
+	}
 	return fmt.Sprintf("LIMIT %d OFFSET %d", take, skip)
 }
 

--- a/internal/lookoutv2/swagger.yaml
+++ b/internal/lookoutv2/swagger.yaml
@@ -268,8 +268,6 @@ paths:
             required:
               - filters
               - order
-              - skip
-              - take
             properties:
               filters:
                 type: array
@@ -290,7 +288,6 @@ paths:
               take:
                 type: integer
                 description: "Number of jobs to fetch."
-                x-nullable: false
 
       produces:
         - application/json
@@ -410,8 +407,6 @@ paths:
               - order
               - groupedField
               - aggregates
-              - skip
-              - take
             properties:
               filters:
                 type: array
@@ -451,7 +446,6 @@ paths:
               take:
                 type: integer
                 description: "Number of job groups to fetch."
-                x-nullable: false
 
       produces:
         - application/json


### PR DESCRIPTION
A user has pointed out that version 2 of the Lookout UI currently struggles to cancel large job sets (containing hundreds of thousands to millions of steps) through the "cancel selected" dialog, because it always calls `/v1/job/cancel` (instead of calling `/v1/jobset/cancel` if the user is cancelling entire job sets).

While we will ultimately want the "cancel selected" dialog to be smarter about this, I am proposing the following change as a way of unblocking the move to version 2 of the Lookout UI: keep the "job counts" variant of `/job-sets` alive,[^1] but populate it using version 2 of the Lookout API. The advantage of making this change is that it unblocks the rest of the migration while only requiring us to reroute a single API call.

[^1]: `/job-sets` previously also had "runtime" and "queued time" variants, but these require data that is not present in version 2 of the Lookout API.