### PR TITLE
LookoutV2 Ingester To Treat All Postgres Errors As Retryable By Default

### DIFF
--- a/config/lookoutingesterv2/config.yaml
+++ b/config/lookoutingesterv2/config.yaml
@@ -23,6 +23,5 @@ batchSize: 10000
 batchDuration: 500ms
 minJobSpecCompressionSize: 1024
 userAnnotationPrefix: "armadaproject.io/"
-maxAttempts: 10
 maxBackoff: 60
 useLegacyEventConversion: true

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/golang-lru v1.0.2
 	github.com/instrumenta/kubeval v0.0.0-20190918223246-8d013ec9fc56
-	github.com/jackc/pgerrcode v0.0.0-20201024163028-a0d42d470451
 	github.com/jackc/pgtype v1.13.0
 	github.com/jackc/pgx/v4 v4.17.2 // indirect
 	github.com/jcmturner/gokrb5/v8 v8.4.4

--- a/go.sum
+++ b/go.sum
@@ -485,8 +485,6 @@ github.com/jackc/pgconn v1.9.0/go.mod h1:YctiPyvzfU11JFxoXokUOOKQXQmDMoJL9vJzHH8
 github.com/jackc/pgconn v1.9.1-0.20210724152538-d89c8390a530/go.mod h1:4z2w8XhRbP1hYxkpTuBjTS3ne3J48K83+u0zoyvg2pI=
 github.com/jackc/pgconn v1.13.0 h1:3L1XMNV2Zvca/8BYhzcRFS70Lr0WlDg16Di6SFGAbys=
 github.com/jackc/pgconn v1.13.0/go.mod h1:AnowpAqO4CMIIJNZl2VJp+KrkAZciAkhEl0W0JIobpI=
-github.com/jackc/pgerrcode v0.0.0-20201024163028-a0d42d470451 h1:WAvSpGf7MsFuzAtK4Vk7R4EVe+liW4x83r4oWu0WHKw=
-github.com/jackc/pgerrcode v0.0.0-20201024163028-a0d42d470451/go.mod h1:a/s9Lp5W7n/DD0VrVoyJ00FbP2ytTPDVOivvn2bMlds=
 github.com/jackc/pgio v1.0.0 h1:g12B9UwVnzGhueNavwioyEEpAmqMe1E/BN9ES+8ovkE=
 github.com/jackc/pgio v1.0.0/go.mod h1:oP+2QK2wFfUWgr+gxjoBH9KGBb31Eio69xUb0w5bYf8=
 github.com/jackc/pgmock v0.0.0-20190831213851-13a1b77aafa2/go.mod h1:fGZlG77KXmcq05nJLRkk0+p82V8B8Dw8KN2/V9c/OAE=

--- a/internal/common/armadaerrors/errors.go
+++ b/internal/common/armadaerrors/errors.go
@@ -12,12 +12,11 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"regexp"
 	"strings"
 	"syscall"
 
 	"github.com/apache/pulsar-client-go/pulsar"
-	"github.com/jackc/pgerrcode"
-	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -150,96 +149,6 @@ func (err *ErrCreateResource) Error() string {
 	} else {
 		return fmt.Sprintf("failed to create %s with name %s; %s", err.Type, err.Name, err.Message)
 	}
-}
-
-// retryablePostgresErrors represents set of postgres errors that can be retried. Fundamentally these are all
-// issues with postgres itself, with the network or with authentication
-var retryablePostgresErrors = map[string]bool{
-	// Connection issues
-	pgerrcode.ConnectionException:                           true,
-	pgerrcode.ConnectionDoesNotExist:                        true,
-	pgerrcode.ConnectionFailure:                             true,
-	pgerrcode.SQLClientUnableToEstablishSQLConnection:       true,
-	pgerrcode.SQLServerRejectedEstablishmentOfSQLConnection: true,
-	pgerrcode.TransactionResolutionUnknown:                  true,
-
-	// Authorization issues
-	pgerrcode.InvalidAuthorizationSpecification: true,
-	pgerrcode.InvalidPassword:                   true,
-
-	// Access Rule Violation
-	pgerrcode.InsufficientPrivilege: true,
-
-	// Coding error with the query/schema mismatch
-	pgerrcode.SyntaxErrorOrAccessRuleViolation:   true,
-	pgerrcode.SyntaxError:                        true,
-	pgerrcode.CannotCoerce:                       true,
-	pgerrcode.GroupingError:                      true,
-	pgerrcode.WindowingError:                     true,
-	pgerrcode.InvalidRecursion:                   true,
-	pgerrcode.InvalidForeignKey:                  true,
-	pgerrcode.InvalidName:                        true,
-	pgerrcode.NameTooLong:                        true,
-	pgerrcode.ReservedName:                       true,
-	pgerrcode.DatatypeMismatch:                   true,
-	pgerrcode.IndeterminateDatatype:              true,
-	pgerrcode.CollationMismatch:                  true,
-	pgerrcode.IndeterminateCollation:             true,
-	pgerrcode.WrongObjectType:                    true,
-	pgerrcode.GeneratedAlways:                    true,
-	pgerrcode.UndefinedColumn:                    true,
-	pgerrcode.UndefinedFunction:                  true,
-	pgerrcode.UndefinedTable:                     true,
-	pgerrcode.UndefinedParameter:                 true,
-	pgerrcode.UndefinedObject:                    true,
-	pgerrcode.DuplicateColumn:                    true,
-	pgerrcode.DuplicateCursor:                    true,
-	pgerrcode.DuplicateDatabase:                  true,
-	pgerrcode.DuplicateFunction:                  true,
-	pgerrcode.DuplicatePreparedStatement:         true,
-	pgerrcode.DuplicateSchema:                    true,
-	pgerrcode.DuplicateTable:                     true,
-	pgerrcode.DuplicateAlias:                     true,
-	pgerrcode.DuplicateObject:                    true,
-	pgerrcode.AmbiguousColumn:                    true,
-	pgerrcode.AmbiguousFunction:                  true,
-	pgerrcode.AmbiguousParameter:                 true,
-	pgerrcode.AmbiguousAlias:                     true,
-	pgerrcode.InvalidColumnReference:             true,
-	pgerrcode.InvalidColumnDefinition:            true,
-	pgerrcode.InvalidCursorDefinition:            true,
-	pgerrcode.InvalidDatabaseDefinition:          true,
-	pgerrcode.InvalidFunctionDefinition:          true,
-	pgerrcode.InvalidPreparedStatementDefinition: true,
-	pgerrcode.InvalidSchemaDefinition:            true,
-	pgerrcode.InvalidTableDefinition:             true,
-	pgerrcode.InvalidObjectDefinition:            true,
-
-	// Resource issues
-	pgerrcode.InsufficientResources:      true,
-	pgerrcode.DiskFull:                   true,
-	pgerrcode.OutOfMemory:                true,
-	pgerrcode.TooManyConnections:         true,
-	pgerrcode.ConfigurationLimitExceeded: true,
-
-	// Operator issues
-	pgerrcode.OperatorIntervention: true,
-	pgerrcode.QueryCanceled:        true,
-	pgerrcode.AdminShutdown:        true,
-	pgerrcode.CrashShutdown:        true,
-	pgerrcode.CannotConnectNow:     true,
-	pgerrcode.DatabaseDropped:      true,
-
-	// External errors
-	pgerrcode.SystemError:   true,
-	pgerrcode.IOError:       true,
-	pgerrcode.UndefinedFile: true,
-	pgerrcode.DuplicateFile: true,
-
-	// Internal Errors
-	pgerrcode.InternalError:  true,
-	pgerrcode.DataCorrupted:  true,
-	pgerrcode.IndexCorrupted: true,
 }
 
 // CodeFromError maps error types to gRPC return codes.
@@ -476,27 +385,21 @@ func StreamServerInterceptor(maxErrorSize uint) grpc.StreamServerInterceptor {
 	}
 }
 
-func IsRetryablePostgresError(err error) bool {
+func IsRetryablePostgresError(err error, fatalErrors []*regexp.Regexp) bool {
 	// Return immediately on nil.
 	if err == nil {
 		return false
 	}
 
 	// PGX will sometimes wrap the underlying error
-	cause := unwrapOrOriginal(err)
-
-	if err, ok := cause.(*pgconn.PgError); ok {
-		_, ok := retryablePostgresErrors[err.Code]
-		return ok
+	original := err.Error()
+	cause := unwrapOrOriginal(err).Error()
+	for _, r := range fatalErrors {
+		if r.MatchString(original) || r.MatchString(cause) {
+			return false
+		}
 	}
-
-	// This is quite nasty: the connectError reported by pgx isn't exported so instead we use a string match
-	if strings.Contains(err.Error(), "failed to connect") {
-		return true
-	}
-
-	// Check to see if we have a wrapped network error
-	return IsNetworkError(cause)
+	return true
 }
 
 func unwrapOrOriginal(err error) error {

--- a/internal/lookoutingesterv2/benchmark/benchmark.go
+++ b/internal/lookoutingesterv2/benchmark/benchmark.go
@@ -49,7 +49,7 @@ func benchmarkSubmissions1000(b *testing.B, config configuration.LookoutIngester
 		UserAnnotationsToCreate: createUserAnnotationInstructions(10*n, jobIds),
 	}
 	withDbBenchmark(b, config, func(b *testing.B, db *pgxpool.Pool) {
-		ldb := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 2, 10)
+		ldb := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 		b.StartTimer()
 		err := ldb.Store(armadacontext.TODO(), instructions)
 		if err != nil {
@@ -67,7 +67,7 @@ func benchmarkSubmissions10000(b *testing.B, config configuration.LookoutIngeste
 		UserAnnotationsToCreate: createUserAnnotationInstructions(10*n, jobIds),
 	}
 	withDbBenchmark(b, config, func(b *testing.B, db *pgxpool.Pool) {
-		ldb := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 2, 10)
+		ldb := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 		b.StartTimer()
 		err := ldb.Store(armadacontext.TODO(), instructions)
 		if err != nil {
@@ -98,7 +98,7 @@ func benchmarkUpdates1000(b *testing.B, config configuration.LookoutIngesterV2Co
 	}
 
 	withDbBenchmark(b, config, func(b *testing.B, db *pgxpool.Pool) {
-		ldb := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 2, 10)
+		ldb := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 		err := ldb.Store(armadacontext.TODO(), initialInstructions)
 		if err != nil {
 			panic(err)
@@ -133,7 +133,7 @@ func benchmarkUpdates10000(b *testing.B, config configuration.LookoutIngesterV2C
 	}
 
 	withDbBenchmark(b, config, func(b *testing.B, db *pgxpool.Pool) {
-		ldb := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 2, 10)
+		ldb := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 		err := ldb.Store(armadacontext.TODO(), initialInstructions)
 		if err != nil {
 			panic(err)

--- a/internal/lookoutingesterv2/benchmark/benchmark.go
+++ b/internal/lookoutingesterv2/benchmark/benchmark.go
@@ -49,7 +49,7 @@ func benchmarkSubmissions1000(b *testing.B, config configuration.LookoutIngester
 		UserAnnotationsToCreate: createUserAnnotationInstructions(10*n, jobIds),
 	}
 	withDbBenchmark(b, config, func(b *testing.B, db *pgxpool.Pool) {
-		ldb := lookoutdb.NewLookoutDb(db, metrics.Get(), 2, 10)
+		ldb := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 2, 10)
 		b.StartTimer()
 		err := ldb.Store(armadacontext.TODO(), instructions)
 		if err != nil {
@@ -67,7 +67,7 @@ func benchmarkSubmissions10000(b *testing.B, config configuration.LookoutIngeste
 		UserAnnotationsToCreate: createUserAnnotationInstructions(10*n, jobIds),
 	}
 	withDbBenchmark(b, config, func(b *testing.B, db *pgxpool.Pool) {
-		ldb := lookoutdb.NewLookoutDb(db, metrics.Get(), 2, 10)
+		ldb := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 2, 10)
 		b.StartTimer()
 		err := ldb.Store(armadacontext.TODO(), instructions)
 		if err != nil {
@@ -98,7 +98,7 @@ func benchmarkUpdates1000(b *testing.B, config configuration.LookoutIngesterV2Co
 	}
 
 	withDbBenchmark(b, config, func(b *testing.B, db *pgxpool.Pool) {
-		ldb := lookoutdb.NewLookoutDb(db, metrics.Get(), 2, 10)
+		ldb := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 2, 10)
 		err := ldb.Store(armadacontext.TODO(), initialInstructions)
 		if err != nil {
 			panic(err)
@@ -133,7 +133,7 @@ func benchmarkUpdates10000(b *testing.B, config configuration.LookoutIngesterV2C
 	}
 
 	withDbBenchmark(b, config, func(b *testing.B, db *pgxpool.Pool) {
-		ldb := lookoutdb.NewLookoutDb(db, metrics.Get(), 2, 10)
+		ldb := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 2, 10)
 		err := ldb.Store(armadacontext.TODO(), initialInstructions)
 		if err != nil {
 			panic(err)

--- a/internal/lookoutingesterv2/configuration/types.go
+++ b/internal/lookoutingesterv2/configuration/types.go
@@ -39,4 +39,6 @@ type LookoutIngesterV2Configuration struct {
 	UseLegacyEventConversion bool
 	// If non-nil, net/http/pprof endpoints are exposed on localhost on this port.
 	PprofPort *uint16
+	// List of Regexes which will identify fatal errors when inserting into postgres
+	FatalInsertionErrors []string
 }

--- a/internal/lookoutingesterv2/configuration/types.go
+++ b/internal/lookoutingesterv2/configuration/types.go
@@ -28,9 +28,6 @@ type LookoutIngesterV2Configuration struct {
 	// User annotations have a common prefix to avoid clashes with other annotations.  This prefix will be stripped from
 	// The annotation before storing in the db
 	UserAnnotationPrefix string
-	// Maximum number of attempts the ingester will try to store batches of data in the database
-	// It will give up after this number is reached
-	MaxAttempts int
 	// Between each attempt to store data in the database, there is an exponential backoff (starting out as 1s).
 	// MaxBackoff caps this backoff to whatever it is specified (in seconds)
 	MaxBackoff int

--- a/internal/lookoutingesterv2/ingester.go
+++ b/internal/lookoutingesterv2/ingester.go
@@ -42,7 +42,7 @@ func Run(config *configuration.LookoutIngesterV2Configuration) {
 		fatalRegexes[i] = rgx
 	}
 
-	lookoutDb := lookoutdb.NewLookoutDb(db, fatalRegexes, m, config.MaxAttempts, config.MaxBackoff)
+	lookoutDb := lookoutdb.NewLookoutDb(db, fatalRegexes, m, config.MaxBackoff)
 
 	compressor, err := compress.NewZlibCompressor(config.MinJobSpecCompressionSize)
 	if err != nil {

--- a/internal/lookoutingesterv2/ingester.go
+++ b/internal/lookoutingesterv2/ingester.go
@@ -1,6 +1,8 @@
 package lookoutingesterv2
 
 import (
+	"regexp"
+
 	"github.com/apache/pulsar-client-go/pulsar"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -29,7 +31,18 @@ func Run(config *configuration.LookoutIngesterV2Configuration) {
 	if err != nil {
 		panic(errors.WithMessage(err, "Error opening connection to postgres"))
 	}
-	lookoutDb := lookoutdb.NewLookoutDb(db, m, config.MaxAttempts, config.MaxBackoff)
+
+	fatalRegexes := make([]*regexp.Regexp, len(config.FatalInsertionErrors))
+	for i, str := range config.FatalInsertionErrors {
+		rgx, err := regexp.Compile(str)
+		if err != nil {
+			log.Errorf("Error compiling regex %s", str)
+			panic(err)
+		}
+		fatalRegexes[i] = rgx
+	}
+
+	lookoutDb := lookoutdb.NewLookoutDb(db, fatalRegexes, m, config.MaxAttempts, config.MaxBackoff)
 
 	compressor, err := compress.NewZlibCompressor(config.MinJobSpecCompressionSize)
 	if err != nil {

--- a/internal/lookoutingesterv2/instructions/instructions.go
+++ b/internal/lookoutingesterv2/instructions/instructions.go
@@ -29,6 +29,8 @@ const (
 	maxQueueLen         = 512
 	maxOwnerLen         = 512
 	maxJobSetLen        = 1024
+	maxAnnotationKeyLen = 1024
+	maxAnnotationValLen = 1024
 	maxPriorityClassLen = 63
 	maxClusterLen       = 512
 	maxNodeLen          = 512
@@ -227,8 +229,8 @@ func extractAnnotations(jobId string, queue string, jobset string, jobAnnotation
 			}
 			annotations = append(annotations, &model.CreateUserAnnotationInstruction{
 				JobId:  jobId,
-				Key:    k,
-				Value:  v,
+				Key:    util.Truncate(k, maxAnnotationKeyLen),
+				Value:  util.Truncate(v, maxAnnotationValLen),
 				Queue:  queue,
 				Jobset: jobset,
 			})

--- a/internal/lookoutingesterv2/lookoutdb/insertion.go
+++ b/internal/lookoutingesterv2/lookoutdb/insertion.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/armadaproject/armada/internal/common/armadacontext"
@@ -22,16 +21,14 @@ import (
 type LookoutDb struct {
 	db          *pgxpool.Pool
 	metrics     *metrics.Metrics
-	maxAttempts int
 	maxBackoff  int
 	fatalErrors []*regexp.Regexp
 }
 
-func NewLookoutDb(db *pgxpool.Pool, fatalErrors []*regexp.Regexp, metrics *metrics.Metrics, maxAttempts int, maxBackoff int) *LookoutDb {
+func NewLookoutDb(db *pgxpool.Pool, fatalErrors []*regexp.Regexp, metrics *metrics.Metrics, maxBackoff int) *LookoutDb {
 	return &LookoutDb{
 		db:          db,
 		metrics:     metrics,
-		maxAttempts: maxAttempts,
 		maxBackoff:  maxBackoff,
 		fatalErrors: fatalErrors,
 	}
@@ -930,9 +927,7 @@ func (l *LookoutDb) withDatabaseRetryInsert(executeDb func() error) error {
 func (l *LookoutDb) withDatabaseRetryQuery(executeDb func() (interface{}, error)) (interface{}, error) {
 	// TODO: arguably this should come from config
 	backOff := 1
-	numRetries := 0
-	var err error = nil
-	for attempt := 0; attempt < l.maxAttempts; attempt++ {
+	for {
 		res, err := executeDb()
 
 		if err == nil {
@@ -941,7 +936,6 @@ func (l *LookoutDb) withDatabaseRetryQuery(executeDb func() (interface{}, error)
 
 		if armadaerrors.IsRetryablePostgresError(err, l.fatalErrors) {
 			backOff = min(2*backOff, l.maxBackoff)
-			numRetries++
 			log.WithError(err).Warnf("Retryable error encountered executing sql, will wait for %d seconds before retrying.", backOff)
 			time.Sleep(time.Duration(backOff) * time.Second)
 		} else {
@@ -949,12 +943,6 @@ func (l *LookoutDb) withDatabaseRetryQuery(executeDb func() (interface{}, error)
 			return nil, err
 		}
 	}
-
-	// If we get to here then we've got an error we can't handle.  Panic
-	panic(errors.WithStack(&armadaerrors.ErrMaxRetriesExceeded{
-		Message:   fmt.Sprintf("Gave up running database query after %d retries", l.maxAttempts),
-		LastError: err,
-	}))
 }
 
 func min(a int, b int) int {

--- a/internal/lookoutingesterv2/lookoutdb/insertion_test.go
+++ b/internal/lookoutingesterv2/lookoutdb/insertion_test.go
@@ -200,7 +200,7 @@ var expectedUserAnnotation = UserAnnotationRow{
 
 func TestCreateJobsBatch(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		ldb := NewLookoutDb(db, m, 2, 10)
+		ldb := NewLookoutDb(db, nil, m, 2, 10)
 		// Insert
 		err := ldb.CreateJobsBatch(armadacontext.Background(), defaultInstructionSet().JobsToCreate)
 		assert.Nil(t, err)
@@ -229,7 +229,7 @@ func TestCreateJobsBatch(t *testing.T) {
 
 func TestUpdateJobsBatch(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		ldb := NewLookoutDb(db, m, 2, 10)
+		ldb := NewLookoutDb(db, nil, m, 2, 10)
 		// Insert
 		err := ldb.CreateJobsBatch(armadacontext.Background(), defaultInstructionSet().JobsToCreate)
 		assert.Nil(t, err)
@@ -264,7 +264,7 @@ func TestUpdateJobsBatch(t *testing.T) {
 
 func TestUpdateJobsScalar(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		ldb := NewLookoutDb(db, m, 2, 10)
+		ldb := NewLookoutDb(db, nil, m, 2, 10)
 		// Insert
 		err := ldb.CreateJobsBatch(armadacontext.Background(), defaultInstructionSet().JobsToCreate)
 		assert.Nil(t, err)
@@ -396,7 +396,7 @@ func TestUpdateJobsWithTerminal(t *testing.T) {
 			LatestRunId:               pointer.String(runIdString),
 		}}
 
-		ldb := NewLookoutDb(db, m, 2, 10)
+		ldb := NewLookoutDb(db, nil, m, 2, 10)
 
 		// Insert
 		ldb.CreateJobs(armadacontext.Background(), initial)
@@ -425,7 +425,7 @@ func TestUpdateJobsWithTerminal(t *testing.T) {
 
 func TestCreateJobsScalar(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		ldb := NewLookoutDb(db, m, 2, 10)
+		ldb := NewLookoutDb(db, nil, m, 2, 10)
 		// Simple create
 		ldb.CreateJobsScalar(armadacontext.Background(), defaultInstructionSet().JobsToCreate)
 		job := getJob(t, db, jobIdString)
@@ -452,7 +452,7 @@ func TestCreateJobsScalar(t *testing.T) {
 
 func TestCreateJobRunsBatch(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		ldb := NewLookoutDb(db, m, 2, 10)
+		ldb := NewLookoutDb(db, nil, m, 2, 10)
 		// Need to make sure we have a job, so we can satisfy PK
 		err := ldb.CreateJobsBatch(armadacontext.Background(), defaultInstructionSet().JobsToCreate)
 		assert.Nil(t, err)
@@ -485,7 +485,7 @@ func TestCreateJobRunsBatch(t *testing.T) {
 
 func TestCreateJobRunsScalar(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		ldb := NewLookoutDb(db, m, 2, 10)
+		ldb := NewLookoutDb(db, nil, m, 2, 10)
 		// Need to make sure we have a job, so we can satisfy PK
 		err := ldb.CreateJobsBatch(armadacontext.Background(), defaultInstructionSet().JobsToCreate)
 		assert.Nil(t, err)
@@ -516,7 +516,7 @@ func TestCreateJobRunsScalar(t *testing.T) {
 
 func TestUpdateJobRunsBatch(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		ldb := NewLookoutDb(db, m, 2, 10)
+		ldb := NewLookoutDb(db, nil, m, 2, 10)
 		// Need to make sure we have a job and run
 		err := ldb.CreateJobsBatch(armadacontext.Background(), defaultInstructionSet().JobsToCreate)
 		assert.Nil(t, err)
@@ -555,7 +555,7 @@ func TestUpdateJobRunsBatch(t *testing.T) {
 
 func TestUpdateJobRunsScalar(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		ldb := NewLookoutDb(db, m, 2, 10)
+		ldb := NewLookoutDb(db, nil, m, 2, 10)
 		// Need to make sure we have a job and run
 		err := ldb.CreateJobsBatch(armadacontext.Background(), defaultInstructionSet().JobsToCreate)
 		assert.Nil(t, err)
@@ -593,7 +593,7 @@ func TestUpdateJobRunsScalar(t *testing.T) {
 
 func TestCreateUserAnnotationsBatch(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		ldb := NewLookoutDb(db, m, 2, 10)
+		ldb := NewLookoutDb(db, nil, m, 2, 10)
 		// Need to make sure we have a job
 		err := ldb.CreateJobsBatch(armadacontext.Background(), defaultInstructionSet().JobsToCreate)
 		assert.Nil(t, err)
@@ -626,7 +626,7 @@ func TestCreateUserAnnotationsBatch(t *testing.T) {
 
 func TestStoreWithEmptyInstructionSet(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		ldb := NewLookoutDb(db, m, 2, 10)
+		ldb := NewLookoutDb(db, nil, m, 2, 10)
 		err := ldb.Store(armadacontext.Background(), &model.InstructionSet{
 			MessageIds: []pulsar.MessageID{pulsarutils.NewMessageId(1)},
 		})
@@ -641,7 +641,7 @@ func TestStoreWithEmptyInstructionSet(t *testing.T) {
 
 func TestCreateUserAnnotationsScalar(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		ldb := NewLookoutDb(db, m, 2, 10)
+		ldb := NewLookoutDb(db, nil, m, 2, 10)
 		// Need to make sure we have a job
 		err := ldb.CreateJobsBatch(armadacontext.Background(), defaultInstructionSet().JobsToCreate)
 		assert.Nil(t, err)
@@ -672,7 +672,7 @@ func TestCreateUserAnnotationsScalar(t *testing.T) {
 
 func TestStore(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		ldb := NewLookoutDb(db, m, 2, 10)
+		ldb := NewLookoutDb(db, nil, m, 2, 10)
 		// Do the update
 		err := ldb.Store(armadacontext.Background(), defaultInstructionSet())
 		assert.NoError(t, err)
@@ -841,7 +841,7 @@ func TestStoreNullValue(t *testing.T) {
 		instructions.JobsToCreate[0].JobProto = jobProto
 		instructions.JobRunsToUpdate[0].Error = errorMsg
 
-		ldb := NewLookoutDb(db, m, 2, 10)
+		ldb := NewLookoutDb(db, nil, m, 2, 10)
 		// Do the update
 		err := ldb.Store(armadacontext.Background(), instructions)
 		assert.NoError(t, err)
@@ -858,7 +858,7 @@ func TestStoreNullValue(t *testing.T) {
 
 func TestStoreEventsForAlreadyTerminalJobs(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		ldb := NewLookoutDb(db, m, 2, 10)
+		ldb := NewLookoutDb(db, nil, m, 2, 10)
 
 		baseInstructions := &model.InstructionSet{
 			JobsToCreate: []*model.CreateJobInstruction{

--- a/internal/lookoutingesterv2/lookoutdb/insertion_test.go
+++ b/internal/lookoutingesterv2/lookoutdb/insertion_test.go
@@ -200,7 +200,7 @@ var expectedUserAnnotation = UserAnnotationRow{
 
 func TestCreateJobsBatch(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		ldb := NewLookoutDb(db, nil, m, 2, 10)
+		ldb := NewLookoutDb(db, nil, m, 10)
 		// Insert
 		err := ldb.CreateJobsBatch(armadacontext.Background(), defaultInstructionSet().JobsToCreate)
 		assert.Nil(t, err)
@@ -229,7 +229,7 @@ func TestCreateJobsBatch(t *testing.T) {
 
 func TestUpdateJobsBatch(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		ldb := NewLookoutDb(db, nil, m, 2, 10)
+		ldb := NewLookoutDb(db, nil, m, 10)
 		// Insert
 		err := ldb.CreateJobsBatch(armadacontext.Background(), defaultInstructionSet().JobsToCreate)
 		assert.Nil(t, err)
@@ -264,7 +264,7 @@ func TestUpdateJobsBatch(t *testing.T) {
 
 func TestUpdateJobsScalar(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		ldb := NewLookoutDb(db, nil, m, 2, 10)
+		ldb := NewLookoutDb(db, nil, m, 10)
 		// Insert
 		err := ldb.CreateJobsBatch(armadacontext.Background(), defaultInstructionSet().JobsToCreate)
 		assert.Nil(t, err)
@@ -396,7 +396,7 @@ func TestUpdateJobsWithTerminal(t *testing.T) {
 			LatestRunId:               pointer.String(runIdString),
 		}}
 
-		ldb := NewLookoutDb(db, nil, m, 2, 10)
+		ldb := NewLookoutDb(db, nil, m, 10)
 
 		// Insert
 		ldb.CreateJobs(armadacontext.Background(), initial)
@@ -425,7 +425,7 @@ func TestUpdateJobsWithTerminal(t *testing.T) {
 
 func TestCreateJobsScalar(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		ldb := NewLookoutDb(db, nil, m, 2, 10)
+		ldb := NewLookoutDb(db, nil, m, 10)
 		// Simple create
 		ldb.CreateJobsScalar(armadacontext.Background(), defaultInstructionSet().JobsToCreate)
 		job := getJob(t, db, jobIdString)
@@ -452,7 +452,7 @@ func TestCreateJobsScalar(t *testing.T) {
 
 func TestCreateJobRunsBatch(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		ldb := NewLookoutDb(db, nil, m, 2, 10)
+		ldb := NewLookoutDb(db, nil, m, 10)
 		// Need to make sure we have a job, so we can satisfy PK
 		err := ldb.CreateJobsBatch(armadacontext.Background(), defaultInstructionSet().JobsToCreate)
 		assert.Nil(t, err)
@@ -485,7 +485,7 @@ func TestCreateJobRunsBatch(t *testing.T) {
 
 func TestCreateJobRunsScalar(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		ldb := NewLookoutDb(db, nil, m, 2, 10)
+		ldb := NewLookoutDb(db, nil, m, 10)
 		// Need to make sure we have a job, so we can satisfy PK
 		err := ldb.CreateJobsBatch(armadacontext.Background(), defaultInstructionSet().JobsToCreate)
 		assert.Nil(t, err)
@@ -516,7 +516,7 @@ func TestCreateJobRunsScalar(t *testing.T) {
 
 func TestUpdateJobRunsBatch(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		ldb := NewLookoutDb(db, nil, m, 2, 10)
+		ldb := NewLookoutDb(db, nil, m, 10)
 		// Need to make sure we have a job and run
 		err := ldb.CreateJobsBatch(armadacontext.Background(), defaultInstructionSet().JobsToCreate)
 		assert.Nil(t, err)
@@ -555,7 +555,7 @@ func TestUpdateJobRunsBatch(t *testing.T) {
 
 func TestUpdateJobRunsScalar(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		ldb := NewLookoutDb(db, nil, m, 2, 10)
+		ldb := NewLookoutDb(db, nil, m, 10)
 		// Need to make sure we have a job and run
 		err := ldb.CreateJobsBatch(armadacontext.Background(), defaultInstructionSet().JobsToCreate)
 		assert.Nil(t, err)
@@ -593,7 +593,7 @@ func TestUpdateJobRunsScalar(t *testing.T) {
 
 func TestCreateUserAnnotationsBatch(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		ldb := NewLookoutDb(db, nil, m, 2, 10)
+		ldb := NewLookoutDb(db, nil, m, 10)
 		// Need to make sure we have a job
 		err := ldb.CreateJobsBatch(armadacontext.Background(), defaultInstructionSet().JobsToCreate)
 		assert.Nil(t, err)
@@ -626,7 +626,7 @@ func TestCreateUserAnnotationsBatch(t *testing.T) {
 
 func TestStoreWithEmptyInstructionSet(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		ldb := NewLookoutDb(db, nil, m, 2, 10)
+		ldb := NewLookoutDb(db, nil, m, 10)
 		err := ldb.Store(armadacontext.Background(), &model.InstructionSet{
 			MessageIds: []pulsar.MessageID{pulsarutils.NewMessageId(1)},
 		})
@@ -641,7 +641,7 @@ func TestStoreWithEmptyInstructionSet(t *testing.T) {
 
 func TestCreateUserAnnotationsScalar(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		ldb := NewLookoutDb(db, nil, m, 2, 10)
+		ldb := NewLookoutDb(db, nil, m, 10)
 		// Need to make sure we have a job
 		err := ldb.CreateJobsBatch(armadacontext.Background(), defaultInstructionSet().JobsToCreate)
 		assert.Nil(t, err)
@@ -672,7 +672,7 @@ func TestCreateUserAnnotationsScalar(t *testing.T) {
 
 func TestStore(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		ldb := NewLookoutDb(db, nil, m, 2, 10)
+		ldb := NewLookoutDb(db, nil, m, 10)
 		// Do the update
 		err := ldb.Store(armadacontext.Background(), defaultInstructionSet())
 		assert.NoError(t, err)
@@ -841,7 +841,7 @@ func TestStoreNullValue(t *testing.T) {
 		instructions.JobsToCreate[0].JobProto = jobProto
 		instructions.JobRunsToUpdate[0].Error = errorMsg
 
-		ldb := NewLookoutDb(db, nil, m, 2, 10)
+		ldb := NewLookoutDb(db, nil, m, 10)
 		// Do the update
 		err := ldb.Store(armadacontext.Background(), instructions)
 		assert.NoError(t, err)
@@ -858,7 +858,7 @@ func TestStoreNullValue(t *testing.T) {
 
 func TestStoreEventsForAlreadyTerminalJobs(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		ldb := NewLookoutDb(db, nil, m, 2, 10)
+		ldb := NewLookoutDb(db, nil, m, 10)
 
 		baseInstructions := &model.InstructionSet{
 			JobsToCreate: []*model.CreateJobInstruction{

--- a/internal/lookoutingesterv2/lookoutdb/insertion_test.go
+++ b/internal/lookoutingesterv2/lookoutdb/insertion_test.go
@@ -2,6 +2,7 @@ package lookoutdb
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 	"testing"
 	"time"
@@ -47,6 +48,7 @@ var (
 	updateTime, _   = time.Parse("2006-01-02T15:04:05.000Z", "2022-03-01T15:04:06.000Z")
 	startTime, _    = time.Parse("2006-01-02T15:04:05.000Z", "2022-03-01T15:04:07.000Z")
 	finishedTime, _ = time.Parse("2006-01-02T15:04:05.000Z", "2022-03-01T15:04:08.000Z")
+	fatalErrors     = []*regexp.Regexp{regexp.MustCompile("SQLSTATE 22001")}
 )
 
 // An invalid job id that exceeds th varchar count
@@ -200,7 +202,7 @@ var expectedUserAnnotation = UserAnnotationRow{
 
 func TestCreateJobsBatch(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		ldb := NewLookoutDb(db, nil, m, 10)
+		ldb := NewLookoutDb(db, fatalErrors, m, 10)
 		// Insert
 		err := ldb.CreateJobsBatch(armadacontext.Background(), defaultInstructionSet().JobsToCreate)
 		assert.Nil(t, err)
@@ -229,7 +231,7 @@ func TestCreateJobsBatch(t *testing.T) {
 
 func TestUpdateJobsBatch(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		ldb := NewLookoutDb(db, nil, m, 10)
+		ldb := NewLookoutDb(db, fatalErrors, m, 10)
 		// Insert
 		err := ldb.CreateJobsBatch(armadacontext.Background(), defaultInstructionSet().JobsToCreate)
 		assert.Nil(t, err)
@@ -264,7 +266,7 @@ func TestUpdateJobsBatch(t *testing.T) {
 
 func TestUpdateJobsScalar(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		ldb := NewLookoutDb(db, nil, m, 10)
+		ldb := NewLookoutDb(db, fatalErrors, m, 10)
 		// Insert
 		err := ldb.CreateJobsBatch(armadacontext.Background(), defaultInstructionSet().JobsToCreate)
 		assert.Nil(t, err)
@@ -396,7 +398,7 @@ func TestUpdateJobsWithTerminal(t *testing.T) {
 			LatestRunId:               pointer.String(runIdString),
 		}}
 
-		ldb := NewLookoutDb(db, nil, m, 10)
+		ldb := NewLookoutDb(db, fatalErrors, m, 10)
 
 		// Insert
 		ldb.CreateJobs(armadacontext.Background(), initial)
@@ -425,7 +427,7 @@ func TestUpdateJobsWithTerminal(t *testing.T) {
 
 func TestCreateJobsScalar(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		ldb := NewLookoutDb(db, nil, m, 10)
+		ldb := NewLookoutDb(db, fatalErrors, m, 10)
 		// Simple create
 		ldb.CreateJobsScalar(armadacontext.Background(), defaultInstructionSet().JobsToCreate)
 		job := getJob(t, db, jobIdString)
@@ -452,7 +454,7 @@ func TestCreateJobsScalar(t *testing.T) {
 
 func TestCreateJobRunsBatch(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		ldb := NewLookoutDb(db, nil, m, 10)
+		ldb := NewLookoutDb(db, fatalErrors, m, 10)
 		// Need to make sure we have a job, so we can satisfy PK
 		err := ldb.CreateJobsBatch(armadacontext.Background(), defaultInstructionSet().JobsToCreate)
 		assert.Nil(t, err)
@@ -485,7 +487,7 @@ func TestCreateJobRunsBatch(t *testing.T) {
 
 func TestCreateJobRunsScalar(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		ldb := NewLookoutDb(db, nil, m, 10)
+		ldb := NewLookoutDb(db, fatalErrors, m, 10)
 		// Need to make sure we have a job, so we can satisfy PK
 		err := ldb.CreateJobsBatch(armadacontext.Background(), defaultInstructionSet().JobsToCreate)
 		assert.Nil(t, err)
@@ -516,7 +518,7 @@ func TestCreateJobRunsScalar(t *testing.T) {
 
 func TestUpdateJobRunsBatch(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		ldb := NewLookoutDb(db, nil, m, 10)
+		ldb := NewLookoutDb(db, fatalErrors, m, 10)
 		// Need to make sure we have a job and run
 		err := ldb.CreateJobsBatch(armadacontext.Background(), defaultInstructionSet().JobsToCreate)
 		assert.Nil(t, err)
@@ -555,7 +557,7 @@ func TestUpdateJobRunsBatch(t *testing.T) {
 
 func TestUpdateJobRunsScalar(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		ldb := NewLookoutDb(db, nil, m, 10)
+		ldb := NewLookoutDb(db, fatalErrors, m, 10)
 		// Need to make sure we have a job and run
 		err := ldb.CreateJobsBatch(armadacontext.Background(), defaultInstructionSet().JobsToCreate)
 		assert.Nil(t, err)
@@ -593,7 +595,7 @@ func TestUpdateJobRunsScalar(t *testing.T) {
 
 func TestCreateUserAnnotationsBatch(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		ldb := NewLookoutDb(db, nil, m, 10)
+		ldb := NewLookoutDb(db, fatalErrors, m, 10)
 		// Need to make sure we have a job
 		err := ldb.CreateJobsBatch(armadacontext.Background(), defaultInstructionSet().JobsToCreate)
 		assert.Nil(t, err)
@@ -626,7 +628,7 @@ func TestCreateUserAnnotationsBatch(t *testing.T) {
 
 func TestStoreWithEmptyInstructionSet(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		ldb := NewLookoutDb(db, nil, m, 10)
+		ldb := NewLookoutDb(db, fatalErrors, m, 10)
 		err := ldb.Store(armadacontext.Background(), &model.InstructionSet{
 			MessageIds: []pulsar.MessageID{pulsarutils.NewMessageId(1)},
 		})
@@ -641,7 +643,7 @@ func TestStoreWithEmptyInstructionSet(t *testing.T) {
 
 func TestCreateUserAnnotationsScalar(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		ldb := NewLookoutDb(db, nil, m, 10)
+		ldb := NewLookoutDb(db, fatalErrors, m, 10)
 		// Need to make sure we have a job
 		err := ldb.CreateJobsBatch(armadacontext.Background(), defaultInstructionSet().JobsToCreate)
 		assert.Nil(t, err)
@@ -672,7 +674,7 @@ func TestCreateUserAnnotationsScalar(t *testing.T) {
 
 func TestStore(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		ldb := NewLookoutDb(db, nil, m, 10)
+		ldb := NewLookoutDb(db, fatalErrors, m, 10)
 		// Do the update
 		err := ldb.Store(armadacontext.Background(), defaultInstructionSet())
 		assert.NoError(t, err)
@@ -841,7 +843,7 @@ func TestStoreNullValue(t *testing.T) {
 		instructions.JobsToCreate[0].JobProto = jobProto
 		instructions.JobRunsToUpdate[0].Error = errorMsg
 
-		ldb := NewLookoutDb(db, nil, m, 10)
+		ldb := NewLookoutDb(db, fatalErrors, m, 10)
 		// Do the update
 		err := ldb.Store(armadacontext.Background(), instructions)
 		assert.NoError(t, err)
@@ -858,7 +860,7 @@ func TestStoreNullValue(t *testing.T) {
 
 func TestStoreEventsForAlreadyTerminalJobs(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		ldb := NewLookoutDb(db, nil, m, 10)
+		ldb := NewLookoutDb(db, fatalErrors, m, 10)
 
 		baseInstructions := &model.InstructionSet{
 			JobsToCreate: []*model.CreateJobInstruction{

--- a/internal/lookoutv2/pruner/pruner_test.go
+++ b/internal/lookoutv2/pruner/pruner_test.go
@@ -109,7 +109,7 @@ func TestPruneDb(t *testing.T) {
 		t.Run(tc.testName, func(t *testing.T) {
 			err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 				converter := instructions.NewInstructionConverter(metrics.Get(), "armadaproject.io/", &compress.NoOpCompressor{}, true)
-				store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
+				store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 
 				ctx, cancel := armadacontext.WithTimeout(armadacontext.Background(), 5*time.Minute)
 				defer cancel()

--- a/internal/lookoutv2/pruner/pruner_test.go
+++ b/internal/lookoutv2/pruner/pruner_test.go
@@ -109,7 +109,7 @@ func TestPruneDb(t *testing.T) {
 		t.Run(tc.testName, func(t *testing.T) {
 			err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 				converter := instructions.NewInstructionConverter(metrics.Get(), "armadaproject.io/", &compress.NoOpCompressor{}, true)
-				store := lookoutdb.NewLookoutDb(db, metrics.Get(), 3, 10)
+				store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
 
 				ctx, cancel := armadacontext.WithTimeout(armadacontext.Background(), 5*time.Minute)
 				defer cancel()

--- a/internal/lookoutv2/repository/getjobrunerror_test.go
+++ b/internal/lookoutv2/repository/getjobrunerror_test.go
@@ -17,7 +17,7 @@ import (
 func TestGetJobRunError(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
 
 		errorStrings := []string{
 			"some bad error happened!",

--- a/internal/lookoutv2/repository/getjobrunerror_test.go
+++ b/internal/lookoutv2/repository/getjobrunerror_test.go
@@ -17,7 +17,7 @@ import (
 func TestGetJobRunError(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 
 		errorStrings := []string{
 			"some bad error happened!",

--- a/internal/lookoutv2/repository/getjobs_test.go
+++ b/internal/lookoutv2/repository/getjobs_test.go
@@ -54,7 +54,7 @@ var (
 func TestGetJobsSingle(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 
 		job := NewJobSimulator(converter, store).
 			Submit(queue, jobSet, owner, namespace, baseTime, &JobOptions{
@@ -91,7 +91,7 @@ func TestGetJobsSingle(t *testing.T) {
 func TestGetJobsMultipleRuns(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 
 		job := NewJobSimulator(converter, store).
 			Submit(queue, jobSet, owner, namespace, baseTime, basicJobOpts).
@@ -162,7 +162,7 @@ func TestOrderByUnsupportedDirection(t *testing.T) {
 func TestGetJobsOrderByJobId(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 
 		firstId := "01f3j0g1md4qx7z5qb148qnh4d"
 		secondId := "01f3j0g1md4qx7z5qb148qnjjj"
@@ -239,7 +239,7 @@ func TestGetJobsOrderByJobId(t *testing.T) {
 func TestGetJobsOrderBySubmissionTime(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 
 		third := NewJobSimulator(converter, store).
 			Submit(queue, jobSet, owner, namespace, baseTime.Add(3*time.Second), basicJobOpts).
@@ -306,7 +306,7 @@ func TestGetJobsOrderBySubmissionTime(t *testing.T) {
 func TestGetJobsOrderByLastTransitionTime(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 
 		runId1 := uuid.NewString()
 		third := NewJobSimulator(converter, store).
@@ -423,7 +423,7 @@ func TestFilterByUnsupportedMatch(t *testing.T) {
 func TestGetJobsById(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 
 		job := NewJobSimulator(converter, store).
 			Submit(queue, jobSet, owner, namespace, baseTime, &JobOptions{JobId: jobId}).
@@ -469,7 +469,7 @@ func TestGetJobsById(t *testing.T) {
 func TestGetJobsByQueue(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 
 		job := NewJobSimulator(converter, store).
 			Submit(queue, jobSet, owner, namespace, baseTime, basicJobOpts).
@@ -574,7 +574,7 @@ func TestGetJobsByQueue(t *testing.T) {
 func TestGetJobsByJobSet(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 
 		job := NewJobSimulator(converter, store).
 			Submit(queue, "job\\set\\1", owner, namespace, baseTime, basicJobOpts).
@@ -679,7 +679,7 @@ func TestGetJobsByJobSet(t *testing.T) {
 func TestGetJobsByOwner(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 
 		job := NewJobSimulator(converter, store).
 			Submit(queue, jobSet, owner, namespace, baseTime, basicJobOpts).
@@ -784,7 +784,7 @@ func TestGetJobsByOwner(t *testing.T) {
 func TestGetJobsByState(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 
 		queued := NewJobSimulator(converter, store).
 			Submit(queue, jobSet, owner, namespace, baseTime, basicJobOpts).
@@ -871,7 +871,7 @@ func TestGetJobsByState(t *testing.T) {
 func TestGetJobsByAnnotation(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 
 		job1 := NewJobSimulator(converter, store).
 			Submit(queue, jobSet, owner, namespace, baseTime, &JobOptions{
@@ -1060,7 +1060,7 @@ func TestGetJobsByAnnotation(t *testing.T) {
 func TestGetJobsByCpu(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 
 		job1 := NewJobSimulator(converter, store).
 			Submit(queue, jobSet, owner, namespace, baseTime, &JobOptions{
@@ -1213,7 +1213,7 @@ func TestGetJobsByCpu(t *testing.T) {
 func TestGetJobsByMemory(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 
 		job1 := NewJobSimulator(converter, store).
 			Submit(queue, jobSet, owner, namespace, baseTime, &JobOptions{
@@ -1366,7 +1366,7 @@ func TestGetJobsByMemory(t *testing.T) {
 func TestGetJobsByEphemeralStorage(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 
 		job1 := NewJobSimulator(converter, store).
 			Submit(queue, jobSet, owner, namespace, baseTime, &JobOptions{
@@ -1519,7 +1519,7 @@ func TestGetJobsByEphemeralStorage(t *testing.T) {
 func TestGetJobsByGpu(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 
 		job1 := NewJobSimulator(converter, store).
 			Submit(queue, jobSet, owner, namespace, baseTime, &JobOptions{
@@ -1672,7 +1672,7 @@ func TestGetJobsByGpu(t *testing.T) {
 func TestGetJobsByPriority(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 
 		job1 := NewJobSimulator(converter, store).
 			Submit(queue, jobSet, owner, namespace, baseTime, &JobOptions{
@@ -1825,7 +1825,7 @@ func TestGetJobsByPriority(t *testing.T) {
 func TestGetJobsByPriorityClass(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 
 		job := NewJobSimulator(converter, store).
 			Submit(queue, jobSet, owner, namespace, baseTime, &JobOptions{
@@ -1940,7 +1940,7 @@ func TestGetJobsByPriorityClass(t *testing.T) {
 func TestGetJobsSkip(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 
 		nJobs := 15
 		jobs := make([]*model.Job, nJobs)
@@ -2022,7 +2022,7 @@ func TestGetJobsSkip(t *testing.T) {
 func TestGetJobsComplex(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 
 		nJobs := 15
 		jobs := make([]*model.Job, nJobs)
@@ -2099,7 +2099,7 @@ func TestGetJobsComplex(t *testing.T) {
 func TestGetJobsActiveJobSet(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 
 		activeJobSet1 := NewJobSimulator(converter, store).
 			Submit("queue-1", "job-set-1", owner, namespace, baseTime, &JobOptions{}).

--- a/internal/lookoutv2/repository/getjobs_test.go
+++ b/internal/lookoutv2/repository/getjobs_test.go
@@ -54,7 +54,7 @@ var (
 func TestGetJobsSingle(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
 
 		job := NewJobSimulator(converter, store).
 			Submit(queue, jobSet, owner, namespace, baseTime, &JobOptions{
@@ -91,7 +91,7 @@ func TestGetJobsSingle(t *testing.T) {
 func TestGetJobsMultipleRuns(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
 
 		job := NewJobSimulator(converter, store).
 			Submit(queue, jobSet, owner, namespace, baseTime, basicJobOpts).
@@ -162,7 +162,7 @@ func TestOrderByUnsupportedDirection(t *testing.T) {
 func TestGetJobsOrderByJobId(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
 
 		firstId := "01f3j0g1md4qx7z5qb148qnh4d"
 		secondId := "01f3j0g1md4qx7z5qb148qnjjj"
@@ -239,7 +239,7 @@ func TestGetJobsOrderByJobId(t *testing.T) {
 func TestGetJobsOrderBySubmissionTime(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
 
 		third := NewJobSimulator(converter, store).
 			Submit(queue, jobSet, owner, namespace, baseTime.Add(3*time.Second), basicJobOpts).
@@ -306,7 +306,7 @@ func TestGetJobsOrderBySubmissionTime(t *testing.T) {
 func TestGetJobsOrderByLastTransitionTime(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
 
 		runId1 := uuid.NewString()
 		third := NewJobSimulator(converter, store).
@@ -423,7 +423,7 @@ func TestFilterByUnsupportedMatch(t *testing.T) {
 func TestGetJobsById(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
 
 		job := NewJobSimulator(converter, store).
 			Submit(queue, jobSet, owner, namespace, baseTime, &JobOptions{JobId: jobId}).
@@ -469,7 +469,7 @@ func TestGetJobsById(t *testing.T) {
 func TestGetJobsByQueue(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
 
 		job := NewJobSimulator(converter, store).
 			Submit(queue, jobSet, owner, namespace, baseTime, basicJobOpts).
@@ -574,7 +574,7 @@ func TestGetJobsByQueue(t *testing.T) {
 func TestGetJobsByJobSet(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
 
 		job := NewJobSimulator(converter, store).
 			Submit(queue, "job\\set\\1", owner, namespace, baseTime, basicJobOpts).
@@ -679,7 +679,7 @@ func TestGetJobsByJobSet(t *testing.T) {
 func TestGetJobsByOwner(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
 
 		job := NewJobSimulator(converter, store).
 			Submit(queue, jobSet, owner, namespace, baseTime, basicJobOpts).
@@ -784,7 +784,7 @@ func TestGetJobsByOwner(t *testing.T) {
 func TestGetJobsByState(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
 
 		queued := NewJobSimulator(converter, store).
 			Submit(queue, jobSet, owner, namespace, baseTime, basicJobOpts).
@@ -871,7 +871,7 @@ func TestGetJobsByState(t *testing.T) {
 func TestGetJobsByAnnotation(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
 
 		job1 := NewJobSimulator(converter, store).
 			Submit(queue, jobSet, owner, namespace, baseTime, &JobOptions{
@@ -1060,7 +1060,7 @@ func TestGetJobsByAnnotation(t *testing.T) {
 func TestGetJobsByCpu(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
 
 		job1 := NewJobSimulator(converter, store).
 			Submit(queue, jobSet, owner, namespace, baseTime, &JobOptions{
@@ -1213,7 +1213,7 @@ func TestGetJobsByCpu(t *testing.T) {
 func TestGetJobsByMemory(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
 
 		job1 := NewJobSimulator(converter, store).
 			Submit(queue, jobSet, owner, namespace, baseTime, &JobOptions{
@@ -1366,7 +1366,7 @@ func TestGetJobsByMemory(t *testing.T) {
 func TestGetJobsByEphemeralStorage(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
 
 		job1 := NewJobSimulator(converter, store).
 			Submit(queue, jobSet, owner, namespace, baseTime, &JobOptions{
@@ -1519,7 +1519,7 @@ func TestGetJobsByEphemeralStorage(t *testing.T) {
 func TestGetJobsByGpu(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
 
 		job1 := NewJobSimulator(converter, store).
 			Submit(queue, jobSet, owner, namespace, baseTime, &JobOptions{
@@ -1672,7 +1672,7 @@ func TestGetJobsByGpu(t *testing.T) {
 func TestGetJobsByPriority(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
 
 		job1 := NewJobSimulator(converter, store).
 			Submit(queue, jobSet, owner, namespace, baseTime, &JobOptions{
@@ -1825,7 +1825,7 @@ func TestGetJobsByPriority(t *testing.T) {
 func TestGetJobsByPriorityClass(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
 
 		job := NewJobSimulator(converter, store).
 			Submit(queue, jobSet, owner, namespace, baseTime, &JobOptions{
@@ -1940,7 +1940,7 @@ func TestGetJobsByPriorityClass(t *testing.T) {
 func TestGetJobsSkip(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
 
 		nJobs := 15
 		jobs := make([]*model.Job, nJobs)
@@ -2022,7 +2022,7 @@ func TestGetJobsSkip(t *testing.T) {
 func TestGetJobsComplex(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
 
 		nJobs := 15
 		jobs := make([]*model.Job, nJobs)
@@ -2099,7 +2099,7 @@ func TestGetJobsComplex(t *testing.T) {
 func TestGetJobsActiveJobSet(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
 
 		activeJobSet1 := NewJobSimulator(converter, store).
 			Submit("queue-1", "job-set-1", owner, namespace, baseTime, &JobOptions{}).

--- a/internal/lookoutv2/repository/getjobspec_test.go
+++ b/internal/lookoutv2/repository/getjobspec_test.go
@@ -18,7 +18,7 @@ import (
 func TestGetJobSpec(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
 
 		job := NewJobSimulator(converter, store).
 			Submit(queue, jobSet, owner, namespace, baseTime, &JobOptions{

--- a/internal/lookoutv2/repository/getjobspec_test.go
+++ b/internal/lookoutv2/repository/getjobspec_test.go
@@ -18,7 +18,7 @@ import (
 func TestGetJobSpec(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 
 		job := NewJobSimulator(converter, store).
 			Submit(queue, jobSet, owner, namespace, baseTime, &JobOptions{

--- a/internal/lookoutv2/repository/groupjobs_test.go
+++ b/internal/lookoutv2/repository/groupjobs_test.go
@@ -22,7 +22,7 @@ import (
 func TestGroupByQueue(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 
 		manyJobs(10, &createJobsOpts{
 			queue:  "queue-1",
@@ -81,7 +81,7 @@ func TestGroupByQueue(t *testing.T) {
 func TestGroupByJobSet(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 
 		manyJobs(10, &createJobsOpts{
 			queue:  queue,
@@ -140,7 +140,7 @@ func TestGroupByJobSet(t *testing.T) {
 func TestGroupByState(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 
 		manyJobs(10, &createJobsOpts{
 			queue:  queue,
@@ -212,7 +212,7 @@ func TestGroupByState(t *testing.T) {
 func TestGroupByWithFilters(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 
 		testAnnotations := map[string]string{
 			"key-1": "val-1",
@@ -400,7 +400,7 @@ func TestGroupByWithFilters(t *testing.T) {
 func TestGroupJobsWithMaxSubmittedTime(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 
 		manyJobs(5, &createJobsOpts{
 			queue:         queue,
@@ -500,7 +500,7 @@ func TestGroupJobsWithMaxSubmittedTime(t *testing.T) {
 func TestGroupJobsWithAvgLastTransitionTime(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 
 		manyJobs(5, &createJobsOpts{
 			queue:         "queue-1",
@@ -600,7 +600,7 @@ func TestGroupJobsWithAvgLastTransitionTime(t *testing.T) {
 func TestGroupJobsWithAllStateCounts(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, false)
-		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 
 		manyJobs(5, &createJobsOpts{
 			queue:  "queue-1",
@@ -727,7 +727,7 @@ func TestGroupJobsWithAllStateCounts(t *testing.T) {
 func TestGroupJobsWithFilteredStateCounts(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, false)
-		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 
 		manyJobs(5, &createJobsOpts{
 			queue:  "queue-1",
@@ -833,7 +833,7 @@ func TestGroupJobsWithFilteredStateCounts(t *testing.T) {
 func TestGroupJobsComplex(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 
 		testAnnotations := map[string]string{
 			"key-1": "val-1",
@@ -971,7 +971,7 @@ func TestGroupJobsComplex(t *testing.T) {
 func TestGroupByAnnotation(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 
 		manyJobs(10, &createJobsOpts{
 			queue:  queue,
@@ -1040,7 +1040,7 @@ func TestGroupByAnnotation(t *testing.T) {
 func TestGroupByAnnotationWithFiltersAndAggregates(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 
 		manyJobs(5, &createJobsOpts{
 			queue:  queue,
@@ -1187,7 +1187,7 @@ func TestGroupByAnnotationWithFiltersAndAggregates(t *testing.T) {
 func TestGroupJobsSkip(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 
 		nGroups := 15
 		for i := 0; i < nGroups; i++ {
@@ -1390,7 +1390,7 @@ func TestGroupJobsValidation(t *testing.T) {
 func TestGroupByActiveJobSets(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 
 		manyJobs(10, &createJobsOpts{
 			queue:  "queue-1",

--- a/internal/lookoutv2/repository/groupjobs_test.go
+++ b/internal/lookoutv2/repository/groupjobs_test.go
@@ -22,7 +22,7 @@ import (
 func TestGroupByQueue(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
 
 		manyJobs(10, &createJobsOpts{
 			queue:  "queue-1",
@@ -81,7 +81,7 @@ func TestGroupByQueue(t *testing.T) {
 func TestGroupByJobSet(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
 
 		manyJobs(10, &createJobsOpts{
 			queue:  queue,
@@ -140,7 +140,7 @@ func TestGroupByJobSet(t *testing.T) {
 func TestGroupByState(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
 
 		manyJobs(10, &createJobsOpts{
 			queue:  queue,
@@ -212,7 +212,7 @@ func TestGroupByState(t *testing.T) {
 func TestGroupByWithFilters(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
 
 		testAnnotations := map[string]string{
 			"key-1": "val-1",
@@ -400,7 +400,7 @@ func TestGroupByWithFilters(t *testing.T) {
 func TestGroupJobsWithMaxSubmittedTime(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
 
 		manyJobs(5, &createJobsOpts{
 			queue:         queue,
@@ -500,7 +500,7 @@ func TestGroupJobsWithMaxSubmittedTime(t *testing.T) {
 func TestGroupJobsWithAvgLastTransitionTime(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
 
 		manyJobs(5, &createJobsOpts{
 			queue:         "queue-1",
@@ -600,7 +600,7 @@ func TestGroupJobsWithAvgLastTransitionTime(t *testing.T) {
 func TestGroupJobsWithAllStateCounts(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, false)
-		store := lookoutdb.NewLookoutDb(db, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
 
 		manyJobs(5, &createJobsOpts{
 			queue:  "queue-1",
@@ -727,7 +727,7 @@ func TestGroupJobsWithAllStateCounts(t *testing.T) {
 func TestGroupJobsWithFilteredStateCounts(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, false)
-		store := lookoutdb.NewLookoutDb(db, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
 
 		manyJobs(5, &createJobsOpts{
 			queue:  "queue-1",
@@ -833,7 +833,7 @@ func TestGroupJobsWithFilteredStateCounts(t *testing.T) {
 func TestGroupJobsComplex(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
 
 		testAnnotations := map[string]string{
 			"key-1": "val-1",
@@ -971,7 +971,7 @@ func TestGroupJobsComplex(t *testing.T) {
 func TestGroupByAnnotation(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
 
 		manyJobs(10, &createJobsOpts{
 			queue:  queue,
@@ -1040,7 +1040,7 @@ func TestGroupByAnnotation(t *testing.T) {
 func TestGroupByAnnotationWithFiltersAndAggregates(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
 
 		manyJobs(5, &createJobsOpts{
 			queue:  queue,
@@ -1187,7 +1187,7 @@ func TestGroupByAnnotationWithFiltersAndAggregates(t *testing.T) {
 func TestGroupJobsSkip(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
 
 		nGroups := 15
 		for i := 0; i < nGroups; i++ {
@@ -1390,7 +1390,7 @@ func TestGroupJobsValidation(t *testing.T) {
 func TestGroupByActiveJobSets(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{}, true)
-		store := lookoutdb.NewLookoutDb(db, metrics.Get(), 3, 10)
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 3, 10)
 
 		manyJobs(10, &createJobsOpts{
 			queue:  "queue-1",


### PR DESCRIPTION
Previously LookoutV2 Ingester had a (hardcoded) list of retryable errors.  If an error occurred that was not on this list then the message would be dropped.

This causes issues as if we encounter a retryable error we haven't previously thought about we can potentially drop a large number of messages and so we end up with a large number of jobs in the wrong state in  lookout.

This PR therefore flips this situation around.  Errors are now considered retryable by default and instead an error is only considered fatal if it matches one of a predefined list of fatal errors.  This list is implmented as a user-defined list of regexes, which means that it should be relatively easy to update at runtime as and when new fatal errors are encountered.

