### PR TITLE
Adding Node, Cluster and ExitCode to Jobs (#80)

### DIFF
--- a/internal/lookout/ui/src/models/lookoutV2Models.ts
+++ b/internal/lookout/ui/src/models/lookoutV2Models.ts
@@ -78,6 +78,9 @@ export type Job = {
   lastActiveRunId?: string
   lastTransitionTime: string
   cancelReason?: string
+  node?: string
+  cluster?: string
+  exitCode?: number
 }
 
 export type JobKey = keyof Job

--- a/internal/lookout/ui/src/utils/jobsTableColumns.tsx
+++ b/internal/lookout/ui/src/utils/jobsTableColumns.tsx
@@ -51,6 +51,9 @@ export enum StandardColumnId {
   SelectorCol = "selectorCol",
 
   Count = "jobCount",
+  Node = "node",
+  Cluster = "cluster",
+  ExitCode = "exitCode",
 }
 
 export const ANNOTATION_COLUMN_PREFIX = "annotation_"
@@ -392,6 +395,30 @@ export const JOB_COLUMNS: JobTableColumn[] = [
     displayName: "Time Since Submitted",
     additionalOptions: {
       enableSorting: true,
+    },
+  }),
+  accessorColumn({
+    id: StandardColumnId.Node,
+    accessor: "node",
+    displayName: "Node",
+    additionalOptions: {
+      size: 200,
+    },
+  }),
+  accessorColumn({
+    id: StandardColumnId.Cluster,
+    accessor: "cluster",
+    displayName: "Cluster",
+    additionalOptions: {
+      size: 200,
+    },
+  }),
+  accessorColumn({
+    id: StandardColumnId.ExitCode,
+    accessor: "exitCode",
+    displayName: "Exit Code",
+    additionalOptions: {
+      size: 100,
     },
   }),
 ]

--- a/internal/lookoutv2/conversions/convert.go
+++ b/internal/lookoutv2/conversions/convert.go
@@ -37,6 +37,9 @@ func ToSwaggerJob(job *model.Job) *models.Job {
 		State:              job.State,
 		Submitted:          strfmt.DateTime(job.Submitted),
 		CancelReason:       job.CancelReason,
+		Node:               job.Node,
+		Cluster:            job.Cluster,
+		ExitCode:           job.ExitCode,
 	}
 }
 

--- a/internal/lookoutv2/gen/models/job.go
+++ b/internal/lookoutv2/gen/models/job.go
@@ -105,6 +105,18 @@ type Job struct {
 	// Min Length: 1
 	// Format: date-time
 	Submitted strfmt.DateTime `json:"submitted"`
+
+	// node
+	// Required: false
+	Node *string `json:"node,omitempty"`
+
+	// cluster
+	// Required: true
+	Cluster string `json:"cluster"`
+
+	//exitCode
+	// Required: false
+	ExitCode *int32 `json:"exitCode,omitempty"`
 }
 
 // Validate validates this job

--- a/internal/lookoutv2/model/model.go
+++ b/internal/lookoutv2/model/model.go
@@ -40,6 +40,9 @@ type Job struct {
 	State              string
 	Submitted          time.Time
 	CancelReason       *string
+	Node               *string
+	Cluster            string
+	ExitCode           *int32
 }
 
 // PostgreSQLTime is a wrapper around time.Time that converts to UTC when

--- a/internal/lookoutv2/repository/getjobs.go
+++ b/internal/lookoutv2/repository/getjobs.go
@@ -51,6 +51,9 @@ type jobRow struct {
 	priorityClass      sql.NullString
 	latestRunId        sql.NullString
 	cancelReason       sql.NullString
+	node               sql.NullString
+	cluster            string
+	exitCode           sql.NullString
 }
 
 type runRow struct {
@@ -125,6 +128,7 @@ func (r *SqlGetJobsRepository) getJobs(ctx *armadacontext.Context, filters []*mo
 			log.WithError(err).Error("failed getting run rows")
 			return err
 		}
+
 		annotationRows, err = makeAnnotationRows(ctx, tx, tempTableName)
 		if err != nil {
 			log.WithError(err).Error("failed getting annotation rows")
@@ -135,7 +139,6 @@ func (r *SqlGetJobsRepository) getJobs(ctx *armadacontext.Context, filters []*mo
 	if err != nil {
 		return nil, err
 	}
-
 	jobs, err := rowsToJobs(jobRows, runRows, annotationRows)
 	if err != nil {
 		return nil, err
@@ -201,6 +204,13 @@ func (r *SqlGetJobsRepository) getJobsJsonb(ctx *armadacontext.Context, filters 
 					return err
 				}
 			}
+			if len(job.Runs) > 0 {
+				lastRun := job.Runs[len(job.Runs)-1] // Get the last run
+				job.Node = lastRun.Node
+				job.Cluster = lastRun.Cluster
+				job.ExitCode = lastRun.ExitCode
+
+			}
 			jobs = append(jobs, job)
 		}
 		return nil
@@ -251,6 +261,13 @@ func rowsToJobs(jobRows []*jobRow, runRows []*runRow, annotationRows []*annotati
 	for i, jobId := range orderedJobIds {
 		job := jobMap[jobId]
 		sortRuns(job.Runs)
+		if len(job.Runs) > 0 {
+			lastRun := job.Runs[len(job.Runs)-1] // Get the last run
+			job.Node = lastRun.Node
+			job.Cluster = lastRun.Cluster
+			job.ExitCode = lastRun.ExitCode
+
+		}
 		jobs[i] = job
 	}
 

--- a/internal/lookoutv2/repository/getjobs_test.go
+++ b/internal/lookoutv2/repository/getjobs_test.go
@@ -1997,3 +1997,69 @@ func TestGetJobsActiveJobSet(t *testing.T) {
 	})
 	require.NoError(t, err)
 }
+
+func TestGetJobsWithLatestRunDetails(t *testing.T) {
+	err := withGetJobsSetup(func(converter *instructions.InstructionConverter, store *lookoutdb.LookoutDb, repo *SqlGetJobsRepository) error {
+		runIdLatest := uuid.NewString()
+		// Simulate job submission and multiple runs, with the latest run being successful
+		NewJobSimulator(converter, store).
+			Submit(queue, jobSet, owner, namespace, baseTime, basicJobOpts).
+			Pending(uuid.NewString(), "first-cluster", baseTime).
+			Running(uuid.NewString(), "first-node", baseTime.Add(time.Minute)).
+			Pending(runIdLatest, "latest-cluster", baseTime.Add(2*time.Minute)).
+			Running(runIdLatest, "latest-node", baseTime.Add(3*time.Minute)).
+			RunSucceeded(runIdLatest, baseTime.Add(4*time.Minute)).
+			Build().
+			Job()
+
+		result, err := repo.GetJobs(armadacontext.TODO(), []*model.Filter{}, false, &model.Order{}, 0, 10)
+		require.NoError(t, err)
+		require.Len(t, result.Jobs, 1)
+
+		// Adjusting assertions to dereference pointer fields
+		if assert.NotNil(t, result.Jobs[0].Node) {
+			assert.Equal(t, "latest-node", *result.Jobs[0].Node)
+		}
+		if assert.NotNil(t, result.Jobs[0].ExitCode) {
+			assert.Equal(t, int32(0), *result.Jobs[0].ExitCode)
+		}
+		if assert.NotNil(t, result.Jobs[0].Cluster) {
+			assert.Equal(t, "latest-cluster", result.Jobs[0].Cluster)
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+func TestGetJobsWithSpecificRunDetails(t *testing.T) {
+	err := withGetJobsSetup(func(converter *instructions.InstructionConverter, store *lookoutdb.LookoutDb, repo *SqlGetJobsRepository) error {
+		runIdSpecific := uuid.NewString()
+		// Simulate job submission and a specific failed run
+		NewJobSimulator(converter, store).
+			Submit(queue, jobSet, owner, namespace, baseTime, basicJobOpts).
+			Pending(runIdSpecific, "specific-cluster", baseTime).
+			Running(runIdSpecific, "specific-node", baseTime.Add(time.Minute)).
+			RunFailed(runIdSpecific, "specific-node", 2, "Specific failure message", baseTime.Add(2*time.Minute)).
+			Build().
+			Job()
+
+		result, err := repo.GetJobs(armadacontext.TODO(), []*model.Filter{}, false, &model.Order{}, 0, 10)
+		require.NoError(t, err)
+		require.Len(t, result.Jobs, 1)
+
+		// Adjusting assertions to dereference pointer fields
+		if assert.NotNil(t, result.Jobs[0].Node) {
+			assert.Equal(t, "specific-node", *result.Jobs[0].Node)
+		}
+		if assert.NotNil(t, result.Jobs[0].ExitCode) {
+			assert.Equal(t, int32(2), *result.Jobs[0].ExitCode)
+		}
+		if assert.NotNil(t, result.Jobs[0].Cluster) {
+			assert.Equal(t, "specific-cluster", result.Jobs[0].Cluster)
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+}

--- a/internal/lookoutv2/repository/util.go
+++ b/internal/lookoutv2/repository/util.go
@@ -225,6 +225,7 @@ func (js *JobSimulator) Pending(runId string, cluster string, timestamp time.Tim
 	js.job.LastActiveRunId = &runId
 	js.job.LastTransitionTime = ts
 	js.job.State = string(lookout.JobPending)
+	js.job.Cluster = cluster
 	rp := &runPatch{
 		runId:       runId,
 		cluster:     &cluster,
@@ -264,6 +265,7 @@ func (js *JobSimulator) Running(runId string, node string, timestamp time.Time) 
 	js.job.LastActiveRunId = &runId
 	js.job.LastTransitionTime = ts
 	js.job.State = string(lookout.JobRunning)
+	js.job.Node = &node
 	updateRun(js.job, &runPatch{
 		runId:       runId,
 		jobRunState: lookout.JobRunRunning,
@@ -613,6 +615,9 @@ func timestampOrNow(timestamp time.Time) time.Time {
 }
 
 func updateRun(job *model.Job, patch *runPatch) {
+	if patch.exitCode != nil {
+		job.ExitCode = patch.exitCode
+	}
 	for _, run := range job.Runs {
 		if run.RunId == patch.runId {
 			patchRun(run, patch)


### PR DESCRIPTION
Adding 3 new columns in Jobs: Cluster, Node and ExitCode. These are pulled directly from the latest JobRun for the specified job.