### PR TITLE
[CI-IMPROVEMENT-4] Speed up unit tests job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,10 +60,6 @@ jobs:
         with:
           cache-prefix: go-unit-tests
 
-      - name: Setup dependencies
-        shell: bash
-        run: go run github.com/magefile/mage@v1.14.0 -v download
-
       - name: Unit Tests
         id: unit_test
         run: go run github.com/magefile/mage@v1.14.0 -v tests


### PR DESCRIPTION
#### What type of PR is this?
This is an improvement PR

#### What this PR does / why we need it:
Fourth one in a series of PRs for improvements. This one removes the "setup dependencies" step from the `go-unit-tests` job. It is not needed, and it speeds up the job run time.

#### Notes for maintainers
Unit tests job run time is reduced.