### PR TITLE
Add queryapi to goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -144,6 +144,15 @@ builds:
       - linux
     goarch:
       - amd64
+  - env: [ CGO_ENABLED=0 ]
+    id: queryapi
+    binary: queryapi
+    main: ./cmd/queryapi/main.go
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    goos:
+      - linux
+    goarch:
+      - amd64
   - env: [CGO_ENABLED=0]
     id: armadactl
     binary: armadactl
@@ -438,6 +447,20 @@ dockers:
     extra_files:
       - config/binoculars/config.yaml
     dockerfile: ./build_goreleaser/binoculars/Dockerfile
+
+  - id: queryapi
+    use: buildx
+    goos: linux
+    goarch: amd64
+    image_templates:
+      - "{{ .Env.DOCKER_REPO }}armada-queryapi:latest"
+      - "{{ .Env.DOCKER_REPO }}armada-queryapi:{{ .Version }}"
+    build_flag_templates: *BUILD_FLAG_TEMPLATES
+    ids:
+      - queryapi
+    extra_files:
+      - config/queryapi/config.yaml
+    dockerfile: ./build_goreleaser/queryapi/Dockerfile
 
   - id: jobservice
     use: buildx

--- a/build_goreleaser/queryapi/Dockerfile
+++ b/build_goreleaser/queryapi/Dockerfile
@@ -8,7 +8,7 @@ RUN addgroup -S -g 2000 armada && adduser -S -u 1000 armada -G armada
 USER armada
 
 COPY queryapi /app/
-COPY config/queriapi/config.yaml /app/config/queryapi/config.yaml
+COPY config/queryapi/config.yaml /app/config/queryapi/config.yaml
 
 WORKDIR /app
 


### PR DESCRIPTION
Previously we created the queryapi component but we didn't add the relevant goreleaser config.  This PR corrects that.