### PR TITLE
Fix a bug in lookout job group sorting 

### DIFF
--- a/internal/lookout/ui/src/hooks/useJobsTableData.ts
+++ b/internal/lookout/ui/src/hooks/useJobsTableData.ts
@@ -61,6 +61,13 @@ const aggregatableFields = new Map<ColumnId, string>([
   [StandardColumnId.State, "state"],
 ])
 
+const groupableFields = new Map<ColumnId, string>([
+  [StandardColumnId.Queue, "queue"],
+  [StandardColumnId.Namespace, "namespace"],
+  [StandardColumnId.JobSet, "jobSet"],
+  [StandardColumnId.State, "state"],
+])
+
 export function columnIsAggregatable(columnId: ColumnId): boolean {
   return aggregatableFields.has(columnId)
 }
@@ -173,7 +180,10 @@ export const useFetchJobsTableData = ({
           const groupedField = columnToGroupedField(groupedCol)
 
           // Override the group order if needed
-          if (rowRequest.order.field !== groupedCol) {
+          if (
+            rowRequest.order.field !== groupedCol &&
+            Array.from(groupableFields.values()).includes(rowRequest.order.field)
+          ) {
             rowRequest.order = defaultGroupOrder
           }
 


### PR DESCRIPTION

The issue: Sorting was not working if we grouped by any column and tried to sort by non-groupable column like Timestamp. It defaulted to count.
The fix:
If a column can't be grouped by, we can always sort by it. Adding a list of groupable columns which is the same as the one defined in the API. If the column is groupable by, keep the same logic.