### PR TITLE
Lookout: update React dev proxy to use LookoutV2 port.

### DIFF
--- a/internal/lookout/ui/package.json
+++ b/internal/lookout/ui/package.json
@@ -81,7 +81,7 @@
       "last 1 safari version"
     ]
   },
-  "proxy": "http://localhost:8089",
+  "proxy": "http://localhost:10000",
   "devDependencies": {
     "@types/react-truncate": "^2.3.4",
     "@types/validator": "^13.7.3"


### PR DESCRIPTION
With the removal of Lookout V1 and full adoption of Lookout V2, the "localdev" setup for running Lookout locally for development needs the React developer proxy to be updated to use the Lookout V2 port, otherwise all Lookout rendering fails on local setups.