### PR TITLE
Set `Cache-Control` header for `index.html`

### DIFF
--- a/internal/common/serve/static.go
+++ b/internal/common/serve/static.go
@@ -9,22 +9,6 @@ import (
 	"github.com/armadaproject/armada/internal/common/logging"
 )
 
-type dirWithIndexFallback struct {
-	dir http.Dir
-}
-
-func CreateDirWithIndexFallback(path string) http.FileSystem {
-	return dirWithIndexFallback{http.Dir(path)}
-}
-
-func (d dirWithIndexFallback) Open(name string) (http.File, error) {
-	file, err := d.dir.Open(name)
-	if err != nil {
-		return d.dir.Open("index.html")
-	}
-	return file, err
-}
-
 // ListenAndServe calls server.ListenAndServe().
 // Additionally, it calls server.Shutdown() if ctx is cancelled.
 func ListenAndServe(ctx *armadacontext.Context, server *http.Server) error {


### PR DESCRIPTION
The Lookout UI `index.html` is only 624 bytes on `master`, but it contains the exact version of the JavaScript bundle to use (something like `/static/js/main.2165d460.js`). Instead of thinking too hard about when to invalidate this cache, this PR turns off caching for `index.html` entirely.