### PR TITLE
[CI-IMPROVEMENT-2] Cache GOCACHE for go unit tests and go integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,9 +56,19 @@ jobs:
 
       - name: Set up Go (no caching)
         uses: actions/setup-go@v4
+        id: setup-go
         with:
           go-version: '1.20'
           cache: false
+
+      - id: cache-info
+        run: echo path=$(go env GOCACHE) >> $GITHUB_OUTPUT
+
+      - name: Setup Cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.cache-info.outputs.path }}
+          key: go-unit-tests-go-${{ steps.setup-go.outputs.go-version }}-mod-${{ hashFiles('go.sum') }}
 
       - name: Setup dependencies
         shell: bash
@@ -113,17 +123,26 @@ jobs:
         run: docker image prune -af
 
       - name: Set up Go (no caching)
+        id: setup-go
         uses: actions/setup-go@v4
         with:
           go-version: '1.20'
           cache: false
 
-      - name: Setup dependencies
-        shell: bash
-        run: go run github.com/magefile/mage@v1.14.0 -v download
+      - id: cache-info
+        run: echo path=$(go env GOCACHE) >> $GITHUB_OUTPUT
 
-      - name: Setup and Run Integration Tests
-        run: go run github.com/magefile/mage@v1.14.0 -v localdev minimal testsuite
+      - name: Setup Cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.cache-info.outputs.path }}
+          key: go-integration-tests-go-${{ steps.setup-go.outputs.go-version }}-mod-${{ hashFiles('go.sum') }}
+
+      - name: Setup Integration Tests
+        run: go run github.com/magefile/mage@v1.14.0 -v localdev minimal
+
+      - name: Run Integration Tests
+        run: go run github.com/magefile/mage@v1.14.0 -v testsuite
 
       - name: Upload JUnit Report Artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
#### What type of PR is this?
This is an improvement PR

#### What this PR does / why we need it:
Second one in a series of PRs for improvements. This one caches GOCACHE for go unit tests and go integration tests, thus decreasing the run time for each job. Obviously, the first run will take the same amount of time (or just slightly more until cache is created and uploaded), but following runs should take less time. Example workflows:

First run: https://github.com/pavlovic-ivan/armada/actions/runs/6970996508/attempts/1
- Unit tests 6m 48s
- Integration tests 12m 7s

Second run: https://github.com/pavlovic-ivan/armada/actions/runs/6970996508
- Unit tests 2m 46s
- Integration tests 7m 17s

#### Notes for maintainers
Overall run time of CI workflow reduced from 12m to 7m with this PR. Further improvements coming in future PRs. Go module cache is omitted on purpose, because it is large (several GB) and is network bound, which means that it would raise our cache quota without any benefits compared to downloading again from the Go proxy.