### PR TITLE
Make `logQuery` log query and values in a single message

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,6 @@ require (
 require (
 	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/benbjohnson/immutable v0.4.3
-	github.com/caarlos0/log v0.4.4
 	github.com/go-openapi/errors v0.21.0
 	github.com/go-openapi/strfmt v0.21.10
 	github.com/go-openapi/swag v0.22.6
@@ -111,6 +110,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.4.0 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
+	github.com/caarlos0/log v0.4.4 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/charmbracelet/lipgloss v0.9.1 // indirect
 	github.com/danieljoos/wincred v1.1.2 // indirect

--- a/internal/executor/application.go
+++ b/internal/executor/application.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/caarlos0/log"
 	"github.com/go-playground/validator/v10"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/prometheus/client_golang/prometheus"
@@ -142,7 +141,7 @@ func StartUpWithContext(
 		os.Exit(-1)
 	}
 
-	stopExecutorApiComponents := setupExecutorApiComponents(config, clusterContext, clusterHealthMonitor, taskManager, pendingPodChecker, nodeInfoService, podUtilisationService)
+	stopExecutorApiComponents := setupExecutorApiComponents(log, config, clusterContext, clusterHealthMonitor, taskManager, pendingPodChecker, nodeInfoService, podUtilisationService)
 
 	resourceCleanupService := service.NewResourceCleanupService(clusterContext, config.Kubernetes)
 	taskManager.Register(resourceCleanupService.CleanupResources, config.Task.ResourceCleanupInterval, "resource_cleanup")
@@ -163,6 +162,7 @@ func StartUpWithContext(
 }
 
 func setupExecutorApiComponents(
+	log *logrus.Entry,
 	config configuration.ExecutorConfiguration,
 	clusterContext executor_context.ClusterContext,
 	clusterHealthMonitor healthmonitor.HealthMonitor,

--- a/internal/lookoutv2/application.go
+++ b/internal/lookoutv2/application.go
@@ -3,7 +3,6 @@
 package lookoutv2
 
 import (
-	"github.com/caarlos0/log"
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/jessevdk/go-flags"
@@ -41,7 +40,9 @@ func Serve(configuration configuration.LookoutV2Config) error {
 	// create new service API
 	api := operations.NewLookoutAPI(swaggerSpec)
 
-	logger := logrus.NewEntry(logrus.New())
+	logger := logrus.NewEntry(logrus.StandardLogger())
+
+	api.Logger = logger.Debugf
 
 	api.GetHealthHandler = operations.GetHealthHandlerFunc(
 		func(params operations.GetHealthParams) middleware.Responder {
@@ -123,7 +124,7 @@ func Serve(configuration configuration.LookoutV2Config) error {
 	defer func() {
 		shutdownErr := server.Shutdown()
 		if shutdownErr != nil {
-			log.WithError(shutdownErr).Error("Failed to shut down server")
+			logger.WithError(shutdownErr).Error("Failed to shut down server")
 		}
 	}()
 

--- a/internal/lookoutv2/repository/getjobs.go
+++ b/internal/lookoutv2/repository/getjobs.go
@@ -88,7 +88,7 @@ func (r *SqlGetJobsRepository) GetJobs(ctx *armadacontext.Context, filters []*mo
 		DeferrableMode: pgx.Deferrable,
 	}, func(tx pgx.Tx) error {
 		createTempTableQuery, tempTableName := NewQueryBuilder(r.lookoutTables).CreateTempTable()
-		logQuery(createTempTableQuery)
+		logQuery(createTempTableQuery, "CreateTempTable")
 		_, err := tx.Exec(ctx, createTempTableQuery.Sql, createTempTableQuery.Args...)
 		if err != nil {
 			return err
@@ -98,7 +98,7 @@ func (r *SqlGetJobsRepository) GetJobs(ctx *armadacontext.Context, filters []*mo
 		if err != nil {
 			return err
 		}
-		logQuery(insertQuery)
+		logQuery(insertQuery, "InsertIntoTempTable")
 		_, err = tx.Exec(ctx, insertQuery.Sql, insertQuery.Args...)
 		if err != nil {
 			return err

--- a/internal/lookoutv2/repository/groupjobs.go
+++ b/internal/lookoutv2/repository/groupjobs.go
@@ -64,7 +64,7 @@ func (r *SqlGroupJobsRepository) GroupBy(
 		if err != nil {
 			return err
 		}
-		logQuery(groupByQuery)
+		logQuery(groupByQuery, "GroupBy")
 		groupRows, err := tx.Query(ctx, groupByQuery.Sql, groupByQuery.Args...)
 		if err != nil {
 			return err

--- a/internal/lookoutv2/repository/util.go
+++ b/internal/lookoutv2/repository/util.go
@@ -675,9 +675,11 @@ func prefixAnnotations(prefix string, annotations map[string]string) map[string]
 	return prefixed
 }
 
-func logQuery(query *Query) {
-	log.Debug(removeNewlinesAndTabs(query.Sql))
-	log.Debugf("%v", query.Args)
+func logQuery(query *Query, description string) {
+	log.
+		WithField("query", removeNewlinesAndTabs(query.Sql)).
+		WithField("values", query.Args).
+		Debug(description)
 }
 
 func removeNewlinesAndTabs(s string) string {


### PR DESCRIPTION
It currently logs them in separate messages, which makes it somewhat cumbersome to look at log messages for specific queries; while I was in the vicinity, I also removed a spurious direct dependency on `github.com/caarlos0/log`.