### PR TITLE
Add an index for (queue,jobset) on the schedulerdb jobs table

### DIFF
--- a/internal/scheduler/database/migrations/007_add_queue_jobset_index.sql
+++ b/internal/scheduler/database/migrations/007_add_queue_jobset_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_jobs_queue_jobset ON jobs (queue, job_set);


### PR DESCRIPTION
Adds an index for (queue,jobset) on the jobs table int he scheduler database.

We need this because when we cancel a jobset we run some sql of the form `update jobs, set cancelRequested = 1 where queue = x and jobset = y`.  As there is no index here, this can be quite expensive as it involves a linear scan.

Adding the index here should solve this.  There will be a cost to pay when inserting or deleting but this shouldn't be too bad.