### PR TITLE
Build and push nuget artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,11 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - name: Setup the latest .NET 7 SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 7.0.x
+
       - name: Set up Go
         uses: actions/setup-go@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,3 +54,42 @@ jobs:
         with:
           name: armada-image-tarballs
           path: /tmp/imgs
+
+  pack-nuget:
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+          cache: false
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: '23.3'
+
+      - name: Create release tag
+        id: create-release-tag
+        run: echo "release_tag=$(git describe --tags --always --dirty --match='v*' 2> /dev/null | sed 's/^v//')" >> $GITHUB_OUTPUT
+
+      - name: Pack dotnet clients
+        env:
+          RELEASE_TAG: ${{ steps.create-release-tag.outputs.release_tag }}
+        run: go run github.com/magefile/mage@v1.14.0 -v download packNuget
+
+      - name: Save nupkg artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: nupkg-artifacts
+          path: |
+            ./bin/client/DotNet/G-Research.Armada.Client.${{ steps.create-release-tag.outputs.release_tag }}.nupkg
+            ./bin/client/DotNet/ArmadaProject.Io.Client.${{ steps.create-release-tag.outputs.release_tag }}.nupkg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,3 +99,26 @@ jobs:
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+
+  push-nuget:
+    name: Push nuget clients
+    needs: validate
+    runs-on: ubuntu-22.04
+    environment: nuget-release
+    steps:
+      - name: Setup the latest .NET 7 SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 7.0.x
+
+      - name: Download artifact
+        run: gh run download ${{ github.event.workflow_run.id }} --repo ${{ github.event.workflow_run.repository.full_name }} --name nupkg-artifacts --dir ./bin/client/DotNet
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Push nuget clients
+        env:
+          TAG: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          VERSION=${TAG#v}
+          dotnet nuget push ./bin/client/DotNet/G-Research.Armada.Client.$VERSION.nupkg ./bin/client/DotNet/ArmadaProject.Io.Client.$VERSION.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json


### PR DESCRIPTION
#### What type of PR is this?
This is an improvement PR
#### What this PR does / why we need it:
This PR add workflow jobs that pack and push nuget artifacts, Armada clients
#### Special notes for your reviewer:
Magefile target that was doing both pack and push (named `PushNuget`), has been refactored to only pack nuget, thus implementing single responsibility principle.

Prerequisites:
- [x] create a protected environment called `nuget-release` with the `NUGET_API_KEY` secret