### PR TITLE
Actually test `MaxUnacknowledgedJobsPerExecutor`

### DIFF
--- a/internal/scheduler/scheduling_algo_test.go
+++ b/internal/scheduler/scheduling_algo_test.go
@@ -70,24 +70,41 @@ func TestSchedule(t *testing.T) {
 			queuedJobs:               testfixtures.N16Cpu128GiJobs(testfixtures.TestQueue, testfixtures.PriorityClass3, 10),
 			expectedScheduledIndices: []int{0, 1},
 		},
-		"do not schedule onto executors with too many unacknowledged jobs": {
-			// TODO: This test doesn't look right; we never set MaxUnacknowledgedJobsPerExecutor.
-			schedulingConfig: testfixtures.TestSchedulingConfig(),
+		"schedule onto executors with some unacknowledged jobs": {
+			schedulingConfig: testfixtures.WithMaxUnacknowledgedJobsPerExecutorConfig(16, testfixtures.TestSchedulingConfig()),
 			executors: []*schedulerobjects.Executor{
 				testfixtures.Test1Node32CoreExecutor("executor1"),
 				testfixtures.Test1Node32CoreExecutor("executor2"),
 			},
 			queues:     []*database.Queue{testfixtures.TestDbQueue()},
-			queuedJobs: testfixtures.N16Cpu128GiJobs(testfixtures.TestQueue, testfixtures.PriorityClass3, 10),
+			queuedJobs: testfixtures.N1Cpu4GiJobs(testfixtures.TestQueue, testfixtures.PriorityClass3, 48),
 			scheduledJobsByExecutorIndexAndNodeIndex: map[int]map[int]scheduledJobs{
 				0: {
 					0: scheduledJobs{
-						jobs:         testfixtures.N16Cpu128GiJobs(testfixtures.TestQueue, testfixtures.PriorityClass3, 2),
+						jobs:         testfixtures.N1Cpu4GiJobs(testfixtures.TestQueue, testfixtures.PriorityClass3, 16),
 						acknowledged: false,
 					},
 				},
 			},
-			expectedScheduledIndices: []int{0, 1},
+			expectedScheduledIndices: testfixtures.IntRange(0, 47),
+		},
+		"do not schedule onto executors with too many unacknowledged jobs": {
+			schedulingConfig: testfixtures.WithMaxUnacknowledgedJobsPerExecutorConfig(15, testfixtures.TestSchedulingConfig()),
+			executors: []*schedulerobjects.Executor{
+				testfixtures.Test1Node32CoreExecutor("executor1"),
+				testfixtures.Test1Node32CoreExecutor("executor2"),
+			},
+			queues:     []*database.Queue{testfixtures.TestDbQueue()},
+			queuedJobs: testfixtures.N1Cpu4GiJobs(testfixtures.TestQueue, testfixtures.PriorityClass3, 48),
+			scheduledJobsByExecutorIndexAndNodeIndex: map[int]map[int]scheduledJobs{
+				0: {
+					0: scheduledJobs{
+						jobs:         testfixtures.N1Cpu4GiJobs(testfixtures.TestQueue, testfixtures.PriorityClass3, 16),
+						acknowledged: false,
+					},
+				},
+			},
+			expectedScheduledIndices: testfixtures.IntRange(0, 31),
 		},
 		"one executor full": {
 			schedulingConfig: testfixtures.TestSchedulingConfig(),


### PR DESCRIPTION
The existing test was dubious; it had no connection to `MaxUnacknowledgedJobsPerExecutor` at all.