### PR TITLE
Allow the Lookout server to turn off auto refresh

### DIFF
--- a/internal/lookout/ui/src/App.tsx
+++ b/internal/lookout/ui/src/App.tsx
@@ -73,8 +73,8 @@ type AppProps = {
   v2UpdateJobsService: UpdateJobsService
   v2UpdateJobSetsService: UpdateJobSetsService
   v2CordonService: ICordonService
-  jobSetsAutoRefreshMs: number
-  jobsAutoRefreshMs: number
+  jobSetsAutoRefreshMs: number | undefined
+  jobsAutoRefreshMs: number | undefined
   debugEnabled: boolean
 }
 

--- a/internal/lookout/ui/src/components/job-sets/JobSets.tsx
+++ b/internal/lookout/ui/src/components/job-sets/JobSets.tsx
@@ -30,7 +30,7 @@ interface JobSetsProps {
   onDeselectAllClick: () => void
   onSelectAllClick: () => void
   onCancelJobSetsClick: () => void
-  onToggleAutoRefresh: (autoRefresh: boolean) => void
+  onToggleAutoRefresh: ((autoRefresh: boolean) => void) | undefined
   onReprioritizeJobSetsClick: () => void
   onOrderChange: (newestFirst: boolean) => void
   onActiveOnlyChange: (activeOnly: boolean) => void
@@ -110,9 +110,11 @@ export default function JobSets(props: JobSetsProps) {
               Cancel
             </Button>
           </div>
-          <div className="auto-refresh">
-            <AutoRefreshToggle autoRefresh={props.autoRefresh} onAutoRefreshChange={props.onToggleAutoRefresh} />
-          </div>
+          {props.onToggleAutoRefresh && (
+            <div className="auto-refresh">
+              <AutoRefreshToggle autoRefresh={props.autoRefresh} onAutoRefreshChange={props.onToggleAutoRefresh} />
+            </div>
+          )}
           <div className="refresh-button">
             <RefreshButton isLoading={props.getJobSetsRequestStatus === "Loading"} onClick={props.onRefresh} />
           </div>

--- a/internal/lookout/ui/src/components/lookoutV2/JobsTableActionBar.tsx
+++ b/internal/lookout/ui/src/components/lookoutV2/JobsTableActionBar.tsx
@@ -27,7 +27,7 @@ export interface JobsTableActionBarProps {
   onActiveJobSetsChanged: (newVal: boolean) => void
   onRefresh: () => void
   autoRefresh: boolean
-  onAutoRefreshChange: (autoRefresh: boolean) => void
+  onAutoRefreshChange: ((autoRefresh: boolean) => void) | undefined
   onAddAnnotationColumn: (annotationKey: string) => void
   onRemoveAnnotationColumn: (colId: ColumnId) => void
   onEditAnnotationColumn: (colId: ColumnId, annotationKey: string) => void
@@ -115,7 +115,9 @@ export const JobsTableActionBar = memo(
             </Tooltip>
           </FormGroup>
           <Divider orientation="vertical" />
-          <AutoRefreshToggle autoRefresh={autoRefresh} onAutoRefreshChange={onAutoRefreshChange} />
+          {onAutoRefreshChange && (
+            <AutoRefreshToggle autoRefresh={autoRefresh} onAutoRefreshChange={onAutoRefreshChange} />
+          )}
           <RefreshButton isLoading={isLoading} onClick={onRefresh} />
           <Divider orientation="vertical" />
           <Button variant="text" onClick={onClearFilters} color="secondary">

--- a/internal/lookout/ui/src/containers/JobSetsContainer.tsx
+++ b/internal/lookout/ui/src/containers/JobSetsContainer.tsx
@@ -15,7 +15,7 @@ import { ApiResult, debounced, PropsWithRouter, RequestStatus, selectItem, setSt
 interface JobSetsContainerProps extends PropsWithRouter {
   v2GroupJobsService: IGroupJobsService
   v2UpdateJobSetsService: UpdateJobSetsService
-  jobSetsAutoRefreshMs: number
+  jobSetsAutoRefreshMs: number | undefined
 }
 
 type JobSetsContainerParams = {
@@ -35,14 +35,15 @@ export type JobSetsContainerState = {
 } & JobSetsContainerParams
 
 class JobSetsContainer extends React.Component<JobSetsContainerProps, JobSetsContainerState> {
-  autoRefreshService: IntervalService
+  autoRefreshService: IntervalService | undefined
   localStorageService: JobSetsLocalStorageService
   queryParamsService: JobSetsQueryParamsService
 
   constructor(props: JobSetsContainerProps) {
     super(props)
 
-    this.autoRefreshService = new IntervalService(props.jobSetsAutoRefreshMs)
+    this.autoRefreshService =
+      props.jobSetsAutoRefreshMs === undefined ? undefined : new IntervalService(props.jobSetsAutoRefreshMs)
     this.localStorageService = new JobSetsLocalStorageService()
     this.queryParamsService = new JobSetsQueryParamsService(this.props.router)
 
@@ -93,12 +94,12 @@ class JobSetsContainer extends React.Component<JobSetsContainerProps, JobSetsCon
 
     await this.loadJobSets()
 
-    this.autoRefreshService.registerCallback(this.loadJobSets)
+    this.autoRefreshService?.registerCallback(this.loadJobSets)
     this.tryStartAutoRefreshService()
   }
 
   componentWillUnmount() {
-    this.autoRefreshService.stop()
+    this.autoRefreshService?.stop()
   }
 
   async setQueue(queue: string) {
@@ -216,9 +217,9 @@ class JobSetsContainer extends React.Component<JobSetsContainerProps, JobSetsCon
 
   tryStartAutoRefreshService() {
     if (this.state.autoRefresh) {
-      this.autoRefreshService.start()
+      this.autoRefreshService?.start()
     } else {
-      this.autoRefreshService.stop()
+      this.autoRefreshService?.stop()
     }
   }
 
@@ -327,7 +328,7 @@ class JobSetsContainer extends React.Component<JobSetsContainerProps, JobSetsCon
           onDeselectAllClick={this.deselectAll}
           onSelectAllClick={this.selectAll}
           onCancelJobSetsClick={() => this.openCancelJobSets(true)}
-          onToggleAutoRefresh={this.toggleAutoRefresh}
+          onToggleAutoRefresh={this.autoRefreshService && this.toggleAutoRefresh}
           onReprioritizeJobSetsClick={() => this.openReprioritizeJobSets(true)}
         />
       </>

--- a/internal/lookout/ui/src/containers/lookoutV2/JobsTableContainer.tsx
+++ b/internal/lookout/ui/src/containers/lookoutV2/JobsTableContainer.tsx
@@ -88,7 +88,7 @@ interface JobsTableContainerProps {
   logService: ILogService
   cordonService: ICordonService
   debug: boolean
-  autoRefreshMs: number
+  autoRefreshMs: number | undefined
 }
 
 export type LookoutColumnFilter = {
@@ -183,14 +183,17 @@ export const JobsTableContainer = ({
     initialPrefs.autoRefresh === undefined ? true : initialPrefs.autoRefresh,
   )
 
-  const autoRefreshService = useMemo(() => new IntervalService(autoRefreshMs), [autoRefreshMs])
+  const autoRefreshService = useMemo(
+    () => (autoRefreshMs === undefined ? undefined : new IntervalService(autoRefreshMs)),
+    [autoRefreshMs],
+  )
 
   const onAutoRefreshChange = (autoRefresh: boolean) => {
     setAutoRefresh(autoRefresh)
     if (autoRefresh) {
-      autoRefreshService.start()
+      autoRefreshService?.start()
     } else {
-      autoRefreshService.stop()
+      autoRefreshService?.stop()
     }
   }
 
@@ -370,11 +373,11 @@ export const JobsTableContainer = ({
   }
 
   useEffect(() => {
-    autoRefreshService.registerCallback(onRefresh)
+    autoRefreshService?.registerCallback(onRefresh)
     if (autoRefresh) {
-      autoRefreshService.start()
+      autoRefreshService?.start()
     }
-    return () => autoRefreshService.stop()
+    return () => autoRefreshService?.stop()
   }, [])
 
   const onColumnVisibilityChange = (colIdToToggle: ColumnId) => {
@@ -730,7 +733,7 @@ export const JobsTableContainer = ({
             }}
             onRefresh={onRefresh}
             autoRefresh={autoRefresh}
-            onAutoRefreshChange={onAutoRefreshChange}
+            onAutoRefreshChange={autoRefreshService && onAutoRefreshChange}
             onAddAnnotationColumn={addAnnotationCol}
             onRemoveAnnotationColumn={removeAnnotationCol}
             onEditAnnotationColumn={editAnnotationCol}

--- a/internal/lookout/ui/src/utils.tsx
+++ b/internal/lookout/ui/src/utils.tsx
@@ -12,8 +12,8 @@ interface UIConfig {
   armadaApiBaseUrl: string
   userAnnotationPrefix: string
   binocularsBaseUrlPattern: string
-  jobSetsAutoRefreshMs: number
-  jobsAutoRefreshMs: number
+  jobSetsAutoRefreshMs: number | undefined
+  jobsAutoRefreshMs: number | undefined
   debugEnabled: boolean
   fakeDataEnabled: boolean
   customTitle: string
@@ -39,8 +39,8 @@ export async function getUIConfig(): Promise<UIConfig> {
     armadaApiBaseUrl: "",
     userAnnotationPrefix: "",
     binocularsBaseUrlPattern: "",
-    jobSetsAutoRefreshMs: 15000,
-    jobsAutoRefreshMs: 30000,
+    jobSetsAutoRefreshMs: undefined,
+    jobsAutoRefreshMs: undefined,
     debugEnabled: searchParams.has("debug"),
     fakeDataEnabled: searchParams.has("fakeData"),
     customTitle: "",

--- a/internal/lookoutv2/configuration/types.go
+++ b/internal/lookoutv2/configuration/types.go
@@ -49,6 +49,6 @@ type UIConfig struct {
 	UserAnnotationPrefix     string
 	BinocularsBaseUrlPattern string
 
-	JobSetsAutoRefreshMs int
-	JobsAutoRefreshMs    int
+	JobSetsAutoRefreshMs *int
+	JobsAutoRefreshMs    *int
 }

--- a/internal/lookoutv2/configuration/types.go
+++ b/internal/lookoutv2/configuration/types.go
@@ -49,6 +49,6 @@ type UIConfig struct {
 	UserAnnotationPrefix     string
 	BinocularsBaseUrlPattern string
 
-	JobSetsAutoRefreshMs *int
-	JobsAutoRefreshMs    *int
+	JobSetsAutoRefreshMs int `json:",omitempty"`
+	JobsAutoRefreshMs    int `json:",omitempty"`
 }


### PR DESCRIPTION
If the server leaves out `JobSetsAutoRefreshMs` or `JobsAutoRefreshMs` in the configuration object that it sends to the UI, then the corresponding page disables auto refresh (and hides the toggle).