### PR TITLE
Move the `PreemptingQueueScheduler` test suite to `JobDb`

### DIFF
--- a/internal/scheduler/jobiteration.go
+++ b/internal/scheduler/jobiteration.go
@@ -87,6 +87,7 @@ func (repo *InMemoryJobRepository) GetQueueJobIds(queue string) ([]string, error
 	), nil
 }
 
+// Should only be used in testing.
 func (repo *InMemoryJobRepository) GetExistingJobsByIds(jobIds []string) ([]interfaces.LegacySchedulerJob, error) {
 	repo.mu.Lock()
 	defer repo.mu.Unlock()

--- a/internal/scheduler/jobiteration.go
+++ b/internal/scheduler/jobiteration.go
@@ -70,15 +70,6 @@ func (repo *InMemoryJobRepository) EnqueueMany(jctxs []*schedulercontext.JobSche
 	}
 }
 
-func (repo *InMemoryJobRepository) Enqueue(jctx *schedulercontext.JobSchedulingContext) {
-	repo.mu.Lock()
-	defer repo.mu.Unlock()
-	queue := jctx.Job.GetQueue()
-	repo.jctxsByQueue[queue] = append(repo.jctxsByQueue[queue], jctx)
-	repo.jctxsById[jctx.Job.GetId()] = jctx
-	repo.sortQueue(queue)
-}
-
 // sortQueue sorts jobs in a specified queue by the order in which they should be scheduled.
 func (repo *InMemoryJobRepository) sortQueue(queue string) {
 	slices.SortFunc(repo.jctxsByQueue[queue], func(a, b *schedulercontext.JobSchedulingContext) bool {
@@ -96,7 +87,6 @@ func (repo *InMemoryJobRepository) GetQueueJobIds(queue string) ([]string, error
 	), nil
 }
 
-// Should only be used in testing.
 func (repo *InMemoryJobRepository) GetExistingJobsByIds(jobIds []string) ([]interfaces.LegacySchedulerJob, error) {
 	repo.mu.Lock()
 	defer repo.mu.Unlock()

--- a/internal/scheduler/queue_scheduler_test.go
+++ b/internal/scheduler/queue_scheduler_test.go
@@ -506,7 +506,7 @@ func TestQueueScheduler(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			nodeDb, err := NewNodeDb()
+			nodeDb, err := NewNodeDb(tc.SchedulingConfig)
 			require.NoError(t, err)
 			txn := nodeDb.Txn(true)
 			for _, node := range tc.Nodes {
@@ -702,13 +702,13 @@ func TestQueueScheduler(t *testing.T) {
 	}
 }
 
-func NewNodeDb() (*nodedb.NodeDb, error) {
+func NewNodeDb(config configuration.SchedulingConfig) (*nodedb.NodeDb, error) {
 	nodeDb, err := nodedb.NewNodeDb(
-		testfixtures.TestPriorityClasses,
-		testfixtures.TestMaxExtraNodesToConsider,
-		testfixtures.TestResources,
-		testfixtures.TestIndexedTaints,
-		testfixtures.TestIndexedNodeLabels,
+		config.Preemption.PriorityClasses,
+		config.MaxExtraNodesToConsider,
+		config.IndexedResources,
+		config.IndexedTaints,
+		config.IndexedNodeLabels,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
I'm making these changes in preparation for home-away preemption: on `master`, the `PreemptingQueueScheduler` test suite doesn't update scheduled jobs (e.g., by attaching new runs to them) between scheduling rounds; I want to attach a "scheduled at priority" field to each run for home-away preemption (and this field is going to influence the outcomes of subsequent scheduling rounds), so this will start to matter.