### PR TITLE
Explain that `/job-sets` requires a queue name

### DIFF
--- a/internal/lookout/ui/src/components/job-sets/JobSetTable.tsx
+++ b/internal/lookout/ui/src/components/job-sets/JobSetTable.tsx
@@ -14,6 +14,7 @@ import "./JobSetTable.css"
 interface JobSetTableProps {
   height: number
   width: number
+  queue: string
   jobSets: JobSet[]
   selectedJobSets: Map<string, JobSet>
   newestFirst: boolean
@@ -40,6 +41,21 @@ function cellRendererForJobSet(cellProps: TableCellProps, width: number) {
 }
 
 export default function JobSetTable(props: JobSetTableProps) {
+  if (props.queue === "") {
+    return (
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          height: props.height,
+          width: props.width,
+        }}
+      >
+        Enter a queue name into the "Queue" field to view job sets.
+      </div>
+    )
+  }
   return (
     <div
       style={{

--- a/internal/lookout/ui/src/components/job-sets/JobSets.tsx
+++ b/internal/lookout/ui/src/components/job-sets/JobSets.tsx
@@ -41,6 +41,7 @@ export default function JobSets(props: JobSetsProps) {
     <JobSetTable
       height={height}
       width={width}
+      queue={props.queue}
       jobSets={props.jobSets}
       selectedJobSets={props.selectedJobSets}
       newestFirst={props.newestFirst}

--- a/internal/lookout/ui/src/containers/JobSetsContainer.tsx
+++ b/internal/lookout/ui/src/containers/JobSetsContainer.tsx
@@ -229,6 +229,9 @@ class JobSetsContainer extends React.Component<JobSetsContainerProps, JobSetsCon
   }
 
   private async loadJobSets() {
+    if (this.state.queue === "") {
+      return
+    }
     await setStateAsync(this, {
       ...this.state,
       getJobSetsRequestStatus: "Loading",


### PR DESCRIPTION
Consider this programmer art; it's just a sentence in the middle of the screen:

![image](https://github.com/armadaproject/armada/assets/41909795/b30aa35e-5f00-4430-9ac4-660231392640)