### PR TITLE
Make `/job-sets` accept `fakeData`

### DIFF
--- a/internal/lookout/ui/src/services/JobSetsQueryParamsService.ts
+++ b/internal/lookout/ui/src/services/JobSetsQueryParamsService.ts
@@ -15,25 +15,21 @@ type JobSetsQueryParams = {
   active_only?: boolean
 }
 
-function makeQueryString(state: JobSetsContainerState): string {
-  const queryObject: JobSetsQueryParams = {}
-
-  if (state.queue) {
-    queryObject.queue = state.queue
-  }
-  queryObject.newest_first = state.newestFirst
-  queryObject.active_only = state.activeOnly
-
-  return queryString.stringify(queryObject)
-}
-
 export default class JobSetsQueryParamsService {
   constructor(private router: Router) {}
 
   saveState(state: JobSetsContainerState) {
+    const params = queryString.parse(this.router.location.search, QUERY_STRING_OPTIONS) as Record<any, any>
+
+    if (state.queue) {
+      params.queue = state.queue
+    }
+    params.newest_first = state.newestFirst
+    params.active_only = state.activeOnly
+
     this.router.navigate({
       ...this.router.location,
-      search: makeQueryString(state),
+      search: queryString.stringify(params, QUERY_STRING_OPTIONS),
     })
   }
 

--- a/internal/lookout/ui/src/services/lookoutV2/mocks/FakeGroupJobsService.ts
+++ b/internal/lookout/ui/src/services/lookoutV2/mocks/FakeGroupJobsService.ts
@@ -25,7 +25,11 @@ export default class FakeGroupJobsService implements IGroupJobsService {
       filtered = filtered.filter((job) => job.queue in active && active[job.queue].includes(job.jobSet))
     }
     const groups = groupBy(filtered, groupedField, aggregates)
-    const sliced = groups.sort(comparator(order)).slice(skip, skip + take)
+    const sorted = groups.sort(comparator(order))
+    // This matches the behavior of version 2 of the Lookout API, which
+    // understands zero to mean "no pagination" (in order to support queries
+    // without pagination, such as those used by `/job-sets`).
+    const sliced = take == 0 ? sorted.slice(skip) : sorted.slice(skip, skip + take)
     return {
       groups: sliced,
       count: groups.length,


### PR DESCRIPTION
Now that `/job-sets` calls version 2 of the Lookout API, it would be convenient to have it accept the same `fakeData` query parameter that the job table already accepts. This PR achieves this by making `/job-sets` retain query parameters that are not part of its state.