### PR TITLE
Pprof endpoints for all services

### DIFF
--- a/cmd/armada/main.go
+++ b/cmd/armada/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"syscall"
@@ -20,6 +19,8 @@ import (
 	gateway "github.com/armadaproject/armada/internal/common/grpc"
 	"github.com/armadaproject/armada/internal/common/health"
 	"github.com/armadaproject/armada/internal/common/logging"
+	"github.com/armadaproject/armada/internal/common/profiling"
+	"github.com/armadaproject/armada/internal/common/serve"
 	"github.com/armadaproject/armada/pkg/api"
 )
 
@@ -46,25 +47,6 @@ func main() {
 
 	log.Info("Starting...")
 
-	// Importing net/http/pprof automatically binds profiling endpoints to http.DefaultServeMux.
-	// Here, we create a new DefaultServeMux to ensure profiling is exposed on a separate mux.
-	// The profiling endpoints are only exposed if config.ProfilingPort is not nil.
-	pprofMux := http.DefaultServeMux
-	http.DefaultServeMux = http.NewServeMux()
-	if config.PprofPort != nil {
-		go func() {
-			server := &http.Server{
-				Addr:    fmt.Sprintf("localhost:%d", *config.PprofPort),
-				Handler: pprofMux,
-			}
-			log := log.NewEntry(log.New())
-			log.Infof("profiling endpoints exposed on %s", server.Addr)
-			if err := server.ListenAndServe(); err != nil {
-				logging.WithStacktrace(log, err).Error("profiling server exited")
-			}
-		}()
-	}
-
 	// Run services within an errgroup to propagate errors between services.
 	g, ctx := armadacontext.ErrGroup(armadacontext.Background())
 
@@ -80,6 +62,12 @@ func main() {
 			// Returning an error cancels the errgroup.
 			return fmt.Errorf("received signal %v", sig)
 		}
+	})
+
+	// Expose profiling endpoints if enabled.
+	pprofServer := profiling.SetupPprofHttpServer(config.PprofPort)
+	g.Go(func() error {
+		return serve.ListenAndServe(ctx, pprofServer)
 	})
 
 	// TODO This starts a separate HTTP server. Is that intended? Should we have a single mux for everything?

--- a/cmd/binoculars/main.go
+++ b/cmd/binoculars/main.go
@@ -16,8 +16,12 @@ import (
 	"github.com/armadaproject/armada/internal/binoculars"
 	"github.com/armadaproject/armada/internal/binoculars/configuration"
 	"github.com/armadaproject/armada/internal/common"
+	"github.com/armadaproject/armada/internal/common/armadacontext"
 	gateway "github.com/armadaproject/armada/internal/common/grpc"
 	"github.com/armadaproject/armada/internal/common/health"
+	"github.com/armadaproject/armada/internal/common/logging"
+	"github.com/armadaproject/armada/internal/common/profiling"
+	"github.com/armadaproject/armada/internal/common/serve"
 	api "github.com/armadaproject/armada/pkg/api/binoculars"
 )
 
@@ -41,6 +45,15 @@ func main() {
 	common.LoadConfig(&config, "./config/binoculars", userSpecifiedConfigs)
 
 	log.Info("Starting...")
+
+	// Expose profiling endpoints if enabled.
+	pprofServer := profiling.SetupPprofHttpServer(config.PprofPort)
+	go func() {
+		ctx := armadacontext.Background()
+		if err := serve.ListenAndServe(ctx, pprofServer); err != nil {
+			logging.WithStacktrace(ctx, err).Error("pprof server failure")
+		}
+	}()
 
 	stopSignal := make(chan os.Signal, 1)
 	signal.Notify(stopSignal, syscall.SIGINT, syscall.SIGTERM)

--- a/cmd/fakeexecutor/main.go
+++ b/cmd/fakeexecutor/main.go
@@ -9,6 +9,10 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/armadaproject/armada/internal/common"
+	"github.com/armadaproject/armada/internal/common/armadacontext"
+	"github.com/armadaproject/armada/internal/common/logging"
+	"github.com/armadaproject/armada/internal/common/profiling"
+	"github.com/armadaproject/armada/internal/common/serve"
 	"github.com/armadaproject/armada/internal/executor/configuration"
 	"github.com/armadaproject/armada/internal/executor/fake"
 	"github.com/armadaproject/armada/internal/executor/fake/context"
@@ -32,6 +36,15 @@ func main() {
 	var config configuration.ExecutorConfiguration
 	userSpecifiedConfigs := viper.GetStringSlice(CustomConfigLocation)
 	v := common.LoadConfig(&config, "./config/executor", userSpecifiedConfigs)
+
+	// Expose profiling endpoints if enabled.
+	pprofServer := profiling.SetupPprofHttpServer(config.PprofPort)
+	go func() {
+		ctx := armadacontext.Background()
+		if err := serve.ListenAndServe(ctx, pprofServer); err != nil {
+			logging.WithStacktrace(ctx, err).Error("pprof server failure")
+		}
+	}()
 
 	var nodes []*context.NodeSpec
 	e := common.UnmarshalKey(v, "nodes", &nodes)

--- a/cmd/lookout/main.go
+++ b/cmd/lookout/main.go
@@ -13,8 +13,11 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/armadaproject/armada/internal/common"
+	"github.com/armadaproject/armada/internal/common/armadacontext"
 	"github.com/armadaproject/armada/internal/common/grpc"
 	"github.com/armadaproject/armada/internal/common/health"
+	"github.com/armadaproject/armada/internal/common/logging"
+	"github.com/armadaproject/armada/internal/common/profiling"
 	"github.com/armadaproject/armada/internal/common/serve"
 	"github.com/armadaproject/armada/internal/lookout"
 	"github.com/armadaproject/armada/internal/lookout/configuration"
@@ -81,6 +84,15 @@ func main() {
 		}
 		os.Exit(0)
 	}
+
+	// Expose profiling endpoints if enabled.
+	pprofServer := profiling.SetupPprofHttpServer(config.PprofPort)
+	go func() {
+		ctx := armadacontext.Background()
+		if err := serve.ListenAndServe(ctx, pprofServer); err != nil {
+			logging.WithStacktrace(ctx, err).Error("pprof server failure")
+		}
+	}()
 
 	shutdownChannel := make(chan os.Signal, 1)
 	signal.Notify(shutdownChannel, syscall.SIGINT, syscall.SIGTERM)

--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	_ "net/http/pprof"
 	"os"
 
 	"github.com/armadaproject/armada/cmd/scheduler/cmd"

--- a/internal/binoculars/configuration/types.go
+++ b/internal/binoculars/configuration/types.go
@@ -9,9 +9,12 @@ type BinocularsConfig struct {
 	Cordon CordonConfiguration
 	Auth   configuration.AuthConfig
 
-	GrpcPort           uint16
-	HttpPort           uint16
-	MetricsPort        uint16
+	GrpcPort    uint16
+	HttpPort    uint16
+	MetricsPort uint16
+	// If non-nil, net/http/pprof endpoints are exposed on localhost on this port.
+	PprofPort *uint16
+
 	CorsAllowedOrigins []string
 
 	Grpc             grpcconfig.GrpcConfig

--- a/internal/common/profiling/http.go
+++ b/internal/common/profiling/http.go
@@ -1,0 +1,24 @@
+package profiling
+
+import (
+	"fmt"
+	"net/http"
+	_ "net/http/pprof"
+)
+
+// SetupPprofHttpServer does two things:
+//
+//  1. Because importing "net/http/pprof" automatically binds profiling endpoints to http.DefaultServeMux,
+//     this function replaces http.DefaultServeMux with a new mux. This to ensure profiling endpoints
+//     are exposed on a separate mux available only from localhost.Hence, this function should be called
+//     before adding any other endpoints to http.DefaultServeMux.
+//  2. If port is non-nil, returns a http server serving net/http/pprof endpoints on localhost:port.
+//     If port is nil, returns nil.
+func SetupPprofHttpServer(port *uint16) *http.Server {
+	pprofMux := http.DefaultServeMux
+	http.DefaultServeMux = http.NewServeMux()
+	return &http.Server{
+		Addr:    fmt.Sprintf("localhost:%d", port),
+		Handler: pprofMux,
+	}
+}

--- a/internal/common/serve/static.go
+++ b/internal/common/serve/static.go
@@ -3,9 +3,10 @@ package serve
 import (
 	"net/http"
 
+	"github.com/pkg/errors"
+
 	"github.com/armadaproject/armada/internal/common/armadacontext"
 	"github.com/armadaproject/armada/internal/common/logging"
-	"github.com/pkg/errors"
 )
 
 type dirWithIndexFallback struct {

--- a/internal/eventingester/configuration/types.go
+++ b/internal/eventingester/configuration/types.go
@@ -29,6 +29,8 @@ type EventIngesterConfiguration struct {
 	EventRetentionPolicy EventRetentionPolicy
 	// List of Regexes which will identify fatal errors when inserting into redis
 	FatalInsertionErrors []string
+	// If non-nil, net/http/pprof endpoints are exposed on localhost on this port.
+	PprofPort *uint16
 }
 
 type EventRetentionPolicy struct {

--- a/internal/executor/configuration/types.go
+++ b/internal/executor/configuration/types.go
@@ -159,7 +159,9 @@ const (
 )
 
 type ExecutorConfiguration struct {
-	HttpPort              uint16
+	HttpPort uint16
+	// If non-nil, net/http/pprof endpoints are exposed on localhost on this port.
+	PprofPort             *uint16
 	Metric                MetricConfiguration
 	Application           ApplicationConfiguration
 	ApiConnection         client.ApiConnectionDetails

--- a/internal/lookout/configuration/types.go
+++ b/internal/lookout/configuration/types.go
@@ -31,6 +31,8 @@ type LookoutConfiguration struct {
 	HttpPort    uint16
 	GrpcPort    uint16
 	MetricsPort uint16
+	// If non-nil, net/http/pprof endpoints are exposed on localhost on this port.
+	PprofPort *uint16
 
 	Grpc grpcconfig.GrpcConfig
 
@@ -68,4 +70,6 @@ type LookoutIngesterConfiguration struct {
 	// User annotations have a common prefix to avoid clashes with other annotations.  This prefix will be stripped from
 	// The annotation before storing in the db
 	UserAnnotationPrefix string
+	// If non-nil, net/http/pprof endpoints are exposed on localhost on this port.
+	PprofPort *uint16
 }

--- a/internal/lookoutingesterv2/configuration/types.go
+++ b/internal/lookoutingesterv2/configuration/types.go
@@ -37,4 +37,6 @@ type LookoutIngesterV2Configuration struct {
 	// If the ingester should process events using the legacy event conversion logic
 	// The two schedulers produce slightly different events - so need to be processed differently
 	UseLegacyEventConversion bool
+	// If non-nil, net/http/pprof endpoints are exposed on localhost on this port.
+	PprofPort *uint16
 }

--- a/internal/lookoutv2/configuration/types.go
+++ b/internal/lookoutv2/configuration/types.go
@@ -7,7 +7,10 @@ import (
 )
 
 type LookoutV2Configuration struct {
-	ApiPort            int
+	ApiPort int
+	// If non-nil, net/http/pprof endpoints are exposed on localhost on this port.
+	PprofPort *uint16
+
 	CorsAllowedOrigins []string
 	Tls                TlsConfig
 

--- a/internal/scheduler/configuration/configuration.go
+++ b/internal/scheduler/configuration/configuration.go
@@ -35,6 +35,8 @@ type Configuration struct {
 	Auth       authconfig.AuthConfig
 	Grpc       grpcconfig.GrpcConfig
 	Http       HttpConfig
+	// If non-nil, net/http/pprof endpoints are exposed on localhost on this port.
+	PprofPort *uint16
 	// Maximum number of strings that should be cached at any one time
 	InternedStringsCacheSize uint32 `validate:"required"`
 	// How often the scheduling cycle should run

--- a/internal/scheduleringester/config.go
+++ b/internal/scheduleringester/config.go
@@ -26,4 +26,6 @@ type Configuration struct {
 	PulsarReceiveTimeout time.Duration
 	// Time for which the pulsar consumer will back off after receiving an error on trying to receive a message
 	PulsarBackoffTime time.Duration
+	// If non-nil, net/http/pprof endpoints are exposed on localhost on this port.
+	PprofPort *uint16
 }


### PR DESCRIPTION
This PR adds the option to expose pprof http profiling endpoints to all Armada services. Previously, this was only possible for the main Armada server.

Ideally we'd run the profiler http server in an errgroup everywhere. But that's a change we can make later.