### PR TITLE
Reset scheduler metrics periodically

### DIFF
--- a/config/scheduler/config.yaml
+++ b/config/scheduler/config.yaml
@@ -18,6 +18,13 @@ metrics:
       start: 1.0
       factor: 1.1
       count: 110
+schedulerMetrics:
+  trackedResourceNames:
+    - "cpu"
+    - "memory"
+    - "ephemeral-storage"
+    - "nvidia.com/gpu"
+  resetInterval: "1h"
 pulsar:
   URL: "pulsar://pulsar:6650"
   jobsetEventsTopic: "events"

--- a/internal/scheduler/configuration/configuration.go
+++ b/internal/scheduler/configuration/configuration.go
@@ -79,6 +79,8 @@ type MetricsConfig struct {
 	// Controls the cycle time metrics.
 	// TODO(albin): Not used yet.
 	CycleTimeConfig PrometheusSummaryConfig
+	// Reset metrics this often. Resetting periodically ensures inactive time series are garbage-collected.
+	ResetInterval time.Duration
 }
 
 // PrometheusSummaryConfig contains the relevant config for a prometheus.Summary.


### PR DESCRIPTION
Resetting every collection cycle causes problems when using Prometheus rate/increase etc. functions.