### PR TITLE
Armada Website: add Linux Foundation trademark link to web-site footer. (#3245)

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -14,6 +14,9 @@
         <div class="copyright">
           <span> © {{ 'now' | date: "%Y" }} Armada Project</span>
         </div>
+        <div class="copyright">
+          <a href="https://www.linuxfoundation.org/legal/trademark-usage">Trademarks</a>
+        </div>
       </div>
       <div class="col-md-6">
         <ul class="nav nav-footer justify-content-end">


### PR DESCRIPTION
Add Linux Foundation trademark link to footer for Armada website, using the suggested link syntax from the bug ticket. Attached image is the lower-left portion of the footer with this link added.

Fixes https://github.com/armadaproject/armada/issues/3245

<img width="325" alt="Screenshot 2024-02-06 at 2 27 28 PM" src="https://github.com/armadaproject/armada/assets/3155623/17bc41a9-8889-4a44-a0e3-cbc4341f9cd9">

