### PR TITLE
Add `annotations` column of type `jsonb` to Lookout

### DIFF
--- a/internal/lookoutingesterv2/instructions/instructions.go
+++ b/internal/lookoutingesterv2/instructions/instructions.go
@@ -189,6 +189,8 @@ func (c *InstructionConverter) handleSubmitJob(
 		priorityClass = &truncatedPriorityClass
 	}
 
+	annotations := extractUserAnnotations(c.userAnnotationPrefix, event.GetObjectMeta().GetAnnotations())
+
 	job := model.CreateJobInstruction{
 		JobId:                     jobId,
 		Queue:                     queue,
@@ -206,31 +208,44 @@ func (c *InstructionConverter) handleSubmitJob(
 		State:                     lookout.JobQueuedOrdinal,
 		JobProto:                  jobProto,
 		PriorityClass:             priorityClass,
+		Annotations:               annotations,
 	}
 	update.JobsToCreate = append(update.JobsToCreate, &job)
 
-	annotationInstructions := extractAnnotations(jobId, queue, jobSet, event.GetObjectMeta().GetAnnotations(), c.userAnnotationPrefix)
+	annotationInstructions := createUserAnnotationInstructions(jobId, queue, jobSet, event.GetObjectMeta().GetAnnotations())
 	update.UserAnnotationsToCreate = append(update.UserAnnotationsToCreate, annotationInstructions...)
 
 	return err
 }
 
-func extractAnnotations(jobId string, queue string, jobset string, jobAnnotations map[string]string, userAnnotationPrefix string) []*model.CreateUserAnnotationInstruction {
+// extractUserAnnotations strips userAnnotationPrefix from all keys and
+// truncates keys and values to their maximal lengths (as specified by
+// maxAnnotationKeyLen and maxAnnotationValLen).
+func extractUserAnnotations(userAnnotationPrefix string, jobAnnotations map[string]string) map[string]string {
+	result := make(map[string]string, len(jobAnnotations))
+	n := len(userAnnotationPrefix)
+	for k, v := range jobAnnotations {
+		if strings.HasPrefix(k, userAnnotationPrefix) {
+			k = k[n:]
+		}
+		k = util.Truncate(k, maxAnnotationKeyLen)
+		v = util.Truncate(v, maxAnnotationValLen)
+		result[k] = v
+	}
+	return result
+}
+
+func createUserAnnotationInstructions(jobId string, queue string, jobset string, userAnnotations map[string]string) []*model.CreateUserAnnotationInstruction {
 	// This intermediate variable exists because we want our output to be deterministic
 	// Iteration over a map in go is non-deterministic, so we read everything into annotations
 	// and then sort it.
-	annotations := make([]*model.CreateUserAnnotationInstruction, 0, len(jobAnnotations))
-
-	for k, v := range jobAnnotations {
+	instructions := make([]*model.CreateUserAnnotationInstruction, 0, len(userAnnotations))
+	for k, v := range userAnnotations {
 		if k != "" {
-			// The annotation will have a key with a prefix.  We want to strip the prefix before storing in the db
-			if strings.HasPrefix(k, userAnnotationPrefix) && len(k) > len(userAnnotationPrefix) {
-				k = k[len(userAnnotationPrefix):]
-			}
-			annotations = append(annotations, &model.CreateUserAnnotationInstruction{
+			instructions = append(instructions, &model.CreateUserAnnotationInstruction{
 				JobId:  jobId,
-				Key:    util.Truncate(k, maxAnnotationKeyLen),
-				Value:  util.Truncate(v, maxAnnotationValLen),
+				Key:    k,
+				Value:  v,
 				Queue:  queue,
 				Jobset: jobset,
 			})
@@ -238,12 +253,11 @@ func extractAnnotations(jobId string, queue string, jobset string, jobAnnotation
 			log.WithField("JobId", jobId).Warnf("Ignoring annotation with empty key")
 		}
 	}
-
 	// sort to make output deterministic
-	sort.Slice(annotations, func(i, j int) bool {
-		return annotations[i].Key < annotations[j].Key
+	sort.Slice(instructions, func(i, j int) bool {
+		return instructions[i].Key < instructions[j].Key
 	})
-	return annotations
+	return instructions
 }
 
 func (c *InstructionConverter) handleReprioritiseJob(ts time.Time, event *armadaevents.ReprioritisedJob, update *model.InstructionSet) error {

--- a/internal/lookoutingesterv2/instructions/instructions_test.go
+++ b/internal/lookoutingesterv2/instructions/instructions_test.go
@@ -174,6 +174,10 @@ func TestConvert(t *testing.T) {
 		Requests: resources,
 	}
 	submit.GetSubmitJob().GetMainObject().GetPodSpec().GetPodSpec().PriorityClassName = priorityClass
+	submit.GetSubmitJob().GetObjectMeta().Annotations = map[string]string{
+		userAnnotationPrefix + "a": "0",
+		"b":                        "1",
+	}
 	job, err := eventutil.ApiJobFromLogSubmitJob(testfixtures.UserId, []string{}, testfixtures.Queue, testfixtures.JobSetName, testfixtures.BaseTime, submit.GetSubmitJob())
 	assert.NoError(t, err)
 	jobProto, err := proto.Marshal(job)
@@ -195,6 +199,10 @@ func TestConvert(t *testing.T) {
 		LastTransitionTimeSeconds: testfixtures.BaseTime.Unix(),
 		JobProto:                  jobProto,
 		PriorityClass:             pointer.String(priorityClass),
+		Annotations: map[string]string{
+			"a": "0",
+			"b": "1",
+		},
 	}
 
 	otherJobIdUlid := util.ULID()
@@ -661,8 +669,13 @@ func TestAnnotations(t *testing.T) {
 			Jobset: testfixtures.JobSetName,
 		},
 	}
-	annotationInstructions := extractAnnotations(testfixtures.JobIdString, testfixtures.Queue, testfixtures.JobSetName, annotations, userAnnotationPrefix)
-	assert.Equal(t, expected, annotationInstructions)
+	instructions := createUserAnnotationInstructions(
+		testfixtures.JobIdString,
+		testfixtures.Queue,
+		testfixtures.JobSetName,
+		extractUserAnnotations(userAnnotationPrefix, annotations),
+	)
+	assert.Equal(t, expected, instructions)
 }
 
 func TestExtractNodeName(t *testing.T) {

--- a/internal/lookoutingesterv2/lookoutdb/insertion_test.go
+++ b/internal/lookoutingesterv2/lookoutdb/insertion_test.go
@@ -43,6 +43,11 @@ const (
 
 var m = metrics.Get()
 
+var annotations = map[string]string{
+	"a": "0",
+	"b": "1",
+}
+
 var (
 	baseTime, _     = time.Parse("2006-01-02T15:04:05.000Z", "2022-03-01T15:04:05.000Z")
 	updateTime, _   = time.Parse("2006-01-02T15:04:05.000Z", "2022-03-01T15:04:06.000Z")
@@ -74,6 +79,7 @@ type JobRow struct {
 	PriorityClass             string
 	LatestRunId               *string
 	CancelReason              *string
+	Annotations               map[string]string
 }
 
 type JobRunRow struct {
@@ -151,6 +157,7 @@ var expectedJobAfterSubmit = JobRow{
 	JobProto:                  []byte(jobProto),
 	Duplicate:                 false,
 	PriorityClass:             priorityClass,
+	Annotations:               annotations,
 }
 
 var expectedJobAfterUpdate = JobRow{
@@ -170,6 +177,7 @@ var expectedJobAfterUpdate = JobRow{
 	JobProto:                  []byte(jobProto),
 	Duplicate:                 false,
 	PriorityClass:             priorityClass,
+	Annotations:               annotations,
 }
 
 var expectedJobRun = JobRunRow{
@@ -927,6 +935,7 @@ func makeCreateJobInstruction(jobId string) *model.CreateJobInstruction {
 		LastTransitionTimeSeconds: baseTime.Unix(),
 		JobProto:                  []byte(jobProto),
 		PriorityClass:             pointer.String(priorityClass),
+		Annotations:               annotations,
 	}
 }
 
@@ -963,7 +972,8 @@ func getJob(t *testing.T, db *pgxpool.Pool, jobId string) JobRow {
     		duplicate,
 			priority_class,
 			latest_run_id,
-			cancel_reason
+			cancel_reason,
+			annotations
 		FROM job WHERE job_id = $1`,
 		jobId)
 	err := r.Scan(
@@ -986,6 +996,7 @@ func getJob(t *testing.T, db *pgxpool.Pool, jobId string) JobRow {
 		&job.PriorityClass,
 		&job.LatestRunId,
 		&job.CancelReason,
+		&job.Annotations,
 	)
 	assert.Nil(t, err)
 	return job

--- a/internal/lookoutingesterv2/model/model.go
+++ b/internal/lookoutingesterv2/model/model.go
@@ -24,6 +24,7 @@ type CreateJobInstruction struct {
 	LastTransitionTimeSeconds int64
 	JobProto                  []byte
 	PriorityClass             *string
+	Annotations               map[string]string
 }
 
 // UpdateJobInstruction is an instruction to update an existing row in the jobs table

--- a/internal/lookoutv2/schema/migrations/005_annotations.sql
+++ b/internal/lookoutv2/schema/migrations/005_annotations.sql
@@ -1,0 +1,8 @@
+ALTER TABLE job ADD COLUMN annotations jsonb;
+
+-- GIN indexes that use the jsonb_path_ops operator class do not support the
+-- key-exists operators of the default operator class, but the operators they do
+-- support are more efficient:
+--
+--     https://www.postgresql.org/docs/current/datatype-json.html#JSON-INDEXING
+CREATE INDEX IF NOT EXISTS idx_job_annotations_path ON job USING GIN (annotations jsonb_path_ops);


### PR DESCRIPTION
On `master`, job annotations (arbitrary key-value pairs that users attach to their jobs) are stored in a separate table called `user_annotation_lookup`:

https://github.com/armadaproject/armada/blob/4f655e381630e348c40fdf03373c74a24879d809/internal/lookoutv2/schema/migrations/001_initial_schema.sql#L37-L44

To filter or group by an annotation we then join the `job` table with `user_annotation_lookup`:

https://github.com/armadaproject/armada/blob/4f655e381630e348c40fdf03373c74a24879d809/internal/lookoutv2/repository/querybuilder.go#L217

While this is a reasonable relational model for annotations, it has a number of downsides in practice:

1. `user_annotation_lookup` and its indexes are quite big (among other reasons, this because the other columns in this table are often larger than the actual `key` and `value` columns that we are interested in). On our biggest production deployment of Lookout, with a total database size of just over 2 TiB, indexes on `user_annotation_lookup` alone account for about 20% of the database; `user_annotation_lookup` itself also accounts for about about the same fraction of the database.
2. In order to combine multiple annotations, we join `job` with `user_annotation_lookup` multiple times; PostgreSQL comes up with query plans like this:

   <details>
   <summary><code>EXPLAIN ANALYZE</code></summary>

   ```
   Limit  (cost=9.24..9.24 rows=1 width=150) (actual time=10077.221..10077.231 rows=50 loops=1)
     Buffers: shared hit=23065774
     ->  Sort  (cost=9.24..9.24 rows=1 width=150) (actual time=10077.219..10077.224 rows=50 loops=1)
           Sort Key: (count(*)) DESC
           Sort Method: top-N heapsort  Memory: 37kB
           Buffers: shared hit=23065774
           ->  GroupAggregate  (cost=2.48..9.23 rows=1 width=150) (actual time=1140.991..10076.848 rows=182 loops=1)
                 Group Key: user_annotation_lookup_1.value
                 Buffers: shared hit=23065774
                 ->  Nested Loop  (cost=2.48..9.17 rows=1 width=56) (actual time=231.216..10074.492 rows=1596 loops=1)
                       Join Filter: ((user_annotation_lookup.job_id)::text = (j.job_id)::text)
                       Buffers: shared hit=23065774
                       ->  Nested Loop  (cost=1.91..6.37 rows=1 width=100) (actual time=231.184..10058.113 rows=1596 loops=1)
                             Join Filter: ((user_annotation_lookup.job_id)::text = (user_annotation_lookup_1.job_id)::text)
                             Rows Removed by Join Filter: 32586330
                             Buffers: shared hit=23057794
                             ->  Index Scan using idx_user_annotation_lookup_queue_jobset_key_value on user_annotation_lookup user_annotation_lookup_1  (cost=0.95..3.17 rows=1 width=73) (actual time=0.054..18.985 rows=21216 loops=1)
                                   Index Cond: (((queue)::text = '…'::text) AND ((jobset)::text = '…'::text) AND ((key)::text = 'key-0'::text))
                                   Buffers: shared hit=17032
                             ->  Index Scan using idx_user_annotation_lookup_queue_jobset_key_value on user_annotation_lookup  (cost=0.95..3.18 rows=1 width=27) (actual time=0.015..0.348 rows=1536 loops=21216)
                                   Index Cond: (((queue)::text = '…'::text) AND ((jobset)::text = '…'::text) AND ((key)::text = 'key-1'::text) AND ((value)::text = 'value-1'::text))
                                   Buffers: shared hit=23040762
                       ->  Index Scan using job_pkey on job j  (cost=0.57..2.79 rows=1 width=37) (actual time=0.009..0.009 rows=1 loops=1596)
                             Index Cond: ((job_id)::text = (user_annotation_lookup_1.job_id)::text)
                             Filter: (((queue)::text = '…'::text) AND ((jobset)::text = '…'::text))
                             Buffers: shared hit=7980
   Planning:
     Buffers: shared hit=90
   Planning Time: 0.871 ms
   Execution Time: 10077.332 ms
   ```
   </details>
5. The fact that the number of joins we have to perform depends on the request complicates the implementation of the query builder significantly.

Storing annotations in a column `annotations` of type `jsonb` as part of the `job` table addresses all of these downsides:

1. A `jsonb_path_ops` GIN index on the same data set is only 17 GiB; we save additional space by no longer duplicating columns like `jobset` into `user_annotation_lookup`.
2. Without complex joins, PostgreSQL has a much easier time figuring out an adequate query plan; using the `annotations` column of type `jsonb` it knows to just scan enough rows:

   <details>
   <summary><code>EXPLAIN ANALYZE</code></summary>

   ```
   Limit  (cost=38.92..38.93 rows=1 width=136) (actual time=40.306..40.319 rows=50 loops=1)
     Buffers: shared hit=11145
     ->  Sort  (cost=38.92..38.93 rows=1 width=136) (actual time=40.304..40.309 rows=50 loops=1)
           Sort Key: (count(*)) DESC
           Sort Method: top-N heapsort  Memory: 37kB
           Buffers: shared hit=11145
           ->  GroupAggregate  (cost=38.85..38.91 rows=1 width=136) (actual time=39.247..40.189 rows=182 loops=1)
                 Group Key: ((annotations ->> 'key-0'::text))
                 Buffers: shared hit=11145
                 ->  Sort  (cost=38.85..38.85 rows=1 width=42) (actual time=39.114..39.251 rows=1596 loops=1)
                       Sort Key: ((annotations ->> 'key-0'::text))
                       Sort Method: quicksort  Memory: 162kB
                       Buffers: shared hit=11145
                       ->  Index Scan using idx_job_queue_jobset_state on job  (cost=0.70..38.84 rows=1 width=42) (actual time=0.091..36.040 rows=1596 loops=1)
                             Index Cond: (((queue)::text = '…'::text) AND ((jobset)::text = '…'::text))
                             Filter: (annotations @> '{"key-1": "value-1"}'::jsonb)
                             Rows Removed by Filter: 19620
                             Buffers: shared hit=11145
   Planning:
     Buffers: shared hit=2
   Planning Time: 0.648 ms
   Execution Time: 40.446 ms
   ```
3. The joins with `user_annotation_lookup` can be replaced by simple conditions like `annotations @> '{"key-1": "value-1"}'`.

This PR is the first step in the migration away from `user_annotation_lookup`, which is to add such an `annotations` column of type `jsonb` to `job` and start populating it.