### PR TITLE
Support OIDC authentication in the Lookout UI

### DIFF
--- a/internal/lookout/configuration/types.go
+++ b/internal/lookout/configuration/types.go
@@ -14,10 +14,9 @@ type LookoutUIConfig struct {
 	// so that clients can override the server's preference.
 	OidcEnabled bool
 	Oidc        struct {
-		Authority   string
-		ClientId    string
-		RedirectUrl string
-		Scope       string
+		Authority string
+		ClientId  string
+		Scope     string
 	}
 
 	ArmadaApiBaseUrl         string

--- a/internal/lookout/configuration/types.go
+++ b/internal/lookout/configuration/types.go
@@ -10,6 +10,16 @@ import (
 type LookoutUIConfig struct {
 	CustomTitle string
 
+	// We have a separate flag here (instead of making the Oidc field optional)
+	// so that clients can override the server's preference.
+	OidcEnabled bool
+	Oidc        struct {
+		Authority   string
+		ClientId    string
+		RedirectUrl string
+		Scope       string
+	}
+
 	ArmadaApiBaseUrl         string
 	UserAnnotationPrefix     string
 	BinocularsEnabled        bool

--- a/internal/lookout/ui/package.json
+++ b/internal/lookout/ui/package.json
@@ -52,6 +52,7 @@
     "jest-junit": "^16.0.0",
     "js-yaml": "^4.0.0",
     "notistack": "^2.0.8",
+    "oidc-client-ts": "^2.3.0",
     "prettier": "^2.8.8",
     "qs": "^6.11.0",
     "query-string": "^6.13.7",

--- a/internal/lookout/ui/src/App.tsx
+++ b/internal/lookout/ui/src/App.tsx
@@ -167,7 +167,7 @@ export function App(props: AppProps): JSX.Element {
         new UserManager({
           authority: props.oidcConfig.authority,
           client_id: props.oidcConfig.clientId,
-          redirect_uri: props.oidcConfig.redirectUrl,
+          redirect_uri: `${window.location.origin}/oidc`,
           scope: props.oidcConfig.scope,
           userStore: new WebStorageStateStore({ store: window.localStorage }),
         })

--- a/internal/lookout/ui/src/components/lookoutV2/CancelDialog.tsx
+++ b/internal/lookout/ui/src/components/lookoutV2/CancelDialog.tsx
@@ -15,6 +15,7 @@ import { formatJobState } from "utils/jobsTableFormatters"
 import dialogStyles from "./DialogStyles.module.css"
 import { JobStatusTable } from "./JobStatusTable"
 import { useCustomSnackbar } from "../../hooks/useCustomSnackbar"
+import { getAccessToken, useUserManager } from "../../oidc"
 
 interface CancelDialogProps {
   onClose: () => void
@@ -40,6 +41,8 @@ export const CancelDialog = ({
   const [isPlatformCancel, setIsPlatformCancel] = useState(false)
   const openSnackbar = useCustomSnackbar()
 
+  const userManager = useUserManager()
+
   // Actions
   const fetchSelectedJobs = useCallback(async () => {
     if (!mounted.current) {
@@ -64,7 +67,8 @@ export const CancelDialog = ({
     setIsCancelling(true)
 
     const reason = isPlatformCancel ? PlatformCancelReason : ""
-    const response = await updateJobsService.cancelJobs(cancellableJobs, reason)
+    const accessToken = userManager && (await getAccessToken(userManager))
+    const response = await updateJobsService.cancelJobs(cancellableJobs, reason, accessToken)
 
     if (response.failedJobIds.length === 0) {
       openSnackbar(

--- a/internal/lookout/ui/src/components/lookoutV2/ReprioritiseDialog.tsx
+++ b/internal/lookout/ui/src/components/lookoutV2/ReprioritiseDialog.tsx
@@ -22,6 +22,7 @@ import { getUniqueJobsMatchingFilters } from "utils/jobsDialogUtils"
 import dialogStyles from "./DialogStyles.module.css"
 import { JobStatusTable } from "./JobStatusTable"
 import { useCustomSnackbar } from "../../hooks/useCustomSnackbar"
+import { getAccessToken, useUserManager } from "../../oidc"
 
 interface ReprioritiseDialogProps {
   onClose: () => void
@@ -50,6 +51,8 @@ export const ReprioritiseDialog = ({
   const [hasAttemptedReprioritise, setHasAttemptedReprioritise] = useState(false)
   const openSnackbar = useCustomSnackbar()
 
+  const userManager = useUserManager()
+
   // Actions
   const fetchSelectedJobs = useCallback(async () => {
     if (!mounted.current) {
@@ -76,7 +79,8 @@ export const ReprioritiseDialog = ({
 
     setIsReprioritising(true)
 
-    const response = await updateJobsService.reprioritiseJobs(reprioritisableJobs, newPriority)
+    const accessToken = userManager && (await getAccessToken(userManager))
+    const response = await updateJobsService.reprioritiseJobs(reprioritisableJobs, newPriority, accessToken)
 
     if (response.failedJobIds.length === 0) {
       openSnackbar(

--- a/internal/lookout/ui/src/components/lookoutV2/sidebar/SidebarTabJobLogs.tsx
+++ b/internal/lookout/ui/src/components/lookoutV2/sidebar/SidebarTabJobLogs.tsx
@@ -17,6 +17,7 @@ import { Job, JobRun } from "models/lookoutV2Models"
 import styles from "./SidebarTabJobLogs.module.css"
 import { useCustomSnackbar } from "../../../hooks/useCustomSnackbar"
 import { useJobSpec } from "../../../hooks/useJobSpec"
+import { getAccessToken, useUserManager } from "../../../oidc"
 import { IGetJobSpecService } from "../../../services/lookoutV2/GetJobSpecService"
 import { ILogService, LogLine } from "../../../services/lookoutV2/LogService"
 import { getErrorMessage, RequestStatus } from "../../../utils"
@@ -107,9 +108,12 @@ export const SidebarTabJobLogs = ({ job, jobSpecService, logService }: SidebarTa
     }
   }, [containers])
 
+  const userManager = useUserManager()
+
   const loadLogs = async (sinceTime: string, tailLines: number | undefined): Promise<LogLine[]> => {
     setLogsRequestStatus("Loading")
     try {
+      const accessToken = userManager && (await getAccessToken(userManager))
       const logLines = await logService.getLogs(
         cluster,
         namespace,
@@ -117,7 +121,7 @@ export const SidebarTabJobLogs = ({ job, jobSpecService, logService }: SidebarTa
         selectedContainer,
         sinceTime,
         tailLines,
-        undefined,
+        accessToken,
       )
       setLogsRequestErrorFull(undefined)
       return logLines

--- a/internal/lookout/ui/src/components/lookoutV2/sidebar/SidebarTabJobRuns.tsx
+++ b/internal/lookout/ui/src/components/lookoutV2/sidebar/SidebarTabJobRuns.tsx
@@ -20,6 +20,7 @@ import { CodeBlock } from "./CodeBlock"
 import { KeyValuePairTable } from "./KeyValuePairTable"
 import styles from "./SidebarTabJobRuns.module.css"
 import { useCustomSnackbar } from "../../../hooks/useCustomSnackbar"
+import { getAccessToken, useUserManager } from "../../../oidc"
 import { ICordonService } from "../../../services/lookoutV2/CordonService"
 import { IGetRunErrorService } from "../../../services/lookoutV2/GetRunErrorService"
 import { getErrorMessage } from "../../../utils"
@@ -51,7 +52,7 @@ export const SidebarTabJobRuns = ({ job, runErrorService, cordonService }: Sideb
     for (const run of job.runs) {
       results.push({
         runId: run.runId,
-        promise: runErrorService.getRunError(run.runId, undefined),
+        promise: runErrorService.getRunError(run.runId),
       })
     }
 
@@ -99,9 +100,12 @@ export const SidebarTabJobRuns = ({ job, runErrorService, cordonService }: Sideb
     setOpen(false)
   }
 
+  const userManager = useUserManager()
+
   const cordon = async (cluster: string, node: string) => {
     try {
-      await cordonService.cordonNode(cluster, node, undefined)
+      const accessToken = userManager && (await getAccessToken(userManager))
+      await cordonService.cordonNode(cluster, node, accessToken)
       openSnackbar("Successfully cordoned node " + node, "success")
     } catch (e) {
       const errMsg = await getErrorMessage(e)

--- a/internal/lookout/ui/src/containers/CancelJobSetsDialog.tsx
+++ b/internal/lookout/ui/src/containers/CancelJobSetsDialog.tsx
@@ -4,6 +4,7 @@ import { Dialog, DialogContent, DialogTitle } from "@material-ui/core"
 
 import CancelJobSets from "../components/job-sets/cancel-job-sets/CancelJobSets"
 import CancelJobSetsOutcome from "../components/job-sets/cancel-job-sets/CancelJobSetsOutcome"
+import { getAccessToken, useUserManager } from "../oidc"
 import { ApiJobState } from "../openapi/armada"
 import { JobSet } from "../services/JobService"
 import { CancelJobSetsResponse, UpdateJobSetsService } from "../services/lookoutV2/UpdateJobSetsService"
@@ -51,6 +52,8 @@ export default function CancelJobSetsDialog(props: CancelJobSetsDialogProps) {
 
   const statesToCancel = getStatesToCancel(includeQueued, includeRunning)
 
+  const userManager = useUserManager()
+
   async function cancelJobSets() {
     if (requestStatus === "Loading") {
       return
@@ -58,11 +61,13 @@ export default function CancelJobSetsDialog(props: CancelJobSetsDialogProps) {
 
     setRequestStatus("Loading")
     const reason = isPlatformCancel ? PlatformCancelReason : ""
+    const accessToken = userManager && (await getAccessToken(userManager))
     const cancelJobSetsResponse = await props.updateJobSetsService.cancelJobSets(
       props.queue,
       jobSetsToCancel,
       statesToCancel,
       reason,
+      accessToken,
     )
     setRequestStatus("Idle")
 

--- a/internal/lookout/ui/src/containers/ReprioritizeJobSetsDialog.tsx
+++ b/internal/lookout/ui/src/containers/ReprioritizeJobSetsDialog.tsx
@@ -4,6 +4,7 @@ import { Dialog, DialogContent, DialogTitle } from "@material-ui/core"
 
 import ReprioritizeJobSets from "../components/job-sets/reprioritize-job-sets/ReprioritizeJobSets"
 import ReprioritizeJobSetsOutcome from "../components/job-sets/reprioritize-job-sets/ReprioritizeJobSetsOutcome"
+import { getAccessToken, useUserManager } from "../oidc"
 import { JobSet } from "../services/JobService"
 import { ReprioritizeJobSetsResponse, UpdateJobSetsService } from "../services/lookoutV2/UpdateJobSetsService"
 import { ApiResult, priorityIsValid, RequestStatus } from "../utils"
@@ -36,16 +37,20 @@ export default function ReprioritizeJobSetsDialog(props: ReprioritizeJobSetsDial
 
   const jobSetsToReprioritize = getReprioritizeableJobSets(props.selectedJobSets)
 
+  const userManager = useUserManager()
+
   async function reprioritizeJobSets() {
     if (requestStatus == "Loading" || !priorityIsValid(priority)) {
       return
     }
 
     setRequestStatus("Loading")
+    const accessToken = userManager && (await getAccessToken(userManager))
     const reprioritizeJobSetsResponse = await props.updateJobSetsService.reprioritizeJobSets(
       props.queue,
       jobSetsToReprioritize,
       Number(priority),
+      accessToken,
     )
     setRequestStatus("Idle")
 

--- a/internal/lookout/ui/src/index.tsx
+++ b/internal/lookout/ui/src/index.tsx
@@ -69,6 +69,7 @@ import "./index.css"
   ReactDOM.render(
     <App
       customTitle={uiConfig.customTitle}
+      oidcConfig={uiConfig.oidcEnabled ? uiConfig.oidc : undefined}
       jobService={jobService}
       v2GetJobsService={v2GetJobsService}
       v2GroupJobsService={v2GroupJobsService}

--- a/internal/lookout/ui/src/oidc.ts
+++ b/internal/lookout/ui/src/oidc.ts
@@ -1,0 +1,21 @@
+import React from "react"
+
+import { UserManager } from "oidc-client-ts"
+
+export const UserManagerContext = React.createContext<UserManager | undefined>(undefined)
+
+export function useUserManager(): UserManager | undefined {
+  return React.useContext(UserManagerContext)
+}
+
+export async function getAccessToken(userManager: UserManager): Promise<string> {
+  const user = await userManager.getUser()
+  if (user !== null && !user.expired) return user.access_token
+  return (await userManager.signinPopup()).access_token
+}
+
+export function getAuthorizationHeaders(accessToken: string): Headers {
+  const headers = new Headers()
+  headers.append("Authorization", `Bearer ${accessToken}`)
+  return headers
+}

--- a/internal/lookout/ui/src/services/lookoutV2/CordonService.ts
+++ b/internal/lookout/ui/src/services/lookoutV2/CordonService.ts
@@ -1,8 +1,9 @@
+import { getAuthorizationHeaders } from "../../oidc"
 import { ConfigurationParameters } from "../../openapi/binoculars"
 import { getBinocularsApi } from "../../utils"
 
 export interface ICordonService {
-  cordonNode(cluster: string, node: string, signal: AbortSignal | undefined): Promise<void>
+  cordonNode(cluster: string, node: string, accessToken?: string, signal?: AbortSignal): Promise<void>
 }
 
 export class CordonService implements ICordonService {
@@ -14,12 +15,15 @@ export class CordonService implements ICordonService {
     this.baseUrlPattern = baseUrlPattern
   }
 
-  async cordonNode(cluster: string, node: string): Promise<void> {
+  async cordonNode(cluster: string, node: string, accessToken?: string): Promise<void> {
     const api = getBinocularsApi(cluster, this.baseUrlPattern, this.config)
-    await api.cordon({
-      body: {
-        nodeName: node,
+    await api.cordon(
+      {
+        body: {
+          nodeName: node,
+        },
       },
-    })
+      accessToken === undefined ? undefined : { headers: getAuthorizationHeaders(accessToken) },
+    )
   }
 }

--- a/internal/lookout/ui/src/services/lookoutV2/GetJobSpecService.ts
+++ b/internal/lookout/ui/src/services/lookoutV2/GetJobSpecService.ts
@@ -1,11 +1,11 @@
 export interface IGetJobSpecService {
-  getJobSpec(jobId: string, abortSignal: AbortSignal | undefined): Promise<Record<string, any>>
+  getJobSpec(jobId: string, abortSignal?: AbortSignal): Promise<Record<string, any>>
 }
 
 export class GetJobSpecService implements IGetJobSpecService {
   constructor(private apiBase: string) {}
 
-  async getJobSpec(jobId: string, abortSignal: AbortSignal | undefined): Promise<Record<string, any>> {
+  async getJobSpec(jobId: string, abortSignal?: AbortSignal): Promise<Record<string, any>> {
     const response = await fetch(this.apiBase + "/api/v1/jobSpec", {
       method: "POST",
       headers: { "Content-Type": "application/json" },

--- a/internal/lookout/ui/src/services/lookoutV2/GetRunErrorService.ts
+++ b/internal/lookout/ui/src/services/lookoutV2/GetRunErrorService.ts
@@ -1,11 +1,11 @@
 export interface IGetRunErrorService {
-  getRunError(runId: string, abortSignal: AbortSignal | undefined): Promise<string>
+  getRunError(runId: string, abortSignal?: AbortSignal): Promise<string>
 }
 
 export class GetRunErrorService implements IGetRunErrorService {
   constructor(private apiBase: string) {}
 
-  async getRunError(runId: string, abortSignal: AbortSignal | undefined): Promise<string> {
+  async getRunError(runId: string, abortSignal?: AbortSignal): Promise<string> {
     const response = await fetch(this.apiBase + "/api/v1/jobRunError", {
       method: "POST",
       headers: { "Content-Type": "application/json" },

--- a/internal/lookout/ui/src/services/lookoutV2/UpdateJobsService.ts
+++ b/internal/lookout/ui/src/services/lookoutV2/UpdateJobsService.ts
@@ -1,5 +1,6 @@
 import _ from "lodash"
 import { Job, JobId } from "models/lookoutV2Models"
+import { getAuthorizationHeaders } from "oidc"
 import { SubmitApi } from "openapi/armada"
 import { getErrorMessage } from "utils"
 
@@ -14,7 +15,7 @@ export type UpdateJobsResponse = {
 export class UpdateJobsService {
   constructor(private submitApi: SubmitApi) {}
 
-  cancelJobs = async (jobs: Job[], reason: string): Promise<UpdateJobsResponse> => {
+  cancelJobs = async (jobs: Job[], reason: string, accessToken?: string): Promise<UpdateJobsResponse> => {
     const response: UpdateJobsResponse = { successfulJobIds: [], failedJobIds: [] }
 
     const maxJobsPerRequest = 10000
@@ -26,14 +27,17 @@ export class UpdateJobsService {
       for (const [jobSet, batches] of jobSetMap) {
         for (const batch of batches) {
           apiResponsePromises.push({
-            promise: this.submitApi.cancelJobs({
-              body: {
-                jobIds: batch,
-                queue: queue,
-                jobSetId: jobSet,
-                reason: reason,
+            promise: this.submitApi.cancelJobs(
+              {
+                body: {
+                  jobIds: batch,
+                  queue: queue,
+                  jobSetId: jobSet,
+                  reason: reason,
+                },
               },
-            }),
+              accessToken === undefined ? undefined : { headers: getAuthorizationHeaders(accessToken) },
+            ),
             jobIds: batch,
           })
         }
@@ -67,7 +71,7 @@ export class UpdateJobsService {
     return response
   }
 
-  reprioritiseJobs = async (jobs: Job[], newPriority: number): Promise<UpdateJobsResponse> => {
+  reprioritiseJobs = async (jobs: Job[], newPriority: number, accessToken?: string): Promise<UpdateJobsResponse> => {
     const response: UpdateJobsResponse = { successfulJobIds: [], failedJobIds: [] }
 
     const maxJobsPerRequest = 10000
@@ -79,14 +83,17 @@ export class UpdateJobsService {
       for (const [jobSet, batches] of jobSetMap) {
         for (const batch of batches) {
           apiResponsePromises.push({
-            promise: this.submitApi.reprioritizeJobs({
-              body: {
-                jobIds: batch,
-                queue: queue,
-                jobSetId: jobSet,
-                newPriority: newPriority,
+            promise: this.submitApi.reprioritizeJobs(
+              {
+                body: {
+                  jobIds: batch,
+                  queue: queue,
+                  jobSetId: jobSet,
+                  newPriority: newPriority,
+                },
               },
-            }),
+              accessToken === undefined ? undefined : { headers: getAuthorizationHeaders(accessToken) },
+            ),
             jobIds: batch,
           })
         }

--- a/internal/lookout/ui/src/services/lookoutV2/mocks/FakeCordonService.ts
+++ b/internal/lookout/ui/src/services/lookoutV2/mocks/FakeCordonService.ts
@@ -4,7 +4,7 @@ import { ICordonService } from "../CordonService"
 export class FakeCordonService implements ICordonService {
   constructor(private simulateApiWait = true) {}
 
-  async cordonNode(cluster: string, node: string, signal: AbortSignal | undefined): Promise<void> {
+  async cordonNode(cluster: string, node: string, accessToken?: string, signal?: AbortSignal): Promise<void> {
     if (this.simulateApiWait) {
       await simulateApiWait(signal)
     }

--- a/internal/lookout/ui/src/services/lookoutV2/mocks/FakeGetJobSpecService.ts
+++ b/internal/lookout/ui/src/services/lookoutV2/mocks/FakeGetJobSpecService.ts
@@ -4,7 +4,7 @@ import { IGetJobSpecService } from "../GetJobSpecService"
 export default class FakeGetJobSpecService implements IGetJobSpecService {
   constructor(private simulateApiWait = true) {}
 
-  async getJobSpec(jobId: string, signal: AbortSignal | undefined): Promise<Record<string, any>> {
+  async getJobSpec(jobId: string, signal?: AbortSignal): Promise<Record<string, any>> {
     if (this.simulateApiWait) {
       await simulateApiWait(signal)
     }

--- a/internal/lookout/ui/src/services/lookoutV2/mocks/FakeGetJobsService.ts
+++ b/internal/lookout/ui/src/services/lookoutV2/mocks/FakeGetJobsService.ts
@@ -11,7 +11,7 @@ export default class FakeGetJobsService implements IGetJobsService {
     order: JobOrder,
     skip: number,
     take: number,
-    signal: AbortSignal | undefined,
+    signal?: AbortSignal,
   ): Promise<GetJobsResponse> {
     if (this.simulateApiWait) {
       await simulateApiWait(signal)

--- a/internal/lookout/ui/src/services/lookoutV2/mocks/FakeGetRunErrorService.ts
+++ b/internal/lookout/ui/src/services/lookoutV2/mocks/FakeGetRunErrorService.ts
@@ -4,7 +4,7 @@ import { IGetRunErrorService } from "../GetRunErrorService"
 export class FakeGetRunErrorService implements IGetRunErrorService {
   constructor(private simulateApiWait = true) {}
 
-  async getRunError(runId: string, signal: AbortSignal | undefined): Promise<string> {
+  async getRunError(runId: string, signal?: AbortSignal): Promise<string> {
     if (this.simulateApiWait) {
       await simulateApiWait(signal)
     }

--- a/internal/lookout/ui/src/services/lookoutV2/mocks/FakeGroupJobsService.ts
+++ b/internal/lookout/ui/src/services/lookoutV2/mocks/FakeGroupJobsService.ts
@@ -13,7 +13,7 @@ export default class FakeGroupJobsService implements IGroupJobsService {
     aggregates: string[],
     skip: number,
     take: number,
-    signal: AbortSignal | undefined,
+    signal?: AbortSignal,
   ): Promise<GroupJobsResponse> {
     if (this.simulateApiWait) {
       await simulateApiWait(signal)

--- a/internal/lookout/ui/src/services/lookoutV2/mocks/FakeLogService.ts
+++ b/internal/lookout/ui/src/services/lookoutV2/mocks/FakeLogService.ts
@@ -11,7 +11,8 @@ export class FakeLogService implements ILogService {
     container: string,
     sinceTime: string,
     tailLines: number | undefined,
-    signal: AbortSignal | undefined,
+    accessToken?: string,
+    signal?: AbortSignal,
   ): Promise<LogLine[]> {
     if (this.simulateApiWait) {
       await simulateApiWait(signal)

--- a/internal/lookout/ui/src/utils.tsx
+++ b/internal/lookout/ui/src/utils.tsx
@@ -5,7 +5,6 @@ import { BinocularsApi, Configuration, ConfigurationParameters } from "./openapi
 export interface OidcConfig {
   authority: string
   clientId: string
-  redirectUrl: string
   scope: string
 }
 

--- a/internal/lookout/ui/src/utils.tsx
+++ b/internal/lookout/ui/src/utils.tsx
@@ -2,6 +2,13 @@ import { Location, NavigateFunction, Params, useLocation, useNavigate, useParams
 
 import { BinocularsApi, Configuration, ConfigurationParameters } from "./openapi/binoculars"
 
+export interface OidcConfig {
+  authority: string
+  clientId: string
+  redirectUrl: string
+  scope: string
+}
+
 interface UIConfig {
   armadaApiBaseUrl: string
   userAnnotationPrefix: string
@@ -14,6 +21,8 @@ interface UIConfig {
   fakeDataEnabled: boolean
   lookoutV2ApiBaseUrl: string
   customTitle: string
+  oidcEnabled: boolean
+  oidc?: OidcConfig
 }
 
 export type RequestStatus = "Loading" | "Idle"
@@ -28,7 +37,7 @@ export interface Padding {
 }
 
 export async function getUIConfig(): Promise<UIConfig> {
-  const queryParams = new URLSearchParams(window.location.search)
+  const searchParams = new URLSearchParams(window.location.search)
 
   const config = {
     armadaApiBaseUrl: "",
@@ -38,10 +47,12 @@ export async function getUIConfig(): Promise<UIConfig> {
     overviewAutoRefreshMs: 15000,
     jobSetsAutoRefreshMs: 15000,
     jobsAutoRefreshMs: 30000,
-    debugEnabled: queryParams.has("debug"),
-    fakeDataEnabled: queryParams.has("fakeData"),
+    debugEnabled: searchParams.has("debug"),
+    fakeDataEnabled: searchParams.has("fakeData"),
     lookoutV2ApiBaseUrl: "",
     customTitle: "",
+    oidcEnabled: false,
+    oidc: undefined,
   }
 
   try {
@@ -56,9 +67,22 @@ export async function getUIConfig(): Promise<UIConfig> {
     if (json.JobsAutoRefreshMs) config.jobsAutoRefreshMs = json.JobsAutoRefreshMs
     if (json.LookoutV2ApiBaseUrl) config.lookoutV2ApiBaseUrl = json.LookoutV2ApiBaseUrl
     if (json.CustomTitle) config.customTitle = json.CustomTitle
+    if (json.OidcEnabled) config.oidcEnabled = json.OidcEnabled
+    if (json.Oidc) config.oidc = json.Oidc
   } catch (e) {
     console.error(e)
   }
+
+  switch (searchParams.get("oidcEnabled")) {
+    case "false":
+      config.oidcEnabled = false
+      break
+    case "true":
+      config.oidcEnabled = true
+      break
+  }
+
+  if (window.location.pathname === "/oidc") config.oidcEnabled = true
 
   return config
 }

--- a/internal/lookout/ui/src/utils.tsx
+++ b/internal/lookout/ui/src/utils.tsx
@@ -38,7 +38,7 @@ export interface Padding {
 export async function getUIConfig(): Promise<UIConfig> {
   const searchParams = new URLSearchParams(window.location.search)
 
-  const config = {
+  const config: UIConfig = {
     armadaApiBaseUrl: "",
     userAnnotationPrefix: "",
     binocularsEnabled: true,
@@ -67,7 +67,13 @@ export async function getUIConfig(): Promise<UIConfig> {
     if (json.LookoutV2ApiBaseUrl) config.lookoutV2ApiBaseUrl = json.LookoutV2ApiBaseUrl
     if (json.CustomTitle) config.customTitle = json.CustomTitle
     if (json.OidcEnabled) config.oidcEnabled = json.OidcEnabled
-    if (json.Oidc) config.oidc = json.Oidc
+    if (json.Oidc) {
+      config.oidc = {
+        authority: json.Oidc.Authority,
+        clientId: json.Oidc.ClientId,
+        scope: json.Oidc.Scope,
+      }
+    }
   } catch (e) {
     console.error(e)
   }

--- a/internal/lookout/ui/yarn.lock
+++ b/internal/lookout/ui/yarn.lock
@@ -4890,6 +4890,11 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+crypto-js@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.1.1.tgz#9e485bcf03521041bd85844786b83fb7619736cf"
+  integrity sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==
+
 crypto-random-string@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
@@ -8136,6 +8141,11 @@ jss@10.9.2, jss@^10.5.1:
     array-includes "^3.1.5"
     object.assign "^4.1.3"
 
+jwt-decode@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-3.1.2.tgz#3fb319f3675a2df0c2895c8f5e9fa4b67b04ed59"
+  integrity sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==
+
 kind-of@^6.0.2:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
@@ -8670,6 +8680,14 @@ obuf@^1.0.0, obuf@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.2.tgz#09bea3343d41859ebd446292d11c9d4db619084e"
   integrity sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==
+
+oidc-client-ts@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/oidc-client-ts/-/oidc-client-ts-2.3.0.tgz#43c90f1f0cc3be2e4ede38b8c68642ba00bfa8f6"
+  integrity sha512-7RUKU+TJFQo+4X9R50IGJAIDF18uRBaFXyZn4VVCfwmwbSUhKcdDnw4zgeut3uEXkiD3NqURq+d88sDPxjf1FA==
+  dependencies:
+    crypto-js "^4.1.1"
+    jwt-decode "^3.1.2"
 
 on-finished@2.4.1:
   version "2.4.1"


### PR DESCRIPTION
This PR adds optional support for OIDC authentication to the Lookout UI, using the `oidc-client-ts` library. Whether OIDC authentication is enabled can be controlled on the server side by setting the `OidcEnabled` field in the JSON record returned by `/config`, and on the client side by setting the query parameter `oidcEnabled`; if neither of these is set to `true`, then OIDC authentication is disabled.