### PR TITLE
Add node and queue success probability estimation

### DIFF
--- a/config/scheduler/config.yaml
+++ b/config/scheduler/config.yaml
@@ -139,4 +139,11 @@ scheduling:
       resolution: "1Mi"
   gangIdAnnotation: armadaproject.io/gangId
   gangCardinalityAnnotation: armadaproject.io/gangCardinality
+  failureEstimatorConfig:
+    nodeSuccessProbabilityCordonThreshold: 0.1
+    queueSuccessProbabilityCordonThreshold: 0.05
+    nodeCordonTimeout: "10m"
+    queueCordonTimeout: "5m"
+    nodeEquilibriumFailureRate: 0.0167 # 1 per minute.
+    queueEquilibriumFailureRate: 0.0167 # 1 per minute.
 

--- a/config/scheduler/config.yaml
+++ b/config/scheduler/config.yaml
@@ -143,7 +143,7 @@ scheduling:
     nodeSuccessProbabilityCordonThreshold: 0.1
     queueSuccessProbabilityCordonThreshold: 0.05
     nodeCordonTimeout: "10m"
-    queueCordonTimeout: "5m"
+    queueCordonTimeout: "1m"
     nodeEquilibriumFailureRate: 0.0167 # 1 per minute.
     queueEquilibriumFailureRate: 0.0167 # 1 per minute.
 

--- a/internal/armada/configuration/types.go
+++ b/internal/armada/configuration/types.go
@@ -219,6 +219,8 @@ type SchedulingConfig struct {
 	ExecutorUpdateFrequency time.Duration
 	// Enable new preemption strategy.
 	EnableNewPreemptionStrategy bool
+	// Controls estimating node and queue failure estimation.
+	FailureEstimatorConfig FailureEstimatorConfig
 }
 
 const (
@@ -313,6 +315,15 @@ type PreemptionConfig struct {
 	DefaultPriorityClass string
 	// If set, override the priority class name of pods with this value when sending to an executor.
 	PriorityClassNameOverride *string
+}
+
+type FailureEstimatorConfig struct {
+	NodeSuccessProbabilityCordonThreshold  float64
+	QueueSuccessProbabilityCordonThreshold float64
+	NodeCordonTimeout                      time.Duration
+	QueueCordonTimeout                     time.Duration
+	NodeEquilibriumFailureRate             float64
+	QueueEquilibriumFailureRate            float64
 }
 
 // TODO: we can probably just typedef this to map[string]string

--- a/internal/armada/configuration/types.go
+++ b/internal/armada/configuration/types.go
@@ -219,7 +219,7 @@ type SchedulingConfig struct {
 	ExecutorUpdateFrequency time.Duration
 	// Enable new preemption strategy.
 	EnableNewPreemptionStrategy bool
-	// Controls estimating node and queue failure estimation.
+	// Controls node and queue success probability estimation.
 	FailureEstimatorConfig FailureEstimatorConfig
 }
 
@@ -317,6 +317,8 @@ type PreemptionConfig struct {
 	PriorityClassNameOverride *string
 }
 
+// FailureEstimatorConfig contains config controlling node and queue success probability estimation.
+// See the internal/scheduler/failureestimator package for details.
 type FailureEstimatorConfig struct {
 	Disabled                               bool
 	NodeSuccessProbabilityCordonThreshold  float64

--- a/internal/armada/configuration/types.go
+++ b/internal/armada/configuration/types.go
@@ -318,6 +318,7 @@ type PreemptionConfig struct {
 }
 
 type FailureEstimatorConfig struct {
+	Disabled                               bool
 	NodeSuccessProbabilityCordonThreshold  float64
 	QueueSuccessProbabilityCordonThreshold float64
 	NodeCordonTimeout                      time.Duration

--- a/internal/scheduler/failureestimator/failureestimator.go
+++ b/internal/scheduler/failureestimator/failureestimator.go
@@ -36,9 +36,11 @@ const (
 // Specifically, we maximise the log-likelihood function of P_q and P_n using observed successes and failures.
 // This maximisation is performed using online gradient descent, where for each success or failure,
 // we update the corresponding P_q and P_n by taking a gradient step.
+// See New(...) for more details regarding step size.
 //
 // Finally, we exponentially decay P_q and P_N towards 1 over time,
 // such that nodes and queues for which we observe no failures appear to become healthier over time.
+// See New(...) function for details regarding decay.
 //
 // This module internally only maintains success probability estimates, as this makes the maths cleaner.
 // When exporting these via API calls we convert to failure probabilities as these are more intuitive to reason about.

--- a/internal/scheduler/failureestimator/failureestimator.go
+++ b/internal/scheduler/failureestimator/failureestimator.go
@@ -1,0 +1,252 @@
+package failureestimator
+
+import (
+	"fmt"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/armadaproject/armada/internal/common/armadaerrors"
+)
+
+const (
+	namespace = "armada"
+	subsystem = "scheduler"
+
+	// Floating point tolerance. Also used when applying limits to avoid divide-by-zero issues.
+	eps = 1e-15
+	// Assumed success probability of "good" nodes (queues) used when calculating step size.
+	healthySuccessProbability = 0.95
+)
+
+// FailureEstimator estimates the success probability of nodes (queues) based on empirical data.
+// The estimate is based on log-likelihood maximisation computed using online gradient descent.
+type FailureEstimator struct {
+	// Map from node (queue) name to the estimated success probability of that node (queue). For example:
+	// - successProbabilityByNode["myNode"] = 0.85]: estimated failure probability of a perfect job run on "myNode" is 15%.
+	// - successProbabilityByQueue["myQueue"] = 0.60]: estimated failure probability of a job from "myQueue" run on a perfect node is 40%.
+	successProbabilityByNode  map[string]float64
+	successProbabilityByQueue map[string]float64
+
+	// Success probability below which to consider nodes (jobs) unhealthy.
+	nodeSuccessProbabilityCordonThreshold  float64
+	queueSuccessProbabilityCordonThreshold float64
+
+	// Controls how quickly estimated node (queue) success probability increase in absence of any evidence.
+	// Computed from {node, queue}SuccessProbabilityCordonThreshold and {node, queue}CordonTimeout.
+	nodeFailureProbabilityDecayRate  float64
+	queueFailureProbabilityDecayRate float64
+	timeOfLastDecay                  time.Time
+
+	// Gradient descent step size. Controls the extent to which new data affects successProbabilityBy{Node, Queue}.
+	// Computed from {node, queue}SuccessProbabilityCordonThreshold, {node, queue}FailureProbabilityDecayRate, {node, queue}EquilibriumFailureRate.
+	nodeStepSize  float64
+	queueStepSize float64
+
+	failureProbabilityByNodeDesc  *prometheus.Desc
+	failureProbabilityByQueueDesc *prometheus.Desc
+
+	mu sync.Mutex
+}
+
+// New returns a new FailureEstimator. Parameters have the following meaning:
+// - {node, queue}SuccessProbabilityCordonThreshold: Success probability below which nodes (queues) are considered unhealthy.
+// - {node, queue}CordonTimeout: Amount of time for which nodes (queues) remain unhealthy in the absence of any job successes or failures for that node (queue).
+// - {node, queue}EquilibriumFailureRate: Job failures per second necessary for a node (queue) to remain unhealthy in the absence of any successes for that node (queue).
+func New(
+	nodeSuccessProbabilityCordonThreshold float64,
+	queueSuccessProbabilityCordonThreshold float64,
+	nodeCordonTimeout time.Duration,
+	queueCordonTimeout time.Duration,
+	nodeEquilibriumFailureRate float64,
+	queueEquilibriumFailureRate float64,
+) (*FailureEstimator, error) {
+	if nodeSuccessProbabilityCordonThreshold < 0 || nodeSuccessProbabilityCordonThreshold > 1 {
+		return nil, errors.WithStack(&armadaerrors.ErrInvalidArgument{
+			Name:    "nodeSuccessProbabilityCordonThreshold",
+			Value:   nodeSuccessProbabilityCordonThreshold,
+			Message: fmt.Sprintf("outside allowed range [0, 1]"),
+		})
+	}
+	if queueSuccessProbabilityCordonThreshold < 0 || queueSuccessProbabilityCordonThreshold > 1 {
+		return nil, errors.WithStack(&armadaerrors.ErrInvalidArgument{
+			Name:    "queueSuccessProbabilityCordonThreshold",
+			Value:   queueSuccessProbabilityCordonThreshold,
+			Message: fmt.Sprintf("outside allowed range [0, 1]"),
+		})
+	}
+	if nodeCordonTimeout < 0 {
+		return nil, errors.WithStack(&armadaerrors.ErrInvalidArgument{
+			Name:    "nodeCordonTimeout",
+			Value:   nodeCordonTimeout,
+			Message: fmt.Sprintf("outside allowed range [0, Inf)"),
+		})
+	}
+	if queueCordonTimeout < 0 {
+		return nil, errors.WithStack(&armadaerrors.ErrInvalidArgument{
+			Name:    "queueCordonTimeout",
+			Value:   queueCordonTimeout,
+			Message: fmt.Sprintf("outside allowed range [0, Inf)"),
+		})
+	}
+	if nodeEquilibriumFailureRate <= 0 {
+		return nil, errors.WithStack(&armadaerrors.ErrInvalidArgument{
+			Name:    "nodeEquilibriumFailureRate",
+			Value:   nodeEquilibriumFailureRate,
+			Message: fmt.Sprintf("outside allowed range (0, Inf)"),
+		})
+	}
+	if queueEquilibriumFailureRate <= 0 {
+		return nil, errors.WithStack(&armadaerrors.ErrInvalidArgument{
+			Name:    "queueEquilibriumFailureRate",
+			Value:   queueEquilibriumFailureRate,
+			Message: fmt.Sprintf("outside allowed range (0, Inf)"),
+		})
+	}
+
+	nodeFailureProbabilityDecayRate := math.Exp(math.Log(1-nodeSuccessProbabilityCordonThreshold) / nodeCordonTimeout.Seconds())
+	queueFailureProbabilityDecayRate := math.Exp(math.Log(1-queueSuccessProbabilityCordonThreshold) / queueCordonTimeout.Seconds())
+
+	dNodeSuccessProbability := healthySuccessProbability / (1 - nodeSuccessProbabilityCordonThreshold*healthySuccessProbability)
+	dQueueSuccessProbability := healthySuccessProbability / (1 - queueSuccessProbabilityCordonThreshold*healthySuccessProbability)
+
+	nodeStepSize := (1 - nodeSuccessProbabilityCordonThreshold - (1-nodeSuccessProbabilityCordonThreshold)*nodeFailureProbabilityDecayRate) / dNodeSuccessProbability / nodeEquilibriumFailureRate
+	queueStepSize := (1 - queueSuccessProbabilityCordonThreshold - (1-queueSuccessProbabilityCordonThreshold)*queueFailureProbabilityDecayRate) / dQueueSuccessProbability / queueEquilibriumFailureRate
+
+	return &FailureEstimator{
+		successProbabilityByNode:               make(map[string]float64, 1024),
+		successProbabilityByQueue:              make(map[string]float64, 128),
+		nodeSuccessProbabilityCordonThreshold:  nodeSuccessProbabilityCordonThreshold,
+		queueSuccessProbabilityCordonThreshold: queueSuccessProbabilityCordonThreshold,
+		nodeFailureProbabilityDecayRate:        nodeFailureProbabilityDecayRate,
+		queueFailureProbabilityDecayRate:       queueFailureProbabilityDecayRate,
+		timeOfLastDecay:                        time.Now(),
+		nodeStepSize:                           nodeStepSize,
+		queueStepSize:                          queueStepSize,
+		failureProbabilityByNodeDesc: prometheus.NewDesc(
+			fmt.Sprintf("%s_%s_node_failure_probability", namespace, subsystem),
+			"Estimated per-node failure probability.",
+			[]string{"node"},
+			nil,
+		),
+		failureProbabilityByQueueDesc: prometheus.NewDesc(
+			fmt.Sprintf("%s_%s_queue_failure_probability", namespace, subsystem),
+			"Estimated per-queue failure probability.",
+			[]string{"queue"},
+			nil,
+		),
+	}, nil
+}
+
+// Decay moves the success probabilities of nodes (queues) closer to 1, depending on the configured cordon timeout.
+// Periodically calling Decay() ensures nodes (queues) considered unhealthy are eventually considered healthy again.
+func (fe *FailureEstimator) Decay() {
+	fe.mu.Lock()
+	defer fe.mu.Unlock()
+	t := time.Now()
+	fe.decay(t.Sub(fe.timeOfLastDecay).Seconds())
+	fe.timeOfLastDecay = t
+	return
+}
+
+func (fe *FailureEstimator) decay(secondsSinceLastDecay float64) {
+	nodeFailureProbabilityDecay := math.Pow(fe.nodeFailureProbabilityDecayRate, secondsSinceLastDecay)
+	for k, v := range fe.successProbabilityByNode {
+		failureProbability := 1 - v
+		failureProbability *= nodeFailureProbabilityDecay
+		successProbability := 1 - failureProbability
+		fe.successProbabilityByNode[k] = applyBounds(successProbability)
+	}
+
+	queueFailureProbabilityDecay := math.Pow(fe.queueFailureProbabilityDecayRate, secondsSinceLastDecay)
+	for k, v := range fe.successProbabilityByQueue {
+		failureProbability := 1 - v
+		failureProbability *= queueFailureProbabilityDecay
+		successProbability := 1 - failureProbability
+		fe.successProbabilityByQueue[k] = applyBounds(successProbability)
+	}
+	return
+}
+
+// Update with success=false decreases the estimated success probability of the provided node and queue.
+// Calling with success=true increases the estimated success probability of the provided node and queue.
+// This update is performed by taking one gradient descent step.
+func (fe *FailureEstimator) Update(node, queue string, success bool) {
+	fe.mu.Lock()
+	defer fe.mu.Unlock()
+
+	// Assume that nodes (queues) we haven't seen previously are healthy.
+	nodeSuccessProbability, ok := fe.successProbabilityByNode[node]
+	if !ok {
+		nodeSuccessProbability = healthySuccessProbability
+	}
+	queueSuccessProbability, ok := fe.successProbabilityByQueue[queue]
+	if !ok {
+		queueSuccessProbability = healthySuccessProbability
+	}
+
+	dNodeSuccessProbability, dQueueSuccessProbability := fe.negLogLikelihoodGradient(nodeSuccessProbability, queueSuccessProbability, success)
+	nodeSuccessProbability -= fe.nodeStepSize * dNodeSuccessProbability
+	queueSuccessProbability -= fe.queueStepSize * dQueueSuccessProbability
+
+	fe.successProbabilityByNode[node] = applyBounds(nodeSuccessProbability)
+	fe.successProbabilityByQueue[queue] = applyBounds(queueSuccessProbability)
+}
+
+// applyBounds ensures values stay in the range [eps, 1-eps].
+// This to avoid divide-by-zero issues.
+func applyBounds(v float64) float64 {
+	if v < eps {
+		return eps
+	} else if v > 1.0-eps {
+		return 1.0 - eps
+	} else {
+		return v
+	}
+}
+
+func (fe *FailureEstimator) negLogLikelihoodGradient(nodeSuccessProbability, queueSuccessProbability float64, success bool) (float64, float64) {
+	if success {
+		dNodeSuccessProbability := -1 / nodeSuccessProbability
+		dQueueSuccessProbability := -1 / queueSuccessProbability
+		return dNodeSuccessProbability, dQueueSuccessProbability
+	} else {
+		dNodeSuccessProbability := queueSuccessProbability / (1 - nodeSuccessProbability*queueSuccessProbability)
+		dQueueSuccessProbability := nodeSuccessProbability / (1 - nodeSuccessProbability*queueSuccessProbability)
+		return dNodeSuccessProbability, dQueueSuccessProbability
+	}
+}
+
+func (fe *FailureEstimator) Describe(ch chan<- *prometheus.Desc) {
+	// if m.IsDisabled() {
+	// 	return
+	// }
+	ch <- fe.failureProbabilityByNodeDesc
+	ch <- fe.failureProbabilityByQueueDesc
+}
+
+// Collect and then reset all metrics.
+// Resetting ensures we do not build up a large number of counters over time.
+func (fe *FailureEstimator) Collect(ch chan<- prometheus.Metric) {
+	// if m.IsDisabled() {
+	// 	return
+	// }
+	fe.mu.Lock()
+	defer fe.mu.Unlock()
+
+	// Report failure probability rounded to nearest multiple of 0.01.
+	// (As it's unlikely the estimate is accurate to within less than this.)
+	for k, v := range fe.successProbabilityByNode {
+		failureProbability := 1 - v
+		failureProbability = math.Round(failureProbability*100) / 100
+		ch <- prometheus.MustNewConstMetric(fe.failureProbabilityByNodeDesc, prometheus.GaugeValue, failureProbability, k)
+	}
+	for k, v := range fe.successProbabilityByQueue {
+		failureProbability := 1 - v
+		failureProbability = math.Round(failureProbability*100) / 100
+		ch <- prometheus.MustNewConstMetric(fe.failureProbabilityByQueueDesc, prometheus.GaugeValue, failureProbability, k)
+	}
+}

--- a/internal/scheduler/failureestimator/failureestimator.go
+++ b/internal/scheduler/failureestimator/failureestimator.go
@@ -129,12 +129,16 @@ func New(
 		})
 	}
 
+	// Compute decay rates such that a node (queue) with success probability 0 will over {node, queue}CordonTimeout time
+	// decay to a success probability of {node, queue}SuccessProbabilityCordonThreshold.
 	nodeFailureProbabilityDecayRate := math.Exp(math.Log(1-nodeSuccessProbabilityCordonThreshold) / nodeCordonTimeout.Seconds())
 	queueFailureProbabilityDecayRate := math.Exp(math.Log(1-queueSuccessProbabilityCordonThreshold) / queueCordonTimeout.Seconds())
 
+	// Compute step size such that a node (queue) with success probability {node, queue}SuccessProbabilityCordonThreshold
+	// for which we observe 0 successes and {node, queue}EquilibriumFailureRate failures per second from "good" nodes (queues)
+	// will remain at exactly {node, queue}SuccessProbabilityCordonThreshold success probability.
 	dNodeSuccessProbability := healthySuccessProbability / (1 - nodeSuccessProbabilityCordonThreshold*healthySuccessProbability)
 	dQueueSuccessProbability := healthySuccessProbability / (1 - queueSuccessProbabilityCordonThreshold*healthySuccessProbability)
-
 	nodeStepSize := (1 - nodeSuccessProbabilityCordonThreshold - (1-nodeSuccessProbabilityCordonThreshold)*nodeFailureProbabilityDecayRate) / dNodeSuccessProbability / nodeEquilibriumFailureRate
 	queueStepSize := (1 - queueSuccessProbabilityCordonThreshold - (1-queueSuccessProbabilityCordonThreshold)*queueFailureProbabilityDecayRate) / dQueueSuccessProbability / queueEquilibriumFailureRate
 

--- a/internal/scheduler/failureestimator/failureestimator.go
+++ b/internal/scheduler/failureestimator/failureestimator.go
@@ -262,8 +262,6 @@ func (fe *FailureEstimator) Describe(ch chan<- *prometheus.Desc) {
 	ch <- fe.failureProbabilityByQueueDesc
 }
 
-// Collect and then reset all metrics.
-// Resetting ensures we do not build up a large number of counters over time.
 func (fe *FailureEstimator) Collect(ch chan<- prometheus.Metric) {
 	if fe.IsDisabled() {
 		return

--- a/internal/scheduler/failureestimator/failureestimator.go
+++ b/internal/scheduler/failureestimator/failureestimator.go
@@ -39,6 +39,9 @@ const (
 //
 // Finally, we exponentially decay P_q and P_N towards 1 over time,
 // such that nodes and queues for which we observe no failures appear to become healthier over time.
+//
+// This module internally only maintains success probability estimates, as this makes the maths cleaner.
+// When exporting these via API calls we convert to failure probabilities as these are more intuitive to reason about.
 type FailureEstimator struct {
 	// Map from node (queue) name to the estimated success probability of that node (queue). For example:
 	// - successProbabilityByNode["myNode"] = 0.85]: estimated failure probability of a perfect job run on "myNode" is 15%.

--- a/internal/scheduler/failureestimator/failureestimator.go
+++ b/internal/scheduler/failureestimator/failureestimator.go
@@ -32,7 +32,12 @@ const (
 // where p_q and p_n are drawn from Bernoulli distributions with parameter P_q and P_n, respectively.
 //
 // Now, the goal is to jointly estimate P_q and P_n for each queue and node using observed successes and failures.
-// The method used is statistical only relies on knowing which queue a job belongs to and on which node it ran.
+// The method used is statistical and only relies on knowing which queue a job belongs to and on which node it ran.
+// The intuition of the method is that:
+// - A job from a queue with many failures doesn't say much about the node; likely it's the job that's the problem.
+// - A job failing on a node with many failures doesn't say much about the job; likely it's the node that's the problem.
+// And vice versa.
+//
 // Specifically, we maximise the log-likelihood function of P_q and P_n using observed successes and failures.
 // This maximisation is performed using online gradient descent, where for each success or failure,
 // we update the corresponding P_q and P_n by taking a gradient step.

--- a/internal/scheduler/failureestimator/failureestimator.go
+++ b/internal/scheduler/failureestimator/failureestimator.go
@@ -220,14 +220,15 @@ func (fe *FailureEstimator) Update(node, queue string, success bool) {
 	fe.mu.Lock()
 	defer fe.mu.Unlock()
 
-	// Assume that nodes (queues) we haven't seen previously are healthy.
+	// Assume that nodes (queues) we haven't seen before have a 50% success probability.
+	// Avoiding extreme values for new nodes (queues) helps avoid drastic changes to existing estimates.
 	nodeSuccessProbability, ok := fe.successProbabilityByNode[node]
 	if !ok {
-		nodeSuccessProbability = healthySuccessProbability
+		nodeSuccessProbability = 0.5
 	}
 	queueSuccessProbability, ok := fe.successProbabilityByQueue[queue]
 	if !ok {
-		queueSuccessProbability = healthySuccessProbability
+		queueSuccessProbability = 0.5
 	}
 
 	dNodeSuccessProbability, dQueueSuccessProbability := fe.negLogLikelihoodGradient(nodeSuccessProbability, queueSuccessProbability, success)

--- a/internal/scheduler/failureestimator/failureestimator_test.go
+++ b/internal/scheduler/failureestimator/failureestimator_test.go
@@ -1,0 +1,190 @@
+package failureestimator
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew(t *testing.T) {
+	successProbabilityCordonThreshold := 0.05
+	cordonTimeout := 10 * time.Minute
+	equilibriumFailureRate := 0.1
+
+	// Node decay rate and step size tests.
+	fe, err := New(
+		successProbabilityCordonThreshold,
+		0,
+		cordonTimeout,
+		0,
+		equilibriumFailureRate,
+		eps,
+	)
+	require.NoError(t, err)
+	assert.LessOrEqual(t, fe.nodeFailureProbabilityDecayRate, 0.9999145148300861+eps)
+	assert.GreaterOrEqual(t, fe.nodeFailureProbabilityDecayRate, 0.9999145148300861-eps)
+	assert.LessOrEqual(t, fe.nodeStepSize, 0.0008142462434300169+eps)
+	assert.GreaterOrEqual(t, fe.nodeStepSize, 0.0008142462434300169-eps)
+
+	// Queue decay rate and step size tests.
+	fe, err = New(
+		0,
+		successProbabilityCordonThreshold,
+		0,
+		cordonTimeout,
+		eps,
+		equilibriumFailureRate,
+	)
+	require.NoError(t, err)
+	assert.LessOrEqual(t, fe.queueFailureProbabilityDecayRate, 0.9999145148300861+eps)
+	assert.GreaterOrEqual(t, fe.queueFailureProbabilityDecayRate, 0.9999145148300861-eps)
+	assert.LessOrEqual(t, fe.queueStepSize, 0.0008142462434300169+eps)
+	assert.GreaterOrEqual(t, fe.queueStepSize, 0.0008142462434300169-eps)
+}
+
+func TestDecay(t *testing.T) {
+	successProbabilityCordonThreshold := 0.05
+	cordonTimeout := 10 * time.Minute
+	equilibriumFailureRate := 0.1
+
+	// Node decay tests.
+	fe, err := New(
+		successProbabilityCordonThreshold,
+		0,
+		cordonTimeout,
+		0,
+		equilibriumFailureRate,
+		eps,
+	)
+	require.NoError(t, err)
+
+	fe.successProbabilityByNode["foo"] = 0.0
+	fe.successProbabilityByNode["bar"] = 0.4
+	fe.successProbabilityByNode["baz"] = 1.0
+
+	fe.decay(0)
+	assert.Equal(
+		t,
+		fe.successProbabilityByNode,
+		map[string]float64{
+			"foo": eps,
+			"bar": 0.4,
+			"baz": 1.0 - eps,
+		},
+	)
+
+	fe.decay(1)
+	assert.Equal(
+		t,
+		fe.successProbabilityByNode,
+		map[string]float64{
+			"foo": 1 - (1-eps)*math.Pow(fe.nodeFailureProbabilityDecayRate, 1),
+			"bar": 1 - (1-0.4)*math.Pow(fe.nodeFailureProbabilityDecayRate, 1),
+			"baz": 1.0 - eps,
+		},
+	)
+
+	fe.decay(1e6)
+	assert.Equal(
+		t,
+		fe.successProbabilityByNode,
+		map[string]float64{
+			"foo": 1.0 - eps,
+			"bar": 1.0 - eps,
+			"baz": 1.0 - eps,
+		},
+	)
+
+	// Queue decay tests.
+	fe, err = New(
+		0,
+		successProbabilityCordonThreshold,
+		0,
+		cordonTimeout,
+		eps,
+		equilibriumFailureRate,
+	)
+	require.NoError(t, err)
+
+	fe.successProbabilityByQueue["foo"] = 0.0
+	fe.successProbabilityByQueue["bar"] = 0.4
+	fe.successProbabilityByQueue["baz"] = 1.0
+
+	fe.decay(0)
+	assert.Equal(
+		t,
+		fe.successProbabilityByQueue,
+		map[string]float64{
+			"foo": eps,
+			"bar": 0.4,
+			"baz": 1.0 - eps,
+		},
+	)
+
+	fe.decay(1)
+	assert.Equal(
+		t,
+		fe.successProbabilityByQueue,
+		map[string]float64{
+			"foo": 1 - (1-eps)*math.Pow(fe.queueFailureProbabilityDecayRate, 1),
+			"bar": 1 - (1-0.4)*math.Pow(fe.queueFailureProbabilityDecayRate, 1),
+			"baz": 1.0 - eps,
+		},
+	)
+
+	fe.decay(1e6)
+	assert.Equal(
+		t,
+		fe.successProbabilityByQueue,
+		map[string]float64{
+			"foo": 1.0 - eps,
+			"bar": 1.0 - eps,
+			"baz": 1.0 - eps,
+		},
+	)
+}
+
+func TestUpdate(t *testing.T) {
+	successProbabilityCordonThreshold := 0.05
+	cordonTimeout := 10 * time.Minute
+	equilibriumFailureRate := 0.1
+
+	fe, err := New(
+		successProbabilityCordonThreshold,
+		successProbabilityCordonThreshold,
+		cordonTimeout,
+		cordonTimeout,
+		equilibriumFailureRate,
+		equilibriumFailureRate,
+	)
+	require.NoError(t, err)
+
+	fe.Update("node", "queue", false)
+	nodeSuccessProbability, ok := fe.successProbabilityByNode["node"]
+	require.True(t, ok)
+	queueSuccessProbability, ok := fe.successProbabilityByQueue["queue"]
+	require.True(t, ok)
+	assert.Greater(t, nodeSuccessProbability, eps)
+	assert.Greater(t, queueSuccessProbability, eps)
+	assert.Less(t, nodeSuccessProbability, healthySuccessProbability-eps)
+	assert.Less(t, queueSuccessProbability, healthySuccessProbability-eps)
+
+	fe.Update("node", "queue", true)
+	assert.Greater(t, fe.successProbabilityByNode["node"], nodeSuccessProbability)
+	assert.Greater(t, fe.successProbabilityByQueue["queue"], queueSuccessProbability)
+
+	for i := 0; i < 100000; i++ {
+		fe.Update("node", "queue", false)
+	}
+	assert.Equal(t, fe.successProbabilityByNode["node"], eps)
+	assert.Equal(t, fe.successProbabilityByQueue["queue"], eps)
+
+	for i := 0; i < 100000; i++ {
+		fe.Update("node", "queue", true)
+	}
+	assert.Equal(t, fe.successProbabilityByNode["node"], 1-eps)
+	assert.Equal(t, fe.successProbabilityByQueue["queue"], 1-eps)
+}

--- a/internal/scheduler/metrics/metrics_test.go
+++ b/internal/scheduler/metrics/metrics_test.go
@@ -1,0 +1,21 @@
+package metrics
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFoo(t *testing.T) {
+	r, err := regexp.Compile("foo.*bar")
+	require.NoError(t, err)
+	assert.True(t, r.MatchString("foobar"))
+	assert.True(t, r.MatchString("foo bar"))
+	assert.True(t, r.MatchString("foo and bar"))
+	assert.True(t, r.MatchString("this is foo and bar so"))
+	assert.False(t, r.MatchString("barfoo"))
+	assert.False(t, r.MatchString("foo"))
+	assert.False(t, r.MatchString("bar"))
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -279,7 +279,7 @@ func (s *Scheduler) cycle(ctx *armadacontext.Context, updateAll bool, leaderToke
 	}
 
 	// Update success probability estimates.
-	if s.failureEstimator != nil {
+	if !s.failureEstimator.IsDisabled() {
 		s.failureEstimator.Decay()
 		for _, jst := range jsts {
 			if jst.Job == nil {

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -779,6 +779,7 @@ func TestScheduler_TestCycle(t *testing.T) {
 				nodeIdLabel,
 				schedulerMetrics,
 				nil,
+				nil,
 			)
 			require.NoError(t, err)
 			sched.EnableAssertions()
@@ -939,6 +940,7 @@ func TestRun(t *testing.T) {
 		maxNumberOfAttempts,
 		nodeIdLabel,
 		schedulerMetrics,
+		nil,
 		nil,
 	)
 	require.NoError(t, err)
@@ -1163,6 +1165,7 @@ func TestScheduler_TestSyncState(t *testing.T) {
 				maxNumberOfAttempts,
 				nodeIdLabel,
 				schedulerMetrics,
+				nil,
 				nil,
 			)
 			require.NoError(t, err)
@@ -2312,6 +2315,7 @@ func TestCycleConsistency(t *testing.T) {
 					maxNumberOfAttempts,
 					nodeIdLabel,
 					schedulerMetrics,
+					nil,
 					nil,
 				)
 				require.NoError(t, err)

--- a/internal/scheduler/schedulerapp.go
+++ b/internal/scheduler/schedulerapp.go
@@ -216,6 +216,7 @@ func Run(config schedulerconfig.Configuration) error {
 	if err := prometheus.Register(schedulerMetrics); err != nil {
 		return errors.WithStack(err)
 	}
+
 	failureEstimator, err := failureestimator.New(
 		config.Scheduling.FailureEstimatorConfig.NodeSuccessProbabilityCordonThreshold,
 		config.Scheduling.FailureEstimatorConfig.QueueSuccessProbabilityCordonThreshold,
@@ -227,9 +228,11 @@ func Run(config schedulerconfig.Configuration) error {
 	if err != nil {
 		return err
 	}
+	failureEstimator.Disable(config.Scheduling.FailureEstimatorConfig.Disabled)
 	if err := prometheus.Register(failureEstimator); err != nil {
 		return errors.WithStack(err)
 	}
+
 	scheduler, err := NewScheduler(
 		jobDb,
 		jobRepository,


### PR DESCRIPTION
This PR introduces a method of estimating the reliability of nodes and jobs. These estimates are currently only exported as metrics. In the future, we may choose to, e.g., rate-limit scheduling onto problematic nodes.

The method is statistical and is based only on observed job successes and failures, without accounting for the particular circumstances of any success or failure, except for on which node it happened and to which queue the job belongs. Success probability of nodes and queues is estimated jointly.  The intuition is that:
- A job from a queue with many failures doesn't say much about the node; likely it's the job that's the problem.
- A job failing on a node with many failures doesn't say much about the job; likely it's the node that's the problem.

And vice versa.