### PR TITLE
Fix Scheduling Weights

### DIFF
--- a/internal/scheduler/scheduling_algo.go
+++ b/internal/scheduler/scheduling_algo.go
@@ -249,11 +249,7 @@ func (l *FairSchedulingAlgo) newFairSchedulingAlgoContext(ctx *armadacontext.Con
 	}
 	priorityFactorByQueue := make(map[string]float64)
 	for _, queue := range queues {
-		weight := 0.0
-		if queue.PriorityFactor != 0 {
-			weight = 1 / float64(queue.PriorityFactor)
-		}
-		priorityFactorByQueue[queue.Name] = weight
+		priorityFactorByQueue[queue.Name] = float64(queue.PriorityFactor)
 	}
 
 	// Get the total capacity available across executors.

--- a/internal/scheduler/scheduling_algo_test.go
+++ b/internal/scheduler/scheduling_algo_test.go
@@ -61,6 +61,28 @@ func TestSchedule(t *testing.T) {
 			queuedJobs:               testfixtures.N16Cpu128GiJobs(testfixtures.TestQueue, testfixtures.PriorityClass3, 10),
 			expectedScheduledIndices: []int{0, 1, 2, 3},
 		},
+		"Fair share": {
+			schedulingConfig: testfixtures.TestSchedulingConfig(),
+			executors: []*schedulerobjects.Executor{
+				testfixtures.Test1Node32CoreExecutor("executor1"),
+				testfixtures.Test1Node32CoreExecutor("executor2"),
+			},
+			queues: []queue.Queue{
+				{
+					Name:           "testQueueA",
+					PriorityFactor: 100,
+				},
+				{
+					Name:           "testQueueB",
+					PriorityFactor: 300,
+				},
+			},
+			queuedJobs: append(
+				testfixtures.N16Cpu128GiJobs("testQueueA", testfixtures.PriorityClass3, 10),
+				testfixtures.N16Cpu128GiJobs("testQueueB", testfixtures.PriorityClass3, 10)...,
+			),
+			expectedScheduledIndices: []int{0, 1, 2, 10},
+		},
 		"do not schedule onto stale executors": {
 			schedulingConfig: testfixtures.TestSchedulingConfig(),
 			executors: []*schedulerobjects.Executor{

--- a/internal/scheduler/testfixtures/testfixtures.go
+++ b/internal/scheduler/testfixtures/testfixtures.go
@@ -790,7 +790,7 @@ func Test1Node32CoreExecutor(executorId string) *schedulerobjects.Executor {
 func MakeTestQueue() queue.Queue {
 	return queue.Queue{
 		Name:           TestQueue,
-		PriorityFactor: 0.01,
+		PriorityFactor: 100,
 	}
 }
 


### PR DESCRIPTION
In  #3429 we introduced a bug whereby we mixed up a weight and priority factor.  As weights are 1/priority_factor this has led to all queue weights being inverted.

This PR addresses this issue and also adds a test that will allow us to spot this if it ever happens again.