### PR TITLE
Fix Profiling

### DIFF
--- a/cmd/armada/main.go
+++ b/cmd/armada/main.go
@@ -65,10 +65,12 @@ func main() {
 	})
 
 	// Expose profiling endpoints if enabled.
-	pprofServer := profiling.SetupPprofHttpServer(config.PprofPort)
-	g.Go(func() error {
-		return serve.ListenAndServe(ctx, pprofServer)
-	})
+	if config.PprofPort != nil {
+		pprofServer := profiling.SetupPprofHttpServer(*config.PprofPort)
+		g.Go(func() error {
+			return serve.ListenAndServe(ctx, pprofServer)
+		})
+	}
 
 	// TODO This starts a separate HTTP server. Is that intended? Should we have a single mux for everything?
 	// TODO: Run in errgroup

--- a/cmd/binoculars/main.go
+++ b/cmd/binoculars/main.go
@@ -2,6 +2,10 @@ package main
 
 import (
 	"context"
+	"github.com/armadaproject/armada/internal/common/armadacontext"
+	"github.com/armadaproject/armada/internal/common/logging"
+	"github.com/armadaproject/armada/internal/common/profiling"
+	"github.com/armadaproject/armada/internal/common/serve"
 	"net/http"
 	"os"
 	"os/signal"
@@ -16,12 +20,8 @@ import (
 	"github.com/armadaproject/armada/internal/binoculars"
 	"github.com/armadaproject/armada/internal/binoculars/configuration"
 	"github.com/armadaproject/armada/internal/common"
-	"github.com/armadaproject/armada/internal/common/armadacontext"
 	gateway "github.com/armadaproject/armada/internal/common/grpc"
 	"github.com/armadaproject/armada/internal/common/health"
-	"github.com/armadaproject/armada/internal/common/logging"
-	"github.com/armadaproject/armada/internal/common/profiling"
-	"github.com/armadaproject/armada/internal/common/serve"
 	api "github.com/armadaproject/armada/pkg/api/binoculars"
 )
 
@@ -47,13 +47,15 @@ func main() {
 	log.Info("Starting...")
 
 	// Expose profiling endpoints if enabled.
-	pprofServer := profiling.SetupPprofHttpServer(config.PprofPort)
-	go func() {
-		ctx := armadacontext.Background()
-		if err := serve.ListenAndServe(ctx, pprofServer); err != nil {
-			logging.WithStacktrace(ctx, err).Error("pprof server failure")
-		}
-	}()
+	if config.PprofPort != nil {
+		pprofServer := profiling.SetupPprofHttpServer(*config.PprofPort)
+		go func() {
+			ctx := armadacontext.Background()
+			if err := serve.ListenAndServe(ctx, pprofServer); err != nil {
+				logging.WithStacktrace(ctx, err).Error("pprof server failure")
+			}
+		}()
+	}
 
 	stopSignal := make(chan os.Signal, 1)
 	signal.Notify(stopSignal, syscall.SIGINT, syscall.SIGTERM)

--- a/cmd/binoculars/main.go
+++ b/cmd/binoculars/main.go
@@ -2,10 +2,6 @@ package main
 
 import (
 	"context"
-	"github.com/armadaproject/armada/internal/common/armadacontext"
-	"github.com/armadaproject/armada/internal/common/logging"
-	"github.com/armadaproject/armada/internal/common/profiling"
-	"github.com/armadaproject/armada/internal/common/serve"
 	"net/http"
 	"os"
 	"os/signal"
@@ -20,8 +16,12 @@ import (
 	"github.com/armadaproject/armada/internal/binoculars"
 	"github.com/armadaproject/armada/internal/binoculars/configuration"
 	"github.com/armadaproject/armada/internal/common"
+	"github.com/armadaproject/armada/internal/common/armadacontext"
 	gateway "github.com/armadaproject/armada/internal/common/grpc"
 	"github.com/armadaproject/armada/internal/common/health"
+	"github.com/armadaproject/armada/internal/common/logging"
+	"github.com/armadaproject/armada/internal/common/profiling"
+	"github.com/armadaproject/armada/internal/common/serve"
 	api "github.com/armadaproject/armada/pkg/api/binoculars"
 )
 

--- a/cmd/executor/main.go
+++ b/cmd/executor/main.go
@@ -1,9 +1,6 @@
 package main
 
 import (
-	"github.com/armadaproject/armada/internal/common/logging"
-	"github.com/armadaproject/armada/internal/common/profiling"
-	"github.com/armadaproject/armada/internal/common/serve"
 	"net/http"
 	"os"
 	"os/signal"
@@ -17,6 +14,9 @@ import (
 	"github.com/armadaproject/armada/internal/common"
 	"github.com/armadaproject/armada/internal/common/armadacontext"
 	"github.com/armadaproject/armada/internal/common/health"
+	"github.com/armadaproject/armada/internal/common/logging"
+	"github.com/armadaproject/armada/internal/common/profiling"
+	"github.com/armadaproject/armada/internal/common/serve"
 	"github.com/armadaproject/armada/internal/executor"
 	"github.com/armadaproject/armada/internal/executor/configuration"
 	"github.com/armadaproject/armada/internal/executor/metrics"

--- a/cmd/executor/main.go
+++ b/cmd/executor/main.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"github.com/armadaproject/armada/internal/common/logging"
+	"github.com/armadaproject/armada/internal/common/profiling"
+	"github.com/armadaproject/armada/internal/common/serve"
 	"net/http"
 	"os"
 	"os/signal"
@@ -14,9 +17,6 @@ import (
 	"github.com/armadaproject/armada/internal/common"
 	"github.com/armadaproject/armada/internal/common/armadacontext"
 	"github.com/armadaproject/armada/internal/common/health"
-	"github.com/armadaproject/armada/internal/common/logging"
-	"github.com/armadaproject/armada/internal/common/profiling"
-	"github.com/armadaproject/armada/internal/common/serve"
 	"github.com/armadaproject/armada/internal/executor"
 	"github.com/armadaproject/armada/internal/executor/configuration"
 	"github.com/armadaproject/armada/internal/executor/metrics"
@@ -42,13 +42,15 @@ func main() {
 	common.LoadConfig(&config, "./config/executor", userSpecifiedConfigs)
 
 	// Expose profiling endpoints if enabled.
-	pprofServer := profiling.SetupPprofHttpServer(config.PprofPort)
-	go func() {
-		ctx := armadacontext.Background()
-		if err := serve.ListenAndServe(ctx, pprofServer); err != nil {
-			logging.WithStacktrace(ctx, err).Error("pprof server failure")
-		}
-	}()
+	if config.PprofPort != nil {
+		pprofServer := profiling.SetupPprofHttpServer(*config.PprofPort)
+		go func() {
+			ctx := armadacontext.Background()
+			if err := serve.ListenAndServe(ctx, pprofServer); err != nil {
+				logging.WithStacktrace(ctx, err).Error("pprof server failure")
+			}
+		}()
+	}
 
 	mux := http.NewServeMux()
 	startupCompleteCheck := health.NewStartupCompleteChecker()

--- a/cmd/fakeexecutor/main.go
+++ b/cmd/fakeexecutor/main.go
@@ -38,13 +38,15 @@ func main() {
 	v := common.LoadConfig(&config, "./config/executor", userSpecifiedConfigs)
 
 	// Expose profiling endpoints if enabled.
-	pprofServer := profiling.SetupPprofHttpServer(config.PprofPort)
-	go func() {
-		ctx := armadacontext.Background()
-		if err := serve.ListenAndServe(ctx, pprofServer); err != nil {
-			logging.WithStacktrace(ctx, err).Error("pprof server failure")
-		}
-	}()
+	if config.PprofPort != nil {
+		pprofServer := profiling.SetupPprofHttpServer(*config.PprofPort)
+		go func() {
+			ctx := armadacontext.Background()
+			if err := serve.ListenAndServe(ctx, pprofServer); err != nil {
+				logging.WithStacktrace(ctx, err).Error("pprof server failure")
+			}
+		}()
+	}
 
 	var nodes []*context.NodeSpec
 	e := common.UnmarshalKey(v, "nodes", &nodes)

--- a/cmd/lookoutv2/main.go
+++ b/cmd/lookoutv2/main.go
@@ -1,9 +1,6 @@
 package main
 
 import (
-	"github.com/armadaproject/armada/internal/common/logging"
-	"github.com/armadaproject/armada/internal/common/profiling"
-	"github.com/armadaproject/armada/internal/common/serve"
 	"os"
 	"os/signal"
 	"syscall"
@@ -16,6 +13,9 @@ import (
 	"github.com/armadaproject/armada/internal/common"
 	"github.com/armadaproject/armada/internal/common/armadacontext"
 	"github.com/armadaproject/armada/internal/common/database"
+	"github.com/armadaproject/armada/internal/common/logging"
+	"github.com/armadaproject/armada/internal/common/profiling"
+	"github.com/armadaproject/armada/internal/common/serve"
 	"github.com/armadaproject/armada/internal/lookoutv2"
 	"github.com/armadaproject/armada/internal/lookoutv2/configuration"
 	"github.com/armadaproject/armada/internal/lookoutv2/gen/restapi"

--- a/deployment/armada/templates/deployment.yaml
+++ b/deployment/armada/templates/deployment.yaml
@@ -69,6 +69,11 @@ spec:
             - containerPort: {{ .Values.applicationConfig.httpPort }}
               protocol: TCP
               name: rest
+            {{- if .Values.applicationConfig.pprofPort }}
+            - containerPort: {{ .Values.applicationConfig.pprofPort }}
+              protocol: TCP
+              name: pprof
+            {{- end }}
           volumeMounts:
             - name: user-config
               mountPath: /config/application_config.yaml

--- a/deployment/binoculars/templates/deployment.yaml
+++ b/deployment/binoculars/templates/deployment.yaml
@@ -54,6 +54,11 @@ spec:
             - containerPort: {{ .Values.applicationConfig.httpPort }}
               protocol: TCP
               name: web
+            {{- if .Values.applicationConfig.pprofPort }}
+            - containerPort: {{ .Values.applicationConfig.pprofPort }}
+              protocol: TCP
+              name: pprof
+            {{- end }}
           volumeMounts:
             - name: user-config
               mountPath: /config/application_config.yaml

--- a/deployment/event-ingester/templates/deployment.yaml
+++ b/deployment/event-ingester/templates/deployment.yaml
@@ -44,6 +44,12 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          ports:
+            {{- if .Values.applicationConfig.pprofPort }}
+            - containerPort: {{ .Values.applicationConfig.pprofPort }}
+              protocol: TCP
+              name: pprof
+            {{- end }}
           volumeMounts:
             - name: user-config
               mountPath: /config/application_config.yaml

--- a/deployment/executor/templates/deployment.yaml
+++ b/deployment/executor/templates/deployment.yaml
@@ -52,6 +52,11 @@ spec:
             - containerPort: 9001
               protocol: TCP
               name: metrics
+            {{- if .Values.applicationConfig.pprofPort }}
+            - containerPort: {{ .Values.applicationConfig.pprofPort }}
+              protocol: TCP
+              name: pprof
+            {{- end }}
           volumeMounts:
             - name: user-config
               mountPath: /config/application_config.yaml

--- a/deployment/lookout-ingester-v2/templates/deployment.yaml
+++ b/deployment/lookout-ingester-v2/templates/deployment.yaml
@@ -44,6 +44,12 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          ports:
+            {{- if .Values.applicationConfig.pprofPort }}
+            - containerPort: {{ .Values.applicationConfig.pprofPort }}
+              protocol: TCP
+              name: pprof
+            {{- end }}
           volumeMounts:
             - name: user-config
               mountPath: /config/application_config.yaml

--- a/deployment/lookout-v2/templates/deployment.yaml
+++ b/deployment/lookout-v2/templates/deployment.yaml
@@ -48,6 +48,11 @@ spec:
             - containerPort: {{ .Values.applicationConfig.apiPort }}
               protocol: TCP
               name: web
+            {{- if .Values.applicationConfig.pprofPort }}
+            - containerPort: {{ .Values.applicationConfig.pprofPort }}
+              protocol: TCP
+              name: pprof
+            {{- end }}
           volumeMounts:
             - name: user-config
               mountPath: /config/application_config.yaml

--- a/deployment/scheduler/templates/scheduler-statefulset.yaml
+++ b/deployment/scheduler/templates/scheduler-statefulset.yaml
@@ -76,6 +76,11 @@ spec:
             - containerPort: {{ .Values.scheduler.applicationConfig.metrics.port }}
               protocol: TCP
               name: metrics
+            {{- if .Values.applicationConfig.pprofPort }}
+            - containerPort: {{ .Values.applicationConfig.pprofPort }}
+              protocol: TCP
+              name: pprof
+            {{- end }}
           volumeMounts:
             - name: user-config
               mountPath: /config/application_config.yaml

--- a/internal/common/profiling/http.go
+++ b/internal/common/profiling/http.go
@@ -12,9 +12,8 @@ import (
 //     this function replaces http.DefaultServeMux with a new mux. This to ensure profiling endpoints
 //     are exposed on a separate mux available only from localhost.Hence, this function should be called
 //     before adding any other endpoints to http.DefaultServeMux.
-//  2. If port is non-nil, returns a http server serving net/http/pprof endpoints on localhost:port.
-//     If port is nil, returns nil.
-func SetupPprofHttpServer(port *uint16) *http.Server {
+//  2. Returns a http server serving net/http/pprof endpoints on localhost:port.
+func SetupPprofHttpServer(port uint16) *http.Server {
 	pprofMux := http.DefaultServeMux
 	http.DefaultServeMux = http.NewServeMux()
 	return &http.Server{

--- a/internal/eventingester/ingester.go
+++ b/internal/eventingester/ingester.go
@@ -1,10 +1,6 @@
 package eventingester
 
 import (
-	"github.com/armadaproject/armada/internal/common/armadacontext"
-	"github.com/armadaproject/armada/internal/common/logging"
-	"github.com/armadaproject/armada/internal/common/profiling"
-	"github.com/armadaproject/armada/internal/common/serve"
 	"regexp"
 	"time"
 
@@ -14,8 +10,12 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/armadaproject/armada/internal/common/app"
+	"github.com/armadaproject/armada/internal/common/armadacontext"
 	"github.com/armadaproject/armada/internal/common/compress"
 	"github.com/armadaproject/armada/internal/common/ingest"
+	"github.com/armadaproject/armada/internal/common/logging"
+	"github.com/armadaproject/armada/internal/common/profiling"
+	"github.com/armadaproject/armada/internal/common/serve"
 	"github.com/armadaproject/armada/internal/eventingester/configuration"
 	"github.com/armadaproject/armada/internal/eventingester/convert"
 	"github.com/armadaproject/armada/internal/eventingester/metrics"

--- a/internal/lookoutingesterv2/ingester.go
+++ b/internal/lookoutingesterv2/ingester.go
@@ -1,10 +1,6 @@
 package lookoutingesterv2
 
 import (
-	"github.com/armadaproject/armada/internal/common/armadacontext"
-	"github.com/armadaproject/armada/internal/common/logging"
-	"github.com/armadaproject/armada/internal/common/profiling"
-	"github.com/armadaproject/armada/internal/common/serve"
 	"regexp"
 
 	"github.com/apache/pulsar-client-go/pulsar"
@@ -12,9 +8,13 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/armadaproject/armada/internal/common/app"
+	"github.com/armadaproject/armada/internal/common/armadacontext"
 	"github.com/armadaproject/armada/internal/common/compress"
 	"github.com/armadaproject/armada/internal/common/database"
 	"github.com/armadaproject/armada/internal/common/ingest"
+	"github.com/armadaproject/armada/internal/common/logging"
+	"github.com/armadaproject/armada/internal/common/profiling"
+	"github.com/armadaproject/armada/internal/common/serve"
 	"github.com/armadaproject/armada/internal/lookoutingesterv2/configuration"
 	"github.com/armadaproject/armada/internal/lookoutingesterv2/instructions"
 	"github.com/armadaproject/armada/internal/lookoutingesterv2/lookoutdb"

--- a/internal/lookoutingesterv2/ingester.go
+++ b/internal/lookoutingesterv2/ingester.go
@@ -1,6 +1,10 @@
 package lookoutingesterv2
 
 import (
+	"github.com/armadaproject/armada/internal/common/armadacontext"
+	"github.com/armadaproject/armada/internal/common/logging"
+	"github.com/armadaproject/armada/internal/common/profiling"
+	"github.com/armadaproject/armada/internal/common/serve"
 	"regexp"
 
 	"github.com/apache/pulsar-client-go/pulsar"
@@ -8,13 +12,9 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/armadaproject/armada/internal/common/app"
-	"github.com/armadaproject/armada/internal/common/armadacontext"
 	"github.com/armadaproject/armada/internal/common/compress"
 	"github.com/armadaproject/armada/internal/common/database"
 	"github.com/armadaproject/armada/internal/common/ingest"
-	"github.com/armadaproject/armada/internal/common/logging"
-	"github.com/armadaproject/armada/internal/common/profiling"
-	"github.com/armadaproject/armada/internal/common/serve"
 	"github.com/armadaproject/armada/internal/lookoutingesterv2/configuration"
 	"github.com/armadaproject/armada/internal/lookoutingesterv2/instructions"
 	"github.com/armadaproject/armada/internal/lookoutingesterv2/lookoutdb"
@@ -50,13 +50,15 @@ func Run(config *configuration.LookoutIngesterV2Configuration) {
 	}
 
 	// Expose profiling endpoints if enabled.
-	pprofServer := profiling.SetupPprofHttpServer(config.PprofPort)
-	go func() {
-		ctx := armadacontext.Background()
-		if err := serve.ListenAndServe(ctx, pprofServer); err != nil {
-			logging.WithStacktrace(ctx, err).Error("pprof server failure")
-		}
-	}()
+	if config.PprofPort != nil {
+		pprofServer := profiling.SetupPprofHttpServer(*config.PprofPort)
+		go func() {
+			ctx := armadacontext.Background()
+			if err := serve.ListenAndServe(ctx, pprofServer); err != nil {
+				logging.WithStacktrace(ctx, err).Error("pprof server failure")
+			}
+		}()
+	}
 
 	converter := instructions.NewInstructionConverter(m, config.UserAnnotationPrefix, compressor, config.UseLegacyEventConversion)
 

--- a/internal/scheduler/schedulerapp.go
+++ b/internal/scheduler/schedulerapp.go
@@ -2,8 +2,6 @@ package scheduler
 
 import (
 	"fmt"
-	"github.com/armadaproject/armada/internal/common/profiling"
-	"github.com/armadaproject/armada/internal/common/serve"
 	"net"
 	"net/http"
 	_ "net/http/pprof"
@@ -27,7 +25,9 @@ import (
 	grpcCommon "github.com/armadaproject/armada/internal/common/grpc"
 	"github.com/armadaproject/armada/internal/common/health"
 	"github.com/armadaproject/armada/internal/common/logging"
+	"github.com/armadaproject/armada/internal/common/profiling"
 	"github.com/armadaproject/armada/internal/common/pulsarutils"
+	"github.com/armadaproject/armada/internal/common/serve"
 	"github.com/armadaproject/armada/internal/common/types"
 	schedulerconfig "github.com/armadaproject/armada/internal/scheduler/configuration"
 	"github.com/armadaproject/armada/internal/scheduler/database"

--- a/internal/scheduler/schedulerapp.go
+++ b/internal/scheduler/schedulerapp.go
@@ -2,6 +2,8 @@ package scheduler
 
 import (
 	"fmt"
+	"github.com/armadaproject/armada/internal/common/profiling"
+	"github.com/armadaproject/armada/internal/common/serve"
 	"net"
 	"net/http"
 	_ "net/http/pprof"
@@ -25,9 +27,7 @@ import (
 	grpcCommon "github.com/armadaproject/armada/internal/common/grpc"
 	"github.com/armadaproject/armada/internal/common/health"
 	"github.com/armadaproject/armada/internal/common/logging"
-	"github.com/armadaproject/armada/internal/common/profiling"
 	"github.com/armadaproject/armada/internal/common/pulsarutils"
-	"github.com/armadaproject/armada/internal/common/serve"
 	"github.com/armadaproject/armada/internal/common/types"
 	schedulerconfig "github.com/armadaproject/armada/internal/scheduler/configuration"
 	"github.com/armadaproject/armada/internal/scheduler/database"
@@ -45,10 +45,12 @@ func Run(config schedulerconfig.Configuration) error {
 	// ////////////////////////////////////////////////////////////////////////
 	// Profiling
 	// ////////////////////////////////////////////////////////////////////////
-	pprofServer := profiling.SetupPprofHttpServer(config.PprofPort)
-	g.Go(func() error {
-		return serve.ListenAndServe(ctx, pprofServer)
-	})
+	if config.PprofPort != nil {
+		pprofServer := profiling.SetupPprofHttpServer(*config.PprofPort)
+		g.Go(func() error {
+			return serve.ListenAndServe(ctx, pprofServer)
+		})
+	}
 
 	// ////////////////////////////////////////////////////////////////////////
 	// Health Checks

--- a/internal/scheduleringester/ingester.go
+++ b/internal/scheduleringester/ingester.go
@@ -1,11 +1,12 @@
 package scheduleringester
 
 import (
+	"time"
+
 	"github.com/armadaproject/armada/internal/common/armadacontext"
 	"github.com/armadaproject/armada/internal/common/logging"
 	"github.com/armadaproject/armada/internal/common/profiling"
 	"github.com/armadaproject/armada/internal/common/serve"
-	"time"
 
 	"github.com/apache/pulsar-client-go/pulsar"
 	"github.com/pkg/errors"


### PR DESCRIPTION
Profiling was broken because:

a) We weren't doing a null check on the profiling port
b) we didn't de reference the profiling port before creating the profiling server.

This change fixes both the above issues and also updates the heklm chart to expose the profiling port if profiling is enabled.