### PR TITLE
Fix loading of job table state from local storage

### DIFF
--- a/internal/lookout/ui/src/services/lookoutV2/JobsTablePreferencesService.ts
+++ b/internal/lookout/ui/src/services/lookoutV2/JobsTablePreferencesService.ts
@@ -62,7 +62,7 @@ type QueryStringJobFilter = {
 // Keys are shortened to keep URL size lower
 export interface QueryStringPrefs {
   // Grouped columns
-  g: string[] | [null]
+  g: string[]
   // Expanded rows
   e: string[]
   // Current page number
@@ -120,13 +120,9 @@ const columnMatchesFromQueryStringFilters = (f: QueryStringJobFilter[]): Record<
 }
 
 const fromQueryStringSafe = (serializedPrefs: Partial<QueryStringPrefs>): Partial<JobsTablePreferences> => {
-  const { e, page, ps, sort, f, sb } = serializedPrefs
-  let g = serializedPrefs.g
-  if (!(Array.isArray(g) && g.length > 0 && g.map((elem) => typeof elem === "string").reduce((a, b) => a && b, true))) {
-    g = []
-  }
+  const { g, e, page, ps, sort, f, sb } = serializedPrefs
   return {
-    ...(g && { groupedColumns: g as ColumnId[] }),
+    ...(g && Array.isArray(g) && g.every((a) => typeof a === "string") && { groupedColumns: g as ColumnId[] }),
     ...(e && { expandedState: Object.fromEntries(e.map((rowId) => [rowId, true])) }),
     ...(page !== undefined && { pageIndex: Number(page) }),
     ...(ps !== undefined && { pageSize: Number(ps) }),


### PR DESCRIPTION
When the job table is mounted, it retrieves the user's job table settings from the query string and local storage, and then merges them by calling `mergeQueryParamsAndLocalStorage`:

https://github.com/armadaproject/armada/blob/0dc6f4e3ae323108fb71a6f6ed269a4c4b8c228b/internal/lookout/ui/src/services/lookoutV2/JobsTablePreferencesService.ts#L222-L224

If the user navigates to `/` (i.e., the query string is empty), then `mergeQueryParamsAndLocalStorage` is supposed to use the settings from local storage:

https://github.com/armadaproject/armada/blob/0dc6f4e3ae323108fb71a6f6ed269a4c4b8c228b/internal/lookout/ui/src/services/lookoutV2/JobsTablePreferencesService.ts#L170

This is currently not the case on `master`, because `fromQueryStringSafe` (which is called by `getPrefsFromQueryParams`) turns the empty object `{}` into `{ groupedColumns: [] }`:

https://github.com/armadaproject/armada/blob/0dc6f4e3ae323108fb71a6f6ed269a4c4b8c228b/internal/lookout/ui/src/services/lookoutV2/JobsTablePreferencesService.ts#L124-L129

This PR fixes this issue by not setting `g` to the empty array (which converts to `true` in boolean contexts) if it was originally `undefined`.