### PR TITLE
Add a metric for home-away preemption

### DIFF
--- a/internal/scheduler/common.go
+++ b/internal/scheduler/common.go
@@ -10,19 +10,25 @@ import (
 	"github.com/armadaproject/armada/internal/armada/configuration"
 	armadamaps "github.com/armadaproject/armada/internal/common/maps"
 	armadaslices "github.com/armadaproject/armada/internal/common/slices"
+	schedulercontext "github.com/armadaproject/armada/internal/scheduler/context"
 	"github.com/armadaproject/armada/internal/scheduler/interfaces"
 	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
 )
 
 // JobsSummary returns a string giving an overview of the provided jobs meant for logging.
 // For example: "affected queues [A, B]; resources {A: {cpu: 1}, B: {cpu: 2}}; jobs [jobAId, jobBId]".
-func JobsSummary(jobs []interfaces.LegacySchedulerJob) string {
-	if len(jobs) == 0 {
+func JobsSummary(jctxs []*schedulercontext.JobSchedulingContext) string {
+	if len(jctxs) == 0 {
 		return ""
 	}
-	jobsByQueue := armadaslices.GroupByFunc(
-		jobs,
-		func(job interfaces.LegacySchedulerJob) string { return job.GetQueue() },
+	jobsByQueue := armadaslices.MapAndGroupByFuncs(
+		jctxs,
+		func(jctx *schedulercontext.JobSchedulingContext) string {
+			return jctx.Job.GetQueue()
+		},
+		func(jctx *schedulercontext.JobSchedulingContext) interfaces.LegacySchedulerJob {
+			return jctx.Job
+		},
 	)
 	resourcesByQueue := armadamaps.MapValues(
 		jobsByQueue,

--- a/internal/scheduler/context/context.go
+++ b/internal/scheduler/context/context.go
@@ -736,6 +736,8 @@ type PodSchedulingContext struct {
 	Created time.Time
 	// ID of the node that the pod was assigned to, or empty.
 	NodeId string
+	// If set, indicates that the pod was scheduled on a specific node type.
+	WellKnownNodeTypeName string
 	// Priority at which this pod was scheduled.
 	ScheduledAtPriority int32
 	// Maximum priority that this pod preempted other pods at.

--- a/internal/scheduler/nodedb/nodedb.go
+++ b/internal/scheduler/nodedb/nodedb.go
@@ -656,6 +656,7 @@ func (nodeDb *NodeDb) SelectNodeForJobWithTxn(txn *memdb.Txn, jctx *schedulercon
 			return nil, err
 		}
 		if node != nil {
+			pctx.WellKnownNodeTypeName = awayNodeType.WellKnownNodeTypeName
 			return node, nil
 		}
 	}

--- a/internal/scheduler/queue_scheduler.go
+++ b/internal/scheduler/queue_scheduler.go
@@ -10,7 +10,6 @@ import (
 	schedulerconstraints "github.com/armadaproject/armada/internal/scheduler/constraints"
 	schedulercontext "github.com/armadaproject/armada/internal/scheduler/context"
 	"github.com/armadaproject/armada/internal/scheduler/fairness"
-	"github.com/armadaproject/armada/internal/scheduler/interfaces"
 	"github.com/armadaproject/armada/internal/scheduler/nodedb"
 	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
 )
@@ -59,8 +58,8 @@ func (sch *QueueScheduler) SkipUnsuccessfulSchedulingKeyCheck() {
 
 func (sch *QueueScheduler) Schedule(ctx *armadacontext.Context) (*SchedulerResult, error) {
 	nodeIdByJobId := make(map[string]string)
-	scheduledJobs := make([]interfaces.LegacySchedulerJob, 0)
-	failedJobs := make([]interfaces.LegacySchedulerJob, 0)
+	var scheduledJobs []*schedulercontext.JobSchedulingContext
+	var failedJobs []*schedulercontext.JobSchedulingContext
 	for {
 		// Peek() returns the next gang to try to schedule. Call Clear() before calling Peek() again.
 		// Calling Clear() after (failing to) schedule ensures we get the next gang in order of smallest fair share.
@@ -92,7 +91,7 @@ func (sch *QueueScheduler) Schedule(ctx *armadacontext.Context) (*SchedulerResul
 			// We scheduled the minimum number of gang jobs required.
 			for _, jctx := range gctx.JobSchedulingContexts {
 				if pctx := jctx.PodSchedulingContext; pctx.IsSuccessful() {
-					scheduledJobs = append(scheduledJobs, jctx.Job)
+					scheduledJobs = append(scheduledJobs, jctx)
 					nodeIdByJobId[jctx.JobId] = pctx.NodeId
 				}
 			}
@@ -100,7 +99,7 @@ func (sch *QueueScheduler) Schedule(ctx *armadacontext.Context) (*SchedulerResul
 			// Report any excess gang jobs that failed
 			for _, jctx := range gctx.JobSchedulingContexts {
 				if jctx.ShouldFail {
-					failedJobs = append(failedJobs, jctx.Job)
+					failedJobs = append(failedJobs, jctx)
 				}
 			}
 		} else if schedulerconstraints.IsTerminalUnschedulableReason(unschedulableReason) {

--- a/internal/scheduler/queue_scheduler_test.go
+++ b/internal/scheduler/queue_scheduler_test.go
@@ -586,10 +586,10 @@ func TestQueueScheduler(t *testing.T) {
 
 			// Check that the right jobs got scheduled.
 			var actualScheduledIndices []int
-			for _, job := range result.ScheduledJobs {
+			for _, jctx := range result.ScheduledJobs {
 				actualScheduledIndices = append(
 					actualScheduledIndices,
-					indexByJobId[job.GetId()],
+					indexByJobId[jctx.JobId],
 				)
 			}
 			slices.Sort(actualScheduledIndices)
@@ -670,8 +670,8 @@ func TestQueueScheduler(t *testing.T) {
 			}
 
 			// Check that each scheduled job was allocated a node.
-			for _, job := range result.ScheduledJobs {
-				nodeId, ok := result.NodeIdByJobId[job.GetId()]
+			for _, jctx := range result.ScheduledJobs {
+				nodeId, ok := result.NodeIdByJobId[jctx.JobId]
 				assert.True(t, ok)
 				assert.NotEmpty(t, nodeId)
 			}

--- a/internal/scheduler/result.go
+++ b/internal/scheduler/result.go
@@ -8,12 +8,12 @@ import (
 // SchedulerResult is returned by Rescheduler.Schedule().
 type SchedulerResult struct {
 	// Running jobs that should be preempted.
-	PreemptedJobs []interfaces.LegacySchedulerJob
+	PreemptedJobs []*schedulercontext.JobSchedulingContext
 	// Queued jobs that should be scheduled.
-	ScheduledJobs []interfaces.LegacySchedulerJob
+	ScheduledJobs []*schedulercontext.JobSchedulingContext
 	// Queued jobs that could not be scheduled.
 	// This is used to fail jobs that could not schedule above `minimumGangCardinality`.
-	FailedJobs []interfaces.LegacySchedulerJob
+	FailedJobs []*schedulercontext.JobSchedulingContext
 	// For each preempted job, maps the job id to the id of the node on which the job was running.
 	// For each scheduled job, maps the job id to the id of the node on which the job should be scheduled.
 	NodeIdByJobId map[string]string
@@ -26,8 +26,8 @@ type SchedulerResult struct {
 // PreemptedJobsFromSchedulerResult returns the slice of preempted jobs in the result cast to type T.
 func PreemptedJobsFromSchedulerResult[T interfaces.LegacySchedulerJob](sr *SchedulerResult) []T {
 	rv := make([]T, len(sr.PreemptedJobs))
-	for i, job := range sr.PreemptedJobs {
-		rv[i] = job.(T)
+	for i, jctx := range sr.PreemptedJobs {
+		rv[i] = jctx.Job.(T)
 	}
 	return rv
 }
@@ -35,8 +35,8 @@ func PreemptedJobsFromSchedulerResult[T interfaces.LegacySchedulerJob](sr *Sched
 // ScheduledJobsFromSchedulerResult returns the slice of scheduled jobs in the result cast to type T.
 func ScheduledJobsFromSchedulerResult[T interfaces.LegacySchedulerJob](sr *SchedulerResult) []T {
 	rv := make([]T, len(sr.ScheduledJobs))
-	for i, job := range sr.ScheduledJobs {
-		rv[i] = job.(T)
+	for i, jctx := range sr.ScheduledJobs {
+		rv[i] = jctx.Job.(T)
 	}
 	return rv
 }
@@ -44,8 +44,8 @@ func ScheduledJobsFromSchedulerResult[T interfaces.LegacySchedulerJob](sr *Sched
 // FailedJobsFromSchedulerResult returns the slice of scheduled jobs in the result cast to type T.
 func FailedJobsFromSchedulerResult[T interfaces.LegacySchedulerJob](sr *SchedulerResult) []T {
 	rv := make([]T, len(sr.FailedJobs))
-	for i, job := range sr.FailedJobs {
-		rv[i] = job.(T)
+	for i, jctx := range sr.FailedJobs {
+		rv[i] = jctx.Job.(T)
 	}
 	return rv
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -286,35 +286,21 @@ func (s *Scheduler) cycle(ctx *armadacontext.Context, updateAll bool, leaderToke
 }
 
 func (s *Scheduler) updateMetricsFromSchedulerResult(ctx *armadacontext.Context, overallSchedulerResult SchedulerResult) error {
-	for _, job := range overallSchedulerResult.ScheduledJobs {
-		if err := s.schedulerMetrics.Update(
-			ctx,
-			jobdb.JobStateTransitions{
-				Job:       job.(*jobdb.Job),
-				Scheduled: true,
-			},
-			nil,
-		); err != nil {
+	for _, jctx := range overallSchedulerResult.ScheduledJobs {
+		if err := s.schedulerMetrics.UpdateScheduled(jctx); err != nil {
 			return err
 		}
 	}
-	for _, job := range overallSchedulerResult.PreemptedJobs {
-		if err := s.schedulerMetrics.Update(
-			ctx,
-			jobdb.JobStateTransitions{
-				Job:       job.(*jobdb.Job),
-				Preempted: true,
-			},
-			nil,
-		); err != nil {
+	for _, jctx := range overallSchedulerResult.PreemptedJobs {
+		if err := s.schedulerMetrics.UpdatePreempted(jctx); err != nil {
 			return err
 		}
 	}
-	for _, job := range overallSchedulerResult.FailedJobs {
+	for _, jctx := range overallSchedulerResult.FailedJobs {
 		if err := s.schedulerMetrics.Update(
 			ctx,
 			jobdb.JobStateTransitions{
-				Job:    job.(*jobdb.Job),
+				Job:    jctx.Job.(*jobdb.Job),
 				Failed: true,
 			},
 			nil,

--- a/internal/scheduler/scheduler_metrics_test.go
+++ b/internal/scheduler/scheduler_metrics_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	schedulercontext "github.com/armadaproject/armada/internal/scheduler/context"
 	"github.com/armadaproject/armada/internal/scheduler/jobdb"
 	"github.com/armadaproject/armada/internal/scheduler/testfixtures"
 )
@@ -20,7 +21,7 @@ func TestAggregateJobs(t *testing.T) {
 		testfixtures.Test1Cpu4GiJob("queue_a", testfixtures.PriorityClass0),
 	}
 
-	actual := aggregateJobs(testJobs)
+	actual := aggregateJobContexts(schedulercontext.JobSchedulingContextsFromJobs(testfixtures.TestPriorityClasses, testJobs, GangIdAndCardinalityFromAnnotations))
 
 	expected := map[collectionKey]int{
 		{queue: "queue_a", priorityClass: testfixtures.PriorityClass0}: 4,

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/armadaproject/armada/internal/common/armadacontext"
 	protoutil "github.com/armadaproject/armada/internal/common/proto"
 	"github.com/armadaproject/armada/internal/common/util"
+	schedulercontext "github.com/armadaproject/armada/internal/scheduler/context"
 	"github.com/armadaproject/armada/internal/scheduler/database"
 	"github.com/armadaproject/armada/internal/scheduler/interfaces"
 	"github.com/armadaproject/armada/internal/scheduler/jobdb"
@@ -1226,23 +1227,11 @@ func NewSchedulerResultForTest[S ~[]T, T interfaces.LegacySchedulerJob](
 	failedJobs S,
 	nodeIdByJobId map[string]string,
 ) *SchedulerResult {
-	castPreemptedJobs := make([]interfaces.LegacySchedulerJob, len(preemptedJobs))
-	for i, job := range preemptedJobs {
-		castPreemptedJobs[i] = job
-	}
-	castScheduledJobs := make([]interfaces.LegacySchedulerJob, len(scheduledJobs))
-	for i, job := range scheduledJobs {
-		castScheduledJobs[i] = job
-	}
-	castFailedJobs := make([]interfaces.LegacySchedulerJob, len(failedJobs))
-	for i, job := range failedJobs {
-		castFailedJobs[i] = job
-	}
 	return &SchedulerResult{
-		PreemptedJobs: castPreemptedJobs,
-		ScheduledJobs: castScheduledJobs,
+		PreemptedJobs: schedulercontext.JobSchedulingContextsFromJobs(testfixtures.TestPriorityClasses, preemptedJobs, GangIdAndCardinalityFromAnnotations),
+		ScheduledJobs: schedulercontext.JobSchedulingContextsFromJobs(testfixtures.TestPriorityClasses, scheduledJobs, GangIdAndCardinalityFromAnnotations),
+		FailedJobs:    schedulercontext.JobSchedulingContextsFromJobs(testfixtures.TestPriorityClasses, failedJobs, GangIdAndCardinalityFromAnnotations),
 		NodeIdByJobId: nodeIdByJobId,
-		FailedJobs:    castFailedJobs,
 	}
 }
 


### PR DESCRIPTION
This piggybacks on the updated scheduler metrics from #3107, by adding a `nodeType` label to the metric for scheduled jobs; initially, this label will only be set for away jobs.

In order to populate this label without going through the event stream, I'm adding the `WellKnownNodeTypeName` field to `PodSchedulingContext` and replacing `[]interfaces.LegacySchedulerJob` by `[]*armadacontext.JobSchedulingContext` everywhere in `SchedulerResult` (so that we can access the `PodSchedulingContext` of the scheduled jobs when updating the metrics).