### PR TITLE
Add `GangInfo`

### DIFF
--- a/internal/armada/server/lease.go
+++ b/internal/armada/server/lease.go
@@ -389,11 +389,11 @@ func (q *AggregatedQueueServer) getJobs(ctx *armadacontext.Context, req *api.Str
 
 		// Group gangs.
 		for _, job := range jobs {
-			gangId, _, _, isGangJob, err := scheduler.GangIdAndCardinalityFromLegacySchedulerJob(job)
+			gangInfo, err := schedulercontext.GangInfoFromLegacySchedulerJob(job)
 			if err != nil {
 				return nil, err
 			}
-			if isGangJob {
+			if gangId := gangInfo.Id; gangId != "" {
 				if m := jobIdsByGangId[gangId]; m != nil {
 					m[job.Id] = true
 				} else {

--- a/internal/common/validation/job_test.go
+++ b/internal/common/validation/job_test.go
@@ -393,7 +393,7 @@ func TestValidateGangs(t *testing.T) {
 			}
 
 			for id, e := range gangDetailsById {
-				assert.Equal(t, tc.ExpectedGangMinimumCardinalityByGangId[id], e.expectedMinimumCardinality)
+				assert.Equal(t, tc.ExpectedGangMinimumCardinalityByGangId[id], e.MinimumCardinality)
 			}
 		})
 	}

--- a/internal/scheduler/common.go
+++ b/internal/scheduler/common.go
@@ -2,12 +2,9 @@ package scheduler
 
 import (
 	"fmt"
-	"strconv"
 
-	"github.com/pkg/errors"
 	"golang.org/x/exp/maps"
 
-	"github.com/armadaproject/armada/internal/armada/configuration"
 	armadamaps "github.com/armadaproject/armada/internal/common/maps"
 	armadaslices "github.com/armadaproject/armada/internal/common/slices"
 	schedulercontext "github.com/armadaproject/armada/internal/scheduler/context"
@@ -61,48 +58,4 @@ func JobsSummary(jctxs []*schedulercontext.JobSchedulingContext) string {
 		),
 		jobIdsByQueue,
 	)
-}
-
-// GangIdAndCardinalityFromLegacySchedulerJob returns a tuple (gangId, gangCardinality, gangMinimumCardinality, isGangJob, error).
-func GangIdAndCardinalityFromLegacySchedulerJob(job interfaces.LegacySchedulerJob) (string, int, int, bool, error) {
-	return GangIdAndCardinalityFromAnnotations(job.GetAnnotations())
-}
-
-// GangIdAndCardinalityFromAnnotations returns a tuple (gangId, gangCardinality, gangMinimumCardinality, isGangJob, error).
-func GangIdAndCardinalityFromAnnotations(annotations map[string]string) (string, int, int, bool, error) {
-	if annotations == nil {
-		return "", 1, 1, false, nil
-	}
-	gangId, ok := annotations[configuration.GangIdAnnotation]
-	if !ok {
-		return "", 1, 1, false, nil
-	}
-	gangCardinalityString, ok := annotations[configuration.GangCardinalityAnnotation]
-	if !ok {
-		return "", 1, 1, false, errors.Errorf("missing annotation %s", configuration.GangCardinalityAnnotation)
-	}
-	gangCardinality, err := strconv.Atoi(gangCardinalityString)
-	if err != nil {
-		return "", 1, 1, false, errors.WithStack(err)
-	}
-	if gangCardinality <= 0 {
-		return "", 1, 1, false, errors.Errorf("gang cardinality is non-positive %d", gangCardinality)
-	}
-	gangMinimumCardinalityString, ok := annotations[configuration.GangMinimumCardinalityAnnotation]
-	if !ok {
-		// If this is not set, default the minimum gang size to gangCardinality
-		return gangId, gangCardinality, gangCardinality, true, nil
-	} else {
-		gangMinimumCardinality, err := strconv.Atoi(gangMinimumCardinalityString)
-		if err != nil {
-			return "", 1, 1, false, errors.WithStack(err)
-		}
-		if gangMinimumCardinality <= 0 {
-			return "", 1, 1, false, errors.Errorf("gang minimum cardinality is non-positive %d", gangMinimumCardinality)
-		}
-		if gangMinimumCardinality > gangCardinality {
-			return "", 1, 1, false, errors.Errorf("gang minimum cardinality %d cannot be greater than gang cardinality %d", gangMinimumCardinality, gangCardinality)
-		}
-		return gangId, gangCardinality, gangMinimumCardinality, true, nil
-	}
 }

--- a/internal/scheduler/constraints/constraints.go
+++ b/internal/scheduler/constraints/constraints.go
@@ -165,8 +165,9 @@ func (constraints *SchedulingConstraints) CheckConstraints(
 	}
 
 	// PriorityClassSchedulingConstraintsByPriorityClassName check.
-	if priorityClassConstraint, ok := constraints.PriorityClassSchedulingConstraintsByPriorityClassName[gctx.PriorityClassName]; ok {
-		if !qctx.AllocatedByPriorityClass[gctx.PriorityClassName].IsStrictlyLessOrEqual(priorityClassConstraint.MaximumResourcesPerQueue) {
+	priorityClassName := gctx.GangInfo.PriorityClassName
+	if priorityClassConstraint, ok := constraints.PriorityClassSchedulingConstraintsByPriorityClassName[priorityClassName]; ok {
+		if !qctx.AllocatedByPriorityClass[priorityClassName].IsStrictlyLessOrEqual(priorityClassConstraint.MaximumResourcesPerQueue) {
 			return false, MaximumResourcesPerQueueExceededUnschedulableReason, nil
 		}
 	}

--- a/internal/scheduler/context/context_test.go
+++ b/internal/scheduler/context/context_test.go
@@ -19,7 +19,7 @@ func TestNewGangSchedulingContext(t *testing.T) {
 	gctx := NewGangSchedulingContext(jctxs)
 	assert.Equal(t, jctxs, gctx.JobSchedulingContexts)
 	assert.Equal(t, "A", gctx.Queue)
-	assert.Equal(t, testfixtures.TestDefaultPriorityClass, gctx.PriorityClassName)
+	assert.Equal(t, testfixtures.TestDefaultPriorityClass, gctx.GangInfo.PriorityClassName)
 	assert.True(
 		t,
 		schedulerobjects.ResourceList{
@@ -89,9 +89,9 @@ func testNSmallCpuJobSchedulingContext(queue, priorityClassName string, n int) [
 func testSmallCpuJobSchedulingContext(queue, priorityClassName string) *JobSchedulingContext {
 	job := testfixtures.Test1Cpu4GiJob(queue, priorityClassName)
 	return &JobSchedulingContext{
-		JobId:              job.GetId(),
-		Job:                job,
-		PodRequirements:    job.GetPodRequirements(testfixtures.TestPriorityClasses),
-		GangMinCardinality: 1,
+		JobId:           job.GetId(),
+		Job:             job,
+		PodRequirements: job.GetPodRequirements(testfixtures.TestPriorityClasses),
+		GangInfo:        EmptyGangInfo(job),
 	}
 }

--- a/internal/scheduler/gang_scheduler_test.go
+++ b/internal/scheduler/gang_scheduler_test.go
@@ -591,7 +591,7 @@ func TestGangScheduler(t *testing.T) {
 			var actualScheduledIndices []int
 			scheduledGangs := 0
 			for i, gang := range tc.Gangs {
-				jctxs := schedulercontext.JobSchedulingContextsFromJobs(tc.SchedulingConfig.Preemption.PriorityClasses, gang, GangIdAndCardinalityFromAnnotations)
+				jctxs := schedulercontext.JobSchedulingContextsFromJobs(tc.SchedulingConfig.Preemption.PriorityClasses, gang)
 				gctx := schedulercontext.NewGangSchedulingContext(jctxs)
 				ok, reason, err := sch.Schedule(armadacontext.Background(), gctx)
 				require.NoError(t, err)
@@ -604,7 +604,7 @@ func TestGangScheduler(t *testing.T) {
 					actualScheduledIndices = append(actualScheduledIndices, i)
 
 					// If there's a node uniformity constraint, check that it's met.
-					if gctx.NodeUniformityLabel != "" {
+					if nodeUniformity := gctx.GangInfo.NodeUniformity; nodeUniformity != "" {
 						nodeUniformityLabelValues := make(map[string]bool)
 						for _, jctx := range jctxs {
 							pctx := jctx.PodSchedulingContext
@@ -613,7 +613,7 @@ func TestGangScheduler(t *testing.T) {
 							}
 							node := nodesById[pctx.NodeId]
 							require.NotNil(t, node)
-							value, ok := node.Labels[gctx.NodeUniformityLabel]
+							value, ok := node.Labels[nodeUniformity]
 							require.True(t, ok, "gang job scheduled onto node with missing nodeUniformityLabel")
 							nodeUniformityLabelValues[value] = true
 						}

--- a/internal/scheduler/jobdb/job.go
+++ b/internal/scheduler/jobdb/job.go
@@ -249,7 +249,10 @@ func (job *Job) GetAnnotations() map[string]string {
 
 // Needed for compatibility with interfaces.LegacySchedulerJob
 func (job *Job) GetPriorityClassName() string {
-	return job.JobSchedulingInfo().PriorityClassName
+	if schedulingInfo := job.JobSchedulingInfo(); schedulingInfo != nil {
+		return schedulingInfo.PriorityClassName
+	}
+	return ""
 }
 
 func (job *Job) GetScheduledAtPriority() (int32, bool) {

--- a/internal/scheduler/jobiteration.go
+++ b/internal/scheduler/jobiteration.go
@@ -151,11 +151,7 @@ func (it *QueuedJobsIterator) Next() (*schedulercontext.JobSchedulingContext, er
 		if !ok {
 			return nil, nil
 		}
-		return schedulercontext.JobSchedulingContextFromJob(
-			it.priorityClasses,
-			job,
-			GangIdAndCardinalityFromAnnotations,
-		), nil
+		return schedulercontext.JobSchedulingContextFromJob(it.priorityClasses, job), nil
 	}
 }
 

--- a/internal/scheduler/nodedb/nodedb_test.go
+++ b/internal/scheduler/nodedb/nodedb_test.go
@@ -2,17 +2,14 @@ package nodedb
 
 import (
 	"fmt"
-	"strconv"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	"github.com/armadaproject/armada/internal/armada/configuration"
 	armadamaps "github.com/armadaproject/armada/internal/common/maps"
 	schedulerconfig "github.com/armadaproject/armada/internal/scheduler/configuration"
 	schedulercontext "github.com/armadaproject/armada/internal/scheduler/context"
@@ -74,7 +71,7 @@ func TestSelectNodeForPod_NodeIdLabel_Success(t *testing.T) {
 		map[string]string{schedulerconfig.NodeIdLabel: nodeId},
 		testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 1),
 	)
-	jctxs := schedulercontext.JobSchedulingContextsFromJobs(testfixtures.TestPriorityClasses, jobs, func(_ map[string]string) (string, int, int, bool, error) { return "", 1, 1, true, nil })
+	jctxs := schedulercontext.JobSchedulingContextsFromJobs(testfixtures.TestPriorityClasses, jobs)
 	for _, jctx := range jctxs {
 		txn := db.Txn(false)
 		node, err := db.SelectNodeForJobWithTxn(txn, jctx)
@@ -101,7 +98,7 @@ func TestSelectNodeForPod_NodeIdLabel_Failure(t *testing.T) {
 		map[string]string{schedulerconfig.NodeIdLabel: "this node does not exist"},
 		testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 1),
 	)
-	jctxs := schedulercontext.JobSchedulingContextsFromJobs(testfixtures.TestPriorityClasses, jobs, func(_ map[string]string) (string, int, int, bool, error) { return "", 1, 1, true, nil })
+	jctxs := schedulercontext.JobSchedulingContextsFromJobs(testfixtures.TestPriorityClasses, jobs)
 	for _, jctx := range jctxs {
 		txn := db.Txn(false)
 		node, err := db.SelectNodeForJobWithTxn(txn, jctx)
@@ -436,31 +433,31 @@ func TestScheduleIndividually(t *testing.T) {
 			nodeDb, err := newNodeDbWithNodes(tc.Nodes)
 			require.NoError(t, err)
 
-			jctxs := schedulercontext.JobSchedulingContextsFromJobs(testfixtures.TestPriorityClasses, tc.Jobs, func(_ map[string]string) (string, int, int, bool, error) { return "", 1, 1, true, nil })
+			jctxs := schedulercontext.JobSchedulingContextsFromJobs(testfixtures.TestPriorityClasses, tc.Jobs)
 
 			for i, jctx := range jctxs {
-				ok, err := nodeDb.ScheduleMany([]*schedulercontext.JobSchedulingContext{jctx})
+				nodeDbTxn := nodeDb.Txn(true)
+				gctx := schedulercontext.NewGangSchedulingContext([]*schedulercontext.JobSchedulingContext{jctx})
+				ok, err := nodeDb.ScheduleManyWithTxn(nodeDbTxn, gctx)
 				require.NoError(t, err)
+
+				require.Equal(t, tc.ExpectSuccess[i], ok)
+
 				pctx := jctx.PodSchedulingContext
 
-				if !tc.ExpectSuccess[i] {
-					assert.False(t, ok)
+				if !ok {
+					nodeDbTxn.Abort()
 					if pctx != nil {
 						assert.Equal(t, "", pctx.NodeId)
 					}
 					continue
 				}
 
-				assert.True(t, ok)
+				nodeDbTxn.Commit()
+
 				require.NotNil(t, pctx)
-
 				nodeId := pctx.NodeId
-				if !tc.ExpectSuccess[i] {
-					assert.Equal(t, "", nodeId)
-					continue
-				}
 				require.NotEqual(t, "", nodeId)
-
 				job := jctx.Job
 				node, err := nodeDb.GetNode(nodeId)
 				require.NoError(t, err)
@@ -531,27 +528,26 @@ func TestScheduleMany(t *testing.T) {
 			nodeDb, err := newNodeDbWithNodes(tc.Nodes)
 			require.NoError(t, err)
 			for i, jobs := range tc.Jobs {
-				minCardinalityStr, ok := jobs[0].GetAnnotations()[configuration.GangMinimumCardinalityAnnotation]
-				if !ok {
-					minCardinalityStr = "1"
-				}
-				minCardinality, err := strconv.Atoi(minCardinalityStr)
-				if err != nil {
-					minCardinality = 1
-				}
-				extractGangInfo := func(_ map[string]string) (string, int, int, bool, error) {
-					id, _ := uuid.NewUUID()
-					return id.String(), 1, minCardinality, true, nil
-				}
-
-				jctxs := schedulercontext.JobSchedulingContextsFromJobs(testfixtures.TestPriorityClasses, jobs, extractGangInfo)
-				ok, err = nodeDb.ScheduleMany(jctxs)
+				nodeDbTxn := nodeDb.Txn(true)
+				jctxs := schedulercontext.JobSchedulingContextsFromJobs(testfixtures.TestPriorityClasses, jobs)
+				gctx := schedulercontext.NewGangSchedulingContext(jctxs)
+				ok, err := nodeDb.ScheduleManyWithTxn(nodeDbTxn, gctx)
 				require.NoError(t, err)
-				assert.Equal(t, tc.ExpectSuccess[i], ok)
+				require.Equal(t, tc.ExpectSuccess[i], ok)
+				if ok {
+					nodeDbTxn.Commit()
+				} else {
+					nodeDbTxn.Abort()
+					// We make no assertions about pctx in this case; if some of
+					// the jobs in the gang were scheduled successfully and
+					// others were not, then pctx.NodeId will be inconsistent
+					// until the gang is returned back to the gang scheduler.
+					continue
+				}
 				for _, jctx := range jctxs {
 					pctx := jctx.PodSchedulingContext
 					require.NotNil(t, pctx)
-					if tc.ExpectSuccess[i] && !jctx.ShouldFail {
+					if !jctx.ShouldFail {
 						assert.NotEqual(t, "", pctx.NodeId)
 					}
 				}
@@ -618,9 +614,10 @@ func benchmarkScheduleMany(b *testing.B, nodes []*schedulerobjects.Node, jobs []
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		jctxs := schedulercontext.JobSchedulingContextsFromJobs(testfixtures.TestPriorityClasses, jobs, func(_ map[string]string) (string, int, int, bool, error) { return "", 1, 1, true, nil })
+		jctxs := schedulercontext.JobSchedulingContextsFromJobs(testfixtures.TestPriorityClasses, jobs)
+		gctx := schedulercontext.NewGangSchedulingContext(jctxs)
 		txn := nodeDb.Txn(true)
-		_, err := nodeDb.ScheduleManyWithTxn(txn, jctxs)
+		_, err := nodeDb.ScheduleManyWithTxn(txn, gctx)
 		txn.Abort()
 		require.NoError(b, err)
 	}

--- a/internal/scheduler/pool_assigner.go
+++ b/internal/scheduler/pool_assigner.go
@@ -131,11 +131,11 @@ func (p *DefaultPoolAssigner) AssignPool(j *jobdb.Job) (string, error) {
 			nodeDb := e.nodeDb
 			txn := nodeDb.Txn(true)
 			jctx := &schedulercontext.JobSchedulingContext{
-				Created:            time.Now(),
-				JobId:              j.GetId(),
-				Job:                j,
-				PodRequirements:    j.GetPodRequirements(p.priorityClasses),
-				GangMinCardinality: 1,
+				Created:         time.Now(),
+				JobId:           j.GetId(),
+				Job:             j,
+				PodRequirements: j.GetPodRequirements(p.priorityClasses),
+				GangInfo:        schedulercontext.EmptyGangInfo(j),
 			}
 			node, err := nodeDb.SelectNodeForJobWithTxn(txn, jctx)
 			txn.Abort()

--- a/internal/scheduler/queue_scheduler.go
+++ b/internal/scheduler/queue_scheduler.go
@@ -228,16 +228,19 @@ func (it *QueuedGangIterator) Peek() (*schedulercontext.GangSchedulingContext, e
 				}
 			}
 		}
-		if jctx.GangCardinality > 1 {
-			gang := it.jctxsByGangId[jctx.GangId]
+		if gangId := jctx.GangInfo.Id; gangId != "" {
+			gang := it.jctxsByGangId[gangId]
 			gang = append(gang, jctx)
-			it.jctxsByGangId[jctx.GangId] = gang
-			if len(gang) == jctx.GangCardinality {
-				delete(it.jctxsByGangId, jctx.GangId)
+			it.jctxsByGangId[gangId] = gang
+			if len(gang) == jctx.GangInfo.Cardinality {
+				delete(it.jctxsByGangId, gangId)
 				it.next = schedulercontext.NewGangSchedulingContext(gang)
 				return it.next, nil
 			}
 		} else {
+			// It's not actually necessary to treat this case separately, but
+			// using the empty string as a key in it.jctxsByGangId sounds like
+			// it would get us in trouble later down the line.
 			it.next = schedulercontext.NewGangSchedulingContext([]*schedulercontext.JobSchedulingContext{jctx})
 			return it.next, nil
 		}

--- a/internal/scheduler/queue_scheduler_test.go
+++ b/internal/scheduler/queue_scheduler_test.go
@@ -534,7 +534,6 @@ func TestQueueScheduler(t *testing.T) {
 				schedulercontext.JobSchedulingContextsFromJobs(
 					tc.SchedulingConfig.Preemption.PriorityClasses,
 					legacySchedulerJobs,
-					GangIdAndCardinalityFromAnnotations,
 				),
 			)
 
@@ -686,9 +685,7 @@ func TestQueueScheduler(t *testing.T) {
 						continue
 					}
 					assert.Equal(t, nodeDb.NumNodes(), pctx.NumNodes)
-					_, _, _, isGangJob, err := GangIdAndCardinalityFromLegacySchedulerJob(jctx.Job)
-					require.NoError(t, err)
-					if !isGangJob {
+					if gangId := jctx.GangInfo.Id; gangId == "" {
 						numExcludedNodes := 0
 						for _, count := range pctx.NumExcludedNodesByReason {
 							numExcludedNodes += count

--- a/internal/scheduler/reports_test.go
+++ b/internal/scheduler/reports_test.go
@@ -253,7 +253,7 @@ func withSuccessfulJobSchedulingContext(sctx *schedulercontext.SchedulingContext
 		qctx.SchedulingContext = nil
 		qctx.Created = time.Time{}
 	}
-	qctx.SuccessfulJobSchedulingContexts[jobId] = &schedulercontext.JobSchedulingContext{JobId: jobId, GangMinCardinality: 1}
+	qctx.SuccessfulJobSchedulingContexts[jobId] = &schedulercontext.JobSchedulingContext{JobId: jobId}
 	rl := schedulerobjects.ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("1")}}
 	qctx.ScheduledResourcesByPriorityClass.AddResourceList("foo", rl)
 	sctx.ScheduledResourcesByPriorityClass.AddResourceList("foo", rl)
@@ -293,7 +293,7 @@ func withUnsuccessfulJobSchedulingContext(sctx *schedulercontext.SchedulingConte
 		qctx.SchedulingContext = nil
 		qctx.Created = time.Time{}
 	}
-	qctx.UnsuccessfulJobSchedulingContexts[jobId] = &schedulercontext.JobSchedulingContext{JobId: jobId, UnschedulableReason: "unknown", GangMinCardinality: 1}
+	qctx.UnsuccessfulJobSchedulingContexts[jobId] = &schedulercontext.JobSchedulingContext{JobId: jobId, UnschedulableReason: "unknown"}
 	return sctx
 }
 

--- a/internal/scheduler/scheduler_metrics_test.go
+++ b/internal/scheduler/scheduler_metrics_test.go
@@ -21,7 +21,7 @@ func TestAggregateJobs(t *testing.T) {
 		testfixtures.Test1Cpu4GiJob("queue_a", testfixtures.PriorityClass0),
 	}
 
-	actual := aggregateJobContexts(schedulercontext.JobSchedulingContextsFromJobs(testfixtures.TestPriorityClasses, testJobs, GangIdAndCardinalityFromAnnotations))
+	actual := aggregateJobContexts(schedulercontext.JobSchedulingContextsFromJobs(testfixtures.TestPriorityClasses, testJobs))
 
 	expected := map[collectionKey]int{
 		{queue: "queue_a", priorityClass: testfixtures.PriorityClass0}: 4,

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1228,9 +1228,9 @@ func NewSchedulerResultForTest[S ~[]T, T interfaces.LegacySchedulerJob](
 	nodeIdByJobId map[string]string,
 ) *SchedulerResult {
 	return &SchedulerResult{
-		PreemptedJobs: schedulercontext.JobSchedulingContextsFromJobs(testfixtures.TestPriorityClasses, preemptedJobs, GangIdAndCardinalityFromAnnotations),
-		ScheduledJobs: schedulercontext.JobSchedulingContextsFromJobs(testfixtures.TestPriorityClasses, scheduledJobs, GangIdAndCardinalityFromAnnotations),
-		FailedJobs:    schedulercontext.JobSchedulingContextsFromJobs(testfixtures.TestPriorityClasses, failedJobs, GangIdAndCardinalityFromAnnotations),
+		PreemptedJobs: schedulercontext.JobSchedulingContextsFromJobs(testfixtures.TestPriorityClasses, preemptedJobs),
+		ScheduledJobs: schedulercontext.JobSchedulingContextsFromJobs(testfixtures.TestPriorityClasses, scheduledJobs),
+		FailedJobs:    schedulercontext.JobSchedulingContextsFromJobs(testfixtures.TestPriorityClasses, failedJobs),
 		NodeIdByJobId: nodeIdByJobId,
 	}
 }

--- a/internal/scheduler/scheduling_algo.go
+++ b/internal/scheduler/scheduling_algo.go
@@ -293,11 +293,11 @@ func (l *FairSchedulingAlgo) newFairSchedulingAlgoContext(ctx *armadacontext.Con
 		}
 		jobsByExecutorId[executorId] = append(jobsByExecutorId[executorId], job)
 		nodeIdByJobId[job.Id()] = nodeId
-		gangId, _, _, isGangJob, err := GangIdAndCardinalityFromLegacySchedulerJob(job)
+		gangInfo, err := schedulercontext.GangInfoFromLegacySchedulerJob(job)
 		if err != nil {
 			return nil, err
 		}
-		if isGangJob {
+		if gangId := gangInfo.Id; gangId != "" {
 			jobIds := jobIdsByGangId[gangId]
 			if jobIds == nil {
 				jobIds = make(map[string]bool)

--- a/pkg/api/util.go
+++ b/pkg/api/util.go
@@ -221,8 +221,10 @@ func PriorityFromPodSpec(podSpec *v1.PodSpec, priorityClasses map[string]types.P
 }
 
 func (job *Job) GetPriorityClassName() string {
-	podSpec := job.GetMainPodSpec()
-	return podSpec.PriorityClassName
+	if podSpec := job.GetMainPodSpec(); podSpec != nil {
+		return podSpec.PriorityClassName
+	}
+	return ""
 }
 
 func (job *Job) GetScheduledAtPriority() (int32, bool) {


### PR DESCRIPTION
This PR reduces the number of places in which we extract gang metadata from a job's annotations by adding the `GangInfo` type and adding a field of this type to `JobSchedulingContext`; it also removes the need to pass `GangIdAndCardinalityFromAnnotations` to `JobSchedulingContextFromJob`, which simplifies the code.