### PR TITLE
Remove UnifiedSchedulingByPool Config Flag

### DIFF
--- a/internal/armada/configuration/types.go
+++ b/internal/armada/configuration/types.go
@@ -85,10 +85,7 @@ type SchedulingConfig struct {
 	DisableScheduling bool
 	// Set to true to enable scheduler assertions. This results in some performance loss.
 	EnableAssertions bool
-	// If true, schedule jobs across all executors in the same pool in a unified manner.
-	// Otherwise, schedule each executor separately.
-	UnifiedSchedulingByPool bool
-	Preemption              PreemptionConfig
+	Preemption       PreemptionConfig
 	// Number of jobs to load from the database at a time.
 	MaxQueueLookback uint
 	// In each invocation of the scheduler, no more jobs are scheduled once this limit has been exceeded.

--- a/internal/scheduler/scheduling_algo.go
+++ b/internal/scheduler/scheduling_algo.go
@@ -200,21 +200,12 @@ func (l *FairSchedulingAlgo) Schedule(
 }
 
 func (l *FairSchedulingAlgo) groupExecutors(executors []*schedulerobjects.Executor) map[string][]*schedulerobjects.Executor {
-	if l.schedulingConfig.UnifiedSchedulingByPool {
-		return armadaslices.GroupByFunc(
-			executors,
-			func(executor *schedulerobjects.Executor) string {
-				return executor.Pool
-			},
-		)
-	} else {
-		return armadaslices.GroupByFunc(
-			executors,
-			func(executor *schedulerobjects.Executor) string {
-				return executor.Id
-			},
-		)
-	}
+	return armadaslices.GroupByFunc(
+		executors,
+		func(executor *schedulerobjects.Executor) string {
+			return executor.Pool
+		},
+	)
 }
 
 type JobQueueIteratorAdapter struct {

--- a/internal/scheduler/scheduling_algo_test.go
+++ b/internal/scheduler/scheduling_algo_test.go
@@ -338,26 +338,6 @@ func TestSchedule(t *testing.T) {
 			},
 			expectedScheduledIndices: []int{0},
 		},
-		"UnifiedSchedulingByPool": {
-			schedulingConfig: testfixtures.WithUnifiedSchedulingByPoolConfig(testfixtures.TestSchedulingConfig()),
-			executors: []*schedulerobjects.Executor{
-				testfixtures.Test1Node32CoreExecutor("executor1"),
-				testfixtures.Test1Node32CoreExecutor("executor2"),
-			},
-			queues:                   []*database.Queue{testfixtures.TestDbQueue()},
-			queuedJobs:               testfixtures.N16Cpu128GiJobs(testfixtures.TestQueue, testfixtures.PriorityClass3, 10),
-			expectedScheduledIndices: []int{0, 1, 2, 3},
-		},
-		"UnifiedSchedulingByPool schedule gang job over multiple executors": {
-			schedulingConfig: testfixtures.WithUnifiedSchedulingByPoolConfig(testfixtures.TestSchedulingConfig()),
-			executors: []*schedulerobjects.Executor{
-				testfixtures.Test1Node32CoreExecutor("executor1"),
-				testfixtures.Test1Node32CoreExecutor("executor2"),
-			},
-			queues:                   []*database.Queue{testfixtures.TestDbQueue()},
-			queuedJobs:               testfixtures.WithGangAnnotationsJobs(testfixtures.N16Cpu128GiJobs(testfixtures.TestQueue, testfixtures.PriorityClass0, 4)),
-			expectedScheduledIndices: []int{0, 1, 2, 3},
-		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/internal/scheduler/scheduling_algo_test.go
+++ b/internal/scheduler/scheduling_algo_test.go
@@ -338,6 +338,16 @@ func TestSchedule(t *testing.T) {
 			},
 			expectedScheduledIndices: []int{0},
 		},
+		"Schedule gang job over multiple executors": {
+			schedulingConfig: testfixtures.TestSchedulingConfig(),
+			executors: []*schedulerobjects.Executor{
+				testfixtures.Test1Node32CoreExecutor("executor1"),
+				testfixtures.Test1Node32CoreExecutor("executor2"),
+			},
+			queues:                   []*database.Queue{testfixtures.TestDbQueue()},
+			queuedJobs:               testfixtures.WithGangAnnotationsJobs(testfixtures.N16Cpu128GiJobs(testfixtures.TestQueue, testfixtures.PriorityClass0, 4)),
+			expectedScheduledIndices: []int{0, 1, 2, 3},
+		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/internal/scheduler/testfixtures/testfixtures.go
+++ b/internal/scheduler/testfixtures/testfixtures.go
@@ -147,11 +147,6 @@ func TestSchedulingConfig() configuration.SchedulingConfig {
 	}
 }
 
-func WithUnifiedSchedulingByPoolConfig(config configuration.SchedulingConfig) configuration.SchedulingConfig {
-	config.UnifiedSchedulingByPool = true
-	return config
-}
-
 func WithMaxUnacknowledgedJobsPerExecutorConfig(v uint, config configuration.SchedulingConfig) configuration.SchedulingConfig {
 	config.MaxUnacknowledgedJobsPerExecutor = v
 	return config


### PR DESCRIPTION
UnifiedSchedulingByPool is onw standard.  Let's remove the config flag.
