### PR TITLE
Fix "best fit" computation for variable-sized gangs

### DIFF
--- a/internal/scheduler/gang_scheduler.go
+++ b/internal/scheduler/gang_scheduler.go
@@ -71,7 +71,7 @@ func (sch *GangScheduler) updateGangSchedulingContextOnFailure(gctx *schedulerco
 	// Ensure all jobs have an unschedulableReason.
 	// Adding jobs with an unschedulableReason to the context ensures they're correctly accounted for as failed.
 	for _, jctx := range gctx.JobSchedulingContexts {
-		jctx.UnschedulableReason = unschedulableReason
+		jctx.Fail(unschedulableReason)
 	}
 	if _, err := sch.schedulingContext.AddGangSchedulingContext(gctx); err != nil {
 		return err
@@ -161,8 +161,8 @@ func (sch *GangScheduler) trySchedule(ctx *armadacontext.Context, gctx *schedule
 
 	// Try all possible values of nodeUniformityLabel one at a time to find the best fit.
 	bestValue := ""
-	var minMeanScheduledAtPriority float64
-	var i int
+	bestFit := schedulercontext.GangSchedulingFit{}
+	i := 0
 	for value := range nodeUniformityLabelValues {
 		i++
 		if value == "" {
@@ -170,21 +170,19 @@ func (sch *GangScheduler) trySchedule(ctx *armadacontext.Context, gctx *schedule
 		}
 		addNodeSelectorToGctx(gctx, gctx.NodeUniformityLabel, value)
 		txn := sch.nodeDb.Txn(true)
-		if ok, unschedulableReason, err = sch.tryScheduleGangWithTxn(ctx, txn, gctx); err != nil {
+		ok, unschedulableReason, err = sch.tryScheduleGangWithTxn(ctx, txn, gctx)
+		if err != nil {
 			txn.Abort()
 			return
-		} else if ok {
-			meanScheduledAtPriority, ok := meanScheduledAtPriorityFromGctx(gctx)
-			if !ok {
-				txn.Abort()
-				continue
-			}
-			if meanScheduledAtPriority == float64(nodedb.MinPriority) {
+		}
+		if ok {
+			currentFit := gctx.Fit()
+			if currentFit.NumScheduled == gctx.Cardinality() && currentFit.MeanPreemptedAtPriority == float64(nodedb.MinPriority) {
 				// Best possible; no need to keep looking.
 				txn.Commit()
 				return true, "", nil
 			}
-			if bestValue == "" || meanScheduledAtPriority <= minMeanScheduledAtPriority {
+			if bestValue == "" || bestFit.Less(currentFit) {
 				if i == len(nodeUniformityLabelValues) {
 					// Minimal meanScheduledAtPriority and no more options; commit and return.
 					txn.Commit()
@@ -192,7 +190,7 @@ func (sch *GangScheduler) trySchedule(ctx *armadacontext.Context, gctx *schedule
 				}
 				// Record the best value seen so far.
 				bestValue = value
-				minMeanScheduledAtPriority = meanScheduledAtPriority
+				bestFit = currentFit
 			}
 		}
 		txn.Abort()
@@ -216,20 +214,9 @@ func (sch *GangScheduler) tryScheduleGang(ctx *armadacontext.Context, gctx *sche
 	return
 }
 
-func clearNodeBindings(jctx *schedulercontext.JobSchedulingContext) {
-	if jctx.PodSchedulingContext != nil {
-		// Clear any node bindings on failure to schedule.
-		jctx.PodSchedulingContext.NodeId = ""
-	}
-}
-
 func (sch *GangScheduler) tryScheduleGangWithTxn(_ *armadacontext.Context, txn *memdb.Txn, gctx *schedulercontext.GangSchedulingContext) (ok bool, unschedulableReason string, err error) {
 	if ok, err = sch.nodeDb.ScheduleManyWithTxn(txn, gctx.JobSchedulingContexts); err == nil {
 		if !ok {
-			for _, jctx := range gctx.JobSchedulingContexts {
-				clearNodeBindings(jctx)
-			}
-
 			if gctx.Cardinality() > 1 {
 				unschedulableReason = "unable to schedule gang since minimum cardinality not met"
 			} else {
@@ -239,8 +226,7 @@ func (sch *GangScheduler) tryScheduleGangWithTxn(_ *armadacontext.Context, txn *
 			// When a gang schedules successfully, update state for failed jobs if they exist.
 			for _, jctx := range gctx.JobSchedulingContexts {
 				if jctx.ShouldFail {
-					clearNodeBindings(jctx)
-					jctx.UnschedulableReason = "job does not fit on any node"
+					jctx.Fail("job does not fit on any node")
 				}
 			}
 		}
@@ -255,15 +241,4 @@ func addNodeSelectorToGctx(gctx *schedulercontext.GangSchedulingContext, nodeSel
 	for _, jctx := range gctx.JobSchedulingContexts {
 		jctx.AddNodeSelector(nodeSelectorKey, nodeSelectorValue)
 	}
-}
-
-func meanScheduledAtPriorityFromGctx(gctx *schedulercontext.GangSchedulingContext) (float64, bool) {
-	var sum int32
-	for _, jctx := range gctx.JobSchedulingContexts {
-		if jctx.PodSchedulingContext == nil {
-			return 0, false
-		}
-		sum += jctx.PodSchedulingContext.ScheduledAtPriority
-	}
-	return float64(sum) / float64(gctx.Cardinality()), true
 }

--- a/internal/scheduler/gang_scheduler_test.go
+++ b/internal/scheduler/gang_scheduler_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/maps"
 	"golang.org/x/time/rate"
 	"k8s.io/apimachinery/pkg/api/resource"
 
@@ -37,6 +38,9 @@ func TestGangScheduler(t *testing.T) {
 		// Cumulative number of jobs we expect to schedule successfully.
 		// Each index `i` is the expected value when processing gang `i`.
 		ExpectedScheduledJobs []int
+		// If present, assert that gang `i` is scheduled on nodes with node
+		// uniformity label `ExpectedNodeUniformity[i]`.
+		ExpectedNodeUniformity map[int]string
 	}{
 		"simple success": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
@@ -355,6 +359,70 @@ func TestGangScheduler(t *testing.T) {
 			ExpectedScheduledIndices: []int{0},
 			ExpectedScheduledJobs:    []int{4},
 		},
+		"NodeUniformityLabel NumScheduled tiebreak": {
+			SchedulingConfig: testfixtures.WithIndexedNodeLabelsConfig(
+				[]string{"my-cool-node-uniformity"},
+				testfixtures.TestSchedulingConfig(),
+			),
+			Nodes: append(
+				testfixtures.WithLabelsNodes(
+					map[string]string{"my-cool-node-uniformity": "a"},
+					testfixtures.N32CpuNodes(2, testfixtures.TestPriorities),
+				),
+				testfixtures.WithLabelsNodes(
+					map[string]string{"my-cool-node-uniformity": "b"},
+					testfixtures.N32CpuNodes(3, testfixtures.TestPriorities),
+				)...,
+			),
+			Gangs: [][]*jobdb.Job{
+				testfixtures.WithGangAnnotationsAndMinCardinalityJobs(
+					2,
+					testfixtures.WithNodeUniformityLabelAnnotationJobs(
+						"my-cool-node-uniformity",
+						testfixtures.N32Cpu256GiJobs("A", testfixtures.PriorityClass0, 4),
+					),
+				),
+			},
+			ExpectedScheduledIndices: []int{0},
+			ExpectedScheduledJobs:    []int{3},
+			ExpectedNodeUniformity:   map[int]string{0: "b"},
+		},
+		"NodeUniformityLabel PreemptedAtPriority tiebreak": {
+			SchedulingConfig: testfixtures.WithIndexedNodeLabelsConfig(
+				[]string{"my-cool-node-uniformity"},
+				testfixtures.TestSchedulingConfig(),
+			),
+			Nodes: append(
+				testfixtures.WithUsedResourcesNodes(
+					1,
+					schedulerobjects.ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("1")}},
+					testfixtures.WithLabelsNodes(
+						map[string]string{"my-cool-node-uniformity": "a"},
+						testfixtures.N32CpuNodes(2, testfixtures.TestPriorities),
+					),
+				),
+				testfixtures.WithUsedResourcesNodes(
+					0,
+					schedulerobjects.ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("1")}},
+					testfixtures.WithLabelsNodes(
+						map[string]string{"my-cool-node-uniformity": "b"},
+						testfixtures.N32CpuNodes(2, testfixtures.TestPriorities),
+					),
+				)...,
+			),
+			Gangs: [][]*jobdb.Job{
+				testfixtures.WithGangAnnotationsAndMinCardinalityJobs(
+					2,
+					testfixtures.WithNodeUniformityLabelAnnotationJobs(
+						"my-cool-node-uniformity",
+						testfixtures.N32Cpu256GiJobs("A", testfixtures.PriorityClass2, 4),
+					),
+				),
+			},
+			ExpectedScheduledIndices: []int{0},
+			ExpectedScheduledJobs:    []int{2},
+			ExpectedNodeUniformity:   map[int]string{0: "b"},
+		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -440,8 +508,11 @@ func TestGangScheduler(t *testing.T) {
 					if gctx.NodeUniformityLabel != "" {
 						nodeUniformityLabelValues := make(map[string]bool)
 						for _, jctx := range jctxs {
-							require.NotNil(t, jctx.PodSchedulingContext)
-							node := nodesById[jctx.PodSchedulingContext.NodeId]
+							pctx := jctx.PodSchedulingContext
+							if !pctx.IsSuccessful() {
+								continue
+							}
+							node := nodesById[pctx.NodeId]
 							require.NotNil(t, node)
 							value, ok := node.Labels[gctx.NodeUniformityLabel]
 							require.True(t, ok, "gang job scheduled onto node with missing nodeUniformityLabel")
@@ -451,6 +522,10 @@ func TestGangScheduler(t *testing.T) {
 							t, 1, len(nodeUniformityLabelValues),
 							"node uniformity constraint not met: %s", nodeUniformityLabelValues,
 						)
+						if expectedValue, ok := tc.ExpectedNodeUniformity[i]; ok {
+							actualValue := maps.Keys(nodeUniformityLabelValues)[0]
+							require.Equal(t, expectedValue, actualValue)
+						}
 					}
 
 					// Verify any excess jobs that failed have the correct state set

--- a/internal/scheduler/queue_scheduler.go
+++ b/internal/scheduler/queue_scheduler.go
@@ -91,8 +91,7 @@ func (sch *QueueScheduler) Schedule(ctx *armadacontext.Context) (*SchedulerResul
 		} else if ok {
 			// We scheduled the minimum number of gang jobs required.
 			for _, jctx := range gctx.JobSchedulingContexts {
-				pctx := jctx.PodSchedulingContext
-				if pctx != nil && pctx.NodeId != "" {
+				if pctx := jctx.PodSchedulingContext; pctx.IsSuccessful() {
 					scheduledJobs = append(scheduledJobs, jctx.Job)
 					nodeIdByJobId[jctx.JobId] = pctx.NodeId
 				}

--- a/internal/scheduler/submitcheck.go
+++ b/internal/scheduler/submitcheck.go
@@ -240,8 +240,7 @@ func (srv *SubmitChecker) getSchedulingResult(jctxs []*schedulercontext.JobSched
 
 		numSuccessfullyScheduled := 0
 		for _, jctx := range jctxs {
-			pctx := jctx.PodSchedulingContext
-			if pctx != nil && pctx.NodeId != "" {
+			if jctx.PodSchedulingContext.IsSuccessful() {
 				numSuccessfullyScheduled++
 			}
 		}


### PR DESCRIPTION
This PR makes the "best fit" computation in `GangScheduler`'s `trySchedule` method compatible with variable-sized gangs (i.e., gangs that set the annotation `armadaproject.io/gangMinimumCardinality`).