### PR TITLE
Add auto refresh to the job table

### DIFF
--- a/internal/lookout/ui/src/App.tsx
+++ b/internal/lookout/ui/src/App.tsx
@@ -134,6 +134,7 @@ export function App(props: AppProps): JSX.Element {
                           logService={props.v2LogService}
                           cordonService={props.v2CordonService}
                           debug={props.debugEnabled}
+                          autoRefreshMs={props.jobsAutoRefreshMs}
                         />
                       }
                     />

--- a/internal/lookout/ui/src/components/AutoRefreshToggle.tsx
+++ b/internal/lookout/ui/src/components/AutoRefreshToggle.tsx
@@ -20,7 +20,7 @@ export default function AutoRefreshToggle(props: AutoRefreshToggle) {
             color="primary"
           />
         }
-        label="Auto-refresh"
+        label="Auto refresh"
         labelPlacement="start"
       />
     </div>

--- a/internal/lookout/ui/src/components/lookoutV2/JobsTableActionBar.tsx
+++ b/internal/lookout/ui/src/components/lookoutV2/JobsTableActionBar.tsx
@@ -1,6 +1,7 @@
 import React, { memo, useCallback, useMemo, useState } from "react"
 
 import { Divider, Button, Checkbox, FormControlLabel, FormGroup, Tooltip } from "@mui/material"
+import AutoRefreshToggle from "components/AutoRefreshToggle"
 import RefreshButton from "components/RefreshButton"
 import ColumnSelect from "components/lookoutV2/ColumnSelect"
 import GroupBySelect from "components/lookoutV2/GroupBySelect"
@@ -25,6 +26,8 @@ export interface JobsTableActionBarProps {
   activeJobSets: boolean
   onActiveJobSetsChanged: (newVal: boolean) => void
   onRefresh: () => void
+  autoRefresh: boolean
+  onAutoRefreshChange: (autoRefresh: boolean) => void
   onAddAnnotationColumn: (annotationKey: string) => void
   onRemoveAnnotationColumn: (colId: ColumnId) => void
   onEditAnnotationColumn: (colId: ColumnId, annotationKey: string) => void
@@ -49,6 +52,8 @@ export const JobsTableActionBar = memo(
     activeJobSets,
     onActiveJobSetsChanged,
     onRefresh,
+    autoRefresh,
+    onAutoRefreshChange,
     onAddAnnotationColumn,
     onRemoveAnnotationColumn,
     onEditAnnotationColumn,
@@ -110,10 +115,12 @@ export const JobsTableActionBar = memo(
             </Tooltip>
           </FormGroup>
           <Divider orientation="vertical" />
+          <AutoRefreshToggle autoRefresh={autoRefresh} onAutoRefreshChange={onAutoRefreshChange} />
+          <RefreshButton isLoading={isLoading} onClick={onRefresh} />
+          <Divider orientation="vertical" />
           <Button variant="text" onClick={onClearFilters} color="secondary">
             Clear Filters
           </Button>
-          <RefreshButton isLoading={isLoading} onClick={onRefresh} />
           <CustomViewPicker
             customViews={customViews}
             onAddCustomView={onAddCustomView}

--- a/internal/lookout/ui/src/containers/lookoutV2/JobsTableContainer.test.tsx
+++ b/internal/lookout/ui/src/containers/lookoutV2/JobsTableContainer.test.tsx
@@ -89,6 +89,7 @@ describe("JobsTableContainer", () => {
           logService={logService}
           cordonService={new FakeCordonService()}
           debug={false}
+          autoRefreshMs={30000}
         />
       </SnackbarProvider>
     )

--- a/internal/lookout/ui/src/services/lookoutV2/JobsTablePreferencesService.ts
+++ b/internal/lookout/ui/src/services/lookoutV2/JobsTablePreferencesService.ts
@@ -30,6 +30,7 @@ export interface JobsTablePreferences {
   sidebarJobId: JobId | undefined
   sidebarWidth?: number
   activeJobSets?: boolean
+  autoRefresh?: boolean
 }
 
 // Need two 'defaults'
@@ -81,6 +82,8 @@ export interface QueryStringPrefs {
   sb: string | undefined
   // This is a boolean field, but the qs library turns it into a string.
   active: string | undefined
+  // This is a boolean field, but the qs library turns it into a string.
+  refresh: string | undefined
 }
 
 const toQueryStringSafe = (prefs: JobsTablePreferences): QueryStringPrefs => {
@@ -105,6 +108,7 @@ const toQueryStringSafe = (prefs: JobsTablePreferences): QueryStringPrefs => {
     ps: prefs.pageSize.toString(),
     sb: prefs.sidebarJobId,
     active: prefs.activeJobSets === undefined ? undefined : `${prefs.activeJobSets}`,
+    refresh: prefs.autoRefresh === undefined ? undefined : `${prefs.autoRefresh}`,
   }
 }
 
@@ -124,7 +128,7 @@ const columnMatchesFromQueryStringFilters = (f: QueryStringJobFilter[]): Record<
 }
 
 const fromQueryStringSafe = (serializedPrefs: Partial<QueryStringPrefs>): Partial<JobsTablePreferences> => {
-  const { g, e, page, ps, sort, f, sb, active } = serializedPrefs
+  const { g, e, page, ps, sort, f, sb, active, refresh } = serializedPrefs
   return {
     ...(g && Array.isArray(g) && g.every((a) => typeof a === "string") && { groupedColumns: g as ColumnId[] }),
     ...(e && { expandedState: Object.fromEntries(e.map((rowId) => [rowId, true])) }),
@@ -137,6 +141,7 @@ const fromQueryStringSafe = (serializedPrefs: Partial<QueryStringPrefs>): Partia
     ...(f && { columnMatches: columnMatchesFromQueryStringFilters(f) }),
     ...(sb && { sidebarJobId: sb }),
     ...(active && { activeJobSets: active.toLowerCase() === "true" }),
+    ...(refresh && { autoRefresh: refresh.toLowerCase() === "true" }),
   }
 }
 
@@ -182,6 +187,7 @@ const mergeQueryParamsAndLocalStorage = (
     }
     mergeColumnMatches(mergedPrefs.columnMatches, queryParamPrefs.columnMatches)
     mergedPrefs.activeJobSets = queryParamPrefs.activeJobSets
+    mergedPrefs.autoRefresh = queryParamPrefs.autoRefresh
   }
   return mergedPrefs
 }


### PR DESCRIPTION
The job table action bar now has the same auto refresh button as `/job-sets`:

<img width="478" alt="actions_after" src="https://github.com/armadaproject/armada/assets/41909795/48c4ec34-85c6-401c-94cb-073a7b8edc3f">

For comparison, here is what that looked like before:

<img width="291" alt="actions_before" src="https://github.com/armadaproject/armada/assets/41909795/c6e9d224-e02a-4d9b-9917-5c51270fa404">

The implementation is mostly taken from the `JobSetsContainer` component, except that I've adapted it to the functional component style of `JobsTableContainer`.