### PR TITLE
Lookoutv2: stop auto-refresh from collapsing groups

### DIFF
--- a/internal/lookout/ui/src/containers/lookoutV2/JobsTableContainer.tsx
+++ b/internal/lookout/ui/src/containers/lookoutV2/JobsTableContainer.tsx
@@ -369,7 +369,7 @@ export const JobsTableContainer = ({
 
   const savedOnRefreshCallback = useRef<() => void>()
 
-  const [autoRefreshIntervalId, setAutoRefreshIntervalId] = useState<NodeJS.Timeout | undefined>(undefined)
+  const [autoRefreshInterval, setAutoRefreshInterval] = useState<NodeJS.Timeout | undefined>(undefined)
 
   useEffect(() => {
     savedOnRefreshCallback.current = onRefresh
@@ -377,9 +377,9 @@ export const JobsTableContainer = ({
 
   useEffect(() => {
     function clearTimer() {
-      if (autoRefreshIntervalId) {
-        clearInterval(autoRefreshIntervalId)
-        setAutoRefreshIntervalId(undefined)
+      if (autoRefreshInterval) {
+        clearInterval(autoRefreshInterval)
+        setAutoRefreshInterval(undefined)
       }
     }
 
@@ -394,7 +394,7 @@ export const JobsTableContainer = ({
           savedOnRefreshCallback.current()
         }
       }, autoRefreshMs)
-      setAutoRefreshIntervalId(id)
+      setAutoRefreshInterval(id)
       return clearTimer
     }
   }, [autoRefresh, autoRefreshMs])

--- a/internal/lookout/ui/src/containers/lookoutV2/JobsTableContainer.tsx
+++ b/internal/lookout/ui/src/containers/lookoutV2/JobsTableContainer.tsx
@@ -389,12 +389,12 @@ export const JobsTableContainer = ({
         return
       }
     } else {
-      const id = setInterval(() => {
+      const tmr = setInterval(() => {
         if (savedOnRefreshCallback.current) {
           savedOnRefreshCallback.current()
         }
       }, autoRefreshMs)
-      setAutoRefreshInterval(id)
+      setAutoRefreshInterval(tmr)
       return clearTimer
     }
   }, [autoRefresh, autoRefreshMs])

--- a/internal/lookout/ui/src/containers/lookoutV2/JobsTableContainer.tsx
+++ b/internal/lookout/ui/src/containers/lookoutV2/JobsTableContainer.tsx
@@ -369,7 +369,7 @@ export const JobsTableContainer = ({
 
   const savedOnRefreshCallback = useRef<() => void>()
 
-  const [autoRefreshInterval, setAutoRefreshInterval] = useState<NodeJS.Timeout | undefined>(undefined)
+  const [autoRefreshIntervalTimer, setAutoRefreshIntervalTimer] = useState<NodeJS.Timeout | undefined>(undefined)
 
   useEffect(() => {
     savedOnRefreshCallback.current = onRefresh
@@ -377,9 +377,9 @@ export const JobsTableContainer = ({
 
   useEffect(() => {
     function clearTimer() {
-      if (autoRefreshInterval) {
-        clearInterval(autoRefreshInterval)
-        setAutoRefreshInterval(undefined)
+      if (autoRefreshIntervalTimer) {
+        clearInterval(autoRefreshIntervalTimer)
+        setAutoRefreshIntervalTimer(undefined)
       }
     }
 
@@ -394,7 +394,7 @@ export const JobsTableContainer = ({
           savedOnRefreshCallback.current()
         }
       }, autoRefreshMs)
-      setAutoRefreshInterval(tmr)
+      setAutoRefreshIntervalTimer(tmr)
       return clearTimer
     }
   }, [autoRefresh, autoRefreshMs])


### PR DESCRIPTION
Currently autorefresh causes expanded groups to collapse - this is because the callback passed to setInterval references an old copy of the table state, so changes made after enabling refreshing are not picked up.

Instead store a reference to the latest state in a ref (see `useRef` call), and update it every time the table changes via a `useEffect`. Use a second `useEffect` call to enable/disable the timer as required.

https://overreacted.io/making-setinterval-declarative-with-react-hooks/ correctly describes the problem, but the proposed solution calls `useEffect` from inside a method, which react doesn't like, so I haven't used it.