### PR TITLE
Fix bug when checking if a pod has exceeded its active deadline

### DIFF
--- a/internal/executor/service/job_manager_test.go
+++ b/internal/executor/service/job_manager_test.go
@@ -197,13 +197,14 @@ func makeTerminatingPod(legacy bool) *v1.Pod {
 	return pod
 }
 
-func makePodWithDeadline(legacy bool, createdTime time.Time, deadlineSeconds, gracePeriodSeconds int) *v1.Pod {
+func makePodWithDeadline(legacy bool, startTime time.Time, deadlineSeconds, gracePeriodSeconds int) *v1.Pod {
 	pod := makeTestPod(legacy, v1.PodStatus{Phase: v1.PodRunning})
 	activeDeadlineSeconds := int64(deadlineSeconds)
 	pod.Spec.ActiveDeadlineSeconds = &activeDeadlineSeconds
 	terminationGracePeriodSeconds := int64(gracePeriodSeconds)
 	pod.Spec.TerminationGracePeriodSeconds = &terminationGracePeriodSeconds
-	pod.CreationTimestamp = metav1.NewTime(createdTime)
+	podStartTime := metav1.NewTime(startTime)
+	pod.Status.StartTime = &podStartTime
 	return pod
 }
 

--- a/internal/executor/service/pod_issue_handler.go
+++ b/internal/executor/service/pod_issue_handler.go
@@ -247,7 +247,14 @@ func (p *IssueHandler) hasExceededActiveDeadline(pod *v1.Pod) bool {
 	if pod.Spec.ActiveDeadlineSeconds == nil {
 		return false
 	}
-	currentRunTimeSeconds := time.Now().Sub(pod.CreationTimestamp.Time).Seconds()
+
+	// Using StartTime here, as kubernetes bases its activeDeadlineSeconds check on the StartTime also
+	startTime := pod.Status.StartTime
+	if startTime == nil || startTime.Time.IsZero() {
+		return false
+	}
+	currentRunTimeSeconds := time.Now().Sub(startTime.Time).Seconds()
+
 	podTerminationGracePeriodSeconds := float64(0)
 	if pod.Spec.TerminationGracePeriodSeconds != nil {
 		podTerminationGracePeriodSeconds = float64(*pod.Spec.TerminationGracePeriodSeconds)

--- a/internal/executor/service/pod_issue_handler_test.go
+++ b/internal/executor/service/pod_issue_handler_test.go
@@ -89,6 +89,11 @@ func TestPodIssueService_DeletesPodAndReportsFailed_IfExceedsActiveDeadline(t *t
 			// Created 10 mins ago, 5 min deadline, 10 minute grace period
 			pod: makePodWithDeadline(false, startTime, 300, 600),
 		},
+		"PodWithNoStartTime": {
+			expectIssueDetected: false,
+			// Created 10 mins ago, 5 min deadline, no start time
+			pod: makePodWithDeadline(false, time.Time{}, 300, 0),
+		},
 	}
 
 	for name, tc := range tests {


### PR DESCRIPTION
The bug is that the CreationTimestamp isn't always set immediately, meaning it gets a value of 0

This in turn makes the currentRunTimeSeconds calculation massively wrong

Now:
 - Use StartTime instead of CreationTimestamp, as kubernetes uses StartTime for its ActiveDeadline check
 - Return false if StartTime is not set or is 0, so we don't incorrectly calculate the run time using invalid values


