### PR TITLE
Fix capitalization in yaml produced by armadactl get queue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -91,7 +91,6 @@ require (
 	golang.org/x/time v0.3.0
 	gonum.org/v1/gonum v0.14.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20230525234035-dd9d682886f9
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -197,6 +196,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.100.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20211109043538-20434351676c // indirect
 	lukechampine.com/uint128 v1.2.0 // indirect

--- a/internal/armadactl/queue.go
+++ b/internal/armadactl/queue.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v3"
+	"sigs.k8s.io/yaml"
 
 	"github.com/armadaproject/armada/pkg/client"
 	"github.com/armadaproject/armada/pkg/client/queue"


### PR DESCRIPTION
It's hit by issue https://github.com/go-yaml/yaml/issues/923, using `sigs.k8s.io/yaml` (already used elsewhere in armada) fixes it.

Before
```
apiVersion: armadaproject.io/v1beta1
kind: Queue
name: queue-a
priorityfactor: 1
userowners: []
groupowners: []
resourcelimits: {}
resourcelimitsbypriorityclassname:
    armada-default:
        maximumresourcefraction:
            cpu: 0.01
            memory: 0.99
        maximumresourcefractionbypool:
            default:
                maximumresourcefraction:
                    cpu: 0.02
                    memory: 0.99
```

After
```
apiVersion: armadaproject.io/v1beta1
kind: Queue
name: queue-a
priorityFactor: 1
resourceLimitsByPriorityClassName:
  armada-default:
    maximumResourceFraction:
      cpu: 0.01
      memory: 0.99
    maximumResourceFractionByPool:
      default:
        maximumResourceFraction:
          cpu: 0.02
          memory: 0.99
```
