### PR TITLE
Bring back `dirWithIndexFallback`

### DIFF
--- a/internal/common/serve/static.go
+++ b/internal/common/serve/static.go
@@ -1,6 +1,7 @@
 package serve
 
 import (
+	"io/fs"
 	"net/http"
 
 	"github.com/pkg/errors"
@@ -8,6 +9,27 @@ import (
 	"github.com/armadaproject/armada/internal/common/armadacontext"
 	"github.com/armadaproject/armada/internal/common/logging"
 )
+
+// dirWithIndexFallback is a http.FileSystem that serves the index.html file at
+// the root of dir if the requested file is not found. This behavior differs
+// from http.Dir, which only forwards requests for /a/ to /a/index.html; we need
+// to serve the index.html file at the root of dir if the requested file is not
+// found, so that the frontend can handle routing in those cases.
+type dirWithIndexFallback struct {
+	dir http.Dir
+}
+
+func CreateDirWithIndexFallback(path string) http.FileSystem {
+	return dirWithIndexFallback{http.Dir(path)}
+}
+
+func (d dirWithIndexFallback) Open(name string) (http.File, error) {
+	file, err := d.dir.Open(name)
+	if errors.Is(err, fs.ErrNotExist) {
+		return d.dir.Open("index.html")
+	}
+	return file, err
+}
 
 // ListenAndServe calls server.ListenAndServe().
 // Additionally, it calls server.Shutdown() if ctx is cancelled.

--- a/internal/lookoutv2/gen/restapi/configure_lookout.go
+++ b/internal/lookoutv2/gen/restapi/configure_lookout.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 
+	"github.com/armadaproject/armada/internal/common/serve"
 	"github.com/armadaproject/armada/internal/common/util"
 	"github.com/armadaproject/armada/internal/lookoutv2/configuration"
 	"github.com/armadaproject/armada/internal/lookoutv2/gen/restapi/operations"
@@ -94,7 +95,7 @@ func setupGlobalMiddleware(apiHandler http.Handler) http.Handler {
 func uiHandler(apiHandler http.Handler) http.Handler {
 	mux := http.NewServeMux()
 
-	mux.Handle("/", setCacheControl(http.FileServer(http.Dir("./internal/lookout/ui/build"))))
+	mux.Handle("/", setCacheControl(http.FileServer(serve.CreateDirWithIndexFallback("./internal/lookout/ui/build"))))
 
 	mux.HandleFunc("/config", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
#3202 broke the routing in Lookout, by making the HTTP server handle paths like `/job-sets` and `/oidc` that were supposed to be handled by the frontend.