### PR TITLE
Fix `mage localdev full` and `mage localdevstop` errors

### DIFF
--- a/magefiles/developer.go
+++ b/magefiles/developer.go
@@ -44,6 +44,9 @@ func getComposeFile() string {
 }
 
 func getComponentsList() []string {
+	if os.Getenv("ARMADA_COMPONENTS") == "" {
+		return []string{}
+	}
 	return strings.Split(os.Getenv("ARMADA_COMPONENTS"), ",")
 }
 


### PR DESCRIPTION
This fixes a bug where, if the `ARMADA_COMPONENTS` env var was a zero-length string (or simply unset),  `getComponents()` would return a slice of length 1, where the entry was a zero-length string. This was causing errors when subsequent conditional to see if the generated slice was zero-length wasn't getting triggered, and a list of appropriate components to start/stop wasn't defined correctly.

Fixes #3178