### PR TITLE
Checkout correct tag in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,8 @@ jobs:
         uses: actions/checkout@v3.3.0
         with:
           fetch-depth: 0
+          # Checkout the tag that triggered the workflow.
+          ref: ${{ github.event.workflow_run.head_branch }}
 
       - name: Fetch Git tags
         run: git fetch --force --tags


### PR DESCRIPTION
The following release failed:
https://github.com/armadaproject/armada/actions/runs/6585743099/job/17959811879
The failure was due to the release process checking out master instead of the commit the tag was created from. Meaning that the release fails when a PR is merged into master between a tag being created and the release workflow running.

For example, this later release succeeded:
https://github.com/armadaproject/armada/actions/runs/6613575211/job/17961696279

It's a bit surprising that we'd need this change, since the checkout action docs state that:

```
    # The branch, tag or SHA to checkout. When checking out the repository that
    # triggered a workflow, this defaults to the reference or SHA for that event.
    # Otherwise, uses the default branch.
    ref: ''
```