### PR TITLE
Add localdev documentation on accessing etcd (#3210)

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -9,6 +9,6 @@ pull_request_rules:
           - "#approved-reviews-by>=2"
           - and: 
             - "#approved-reviews-by>=1"
-            - "author~=^(JamesMurkin|severinson|d80tb7|carlocamurri|dejanzele|Sharpz7|ClifHouck|robertdavidsmith|theAntiYeti|richscott|suprjinx|zuqq|msumner91|mustafai)"
+            - "author~=^(JamesMurkin|severinson|d80tb7|carlocamurri|dejanzele|Sharpz7|ClifHouck|robertdavidsmith|theAntiYeti|richscott|suprjinx|zuqq|msumner91|MustafaI)"
         title:
           Two are checks required.

--- a/developer/config/etcdclient.yaml
+++ b/developer/config/etcdclient.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    component: etcdclient
+    tier: debug
+  name: etcdclient
+  namespace: kube-system
+spec:
+  containers:
+  - command:
+    - sleep
+    - 9999d
+    image: apecloud/etcd:v3.5.6
+    imagePullPolicy: IfNotPresent
+    name: etcdclient
+    resources: {}
+    volumeMounts:
+    - mountPath: /etc/kubernetes/pki/etcd
+      name: etcd-certs
+      readOnly: true
+    - mountPath: /var/lib/etcd
+      name: etcd-data
+      readOnly: false
+    env:
+    - name: ETCDCTL_API
+      value: "3"
+    - name: ETCDCTL_CACERT
+      value: /etc/kubernetes/pki/etcd/ca.crt
+    - name: ETCDCTL_CERT
+      value: /etc/kubernetes/pki/etcd/healthcheck-client.crt
+    - name: ETCDCTL_KEY
+      value: /etc/kubernetes/pki/etcd/healthcheck-client.key
+    - name: ETCDCTL_ENDPOINTS
+      value: "https://127.0.0.1:2379"
+    # - name: ETCDCTL_CLUSTER
+    #  value: "true"
+  hostNetwork: true
+  volumes:
+  - hostPath:
+      path: /etc/kubernetes/pki/etcd
+      type: DirectoryOrCreate
+    name: etcd-certs
+  - hostPath:
+      path: /var/lib/etcd
+      type: DirectoryOrCreate
+    name: etcd-data

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -47,6 +47,7 @@ Please see these documents for more information about Armadas Design:
 * [Using OIDC with Armada](./developer/oidc.md)
 * [Building the Website](./developer/website.md)
 * [Using Localdev Manually](./developer/manual-localdev.md)
+* [Inspecting and Debugging etcd in Localdev setup](./developer/etc-localdev.md)
 
 ## Pre-requisites
 

--- a/docs/developer/etcd-localdev.md
+++ b/docs/developer/etcd-localdev.md
@@ -1,0 +1,66 @@
+# Inspect and Debugging etcd in Localdev setup
+
+When developing or testing Armada in the Localdev setup, it's sometimes helpful
+to directly query the etcd database to gather various statistics. However, by
+default, the `kind` tool (for running Kubernetes clusters inside a local Docker
+side) does not expose the etcd interface for direct querying. The following
+steps give a solution for querying an etcd instance running inside of `kind`.
+
+
+First, verify the running nodes and podes.
+```bash
+$ kubectl get nodes -A
+NAME                        STATUS   ROLES           AGE   VERSION
+armada-test-control-plane   Ready    control-plane   78m   v1.24.7
+armada-test-worker          Ready    <none>          77m   v1.24.7
+
+$ kubectl get pods -A
+NAMESPACE            NAME                                                READY   STATUS      RESTARTS   AGE
+ingress-nginx        ingress-nginx-admission-create-9xnpn                0/1     Completed   0          78m
+ingress-nginx        ingress-nginx-admission-patch-phkgm                 0/1     Completed   1          78m
+ingress-nginx        ingress-nginx-controller-646df5f698-zbgqz           1/1     Running     0          78m
+kube-system          coredns-6d4b75cb6d-9z87w                            1/1     Running     0          79m
+kube-system          coredns-6d4b75cb6d-flz4r                            1/1     Running     0          79m
+kube-system          etcd-armada-test-control-plane                      1/1     Running     0          79m
+kube-system          kindnet-nx952                                       1/1     Running     0          79m
+kube-system          kindnet-rtqkc                                       1/1     Running     0          79m
+kube-system          kube-apiserver-armada-test-control-plane            1/1     Running     0          79m
+kube-system          kube-controller-manager-armada-test-control-plane   1/1     Running     0          79m
+kube-system          kube-proxy-cwl2r                                    1/1     Running     0          79m
+kube-system          kube-proxy-wjqft                                    1/1     Running     0          79m
+kube-system          kube-scheduler-armada-test-control-plane            1/1     Running     0          79m
+local-path-storage   local-path-provisioner-6b84c5c67f-22m8m             1/1     Running     0          79m
+```
+You should see an etcd control plane pod in the list of pods.
+
+Then, open a shell in the main Armada control plane node:
+```bash
+$ docker exec -it -u 0 --privileged armada-test-control-plane  /bin/bash
+```
+Once in, fetch a copy of the pod deployment YAML for the etcdclient container, and move it
+to the Kubernetes deployments source directory. Kubernetes (Kind) will notice the file's
+appearance and will deploy the new pod.
+```bash
+root@armada-test-control-plane:/# curl -LO git.io/etcdclient.yaml
+
+root@armada-test-control-plane:/# mv etcdclient.yaml /etc/kubernetes/manifests/
+root@armada-test-control-plane:/# exit
+```
+Open a shell in the new etcdclient utility pod, and start using `etcdctl` to query etcd!
+```bash
+$ kubectl exec -n kube-system -it etcdclient-armada-test-control-plane -- sh
+/ # etcdctl endpoint status -w table
++-------------------------+------------------+---------+---------+-----------+-----------+------------+
+|        ENDPOINT         |        ID        | VERSION | DB SIZE | IS LEADER | RAFT TERM | RAFT INDEX |
++-------------------------+------------------+---------+---------+-----------+-----------+------------+
+| https://172.19.0.2:2379 | d7380397c3ec4b90 |   3.5.3 |  3.9 MB |      true |         2 |      16727 |
++-------------------------+------------------+---------+---------+-----------+-----------+------------+
+/ #
+/ # exit
+```
+At this point, you can use `etcdctl` to query etcd for key-value pairs, get the health and/or metrics
+of the etcd server.
+
+## References
+
+https://mauilion.dev/posts/etcdclient/

--- a/docs/developer/etcd-localdev.md
+++ b/docs/developer/etcd-localdev.md
@@ -33,20 +33,28 @@ local-path-storage   local-path-provisioner-6b84c5c67f-22m8m             1/1    
 ```
 You should see an etcd control plane pod in the list of pods.
 
-Then, open a shell in the main Armada control plane node:
+Copy the etcdclient deployment YAML into the cluster control plane node:
+
+```bash
+$ docker cp developer/config/etcdclient.yaml armada-test-control-plane:/
+```
+
+Then, open a shell in the control plane node:
 ```bash
 $ docker exec -it -u 0 --privileged armada-test-control-plane  /bin/bash
 ```
-Once in, fetch a copy of the pod deployment YAML for the etcdclient container, and move it
-to the Kubernetes deployments source directory. Kubernetes (Kind) will notice the file's
-appearance and will deploy the new pod.
-```bash
-root@armada-test-control-plane:/# curl -LO git.io/etcdclient.yaml
 
+In the container shell, move the deployment YAML file to the Kubernetes deployments source
+directory. Kubernetes (Kind) will notice the file's appearance and will deploy
+the new pod.
+```bash
 root@armada-test-control-plane:/# mv etcdclient.yaml /etc/kubernetes/manifests/
 root@armada-test-control-plane:/# exit
+$ kubectl get pods -A
 ```
-Open a shell in the new etcdclient utility pod, and start using `etcdctl` to query etcd!
+You should see an etcdclient pod running.
+
+Open a shell in the new etcdclient utility pod, and start using `etcdctl` to query etcd.
 ```bash
 $ kubectl exec -n kube-system -it etcdclient-armada-test-control-plane -- sh
 / # etcdctl endpoint status -w table

--- a/docs/developer/manual-localdev.md
+++ b/docs/developer/manual-localdev.md
@@ -4,7 +4,7 @@ Here, we give an overview of a development setup for Armada that gives users ful
 
 Before starting, please ensure you have installed [Go](https://go.dev/doc/install) (version 1.20 or later), gcc (for Windows, see, e.g., [tdm-gcc](https://jmeubank.github.io/tdm-gcc/)), [mage](https://magefile.org/), [docker](https://docs.docker.com/get-docker/), [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl), and, if you need to compile `.proto` files, [protoc](https://github.com/protocolbuffers/protobuf/releases).
 
-For a full lust of mage commands, run `mage -l`.
+For a full list of mage commands, run `mage -l`.
 
 ## Setup
 

--- a/internal/lookout/ui/src/components/LinkCell.css
+++ b/internal/lookout/ui/src/components/LinkCell.css
@@ -1,0 +1,9 @@
+.link {
+    width: 100%;
+    color: blue;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    text-decoration: underline;
+    cursor: pointer;
+}

--- a/internal/lookout/ui/src/components/LinkCell.tsx
+++ b/internal/lookout/ui/src/components/LinkCell.tsx
@@ -1,0 +1,17 @@
+import React from "react"
+
+import { TableCellProps } from "react-virtualized"
+
+import "./LinkCell.css"
+
+type LinkCellProps = {
+  onClick: () => void
+} & TableCellProps
+
+export default function LinkCell(props: LinkCellProps) {
+  return (
+    <div className="link" onClick={props.onClick}>
+      {props.cellData}
+    </div>
+  )
+}

--- a/internal/lookout/ui/src/components/job-sets/JobSetTable.tsx
+++ b/internal/lookout/ui/src/components/job-sets/JobSetTable.tsx
@@ -4,12 +4,13 @@ import Truncate from "react-truncate"
 import { TableCellProps, Table as VirtualizedTable } from "react-virtualized"
 import { Column, defaultTableCellRenderer } from "react-virtualized"
 
+import { JobState } from "../../models/lookoutV2Models"
 import { JobSet } from "../../services/JobService"
 import CheckboxHeaderRow from "../CheckboxHeaderRow"
 import CheckboxRow from "../CheckboxRow"
-import SortableHeaderCell from "../SortableHeaderCell"
-
 import "./JobSetTable.css"
+import LinkCell from "../LinkCell"
+import SortableHeaderCell from "../SortableHeaderCell"
 
 interface JobSetTableProps {
   height: number
@@ -23,12 +24,14 @@ interface JobSetTableProps {
   onDeselectAllClick: () => void
   onSelectAllClick: () => void
   onOrderChange: (newestFirst: boolean) => void
+  onJobSetStateClick(rowIndex: number, state: string): void
 }
 
-function cellRendererForState(cellProps: TableCellProps) {
-  if (cellProps.cellData) {
-    return cellProps.cellData
+function cellRendererForState(cellProps: TableCellProps, onClickFunc: () => void) {
+  if (cellProps.cellData > 0) {
+    return <LinkCell onClick={onClickFunc} {...cellProps} />
   }
+
   return defaultTableCellRenderer(cellProps)
 }
 
@@ -121,42 +124,54 @@ export default function JobSetTable(props: JobSetTableProps) {
           width={0.06 * props.width}
           label="Queued"
           className="job-set-table-number-cell"
-          cellRenderer={(cellProps) => cellRendererForState(cellProps)}
+          cellRenderer={(cellProps) =>
+            cellRendererForState(cellProps, () => props.onJobSetStateClick(cellProps.rowIndex, JobState.Queued))
+          }
         />
         <Column
           dataKey="jobsPending"
           width={0.06 * props.width}
           label="Pending"
           className="job-set-table-number-cell"
-          cellRenderer={(cellProps) => cellRendererForState(cellProps)}
+          cellRenderer={(cellProps) =>
+            cellRendererForState(cellProps, () => props.onJobSetStateClick(cellProps.rowIndex, JobState.Pending))
+          }
         />
         <Column
           dataKey="jobsRunning"
           width={0.06 * props.width}
           label="Running"
           className="job-set-table-number-cell"
-          cellRenderer={(cellProps) => cellRendererForState(cellProps)}
+          cellRenderer={(cellProps) =>
+            cellRendererForState(cellProps, () => props.onJobSetStateClick(cellProps.rowIndex, JobState.Running))
+          }
         />
         <Column
           dataKey="jobsSucceeded"
           width={0.06 * props.width}
           label="Succeeded"
           className="job-set-table-number-cell"
-          cellRenderer={(cellProps) => cellRendererForState(cellProps)}
+          cellRenderer={(cellProps) =>
+            cellRendererForState(cellProps, () => props.onJobSetStateClick(cellProps.rowIndex, JobState.Succeeded))
+          }
         />
         <Column
           dataKey="jobsFailed"
           width={0.06 * props.width}
           label="Failed"
           className="job-set-table-number-cell"
-          cellRenderer={(cellProps) => cellRendererForState(cellProps)}
+          cellRenderer={(cellProps) =>
+            cellRendererForState(cellProps, () => props.onJobSetStateClick(cellProps.rowIndex, JobState.Failed))
+          }
         />
         <Column
           dataKey="jobsCancelled"
           width={0.06 * props.width}
           label="Cancelled"
           className="job-set-table-number-cell"
-          cellRenderer={(cellProps) => cellRendererForState(cellProps)}
+          cellRenderer={(cellProps) =>
+            cellRendererForState(cellProps, () => props.onJobSetStateClick(cellProps.rowIndex, JobState.Cancelled))
+          }
         />
       </VirtualizedTable>
     </div>

--- a/internal/lookout/ui/src/components/job-sets/JobSets.tsx
+++ b/internal/lookout/ui/src/components/job-sets/JobSets.tsx
@@ -34,6 +34,7 @@ interface JobSetsProps {
   onReprioritizeJobSetsClick: () => void
   onOrderChange: (newestFirst: boolean) => void
   onActiveOnlyChange: (activeOnly: boolean) => void
+  onJobSetStateClick(rowIndex: number, state: string): void
 }
 
 export default function JobSets(props: JobSetsProps) {
@@ -50,6 +51,7 @@ export default function JobSets(props: JobSetsProps) {
       onDeselectAllClick={props.onDeselectAllClick}
       onSelectAllClick={props.onSelectAllClick}
       onOrderChange={props.onOrderChange}
+      onJobSetStateClick={props.onJobSetStateClick}
     />
   )
 

--- a/internal/lookout/ui/src/containers/lookoutV2/JobsTableContainer.tsx
+++ b/internal/lookout/ui/src/containers/lookoutV2/JobsTableContainer.tsx
@@ -756,7 +756,7 @@ export const JobsTableContainer = ({
             }}
             onRefresh={onRefresh}
             autoRefresh={autoRefresh}
-            onAutoRefreshChange={onAutoRefreshChange}
+            onAutoRefreshChange={autoRefreshMs === undefined ? undefined : onAutoRefreshChange}
             onAddAnnotationColumn={addAnnotationCol}
             onRemoveAnnotationColumn={removeAnnotationCol}
             onEditAnnotationColumn={editAnnotationCol}

--- a/internal/lookout/ui/src/containers/lookoutV2/JobsTableContainer.tsx
+++ b/internal/lookout/ui/src/containers/lookoutV2/JobsTableContainer.tsx
@@ -1,4 +1,4 @@
-import React, { RefObject, useCallback, useEffect, useMemo, useState } from "react"
+import React, { RefObject, useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 import {
   Box,
@@ -41,7 +41,6 @@ import _ from "lodash"
 import { isJobGroupRow, JobRow, JobTableRow } from "models/jobsTableModels"
 import { Job, JobFilter, JobId, Match, SortDirection } from "models/lookoutV2Models"
 import { useLocation, useNavigate, useParams } from "react-router-dom"
-import IntervalService from "services/IntervalService"
 import { IGetJobsService } from "services/lookoutV2/GetJobsService"
 import { IGetRunErrorService } from "services/lookoutV2/GetRunErrorService"
 import { IGroupJobsService } from "services/lookoutV2/GroupJobsService"
@@ -183,18 +182,8 @@ export const JobsTableContainer = ({
     initialPrefs.autoRefresh === undefined ? true : initialPrefs.autoRefresh,
   )
 
-  const autoRefreshService = useMemo(
-    () => (autoRefreshMs === undefined ? undefined : new IntervalService(autoRefreshMs)),
-    [autoRefreshMs],
-  )
-
   const onAutoRefreshChange = (autoRefresh: boolean) => {
     setAutoRefresh(autoRefresh)
-    if (autoRefresh) {
-      autoRefreshService?.start()
-    } else {
-      autoRefreshService?.stop()
-    }
   }
 
   // Filtering
@@ -378,13 +367,37 @@ export const JobsTableContainer = ({
     setRowsToFetch(pendingDataForAllVisibleData(expanded, data, pageSize, pageIndex * pageSize))
   }
 
+  const savedOnRefreshCallback = useRef<() => void>()
+
+  const [autoRefreshIntervalTimer, setAutoRefreshIntervalTimer] = useState<NodeJS.Timeout | undefined>(undefined)
+
   useEffect(() => {
-    autoRefreshService?.registerCallback(onRefresh)
-    if (autoRefresh) {
-      autoRefreshService?.start()
+    savedOnRefreshCallback.current = onRefresh
+  })
+
+  useEffect(() => {
+    function clearTimer() {
+      if (autoRefreshIntervalTimer) {
+        clearInterval(autoRefreshIntervalTimer)
+        setAutoRefreshIntervalTimer(undefined)
+      }
     }
-    return () => autoRefreshService?.stop()
-  }, [])
+
+    if (autoRefreshMs === undefined || !autoRefresh) {
+      clearTimer()
+      return () => {
+        return
+      }
+    } else {
+      const tmr = setInterval(() => {
+        if (savedOnRefreshCallback.current) {
+          savedOnRefreshCallback.current()
+        }
+      }, autoRefreshMs)
+      setAutoRefreshIntervalTimer(tmr)
+      return clearTimer
+    }
+  }, [autoRefresh, autoRefreshMs])
 
   const onColumnVisibilityChange = (colIdToToggle: ColumnId) => {
     // Refresh if we make a new aggregate column visible
@@ -743,7 +756,7 @@ export const JobsTableContainer = ({
             }}
             onRefresh={onRefresh}
             autoRefresh={autoRefresh}
-            onAutoRefreshChange={autoRefreshService && onAutoRefreshChange}
+            onAutoRefreshChange={onAutoRefreshChange}
             onAddAnnotationColumn={addAnnotationCol}
             onRemoveAnnotationColumn={removeAnnotationCol}
             onEditAnnotationColumn={editAnnotationCol}

--- a/internal/lookout/ui/src/services/lookoutV2/JobsTablePreferencesService.ts
+++ b/internal/lookout/ui/src/services/lookoutV2/JobsTablePreferencesService.ts
@@ -86,7 +86,7 @@ export interface QueryStringPrefs {
   refresh: string | undefined
 }
 
-const toQueryStringSafe = (prefs: JobsTablePreferences): QueryStringPrefs => {
+export const toQueryStringSafe = (prefs: JobsTablePreferences): QueryStringPrefs => {
   // The order of these keys are the order they'll show in the URL bar (in modern browsers)
   return {
     page: prefs.pageIndex.toString(),


### PR DESCRIPTION
Add documentation on accessing the etcd instance in a localev setup (a Kind cluster). This shows the steps for deploying a pod (named "etcdclient") so that users can go into that pod and run `etcdctl` (or whatever etcd client they want), to interact directly with the etcd instance in a Kind cluster.
