### PR TITLE
[CI-IMPROVEMENT-5] Remove mage 'download' target entirely, shave off 3 minutes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Pack dotnet clients
         env:
           RELEASE_TAG: ${{ steps.create-release-tag.outputs.release_tag }}
-        run: go run github.com/magefile/mage@v1.14.0 -v download packNuget
+        run: go run github.com/magefile/mage@v1.14.0 -v packNuget
 
       - name: Save nupkg artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/go-setup/action.yml
+++ b/.github/workflows/go-setup/action.yml
@@ -7,7 +7,3 @@ runs:
     - uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go }}
-    - name: Setup dependencies
-      shell: bash
-      run: go run github.com/magefile/mage@v1.14.0 download
-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -213,10 +213,6 @@ jobs:
           go-version: ${{ matrix.go }}
           cache: false
 
-      - name: Setup dependencies
-        shell: bash
-        run: go run github.com/magefile/mage@v1.14.0 -v download
-
       # TODO(JayF): Consider moving this into its own job, that runs under a larger set of circumstances
       #             since it's possible for this to fail without any go changes being made.
       - name: Validate no changes in generated proto files

--- a/magefiles/main.go
+++ b/magefiles/main.go
@@ -35,33 +35,6 @@ func BootstrapTools() error {
 	return nil
 }
 
-// Download install the bootstap tools and download mod and make it tidy
-func Download() error {
-	mg.Deps(BootstrapTools)
-	go_test_cmd, err := go_TEST_CMD()
-	if err != nil {
-		return err
-	}
-	if len(go_test_cmd) == 0 {
-		if err = sh.Run("go", "mod", "download"); err != nil {
-			return err
-		}
-		if err = sh.Run("go", "mod", "tidy"); err != nil {
-			return err
-		}
-	} else {
-		cmd := append(go_test_cmd, "go", "mod", "download")
-		if err := dockerRun(cmd...); err != nil {
-			return err
-		}
-		cmd = append(go_test_cmd, "go", "mod", "tidy")
-		if err := dockerRun(cmd...); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 // Check dependent tools are present and the correct version.
 func CheckDeps() error {
 	checks := []struct {
@@ -137,6 +110,7 @@ func HelmDocs() error {
 
 // Generate Protos.
 func Proto() {
+	mg.Deps(BootstrapTools)
 	mg.Deps(BootstrapProto)
 	mg.Deps(protoGenerate)
 }

--- a/magefiles/proto.go
+++ b/magefiles/proto.go
@@ -44,15 +44,20 @@ func protoPrepareThirdPartyProtos() error {
 		},
 	}
 
-	goPath, err := goEnv("GOPATH")
+	goModPath, err := goEnv("GOMODCACHE")
 	if err != nil {
-		return errors.Errorf("error getting GOPATH: %v", err)
+		return errors.Errorf("error getting GOMODCACHE: %v", err)
 	}
-	if goPath == "" {
-		return errors.New("error GOPATH is not set")
+	if goModPath == "" {
+		return errors.New("error GOMODCACHE is not set")
 	}
-	goModPath := filepath.Join(goPath, "pkg", "mod")
+
 	for _, module := range modules {
+		err = goRun("mod", "download", module.name)
+		if err != nil {
+			return err
+		}
+
 		version, err := goModuleVersion(module.name)
 		if err != nil {
 			return err


### PR DESCRIPTION
#### What type of PR is this?
This is an improvement PR

#### What this PR does / why we need it:
Fifth one in a series of PRs for improvements. This one removes the "download" mage target entirely, as it just adds time to the run time of several jobs, when in fact calling BootstrapTools is enough. This step is a preparation for caching the bootstraped tools that will further reduce run time after creating first cached artifact.

#### Notes for maintainers
Several jobs' run time is reduced by ~3 minutes:
- Release Airflow Operator to PYPI > run-python-tests > Run .github/workflows/go-setup. https://github.com/pavlovic-ivan/armada/actions/runs/7129650531/job/19414192610
- Python Client > python-client-tox > Run .github/workflows/go-setup. https://github.com/pavlovic-ivan/armada/actions/runs/7129629723/job/19414126276
- Python Airflow Operator > airflow-tox > Run .github/workflows/go-setup. https://github.com/pavlovic-ivan/armada/actions/runs/7129629716/job/19414126241