### PR TITLE
Remove mentions of BASE_IMAGE in Goreleaser config and processing.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,8 +13,6 @@ snapshot:
 env:
   - GOPROXY={{ if index .Env "GOPROXY"  }}{{ .Env.GOPROXY }}{{ else }}https://proxy.golang.org,direct{{ end }}
   - GOSUMDB={{ if index .Env "GOSUMDB"  }}{{ .Env.GOSUMDB }}{{ else }}sum.golang.org{{ end }}
-  # If set, BASE_IMAGE determines the base image used for all containers.
-  - BASE_IMAGE_ARG={{ if index .Env "BASE_IMAGE"  }}BASE_IMAGE={{ .Env.BASE_IMAGE }}{{ else }}{{ end }}
   - DOCKER_REPO={{ if index .Env "DOCKER_REPO"  }}{{ .Env.DOCKER_REPO }}/{{ else }}gresearch/{{ end }}
   # Goreleaser always uses the docker buildx builder with name "default"; see
   # https://github.com/goreleaser/goreleaser/pull/3199
@@ -206,7 +204,6 @@ dockers:
       - "{{ .Env.DOCKER_REPO }}armada-bundle:latest"
       - "{{ .Env.DOCKER_REPO }}armada-bundle:{{ .Version }}"
     build_flag_templates: &BUILD_FLAG_TEMPLATES
-      - --build-arg={{ .Env.BASE_IMAGE_ARG }}
       - --builder={{ .Env.DOCKER_BUILDX_BUILDER }}
       - --cache-to={{ .Env.DOCKER_BUILDX_CACHE_TO }}
       - --cache-from={{ .Env.DOCKER_BUILDX_CACHE_FROM }}


### PR DESCRIPTION
This is intended to be a more robust fix for Goreleaser issuing `docker buildx` commands with a faulty `--build-args= ` option.  The error manifests as:
```
failed to build gresearch/<some-image>:latest: exit status 1: ERROR: invalid key-value pair "": empty key
```

These changes revert the earlier fix (which only worked for `mage`-invoked Goreleaser executions), plus removes all mentions of `BASE_IMAGE` in .goreleaser.yml, since it isn't actually used with env-var definitions in practice, and already pervasively defined in Dockerfiles.

Revert "Filter out docker build-arg option if no BASE_IMAGE (#3259) (#3261)"

This reverts commit a4684492c6f2c738bc3322195b35de6f58b0160d.
