### PR TITLE
ARMADA-2343 minor testsuite usability improvements (#35)

### DIFF
--- a/internal/testsuite/app.go
+++ b/internal/testsuite/app.go
@@ -90,7 +90,7 @@ func (a *App) TestPattern(ctx context.Context, pattern string) (*TestSuiteReport
 func TestSpecsFromPattern(pattern string) ([]*api.TestSpec, error) {
 	filePaths, err := zglob.Glob(pattern)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errors.Wrapf(err, "failed to glob test specs with pattern %s", pattern)
 	}
 	return TestSpecsFromFilePaths(filePaths)
 }


### PR DESCRIPTION
Some minor testsuite usability improvements 

- Include jobset in sumary
- Round times to nearest second
- Give better error messages in case of incorrect/missing `--tests` arg (this was mildly annoying/confusing before as it would just say `Error: file does not exist` if you ran with just test).

