### PR TITLE
Disable grouping by namespace in the Lookout UI

### DIFF
--- a/internal/lookout/ui/src/utils/jobsTableColumns.tsx
+++ b/internal/lookout/ui/src/utils/jobsTableColumns.tsx
@@ -175,7 +175,7 @@ export const JOB_COLUMNS: JobTableColumn[] = [
     accessor: "namespace",
     displayName: "Namespace",
     additionalOptions: {
-      enableGrouping: true,
+      enableGrouping: false,
       enableColumnFilter: true,
       size: 300,
     },


### PR DESCRIPTION
I optimistically turned on grouping by namespace in #3128, but that was wrong: the `/jobGroups` endpoint assumes that the values it groups by are never null. Instead of making this endpoint handle null, let's do the following:

1. Wait for rows with null `namespace` to drop out of the database at the end of their retention period.
2. Add a `NOT NULL` constraint to the `namespace` column (in recent PostgreSQL versions this can be done without holding an exclusive lock for a long time; see https://dba.stackexchange.com/a/268128).
3. Add indexes that make grouping by namespace fast.
4. Enable grouping by namespace in the Lookout UI.