### PR TITLE
[CI-IMPROVEMENT-10] Remove unused buildx flags

### DIFF
--- a/.github/workflows/airflow-operator.yml
+++ b/.github/workflows/airflow-operator.yml
@@ -77,8 +77,6 @@ jobs:
     # due to longer queue times.
     runs-on: ubuntu-22.04
     env:
-      # Cache Docker layers in the Github actions cache.
-      # These variables are picked up by the goreleaser config.
       DOCKER_BUILDX_BUILDER: "builder"
     steps:
       - uses: actions/checkout@v3.3.0

--- a/.github/workflows/airflow-operator.yml
+++ b/.github/workflows/airflow-operator.yml
@@ -79,8 +79,6 @@ jobs:
     env:
       # Cache Docker layers in the Github actions cache.
       # These variables are picked up by the goreleaser config.
-      DOCKER_BUILDX_CACHE_FROM: "type=gha"
-      DOCKER_BUILDX_CACHE_TO: "type=gha,mode=max"
       DOCKER_BUILDX_BUILDER: "builder"
     steps:
       - uses: actions/checkout@v3.3.0

--- a/.github/workflows/airflow-operator.yml
+++ b/.github/workflows/airflow-operator.yml
@@ -77,6 +77,7 @@ jobs:
     # due to longer queue times.
     runs-on: ubuntu-22.04
     env:
+      # This variable is picked up by the goreleaser config.
       DOCKER_BUILDX_BUILDER: "builder"
     steps:
       - uses: actions/checkout@v3.3.0

--- a/.github/workflows/python-client.yml
+++ b/.github/workflows/python-client.yml
@@ -60,8 +60,6 @@ jobs:
     # due to longer queue times.
     runs-on: ubuntu-22.04
     env:
-      # Cache Docker layers in the Github actions cache.
-      # These variables are picked up by the goreleaser config.
       DOCKER_BUILDX_BUILDER: "builder"
     steps:
       - uses: actions/checkout@v3.3.0

--- a/.github/workflows/python-client.yml
+++ b/.github/workflows/python-client.yml
@@ -62,8 +62,6 @@ jobs:
     env:
       # Cache Docker layers in the Github actions cache.
       # These variables are picked up by the goreleaser config.
-      DOCKER_BUILDX_CACHE_FROM: "type=gha"
-      DOCKER_BUILDX_CACHE_TO: "type=gha,mode=max"
       DOCKER_BUILDX_BUILDER: "builder"
     steps:
       - uses: actions/checkout@v3.3.0

--- a/.github/workflows/python-client.yml
+++ b/.github/workflows/python-client.yml
@@ -60,6 +60,7 @@ jobs:
     # due to longer queue times.
     runs-on: ubuntu-22.04
     env:
+      # This variable is picked up by the goreleaser config.
       DOCKER_BUILDX_BUILDER: "builder"
     steps:
       - uses: actions/checkout@v3.3.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,8 +90,6 @@ jobs:
     env:
       ARMADA_EXECUTOR_INGRESS_URL: "http://localhost"
       ARMADA_EXECUTOR_INGRESS_PORT: 5001
-      # Cache Docker layers in the GitHub actions cache.
-      # These variables are picked up by the goreleaser config.
       DOCKER_BUILDX_BUILDER: "builder"
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,6 +90,7 @@ jobs:
     env:
       ARMADA_EXECUTOR_INGRESS_URL: "http://localhost"
       ARMADA_EXECUTOR_INGRESS_PORT: 5001
+      # This variable is picked up by the goreleaser config.
       DOCKER_BUILDX_BUILDER: "builder"
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,8 +92,6 @@ jobs:
       ARMADA_EXECUTOR_INGRESS_PORT: 5001
       # Cache Docker layers in the GitHub actions cache.
       # These variables are picked up by the goreleaser config.
-      DOCKER_BUILDX_CACHE_FROM: "type=gha"
-      DOCKER_BUILDX_CACHE_TO: "type=gha,mode=max"
       DOCKER_BUILDX_BUILDER: "builder"
 
     steps:


### PR DESCRIPTION
#### What type of PR is this?
This is an improvement PR

#### What this PR does / why we need it:
10th in a series of PRs for improvements. This PR removes buildx flags used for caching docker layers in Github actions. The reason why these are removes specifically is because they are not used at all in those places from which they are removed. When running goreleaser as a mage target, the flags are not utilised, because two other flags are missing (url to which the cache will be pushed, and token). In other places, where goreleaser github action is used, the buildx flags are picked up properly. 

This PR removes confusion, and reveals places where to focus and try to implement targeted caching for docker layers

#### Notes for maintainers
/