### PR TITLE
Build the Lookout UI in `lookoutv2`

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -379,6 +379,9 @@ dockers:
       - lookoutv2
       - lookoutingesterv2
     extra_files:
+      - internal/lookout/ui
+      - pkg/api/api.swagger.json
+      - pkg/api/binoculars/api.swagger.json
       - config/lookoutv2/config.yaml
       - config/lookoutingesterv2/config.yaml
     dockerfile: ./build_goreleaser/lookoutv2/Dockerfile

--- a/build/lookoutv2/Dockerfile
+++ b/build/lookoutv2/Dockerfile
@@ -5,7 +5,7 @@ RUN addgroup -S -g 2000 armada && adduser -S -u 1000 armada -G armada
 USER armada
 
 COPY ./lookoutv2 /app/
-
+COPY ./internal/lookout/ui/build/ /app/internal/lookout/ui/build
 COPY ./config/ /app/config/lookoutv2
 
 WORKDIR /app

--- a/build_goreleaser/lookoutv2/Dockerfile
+++ b/build_goreleaser/lookoutv2/Dockerfile
@@ -1,10 +1,27 @@
+ARG NODE_BUILD_IMAGE=node:16.14-buster
+ARG OPENAPI_BUILD_IMAGE=openapitools/openapi-generator-cli:v5.4.0
 ARG BASE_IMAGE=alpine:3.18.3
+
+FROM ${OPENAPI_BUILD_IMAGE} AS OPENAPI
+
+COPY internal/lookout/ui /project/internal/lookout/ui
+COPY pkg/api/*.swagger.json /project/pkg/api/
+COPY pkg/api/binoculars/*.swagger.json /project/pkg/api/binoculars/
+RUN ./project/internal/lookout/ui/openapi.sh
+
+FROM ${NODE_BUILD_IMAGE} AS NODE
+COPY --from=OPENAPI /project/internal/lookout/ui /ui/
+WORKDIR /ui
+RUN yarn install --immutable
+RUN yarn run build
+
 FROM ${BASE_IMAGE}
 RUN addgroup -S -g 2000 armada && adduser -S -u 1000 armada -G armada
 LABEL org.opencontainers.image.title=lookoutv2
 LABEL org.opencontainers.image.description="Lookout V2"
 LABEL org.opencontainers.image.url=https://hub.docker.com/r/gresearchdev/lookoutv2
 USER armada
+COPY --from=NODE /ui/build/ /app/internal/lookout/ui/build
 COPY lookoutv2 /app/
 COPY config/lookoutv2/config.yaml /app/config/lookoutv2/config.yaml
 COPY lookoutingesterv2 /app/


### PR DESCRIPTION
I've checked that `mage builddockers lookoutv2` now builds an image that includes the Lookout UI (which is served by `lookoutv2` on `master`); I have not checked the change to `build/lookoutv2/Dockerfile`, because I'm told that it's unused.