### PR TITLE
Remove readyness and liveness probes from queryapi

### DIFF
--- a/deployment/queryapi/templates/deployment.yaml
+++ b/deployment/queryapi/templates/deployment.yaml
@@ -69,20 +69,6 @@ spec:
             {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
-          readinessProbe:
-            httpGet:
-              path: /health
-              port: web
-            initialDelaySeconds: 5
-            timeoutSeconds: 5
-            failureThreshold: 2
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: web
-            initialDelaySeconds: 10
-            timeoutSeconds: 10
-            failureThreshold: 3
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
While this is experimental, I don't want any probes