### PR TITLE
Fix Scheduler Helm Chart

### DIFF
--- a/deployment/scheduler/templates/scheduler-statefulset.yaml
+++ b/deployment/scheduler/templates/scheduler-statefulset.yaml
@@ -76,8 +76,8 @@ spec:
             - containerPort: {{ .Values.scheduler.applicationConfig.metrics.port }}
               protocol: TCP
               name: metrics
-            {{- if .Values.applicationConfig.pprofPort }}
-            - containerPort: {{ .Values.applicationConfig.pprofPort }}
+            {{- if .Values.scheduler.applicationConfig.pprofPort }}
+            - containerPort: {{ .Values.scheduler.applicationConfig.pprofPort }}
               protocol: TCP
               name: pprof
             {{- end }}


### PR DESCRIPTION
Turns out that the the scheduler helm chart is different from all the others in that everythign lives under a top level `scheduler` block.  Thus it should be `.Values.scheduler.applicationConfig.pprofPort` and not `.Values.applicationConfig.pprofPort` 