### PR TITLE
CI: Fix deprecation and warnings in jobs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,14 @@
 
 version: 2
 updates:
+
+  # Enable version updated for GitHub actions used in workflows 
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"
+
   # Enable version updates for npm
   - package-ecosystem: "npm"
     # Look for `package.json` and `lock` files in the `internal/lookout` directory


### PR DESCRIPTION
#### What type of PR is this?

CI: Resolve deprecation & warning messages in workflows

#### What this PR does / why we need it:

- Add GitHub actions for DependaBot
  - Following [PRs](https://github.com/ljubon/armada/pulls?q=is%3Apr+is%3Aopen+Bump+actions+label%3Agithub_actions) will be opened upon merging 

Node16 has been out of support since [September 2023](https://github.com/nodejs/Release/#end-of-life-releases). - more info in the [post](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/) 

#### Which issue(s) this PR fixes:

Fixes https://github.com/G-Research/gr-oss/issues/586
