### PR TITLE
Filter out docker build-arg option if no BASE_IMAGE (#3259)

### DIFF
--- a/magefiles/goreleaser.go
+++ b/magefiles/goreleaser.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"os"
 	"regexp"
-	"slices"
 	"time"
+
+	"golang.org/x/exp/slices"
 
 	goreleaserConfig "github.com/goreleaser/goreleaser/pkg/config"
 	"github.com/magefile/mage/sh"
@@ -66,9 +67,15 @@ func goreleaserWriteMinimalReleaseConfig(dockerIds ...string) error {
 			// see .goreleaser.yml for how it's used. Goreleaser does not support conditional
 			// templating of YAML in its 'dockers' section, so we filter it out here.
 			if os.Getenv("BASE_IMAGE") == "" {
-				docker.BuildFlagTemplates = slices.DeleteFunc(docker.BuildFlagTemplates, func(t string) bool {
-					return buildArgBaseRE.MatchString(t)
-				})
+				deleteIdx := -1
+				for idx, tpl := range docker.BuildFlagTemplates {
+					if buildArgBaseRE.MatchString(tpl) {
+						deleteIdx = idx
+						break
+					}
+				}
+
+				docker.BuildFlagTemplates = slices.Delete(docker.BuildFlagTemplates, deleteIdx, deleteIdx+1)
 			}
 
 			dockersById[docker.ID] = docker


### PR DESCRIPTION
If the `BASE_IMAGE` var is not defined in the environment, filter out the build template entry for Goreleaser to invoke `docker build[x]` so that we avoid calling `docker build` with an invalid `--build-arg= ` (no value) option, which was causing the build to fail.

I originally tried doing this directly in `.goreleaser.yml` - I researched and tried using template conditionals to omit the whole `- --build-arg={{ .Env.BASE_IMAGE_ARG }}` entry under `dockers.build_flag_templates`, with no success, whether using inline or multi-line `{{ if ... }} .. {{ end }}` conditionals. It's not clear if it's possible to conditionally include an element in a list via Goreleaser's template processing (YAML itself does not support conditionals); the Goreleaser support forum stated that it's not used in all sections of the file.

Fixes #3259 