### PR TITLE
Scheduler and submission config refactoring and cleanup

### DIFF
--- a/config/armada/config.yaml
+++ b/config/armada/config.yaml
@@ -31,52 +31,43 @@ eventsApiRedis:
   password: ""
   db: 1
   poolSize: 1000
+# Scheduling config used by the job submitChecker. Only needs the following subset of config options.
+# You may also wish to configure indexedNodeLabels and indexedTaints to speed up checking.
+#
+# This config must be consistent with the scheduling config used by the scheduler.
+# You may want to insert the scheduling config used for the scheduler automatically, e.g., using PyYAML, to guarantee consistency.
 scheduling:
-  enableAssertions: true
-  fairnessModel: "AssetFairness"
-  dominantResourceFairnessResourcesToConsider:
-    - "cpu"
-    - "memory"
-    - "nvidia.com/gpu"
-  resourceScarcity:
-    cpu: 1.0
-  preemption:
-    nodeEvictionProbability: 1.0
-    nodeOversubscriptionEvictionProbability: 1.0
-    protectedFractionOfFairShare: 1.0
-    setNodeIdSelector: true
-    nodeIdLabel: kubernetes.io/hostname
-    setNodeName: false
-    priorityClasses:
-      armada-default:
-        priority: 1000
-        preemptible: false
-        maximumResourceFractionPerQueue:
-          memory: 1.0
-          cpu: 1.0
-      armada-preemptible:
-        priority: 1000
-        preemptible: true
-    defaultPriorityClass: armada-default
-    priorityClassNameOverride: armada-default
-  executorTimeout: 60m
-  maxQueueLookback: 1000
-  maxExtraNodesToConsider: 1
-  maximumResourceFractionToSchedule:
-    memory: 1.0
-    cpu: 1.0
-  maximumSchedulingRate: 100.0
-  maximumSchedulingBurst: 1000
-  maximumPerQueueSchedulingRate: 50.0
-  maximumPerQueueSchedulingBurst: 1000
-  maxJobSchedulingContextsPerExecutor: 10000
-  lease:
-    expireAfter: 15m
-    expiryLoopInterval: 5s
+  executorTimeout: "60m"
+  executorUpdateFrequency: "1m"
+  priorityClasses:
+    armada-default:
+      priority: 1000
+      preemptible: false
+      maximumResourceFractionPerQueue:
+        memory: 1.0
+        cpu: 1.0
+    armada-preemptible:
+      priority: 1000
+      preemptible: true
+  indexedResources:
+    - name: "nvidia.com/gpu"
+      resolution: "1"
+    - name: "cpu"
+      resolution: "100m"
+    - name: "memory"
+      resolution: "100Mi"
+    - name: "ephemeral-storage"
+      resolution: "1Gi"
+submission:
+  allowedPriorityClassNames:
+    armada-default: true
+    armada-preemptible: true
+    armada-resilient: true
+  defaultPriorityClassName: "armada-default"
   defaultJobLimits:
-    cpu: 1
-    memory: 1Gi
-    ephemeral-storage: 8Gi
+    cpu: "1"
+    memory: "1Gi"
+    ephemeral-storage: "8Gi"
   defaultJobTolerations:
     - key: "armadaproject.io/armada"
       operator: "Equal"
@@ -93,18 +84,20 @@ scheduling:
         operator: "Equal"
         value: "true"
         effect: "NoSchedule"
-  maxRetries: 5
+  defaultJobTolerationsByResourceRequest:
+    - "nvidia.com/gpu":
+        - key: "armadaproject.io/gpu"
+          operator: "Equal"
+          value: "true"
+          effect: "NoSchedule"
   maxPodSpecSizeBytes: 65535
   minJobResources:
-    memory: 1Mi
-  indexedResources:
-    - name: "cpu"
-      resolution: "100m"
-    - name: "memory"
-      resolution: "1Mi"
-  minTerminationGracePeriod: 1s
-  maxTerminationGracePeriod: 300s
-  executorUpdateFrequency: 1m
+    memory: "1Mi"
+  minTerminationGracePeriod: "1s"
+  maxTerminationGracePeriod: "5m"
+  defaultActiveDeadline: "72h" # 3 days.
+  defaultActiveDeadlineByResourceRequest:
+    nvidia.com/gpu: "336h" # 14 days.
 eventRetention:
   expiryEnabled: true
   retentionDuration: 336h

--- a/config/executor/config.yaml
+++ b/config/executor/config.yaml
@@ -31,6 +31,8 @@ kubernetes:
   impersonateUsers: false
   trackedNodeLabels:
     - kubernetes.io/hostname
+  toleratedTaints:
+    - "mytaint"
   QPS: 10000
   Burst: 10000
   nodeIdLabel: kubernetes.io/hostname

--- a/config/executor/config.yaml
+++ b/config/executor/config.yaml
@@ -31,8 +31,6 @@ kubernetes:
   impersonateUsers: false
   trackedNodeLabels:
     - kubernetes.io/hostname
-  toleratedTaints:
-    - "mytaint"
   QPS: 10000
   Burst: 10000
   nodeIdLabel: kubernetes.io/hostname

--- a/config/scheduler/config.yaml
+++ b/config/scheduler/config.yaml
@@ -83,27 +83,24 @@ scheduling:
     - "cpu"
     - "memory"
     - "nvidia.com/gpu"
-  resourceScarcity:
-    cpu: 1.0
-  preemption:
-    alwaysAttemptScheduling: false
-    enabled: true
-    nodeEvictionProbability: 1.0
-    nodeOversubscriptionEvictionProbability: 1.0
-    protectedFractionOfFairShare: 1.0
-    nodeIdLabel: kubernetes.io/hostname
-    priorityClasses:
-      armada-default:
-        priority: 1000
-        preemptible: false
-        maximumResourceFractionPerQueue:
-          memory: 1.0
-          cpu: 1.0
-      armada-preemptible:
-        priority: 1000
-        preemptible: true
-    defaultPriorityClass: armada-default
-    priorityClassNameOverride: armada-default
+  alwaysAttemptScheduling: false
+  enabled: true
+  nodeEvictionProbability: 1.0
+  nodeOversubscriptionEvictionProbability: 1.0
+  protectedFractionOfFairShare: 1.0
+  nodeIdLabel: kubernetes.io/hostname
+  priorityClasses:
+    armada-default:
+      priority: 1000
+      preemptible: false
+      maximumResourceFractionPerQueue:
+        memory: 1.0
+        cpu: 1.0
+    armada-preemptible:
+      priority: 1000
+      preemptible: true
+  defaultPriorityClass: armada-default
+  priorityClassNameOverride: armada-default
   maxQueueLookback: 1000
   maxExtraNodesToConsider: 1
   maximumResourceFractionToSchedule:

--- a/config/scheduler/config.yaml
+++ b/config/scheduler/config.yaml
@@ -74,21 +74,14 @@ grpc:
     permitWithoutStream: true
   tls:
     enabled: false
+# You may want to configure indexedNodeLabels and indexedTaints to speed up scheduling.
 scheduling:
-  executorTimeout: 10m
-  executorUpdateFrequency: 1m
-  enableAssertions: true
-  fairnessModel: "AssetFairness"
-  dominantResourceFairnessResourcesToConsider:
-    - "cpu"
-    - "memory"
-    - "nvidia.com/gpu"
-  alwaysAttemptScheduling: false
-  enabled: true
+  disableScheduling: false
+  enableAssertions: false
   nodeEvictionProbability: 1.0
   nodeOversubscriptionEvictionProbability: 1.0
   protectedFractionOfFairShare: 1.0
-  nodeIdLabel: kubernetes.io/hostname
+  nodeIdLabel: "kubernetes.io/hostname"
   priorityClasses:
     armada-default:
       priority: 1000
@@ -101,8 +94,7 @@ scheduling:
       preemptible: true
   defaultPriorityClass: armada-default
   priorityClassNameOverride: armada-default
-  maxQueueLookback: 1000
-  maxExtraNodesToConsider: 1
+  maxQueueLookback: 100000
   maximumResourceFractionToSchedule:
     memory: 1.0
     cpu: 1.0
@@ -110,36 +102,26 @@ scheduling:
   maximumSchedulingBurst: 1000
   maximumPerQueueSchedulingRate: 50.0
   maximumPerQueueSchedulingBurst: 1000
-  maxUnacknowledgedJobsPerExecutor: 2500
   maxJobSchedulingContextsPerExecutor: 10000
-  defaultJobLimits:
-    cpu: 1
-    memory: 1Gi
-    ephemeral-storage: 8Gi
-  defaultJobTolerations:
-    - key: "armadaproject.io/armada"
-      operator: "Equal"
-      value: "true"
-      effect: "NoSchedule"
-  defaultJobTolerationsByPriorityClass:
-    armada-default:
-      - key: "armadaproject.io/pc-armada-default"
-        operator: "Equal"
-        value: "true"
-        effect: "NoSchedule"
-    armada-preemptible:
-      - key: "armadaproject.io/pc-armada-preemptible"
-        operator: "Equal"
-        value: "true"
-        effect: "NoSchedule"
-  maxRetries: 5
+  maxRetries: 3
+  dominantResourceFairnessResourcesToConsider:
+    - "cpu"
+    - "memory"
+    - "nvidia.com/gpu"
+    - "ephemeral-storage"
   indexedResources:
+    - name: "nvidia.com/gpu"
+      resolution: "1"
     - name: "cpu"
       resolution: "100m"
     - name: "memory"
-      resolution: "1Mi"
-  gangIdAnnotation: armadaproject.io/gangId
-  gangCardinalityAnnotation: armadaproject.io/gangCardinality
+      resolution: "100Mi"
+    - name: "ephemeral-storage"
+      resolution: "1Gi"
+  executorTimeout: "10m"
+  maxUnacknowledgedJobsPerExecutor: 2500
+  alwaysAttemptScheduling: false
+  executorUpdateFrequency: "1m"
   failureEstimatorConfig:
     # Optimised default parameters.
     numInnerIterations: 10

--- a/config/scheduler/config.yaml
+++ b/config/scheduler/config.yaml
@@ -92,8 +92,8 @@ scheduling:
     armada-preemptible:
       priority: 1000
       preemptible: true
-  defaultPriorityClass: armada-default
-  priorityClassNameOverride: armada-default
+  defaultPriorityClassName: "armada-default"
+  priorityClassNameOverride: "armada-default"
   maxQueueLookback: 100000
   maximumResourceFractionToSchedule:
     memory: 1.0

--- a/internal/armada/configuration/constants.go
+++ b/internal/armada/configuration/constants.go
@@ -1,7 +1,7 @@
 package configuration
 
 const (
-	// GangIdAnnotation Jobs with equal value for this annotation make up a gang.
+	// GangIdAnnotation maps to a unique id of the gang the job is part of; jobs with equal value make up a gang.
 	// All jobs in a gang are guaranteed to be scheduled onto the same cluster at the same time.
 	GangIdAnnotation = "armadaproject.io/gangId"
 	// GangCardinalityAnnotation All jobs in a gang must specify the total number of jobs in the gang via this annotation.
@@ -14,16 +14,10 @@ const (
 	// Specifically, if provided, all gang jobs are scheduled onto nodes for which the value of the provided label is equal.
 	// Used to ensure, e.g., that all gang jobs are scheduled onto the same cluster or rack.
 	GangNodeUniformityLabelAnnotation = "armadaproject.io/gangNodeUniformityLabel"
-	// Armada normally tries to re-schedule jobs for which a pod fails to start.
-	// Pods for which this annotation has value "true" are not retried.
+	// GangNumJobsScheduledAnnotation is set by the scheduler and indicates how many gang jobs were scheduled.
+	// For example, a gang composed of 4 jobs may only have a subset be scheduled if  GangMinimumCardinalityAnnotation < 4.
+	GangNumJobsScheduledAnnotation = "armadaproject.io/numGangJobsScheduled"
+	// FailFastAnnotation, if set to true, ensures Armada does not re-schedule jobs that fail to start.
 	// Instead, the job the pod is part of fails immediately.
 	FailFastAnnotation = "armadaproject.io/failFast"
 )
-
-const (
-	RuntimeGangCardinality = "runtime_gang_cardinality"
-)
-
-var ReturnLeaseRequestTrackedAnnotations = map[string]struct{}{
-	FailFastAnnotation: {},
-}

--- a/internal/armada/configuration/types.go
+++ b/internal/armada/configuration/types.go
@@ -171,6 +171,10 @@ type SchedulingConfig struct {
 	// Must be consistent with Kubernetes priority classes.
 	// I.e., priority classes defined here must be defined in all executor clusters and should map to the same priority.
 	PriorityClasses map[string]types.PriorityClass `validate:"dive"`
+	// Jobs with no priority class are assigned this priority class when ingested by the scheduler.
+	// Must be a key in the PriorityClasses map above.
+	// TODO(albin): Validate.
+	DefaultPriorityClassName string
 	// If set, override the priority class name of pods with this value when sending to an executor.
 	PriorityClassNameOverride *string
 	// Number of jobs to load from the database at a time.

--- a/internal/armada/configuration/types.go
+++ b/internal/armada/configuration/types.go
@@ -34,13 +34,17 @@ type ArmadaConfig struct {
 	SchedulerApiConnection client.ApiConnectionDetails
 
 	CancelJobsBatchSize int
-	Redis               redis.UniversalOptions
-	EventsApiRedis      redis.UniversalOptions
-	Submission          SubmissionConfig
-	Scheduling          SchedulingConfig
-	Pulsar              PulsarConfig
-	Postgres            PostgresConfig // Used for Pulsar submit API deduplication
-	QueryApi            QueryApiConfig
+
+	Redis          redis.UniversalOptions
+	EventsApiRedis redis.UniversalOptions
+	Pulsar         PulsarConfig
+	Postgres       PostgresConfig // Used for Pulsar submit API deduplication
+	QueryApi       QueryApiConfig
+
+	// Config relating to job submission.
+	Submission SubmissionConfig
+	// Scheduling config used by the submitChecker.
+	Scheduling SchedulingConfig
 }
 
 type PulsarConfig struct {
@@ -90,24 +94,21 @@ type SubmissionConfig struct {
 	// Must be an entry in PriorityClasses above.
 	DefaultPriorityClassName string
 	// Default job resource limits added to pods.
-	// TODO(albin): Move to server config.
 	DefaultJobLimits armadaresource.ComputeResources
 	// Tolerations added to all submitted pods.
-	// TODO(albin): Move to server config.
 	DefaultJobTolerations []v1.Toleration
 	// Tolerations added to all submitted pods of a given priority class.
-	// TODO(albin): Move to server config.
+	// TODO(albin): Rename to defaultJobTolerationsByPriorityClassName.
 	DefaultJobTolerationsByPriorityClass map[string][]v1.Toleration
 	// Tolerations added to all submitted pods requesting a non-zero amount of some resource.
-	// TODO(albin): Move to server config.
 	DefaultJobTolerationsByResourceRequest map[string][]v1.Toleration
 	// Pods of size greater than this are rejected at submission.
-	// TODO(albin): Move to server config.
 	MaxPodSpecSizeBytes uint
 	// Jobs requesting less than this amount of resources are rejected at submission.
-	// TODO(albin): Move to server config.
 	MinJobResources v1.ResourceList
 	// Default value of GangNodeUniformityLabelAnnotation if not set on submitted jobs.
+	// TODO(albin): We should add a label to nodes in the nodeDb indicating which cluster it came from.
+	//              If we do, we can default to that label if the uniformity label is empty.
 	DefaultGangNodeUniformityLabel string
 	// Minimum allowed termination grace period for pods submitted to Armada.
 	// Should normally be set to a positive value, e.g., "10m".
@@ -176,6 +177,7 @@ type SchedulingConfig struct {
 	// TODO(albin): Validate.
 	DefaultPriorityClassName string
 	// If set, override the priority class name of pods with this value when sending to an executor.
+	// TODO(albin): We should pass the scheduled priority class through as an annotation.
 	PriorityClassNameOverride *string
 	// Number of jobs to load from the database at a time.
 	MaxQueueLookback uint

--- a/internal/armada/configuration/types.go
+++ b/internal/armada/configuration/types.go
@@ -265,22 +265,20 @@ type WellKnownNodeType struct {
 type PreemptionConfig struct {
 	// If using PreemptToFairShare,
 	// the probability of evicting jobs on a node to balance resource usage.
+	// TODO(albin): Remove.
 	NodeEvictionProbability float64
 	// If using PreemptToFairShare,
 	// the probability of evicting jobs on oversubscribed nodes, i.e.,
 	// nodes on which the total resource requests are greater than the available resources.
+	// TODO(albin): Remove.
 	NodeOversubscriptionEvictionProbability float64
 	// Only queues allocated more than this fraction of their fair share are considered for preemption.
-	ProtectedFractionOfFairShare float64
-	// If true, the Armada scheduler will add to scheduled pods a node selector
-	// NodeIdLabel: <value of label on node selected by scheduler>.
-	// If true, NodeIdLabel must be non-empty.
-	SetNodeIdSelector bool
-	// Label used with SetNodeIdSelector. Must be non-empty if SetNodeIdSelector is true.
+	ProtectedFractionOfFairShare float64 `validate:"gte=0"`
+	// Armada adds a node selector term to every scheduled pod using this label with the node name as value.
+	// This to force kube-scheduler to schedule pods on the node chosen by Armada.
+	// For example, if NodeIdLabel is "kubernetes.io/hostname" and armada schedules a pod on node "myNode",
+	// then Armada adds "kubernetes.io/hostname": "myNode" to the pod node selector before sending it to the executor.
 	NodeIdLabel string `validate:"required"`
-	// If true, the Armada scheduler will set the node name of the selected node directly on scheduled pods,
-	// thus bypassing kube-scheduler entirely.
-	SetNodeName bool
 	// Map from priority class names to priority classes.
 	// Must be consistent with Kubernetes priority classes.
 	// I.e., priority classes defined here must be defined in all executor clusters and should map to the same priority.

--- a/internal/armada/configuration/types.go
+++ b/internal/armada/configuration/types.go
@@ -98,7 +98,6 @@ type SubmissionConfig struct {
 	// Tolerations added to all submitted pods.
 	DefaultJobTolerations []v1.Toleration
 	// Tolerations added to all submitted pods of a given priority class.
-	// TODO(albin): Rename to defaultJobTolerationsByPriorityClassName.
 	DefaultJobTolerationsByPriorityClass map[string][]v1.Toleration
 	// Tolerations added to all submitted pods requesting a non-zero amount of some resource.
 	DefaultJobTolerationsByResourceRequest map[string][]v1.Toleration
@@ -174,10 +173,8 @@ type SchedulingConfig struct {
 	PriorityClasses map[string]types.PriorityClass `validate:"dive"`
 	// Jobs with no priority class are assigned this priority class when ingested by the scheduler.
 	// Must be a key in the PriorityClasses map above.
-	// TODO(albin): Validate.
 	DefaultPriorityClassName string
 	// If set, override the priority class name of pods with this value when sending to an executor.
-	// TODO(albin): We should pass the scheduled priority class through as an annotation.
 	PriorityClassNameOverride *string
 	// Number of jobs to load from the database at a time.
 	MaxQueueLookback uint

--- a/internal/armada/server.go
+++ b/internal/armada/server.go
@@ -39,8 +39,8 @@ import (
 
 func Serve(ctx *armadacontext.Context, config *configuration.ArmadaConfig, healthChecks *health.MultiChecker) error {
 	log.Info("Armada server starting")
-	log.Infof("Armada priority classes: %v", config.Scheduling.Preemption.PriorityClasses)
-	log.Infof("Default priority class: %s", config.Scheduling.Preemption.DefaultPriorityClass)
+	log.Infof("Armada priority classes: %v", config.Scheduling.PriorityClasses)
+	log.Infof("Default priority class: %s", config.Scheduling.DefaultPriorityClass)
 	defer log.Info("Armada server shutting down")
 
 	// We call startupCompleteCheck.MarkComplete() when all services have been started.

--- a/internal/armada/server/applydefaults.go
+++ b/internal/armada/server/applydefaults.go
@@ -10,14 +10,14 @@ import (
 	armadaresource "github.com/armadaproject/armada/internal/common/resource"
 )
 
-func applyDefaultsToAnnotations(annotations map[string]string, config configuration.SchedulingConfig) {
+func applyDefaultsToAnnotations(annotations map[string]string, config configuration.SubmissionConfig) {
 	if annotations == nil {
 		return
 	}
 	applyDefaultNodeUniformityLabelAnnotation(annotations, config)
 }
 
-func applyDefaultNodeUniformityLabelAnnotation(annotations map[string]string, config configuration.SchedulingConfig) {
+func applyDefaultNodeUniformityLabelAnnotation(annotations map[string]string, config configuration.SubmissionConfig) {
 	if _, ok := annotations[configuration.GangIdAnnotation]; ok {
 		if _, ok := annotations[configuration.GangNodeUniformityLabelAnnotation]; !ok {
 			annotations[configuration.GangNodeUniformityLabelAnnotation] = config.DefaultGangNodeUniformityLabel
@@ -25,7 +25,7 @@ func applyDefaultNodeUniformityLabelAnnotation(annotations map[string]string, co
 	}
 }
 
-func applyDefaultsToPodSpec(spec *v1.PodSpec, config configuration.SchedulingConfig) {
+func applyDefaultsToPodSpec(spec *v1.PodSpec, config configuration.SubmissionConfig) {
 	if spec == nil {
 		return
 	}
@@ -36,7 +36,7 @@ func applyDefaultsToPodSpec(spec *v1.PodSpec, config configuration.SchedulingCon
 	applyDefaultTerminationGracePeriodToPodSpec(spec, config)
 }
 
-func applyDefaultRequestsAndLimitsToPodSpec(spec *v1.PodSpec, config configuration.SchedulingConfig) {
+func applyDefaultRequestsAndLimitsToPodSpec(spec *v1.PodSpec, config configuration.SubmissionConfig) {
 	for i := range spec.Containers {
 		c := &spec.Containers[i]
 		if c.Resources.Limits == nil {
@@ -56,7 +56,7 @@ func applyDefaultRequestsAndLimitsToPodSpec(spec *v1.PodSpec, config configurati
 	}
 }
 
-func applyDefaultTolerationsToPodSpec(spec *v1.PodSpec, config configuration.SchedulingConfig) {
+func applyDefaultTolerationsToPodSpec(spec *v1.PodSpec, config configuration.SubmissionConfig) {
 	spec.Tolerations = append(spec.Tolerations, config.DefaultJobTolerations...)
 	if config.DefaultJobTolerationsByPriorityClass != nil {
 		if tolerations, ok := config.DefaultJobTolerationsByPriorityClass[spec.PriorityClassName]; ok {
@@ -77,9 +77,9 @@ func applyDefaultTolerationsToPodSpec(spec *v1.PodSpec, config configuration.Sch
 	}
 }
 
-func applyDefaultPriorityClassNameToPodSpec(spec *v1.PodSpec, config configuration.SchedulingConfig) {
+func applyDefaultPriorityClassNameToPodSpec(spec *v1.PodSpec, config configuration.SubmissionConfig) {
 	if spec.PriorityClassName == "" {
-		spec.PriorityClassName = config.DefaultPriorityClass
+		spec.PriorityClassName = config.DefaultPriorityClassName
 	}
 }
 
@@ -87,7 +87,7 @@ func applyDefaultPriorityClassNameToPodSpec(spec *v1.PodSpec, config configurati
 // of the pod equal to the minimum if
 // - the pod does not explicitly set a termination period, or
 // - the pod explicitly sets a termination period of 0.
-func applyDefaultTerminationGracePeriodToPodSpec(spec *v1.PodSpec, config configuration.SchedulingConfig) {
+func applyDefaultTerminationGracePeriodToPodSpec(spec *v1.PodSpec, config configuration.SubmissionConfig) {
 	if config.MinTerminationGracePeriod.Seconds() == 0 {
 		return
 	}
@@ -103,7 +103,7 @@ func applyDefaultTerminationGracePeriodToPodSpec(spec *v1.PodSpec, config config
 	}
 }
 
-func applyDefaultActiveDeadlineSecondsToPodSpec(spec *v1.PodSpec, config configuration.SchedulingConfig) {
+func applyDefaultActiveDeadlineSecondsToPodSpec(spec *v1.PodSpec, config configuration.SubmissionConfig) {
 	if spec.ActiveDeadlineSeconds != nil {
 		return
 	}

--- a/internal/armada/server/applydefaults.go
+++ b/internal/armada/server/applydefaults.go
@@ -79,7 +79,7 @@ func applyDefaultTolerationsToPodSpec(spec *v1.PodSpec, config configuration.Sch
 
 func applyDefaultPriorityClassNameToPodSpec(spec *v1.PodSpec, config configuration.SchedulingConfig) {
 	if spec.PriorityClassName == "" {
-		spec.PriorityClassName = config.Preemption.DefaultPriorityClass
+		spec.PriorityClassName = config.DefaultPriorityClass
 	}
 }
 

--- a/internal/armada/server/applydefaults_test.go
+++ b/internal/armada/server/applydefaults_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestApplyDefaultsToAnnotations(t *testing.T) {
 	tests := map[string]struct {
-		Config      configuration.SchedulingConfig
+		Config      configuration.SubmissionConfig
 		Annotations map[string]string
 		Expected    map[string]string
 	}{
@@ -22,7 +22,7 @@ func TestApplyDefaultsToAnnotations(t *testing.T) {
 			Expected:    make(map[string]string),
 		},
 		"DefaultNodeUniformityLabelAnnotation no change for non-gang jobs": {
-			Config: configuration.SchedulingConfig{
+			Config: configuration.SubmissionConfig{
 				DefaultGangNodeUniformityLabel: "foo",
 			},
 			Annotations: make(map[string]string),
@@ -38,7 +38,7 @@ func TestApplyDefaultsToAnnotations(t *testing.T) {
 			},
 		},
 		"DefaultNodeUniformityLabelAnnotation": {
-			Config: configuration.SchedulingConfig{
+			Config: configuration.SubmissionConfig{
 				DefaultGangNodeUniformityLabel: "foo",
 			},
 			Annotations: map[string]string{
@@ -60,15 +60,13 @@ func TestApplyDefaultsToAnnotations(t *testing.T) {
 
 func TestApplyDefaultsToPodSpec(t *testing.T) {
 	tests := map[string]struct {
-		Config   configuration.SchedulingConfig
+		Config   configuration.SubmissionConfig
 		PodSpec  v1.PodSpec
 		Expected v1.PodSpec
 	}{
 		"DefaultPriorityClassName": {
-			Config: configuration.SchedulingConfig{
-				Preemption: configuration.PreemptionConfig{
-					DefaultPriorityClass: "pc",
-				},
+			Config: configuration.SubmissionConfig{
+				DefaultPriorityClassName: "pc",
 			},
 			PodSpec: v1.PodSpec{},
 			Expected: v1.PodSpec{
@@ -76,7 +74,7 @@ func TestApplyDefaultsToPodSpec(t *testing.T) {
 			},
 		},
 		"DefaultJobLimits": {
-			Config: configuration.SchedulingConfig{
+			Config: configuration.SubmissionConfig{
 				DefaultJobLimits: map[string]resource.Quantity{
 					"cpu":    resource.MustParse("10"),
 					"memory": resource.MustParse("1Gi"),
@@ -115,7 +113,7 @@ func TestApplyDefaultsToPodSpec(t *testing.T) {
 			},
 		},
 		"DefaultJobTolerations": {
-			Config: configuration.SchedulingConfig{
+			Config: configuration.SubmissionConfig{
 				DefaultJobTolerations: []v1.Toleration{{Key: "foo"}, {Key: "bar"}},
 			},
 			PodSpec: v1.PodSpec{
@@ -126,7 +124,7 @@ func TestApplyDefaultsToPodSpec(t *testing.T) {
 			},
 		},
 		"DefaultJobTolerationsByPriorityClass": {
-			Config: configuration.SchedulingConfig{
+			Config: configuration.SubmissionConfig{
 				DefaultJobTolerationsByPriorityClass: map[string][]v1.Toleration{
 					"pc-1": {{Key: "foo"}, {Key: "bar"}},
 					"pc-2": {{Key: "oof"}, {Key: "rab"}},
@@ -142,7 +140,7 @@ func TestApplyDefaultsToPodSpec(t *testing.T) {
 			},
 		},
 		"DefaultJobTolerationsByResourceRequest": {
-			Config: configuration.SchedulingConfig{
+			Config: configuration.SubmissionConfig{
 				DefaultJobTolerationsByResourceRequest: map[string][]v1.Toleration{
 					"gpu": {{Key: "foo"}, {Key: "bar"}},
 				},
@@ -177,7 +175,7 @@ func TestApplyDefaultsToPodSpec(t *testing.T) {
 			},
 		},
 		"DefaultJobTolerationsByResourceRequest explicit zero resource": {
-			Config: configuration.SchedulingConfig{
+			Config: configuration.SubmissionConfig{
 				DefaultJobTolerationsByResourceRequest: map[string][]v1.Toleration{
 					"gpu": {{Key: "foo"}, {Key: "bar"}},
 				},
@@ -212,10 +210,8 @@ func TestApplyDefaultsToPodSpec(t *testing.T) {
 			},
 		},
 		"DefaultPriorityClassName + DefaultJobTolerationsByPriorityClass": {
-			Config: configuration.SchedulingConfig{
-				Preemption: configuration.PreemptionConfig{
-					DefaultPriorityClass: "pc",
-				},
+			Config: configuration.SubmissionConfig{
+				DefaultPriorityClassName: "pc",
 				DefaultJobTolerationsByPriorityClass: map[string][]v1.Toleration{
 					"pc": {{Key: "foo"}, {Key: "bar"}},
 				},
@@ -227,7 +223,7 @@ func TestApplyDefaultsToPodSpec(t *testing.T) {
 			},
 		},
 		"DefaultActiveDeadlineSeconds": {
-			Config: configuration.SchedulingConfig{
+			Config: configuration.SubmissionConfig{
 				DefaultActiveDeadline: time.Second,
 			},
 			Expected: v1.PodSpec{
@@ -235,7 +231,7 @@ func TestApplyDefaultsToPodSpec(t *testing.T) {
 			},
 		},
 		"DefaultActiveDeadlineSecondsByResource": {
-			Config: configuration.SchedulingConfig{
+			Config: configuration.SubmissionConfig{
 				DefaultActiveDeadlineByResourceRequest: map[string]time.Duration{
 					"memory": 2 * time.Minute,
 					"gpu":    time.Minute,
@@ -272,7 +268,7 @@ func TestApplyDefaultsToPodSpec(t *testing.T) {
 			},
 		},
 		"DefaultActiveDeadlineSeconds + DefaultActiveDeadlineSecondsByResource": {
-			Config: configuration.SchedulingConfig{
+			Config: configuration.SubmissionConfig{
 				DefaultActiveDeadline: time.Second,
 				DefaultActiveDeadlineByResourceRequest: map[string]time.Duration{
 					"gpu": time.Minute,
@@ -307,7 +303,7 @@ func TestApplyDefaultsToPodSpec(t *testing.T) {
 			},
 		},
 		"DefaultActiveDeadlineSecondsByResource trumps DefaultActiveDeadlineSeconds": {
-			Config: configuration.SchedulingConfig{
+			Config: configuration.SubmissionConfig{
 				DefaultActiveDeadline: time.Minute,
 				DefaultActiveDeadlineByResourceRequest: map[string]time.Duration{
 					"gpu": time.Second,
@@ -340,7 +336,7 @@ func TestApplyDefaultsToPodSpec(t *testing.T) {
 			},
 		},
 		"DefaultActiveDeadlineSecondsByResource explicit zero resource": {
-			Config: configuration.SchedulingConfig{
+			Config: configuration.SubmissionConfig{
 				DefaultActiveDeadlineByResourceRequest: map[string]time.Duration{
 					"gpu": time.Second,
 				},
@@ -371,7 +367,7 @@ func TestApplyDefaultsToPodSpec(t *testing.T) {
 			},
 		},
 		"MinTerminationGracePeriod": {
-			Config: configuration.SchedulingConfig{
+			Config: configuration.SubmissionConfig{
 				MinTerminationGracePeriod: time.Second,
 			},
 			Expected: v1.PodSpec{
@@ -379,7 +375,7 @@ func TestApplyDefaultsToPodSpec(t *testing.T) {
 			},
 		},
 		"MinTerminationGracePeriod convert 0 to 1": {
-			Config: configuration.SchedulingConfig{
+			Config: configuration.SubmissionConfig{
 				MinTerminationGracePeriod: time.Second,
 			},
 			PodSpec: v1.PodSpec{

--- a/internal/armada/validation/job.go
+++ b/internal/armada/validation/job.go
@@ -77,11 +77,11 @@ func ValidateApiJob(job *api.Job, config configuration.SchedulingConfig) error {
 	if err := ValidateApiJobPodSpecs(job); err != nil {
 		return err
 	}
-	if err := validatePodSpecPriorityClass(job.PodSpec, true, config.Preemption.PriorityClasses); err != nil {
+	if err := validatePodSpecPriorityClass(job.PodSpec, true, config.PriorityClasses); err != nil {
 		return err
 	}
 	for _, podSpec := range job.PodSpecs {
-		if err := validatePodSpecPriorityClass(podSpec, true, config.Preemption.PriorityClasses); err != nil {
+		if err := validatePodSpecPriorityClass(podSpec, true, config.PriorityClasses); err != nil {
 			return err
 		}
 	}

--- a/internal/armada/validation/podspec_test.go
+++ b/internal/armada/validation/podspec_test.go
@@ -14,16 +14,16 @@ import (
 )
 
 func Test_ValidatePodSpec_checkForMissingValues(t *testing.T) {
-	schedulingConfig := configuration.SchedulingConfig{
+	config := configuration.SubmissionConfig{
 		MinJobResources:     v1.ResourceList{},
 		MaxPodSpecSizeBytes: 65535,
 	}
 
-	assert.Error(t, ValidatePodSpec(nil, schedulingConfig))
-	assert.Error(t, ValidatePodSpec(&v1.PodSpec{}, schedulingConfig))
+	assert.Error(t, ValidatePodSpec(nil, config))
+	assert.Error(t, ValidatePodSpec(&v1.PodSpec{}, config))
 	assert.Error(t, ValidatePodSpec(&v1.PodSpec{
 		Containers: []v1.Container{{}},
-	}, schedulingConfig))
+	}, config))
 }
 
 func Test_ValidatePodSpec_checkForResources(t *testing.T) {
@@ -34,7 +34,7 @@ func Test_ValidatePodSpec_checkForResources(t *testing.T) {
 	resources1 := v1.ResourceList{"cpu": cpu, "memory": memory}
 	resources2 := v1.ResourceList{"cpu": cpu2, "memory": memory}
 
-	schedulingConfig := configuration.SchedulingConfig{
+	config := configuration.SubmissionConfig{
 		MinJobResources:     v1.ResourceList{},
 		MaxPodSpecSizeBytes: 65535,
 	}
@@ -46,7 +46,7 @@ func Test_ValidatePodSpec_checkForResources(t *testing.T) {
 				Requests: resources2,
 			},
 		}},
-	}, schedulingConfig))
+	}, config))
 
 	assert.NoError(t, ValidatePodSpec(&v1.PodSpec{
 		Containers: []v1.Container{{
@@ -55,15 +55,13 @@ func Test_ValidatePodSpec_checkForResources(t *testing.T) {
 				Requests: resources1,
 			},
 		}},
-	}, schedulingConfig))
+	}, config))
 }
 
 func Test_ValidatePodSpec_terminationGracePeriod(t *testing.T) {
-	schedulingConfig := configuration.SchedulingConfig{
-		Preemption: configuration.PreemptionConfig{
-			DefaultPriorityClass: "high",
-			PriorityClasses:      map[string]types.PriorityClass{"high": {Priority: 0}},
-		},
+	config := configuration.SubmissionConfig{
+		DefaultPriorityClassName:  "high",
+		AllowedPriorityClassNames: map[string]bool{"high": true},
 		MinTerminationGracePeriod: time.Duration(30 * time.Second),
 		MaxTerminationGracePeriod: time.Duration(300 * time.Second),
 	}
@@ -80,13 +78,13 @@ func Test_ValidatePodSpec_terminationGracePeriod(t *testing.T) {
 		PriorityClassName: "high",
 	}
 
-	assert.Error(t, validateTerminationGracePeriod(podspecOutsideRange, schedulingConfig))
-	assert.NoError(t, validateTerminationGracePeriod(podspecWithinRange, schedulingConfig))
-	assert.NoError(t, validateTerminationGracePeriod(podspecNoSetting, schedulingConfig))
+	assert.Error(t, validateTerminationGracePeriod(podspecOutsideRange, config))
+	assert.NoError(t, validateTerminationGracePeriod(podspecWithinRange, config))
+	assert.NoError(t, validateTerminationGracePeriod(podspecNoSetting, config))
 }
 
 func Test_ValidatePodSpec_checkForPortConfiguration(t *testing.T) {
-	schedulingConfig := configuration.SchedulingConfig{
+	config := configuration.SubmissionConfig{
 		MinJobResources:     v1.ResourceList{},
 		MaxPodSpecSizeBytes: 65535,
 	}
@@ -120,12 +118,12 @@ func Test_ValidatePodSpec_checkForPortConfiguration(t *testing.T) {
 			},
 		},
 	}
-	assert.Error(t, ValidatePodSpec(portsUniqueToContainer, schedulingConfig))
-	assert.Error(t, ValidatePodSpec(portExposeOverMultipleContainers, schedulingConfig))
+	assert.Error(t, ValidatePodSpec(portsUniqueToContainer, config))
+	assert.Error(t, ValidatePodSpec(portExposeOverMultipleContainers, config))
 }
 
 func Test_ValidatePodSpec_WhenPreferredAffinitySet_Fails(t *testing.T) {
-	schedulingConfig := configuration.SchedulingConfig{
+	config := configuration.SubmissionConfig{
 		MinJobResources:     v1.ResourceList{},
 		MaxPodSpecSizeBytes: 65535,
 	}
@@ -152,11 +150,11 @@ func Test_ValidatePodSpec_WhenPreferredAffinitySet_Fails(t *testing.T) {
 		},
 	}
 
-	assert.Error(t, ValidatePodSpec(podSpec, schedulingConfig))
+	assert.Error(t, ValidatePodSpec(podSpec, config))
 }
 
 func Test_ValidatePodSpec_WhenValidRequiredAffinitySet_Succeeds(t *testing.T) {
-	schedulingConfig := configuration.SchedulingConfig{
+	config := configuration.SubmissionConfig{
 		MinJobResources:     v1.ResourceList{},
 		MaxPodSpecSizeBytes: 65535,
 	}
@@ -182,11 +180,11 @@ func Test_ValidatePodSpec_WhenValidRequiredAffinitySet_Succeeds(t *testing.T) {
 		},
 	}
 
-	assert.Nil(t, ValidatePodSpec(podSpec, schedulingConfig))
+	assert.Nil(t, ValidatePodSpec(podSpec, config))
 }
 
 func Test_ValidatePodSpec_WhenInvalidRequiredAffinitySet_Fails(t *testing.T) {
-	schedulingConfig := configuration.SchedulingConfig{
+	config := configuration.SubmissionConfig{
 		MinJobResources:     v1.ResourceList{},
 		MaxPodSpecSizeBytes: 65535,
 	}
@@ -212,34 +210,34 @@ func Test_ValidatePodSpec_WhenInvalidRequiredAffinitySet_Fails(t *testing.T) {
 		},
 	}
 
-	assert.Error(t, ValidatePodSpec(podSpec, schedulingConfig))
+	assert.Error(t, ValidatePodSpec(podSpec, config))
 }
 
 func Test_ValidatePodSpec_WhenExceedsMaxSize_Fails(t *testing.T) {
 	spec := minimalValidPodSpec()
 	specSize := uint(spec.Size())
 
-	schedulingConfig := configuration.SchedulingConfig{
+	config := configuration.SubmissionConfig{
 		MinJobResources:     v1.ResourceList{},
 		MaxPodSpecSizeBytes: specSize,
 	}
-	assert.NoError(t, ValidatePodSpec(spec, schedulingConfig))
+	assert.NoError(t, ValidatePodSpec(spec, config))
 
-	schedulingConfig.MaxPodSpecSizeBytes -= 1
-	assert.Error(t, ValidatePodSpec(spec, schedulingConfig))
+	config.MaxPodSpecSizeBytes -= 1
+	assert.Error(t, ValidatePodSpec(spec, config))
 }
 
 func Test_ValidatePodSpec_WhenResourcesAboveMinimum_Succeeds(t *testing.T) {
 	spec := minimalValidPodSpec()
 
-	schedulingConfig := configuration.SchedulingConfig{
+	config := configuration.SubmissionConfig{
 		MaxPodSpecSizeBytes: uint(spec.Size()),
 		MinJobResources: v1.ResourceList{
 			"memory": resource.MustParse("100Mi"),
 		},
 	}
 
-	assert.NoError(t, ValidatePodSpec(spec, schedulingConfig))
+	assert.NoError(t, ValidatePodSpec(spec, config))
 }
 
 func Test_ValidatePodSpec_WhenResourcesBelowMinimum_Fails(t *testing.T) {
@@ -258,14 +256,14 @@ func Test_ValidatePodSpec_WhenResourcesBelowMinimum_Fails(t *testing.T) {
 		},
 	}
 
-	schedulingConfig := configuration.SchedulingConfig{
+	config := configuration.SubmissionConfig{
 		MaxPodSpecSizeBytes: uint(spec.Size()),
 		MinJobResources: v1.ResourceList{
 			"memory": resource.MustParse("100Mi"),
 		},
 	}
 
-	assert.Error(t, ValidatePodSpec(spec, schedulingConfig))
+	assert.Error(t, ValidatePodSpec(spec, config))
 }
 
 func minimalValidPodSpec() *v1.PodSpec {

--- a/internal/common/validation/job.go
+++ b/internal/common/validation/job.go
@@ -77,11 +77,11 @@ func ValidateApiJob(job *api.Job, config configuration.SubmissionConfig) error {
 	if err := ValidateApiJobPodSpecs(job); err != nil {
 		return err
 	}
-	if err := validatePodSpecPriorityClass(job.PodSpec, true, config.AllowedPriorityClassNames); err != nil {
+	if err := validatePodSpecPriorityClass(job.PodSpec, config.AllowedPriorityClassNames); err != nil {
 		return err
 	}
 	for _, podSpec := range job.PodSpecs {
-		if err := validatePodSpecPriorityClass(podSpec, true, config.AllowedPriorityClassNames); err != nil {
+		if err := validatePodSpecPriorityClass(podSpec, config.AllowedPriorityClassNames); err != nil {
 			return err
 		}
 	}

--- a/internal/common/validation/job.go
+++ b/internal/common/validation/job.go
@@ -9,7 +9,7 @@ import (
 	"github.com/armadaproject/armada/pkg/api"
 )
 
-func ValidateApiJobs(jobs []*api.Job, config configuration.SchedulingConfig) ([]*api.JobSubmitResponseItem, error) {
+func ValidateApiJobs(jobs []*api.Job, config configuration.SubmissionConfig) ([]*api.JobSubmitResponseItem, error) {
 	if _, err := validateGangs(jobs); err != nil {
 		return nil, err
 	}
@@ -73,15 +73,15 @@ func validateGangs(jobs []*api.Job) (map[string]schedulercontext.GangInfo, error
 	return gangDetailsByGangId, nil
 }
 
-func ValidateApiJob(job *api.Job, config configuration.SchedulingConfig) error {
+func ValidateApiJob(job *api.Job, config configuration.SubmissionConfig) error {
 	if err := ValidateApiJobPodSpecs(job); err != nil {
 		return err
 	}
-	if err := validatePodSpecPriorityClass(job.PodSpec, true, config.PriorityClasses); err != nil {
+	if err := validatePodSpecPriorityClass(job.PodSpec, true, config.AllowedPriorityClassNames); err != nil {
 		return err
 	}
 	for _, podSpec := range job.PodSpecs {
-		if err := validatePodSpecPriorityClass(podSpec, true, config.PriorityClasses); err != nil {
+		if err := validatePodSpecPriorityClass(podSpec, true, config.AllowedPriorityClassNames); err != nil {
 			return err
 		}
 	}

--- a/internal/common/validation/job.go
+++ b/internal/common/validation/job.go
@@ -77,11 +77,11 @@ func ValidateApiJob(job *api.Job, config configuration.SchedulingConfig) error {
 	if err := ValidateApiJobPodSpecs(job); err != nil {
 		return err
 	}
-	if err := validatePodSpecPriorityClass(job.PodSpec, true, config.Preemption.PriorityClasses); err != nil {
+	if err := validatePodSpecPriorityClass(job.PodSpec, true, config.PriorityClasses); err != nil {
 		return err
 	}
 	for _, podSpec := range job.PodSpecs {
-		if err := validatePodSpecPriorityClass(podSpec, true, config.Preemption.PriorityClasses); err != nil {
+		if err := validatePodSpecPriorityClass(podSpec, true, config.PriorityClasses); err != nil {
 			return err
 		}
 	}

--- a/internal/common/validation/podspec_test.go
+++ b/internal/common/validation/podspec_test.go
@@ -10,20 +10,19 @@ import (
 	"k8s.io/utils/pointer"
 
 	"github.com/armadaproject/armada/internal/armada/configuration"
-	"github.com/armadaproject/armada/internal/common/types"
 )
 
 func Test_ValidatePodSpec_checkForMissingValues(t *testing.T) {
-	schedulingConfig := &configuration.SchedulingConfig{
+	config := &configuration.SubmissionConfig{
 		MinJobResources:     v1.ResourceList{},
 		MaxPodSpecSizeBytes: 65535,
 	}
 
-	assert.Error(t, ValidatePodSpec(nil, schedulingConfig))
-	assert.Error(t, ValidatePodSpec(&v1.PodSpec{}, schedulingConfig))
+	assert.Error(t, ValidatePodSpec(nil, config))
+	assert.Error(t, ValidatePodSpec(&v1.PodSpec{}, config))
 	assert.Error(t, ValidatePodSpec(&v1.PodSpec{
 		Containers: []v1.Container{{}},
-	}, schedulingConfig))
+	}, config))
 }
 
 func Test_ValidatePodSpec_checkForResources(t *testing.T) {
@@ -34,7 +33,7 @@ func Test_ValidatePodSpec_checkForResources(t *testing.T) {
 	resources1 := v1.ResourceList{"cpu": cpu, "memory": memory}
 	resources2 := v1.ResourceList{"cpu": cpu2, "memory": memory}
 
-	schedulingConfig := &configuration.SchedulingConfig{
+	config := &configuration.SubmissionConfig{
 		MinJobResources:     v1.ResourceList{},
 		MaxPodSpecSizeBytes: 65535,
 	}
@@ -46,7 +45,7 @@ func Test_ValidatePodSpec_checkForResources(t *testing.T) {
 				Requests: resources2,
 			},
 		}},
-	}, schedulingConfig))
+	}, config))
 
 	assert.NoError(t, ValidatePodSpec(&v1.PodSpec{
 		Containers: []v1.Container{{
@@ -55,15 +54,13 @@ func Test_ValidatePodSpec_checkForResources(t *testing.T) {
 				Requests: resources1,
 			},
 		}},
-	}, schedulingConfig))
+	}, config))
 }
 
 func Test_ValidatePodSpec_terminationGracePeriod(t *testing.T) {
-	schedulingConfig := &configuration.SchedulingConfig{
-		Preemption: configuration.PreemptionConfig{
-			DefaultPriorityClass: "high",
-			PriorityClasses:      map[string]types.PriorityClass{"high": {Priority: 0}},
-		},
+	config := &configuration.SubmissionConfig{
+		DefaultPriorityClassName:  "high",
+		AllowedPriorityClassNames: map[string]bool{"high": true},
 		MinTerminationGracePeriod: time.Duration(30 * time.Second),
 		MaxTerminationGracePeriod: time.Duration(300 * time.Second),
 	}
@@ -80,13 +77,13 @@ func Test_ValidatePodSpec_terminationGracePeriod(t *testing.T) {
 		PriorityClassName: "high",
 	}
 
-	assert.Error(t, validateTerminationGracePeriod(podspecOutsideRange, schedulingConfig))
-	assert.NoError(t, validateTerminationGracePeriod(podspecWithinRange, schedulingConfig))
-	assert.NoError(t, validateTerminationGracePeriod(podspecNoSetting, schedulingConfig))
+	assert.Error(t, validateTerminationGracePeriod(podspecOutsideRange, config))
+	assert.NoError(t, validateTerminationGracePeriod(podspecWithinRange, config))
+	assert.NoError(t, validateTerminationGracePeriod(podspecNoSetting, config))
 }
 
 func Test_ValidatePodSpec_checkForPortConfiguration(t *testing.T) {
-	schedulingConfig := &configuration.SchedulingConfig{
+	config := &configuration.SubmissionConfig{
 		MinJobResources:     v1.ResourceList{},
 		MaxPodSpecSizeBytes: 65535,
 	}
@@ -120,12 +117,12 @@ func Test_ValidatePodSpec_checkForPortConfiguration(t *testing.T) {
 			},
 		},
 	}
-	assert.Error(t, ValidatePodSpec(portsUniqueToContainer, schedulingConfig))
-	assert.Error(t, ValidatePodSpec(portExposeOverMultipleContainers, schedulingConfig))
+	assert.Error(t, ValidatePodSpec(portsUniqueToContainer, config))
+	assert.Error(t, ValidatePodSpec(portExposeOverMultipleContainers, config))
 }
 
 func Test_ValidatePodSpec_WhenPreferredAffinitySet_Fails(t *testing.T) {
-	schedulingConfig := &configuration.SchedulingConfig{
+	config := &configuration.SubmissionConfig{
 		MinJobResources:     v1.ResourceList{},
 		MaxPodSpecSizeBytes: 65535,
 	}
@@ -152,11 +149,11 @@ func Test_ValidatePodSpec_WhenPreferredAffinitySet_Fails(t *testing.T) {
 		},
 	}
 
-	assert.Error(t, ValidatePodSpec(podSpec, schedulingConfig))
+	assert.Error(t, ValidatePodSpec(podSpec, config))
 }
 
 func Test_ValidatePodSpec_WhenValidRequiredAffinitySet_Succeeds(t *testing.T) {
-	schedulingConfig := &configuration.SchedulingConfig{
+	config := &configuration.SubmissionConfig{
 		MinJobResources:     v1.ResourceList{},
 		MaxPodSpecSizeBytes: 65535,
 	}
@@ -182,11 +179,11 @@ func Test_ValidatePodSpec_WhenValidRequiredAffinitySet_Succeeds(t *testing.T) {
 		},
 	}
 
-	assert.Nil(t, ValidatePodSpec(podSpec, schedulingConfig))
+	assert.Nil(t, ValidatePodSpec(podSpec, config))
 }
 
 func Test_ValidatePodSpec_WhenInvalidRequiredAffinitySet_Fails(t *testing.T) {
-	schedulingConfig := &configuration.SchedulingConfig{
+	config := &configuration.SubmissionConfig{
 		MinJobResources:     v1.ResourceList{},
 		MaxPodSpecSizeBytes: 65535,
 	}
@@ -212,34 +209,34 @@ func Test_ValidatePodSpec_WhenInvalidRequiredAffinitySet_Fails(t *testing.T) {
 		},
 	}
 
-	assert.Error(t, ValidatePodSpec(podSpec, schedulingConfig))
+	assert.Error(t, ValidatePodSpec(podSpec, config))
 }
 
 func Test_ValidatePodSpec_WhenExceedsMaxSize_Fails(t *testing.T) {
 	spec := minimalValidPodSpec()
 	specSize := uint(spec.Size())
 
-	schedulingConfig := &configuration.SchedulingConfig{
+	config := &configuration.SubmissionConfig{
 		MinJobResources:     v1.ResourceList{},
 		MaxPodSpecSizeBytes: specSize,
 	}
-	assert.NoError(t, ValidatePodSpec(spec, schedulingConfig))
+	assert.NoError(t, ValidatePodSpec(spec, config))
 
-	schedulingConfig.MaxPodSpecSizeBytes -= 1
-	assert.Error(t, ValidatePodSpec(spec, schedulingConfig))
+	config.MaxPodSpecSizeBytes -= 1
+	assert.Error(t, ValidatePodSpec(spec, config))
 }
 
 func Test_ValidatePodSpec_WhenResourcesAboveMinimum_Succeeds(t *testing.T) {
 	spec := minimalValidPodSpec()
 
-	schedulingConfig := &configuration.SchedulingConfig{
+	config := &configuration.SubmissionConfig{
 		MaxPodSpecSizeBytes: uint(spec.Size()),
 		MinJobResources: v1.ResourceList{
 			"memory": resource.MustParse("100Mi"),
 		},
 	}
 
-	assert.NoError(t, ValidatePodSpec(spec, schedulingConfig))
+	assert.NoError(t, ValidatePodSpec(spec, config))
 }
 
 func Test_ValidatePodSpec_WhenResourcesBelowMinimum_Fails(t *testing.T) {
@@ -258,14 +255,14 @@ func Test_ValidatePodSpec_WhenResourcesBelowMinimum_Fails(t *testing.T) {
 		},
 	}
 
-	schedulingConfig := &configuration.SchedulingConfig{
+	config := &configuration.SubmissionConfig{
 		MaxPodSpecSizeBytes: uint(spec.Size()),
 		MinJobResources: v1.ResourceList{
 			"memory": resource.MustParse("100Mi"),
 		},
 	}
 
-	assert.Error(t, ValidatePodSpec(spec, schedulingConfig))
+	assert.Error(t, ValidatePodSpec(spec, config))
 }
 
 func minimalValidPodSpec() *v1.PodSpec {
@@ -287,14 +284,14 @@ func minimalValidPodSpec() *v1.PodSpec {
 
 func Test_ValidatePodSpecPriorityClass(t *testing.T) {
 	validPriorityClass := &v1.PodSpec{PriorityClassName: "some-priority-class"}
-	allowedPriorityClasses := map[string]types.PriorityClass{"some-priority-class": {Priority: 10}}
+	allowedPriorityClasses := map[string]bool{"some-priority-class": true}
 	assert.NoError(
 		t,
-		validatePodSpecPriorityClass(validPriorityClass, true, allowedPriorityClasses),
+		validatePodSpecPriorityClass(validPriorityClass, allowedPriorityClasses),
 		"validation should pass when specified priority class is configured to be allowed and preemption is enabled",
 	)
 
-	err := validatePodSpecPriorityClass(validPriorityClass, false, allowedPriorityClasses)
+	err := validatePodSpecPriorityClass(validPriorityClass, allowedPriorityClasses)
 	assert.Error(
 		t,
 		err,
@@ -303,7 +300,7 @@ func Test_ValidatePodSpecPriorityClass(t *testing.T) {
 	validateInvalidArgumentErrorMessage(t, err, "Preemption is disabled in Server config")
 
 	invalidPriorityClass := &v1.PodSpec{PriorityClassName: "some-other-priority-class"}
-	err = validatePodSpecPriorityClass(invalidPriorityClass, true, allowedPriorityClasses)
+	err = validatePodSpecPriorityClass(invalidPriorityClass, allowedPriorityClasses)
 	assert.Error(
 		t,
 		err,

--- a/internal/common/validation/podspec_test.go
+++ b/internal/common/validation/podspec_test.go
@@ -298,5 +298,5 @@ func Test_ValidatePodSpecPriorityClass(t *testing.T) {
 		err,
 		"validation should fail if specified priority class is not configured to be allowed",
 	)
-	validateInvalidArgumentErrorMessage(t, err, "Specified Priority Class is not supported in Server config")
+	validateInvalidArgumentErrorMessage(t, err, "priorityClassName not in map[some-priority-class:true]")
 }

--- a/internal/common/validation/podspec_test.go
+++ b/internal/common/validation/podspec_test.go
@@ -291,16 +291,8 @@ func Test_ValidatePodSpecPriorityClass(t *testing.T) {
 		"validation should pass when specified priority class is configured to be allowed and preemption is enabled",
 	)
 
-	err := validatePodSpecPriorityClass(validPriorityClass, allowedPriorityClasses)
-	assert.Error(
-		t,
-		err,
-		"validation should fail if priority class is specified and disabled",
-	)
-	validateInvalidArgumentErrorMessage(t, err, "Preemption is disabled in Server config")
-
 	invalidPriorityClass := &v1.PodSpec{PriorityClassName: "some-other-priority-class"}
-	err = validatePodSpecPriorityClass(invalidPriorityClass, allowedPriorityClasses)
+	err := validatePodSpecPriorityClass(invalidPriorityClass, allowedPriorityClasses)
 	assert.Error(
 		t,
 		err,

--- a/internal/scheduler/configuration/configuration_test.go
+++ b/internal/scheduler/configuration/configuration_test.go
@@ -23,16 +23,14 @@ func TestSchedulingConfigValidate(t *testing.T) {
 					Taints: []v1.Taint{{Key: "other-key", Value: "true", Effect: v1.TaintEffectNoSchedule}},
 				},
 			},
-			Preemption: configuration.PreemptionConfig{
-				PriorityClasses: map[string]types.PriorityClass{
-					"armada-preemptible-away": {
-						Priority: 100,
+			PriorityClasses: map[string]types.PriorityClass{
+				"armada-preemptible-away": {
+					Priority: 100,
 
-						AwayNodeTypes: []types.AwayNodeType{
-							{
-								Priority:              50,
-								WellKnownNodeTypeName: "not-gpu",
-							},
+					AwayNodeTypes: []types.AwayNodeType{
+						{
+							Priority:              50,
+							WellKnownNodeTypeName: "not-gpu",
 						},
 					},
 				},

--- a/internal/scheduler/constraints/constraints.go
+++ b/internal/scheduler/constraints/constraints.go
@@ -92,8 +92,8 @@ func NewSchedulingConstraints(
 	config configuration.SchedulingConfig,
 	queues []queue.Queue,
 ) SchedulingConstraints {
-	priorityClassSchedulingConstraintsByPriorityClassName := make(map[string]PriorityClassSchedulingConstraints, len(config.Preemption.PriorityClasses))
-	for name, priorityClass := range config.Preemption.PriorityClasses {
+	priorityClassSchedulingConstraintsByPriorityClassName := make(map[string]PriorityClassSchedulingConstraints, len(config.PriorityClasses))
+	for name, priorityClass := range config.PriorityClasses {
 		maximumResourceFractionPerQueue := priorityClass.MaximumResourceFractionPerQueue
 		if m, ok := priorityClass.MaximumResourceFractionPerQueueByPool[pool]; ok {
 			// Use pool-specific config is available.

--- a/internal/scheduler/constraints/constraints_test.go
+++ b/internal/scheduler/constraints/constraints_test.go
@@ -53,9 +53,7 @@ func TestConstraints(t *testing.T) {
 			configuration.SchedulingConfig{
 				MaximumResourceFractionToSchedule: map[string]float64{"cpu": 0.1, "memory": 0.1},
 				MaxQueueLookback:                  1000,
-				Preemption: configuration.PreemptionConfig{
-					PriorityClasses: map[string]types.PriorityClass{"priority-class-1": {MaximumResourceFractionPerQueueByPool: map[string]map[string]float64{"pool-1": {"cpu": 0.9, "memory": 0.9}}}},
-				},
+				PriorityClasses:                   map[string]types.PriorityClass{"priority-class-1": {MaximumResourceFractionPerQueueByPool: map[string]map[string]float64{"pool-1": {"cpu": 0.9, "memory": 0.9}}}},
 			},
 			[]queue.Queue{{Name: "queue-1", ResourceLimitsByPriorityClassName: map[string]api.PriorityClassResourceLimits{"priority-class-1": {MaximumResourceFraction: map[string]float64{"cpu": 0.9, "memory": 0.9}}}}},
 		)),
@@ -111,9 +109,7 @@ func TestConstraints(t *testing.T) {
 				configuration.SchedulingConfig{
 					MaximumResourceFractionToSchedule: map[string]float64{"cpu": 0.1, "memory": 0.1},
 					MaxQueueLookback:                  1000,
-					Preemption: configuration.PreemptionConfig{
-						PriorityClasses: map[string]types.PriorityClass{"priority-class-1": {MaximumResourceFractionPerQueueByPool: map[string]map[string]float64{"pool-1": {"cpu": 0.00000001, "memory": 0.9}}}},
-					},
+					PriorityClasses:                   map[string]types.PriorityClass{"priority-class-1": {MaximumResourceFractionPerQueueByPool: map[string]map[string]float64{"pool-1": {"cpu": 0.00000001, "memory": 0.9}}}},
 				},
 				[]queue.Queue{},
 			))
@@ -127,9 +123,7 @@ func TestConstraints(t *testing.T) {
 			configuration.SchedulingConfig{
 				MaximumResourceFractionToSchedule: map[string]float64{"cpu": 0.1, "memory": 0.1},
 				MaxQueueLookback:                  1000,
-				Preemption: configuration.PreemptionConfig{
-					PriorityClasses: map[string]types.PriorityClass{"priority-class-1": {MaximumResourceFractionPerQueueByPool: map[string]map[string]float64{"pool-1": {"cpu": 0.00000001, "memory": 0.9}}}},
-				},
+				PriorityClasses:                   map[string]types.PriorityClass{"priority-class-1": {MaximumResourceFractionPerQueueByPool: map[string]map[string]float64{"pool-1": {"cpu": 0.00000001, "memory": 0.9}}}},
 			},
 			[]queue.Queue{{Name: "queue-1", ResourceLimitsByPriorityClassName: map[string]api.PriorityClassResourceLimits{"priority-class-1": {MaximumResourceFraction: map[string]float64{"cpu": 0.9, "memory": 0.9}}}}},
 		)),
@@ -241,7 +235,7 @@ func makeSchedulingConfig() configuration.SchedulingConfig {
 	return configuration.SchedulingConfig{
 		MaximumResourceFractionToSchedule: map[string]float64{"cpu": 0.1, "memory": 0.1},
 		MaxQueueLookback:                  1000,
-		Preemption:                        configuration.PreemptionConfig{PriorityClasses: map[string]types.PriorityClass{"priority-class-1": {}}},
+		PriorityClasses:                   map[string]types.PriorityClass{"priority-class-1": {}},
 	}
 }
 

--- a/internal/scheduler/gang_scheduler_test.go
+++ b/internal/scheduler/gang_scheduler_test.go
@@ -452,7 +452,7 @@ func TestGangScheduler(t *testing.T) {
 		"AwayNodeTypes": {
 			SchedulingConfig: func() configuration.SchedulingConfig {
 				config := testfixtures.TestSchedulingConfig()
-				config.Preemption.PriorityClasses = map[string]types.PriorityClass{
+				config.PriorityClasses = map[string]types.PriorityClass{
 					"armada-preemptible-away": {
 						Priority:    30000,
 						Preemptible: true,
@@ -471,7 +471,7 @@ func TestGangScheduler(t *testing.T) {
 						},
 					},
 				}
-				config.Preemption.DefaultPriorityClass = "armada-preemptible-away"
+				config.DefaultPriorityClass = "armada-preemptible-away"
 				config.WellKnownNodeTypes = []configuration.WellKnownNodeType{
 					{
 						Name: "node-type-a",
@@ -520,7 +520,7 @@ func TestGangScheduler(t *testing.T) {
 		"Home-away scheduling": {
 			SchedulingConfig: func() configuration.SchedulingConfig {
 				config := testfixtures.TestSchedulingConfig()
-				config.Preemption.PriorityClasses = map[string]types.PriorityClass{
+				config.PriorityClasses = map[string]types.PriorityClass{
 					"armada-preemptible": {
 						Priority:    30000,
 						Preemptible: true,
@@ -533,7 +533,7 @@ func TestGangScheduler(t *testing.T) {
 						},
 					},
 				}
-				config.Preemption.DefaultPriorityClass = "armada-preemptible"
+				config.DefaultPriorityClass = "armada-preemptible"
 				config.WellKnownNodeTypes = []configuration.WellKnownNodeType{
 					{
 						Name: "node-type-a",
@@ -572,7 +572,7 @@ func TestGangScheduler(t *testing.T) {
 				nodesById[node.Id] = node
 			}
 			nodeDb, err := nodedb.NewNodeDb(
-				tc.SchedulingConfig.Preemption.PriorityClasses,
+				tc.SchedulingConfig.PriorityClasses,
 				tc.SchedulingConfig.MaxExtraNodesToConsider,
 				tc.SchedulingConfig.IndexedResources,
 				tc.SchedulingConfig.IndexedTaints,
@@ -605,8 +605,8 @@ func TestGangScheduler(t *testing.T) {
 			sctx := schedulercontext.NewSchedulingContext(
 				"executor",
 				"pool",
-				tc.SchedulingConfig.Preemption.PriorityClasses,
-				tc.SchedulingConfig.Preemption.DefaultPriorityClass,
+				tc.SchedulingConfig.PriorityClasses,
+				tc.SchedulingConfig.DefaultPriorityClass,
 				fairnessCostProvider,
 				rate.NewLimiter(
 					rate.Limit(tc.SchedulingConfig.MaximumSchedulingRate),
@@ -639,7 +639,7 @@ func TestGangScheduler(t *testing.T) {
 			var actualScheduledIndices []int
 			scheduledGangs := 0
 			for i, gang := range tc.Gangs {
-				jctxs := schedulercontext.JobSchedulingContextsFromJobs(tc.SchedulingConfig.Preemption.PriorityClasses, gang)
+				jctxs := schedulercontext.JobSchedulingContextsFromJobs(tc.SchedulingConfig.PriorityClasses, gang)
 				gctx := schedulercontext.NewGangSchedulingContext(jctxs)
 				ok, reason, err := sch.Schedule(armadacontext.Background(), gctx)
 				require.NoError(t, err)

--- a/internal/scheduler/gang_scheduler_test.go
+++ b/internal/scheduler/gang_scheduler_test.go
@@ -471,7 +471,7 @@ func TestGangScheduler(t *testing.T) {
 						},
 					},
 				}
-				config.DefaultPriorityClass = "armada-preemptible-away"
+				config.DefaultPriorityClassName = "armada-preemptible-away"
 				config.WellKnownNodeTypes = []configuration.WellKnownNodeType{
 					{
 						Name: "node-type-a",
@@ -533,7 +533,7 @@ func TestGangScheduler(t *testing.T) {
 						},
 					},
 				}
-				config.DefaultPriorityClass = "armada-preemptible"
+				config.DefaultPriorityClassName = "armada-preemptible"
 				config.WellKnownNodeTypes = []configuration.WellKnownNodeType{
 					{
 						Name: "node-type-a",
@@ -606,7 +606,7 @@ func TestGangScheduler(t *testing.T) {
 				"executor",
 				"pool",
 				tc.SchedulingConfig.PriorityClasses,
-				tc.SchedulingConfig.DefaultPriorityClass,
+				tc.SchedulingConfig.DefaultPriorityClassName,
 				fairnessCostProvider,
 				rate.NewLimiter(
 					rate.Limit(tc.SchedulingConfig.MaximumSchedulingRate),

--- a/internal/scheduler/pool_assigner.go
+++ b/internal/scheduler/pool_assigner.go
@@ -58,10 +58,10 @@ func NewPoolAssigner(executorTimeout time.Duration,
 	}
 	return &DefaultPoolAssigner{
 		executorTimeout:        executorTimeout,
-		priorityClasses:        schedulingConfig.Preemption.PriorityClasses,
+		priorityClasses:        schedulingConfig.PriorityClasses,
 		executorsByPool:        map[string][]*executor{},
 		poolByExecutorId:       map[string]string{},
-		priorities:             types.AllowedPriorities(schedulingConfig.Preemption.PriorityClasses),
+		priorities:             types.AllowedPriorities(schedulingConfig.PriorityClasses),
 		indexedResources:       schedulingConfig.IndexedResources,
 		indexedTaints:          schedulingConfig.IndexedTaints,
 		wellKnownNodeTypes:     schedulingConfig.WellKnownNodeTypes,

--- a/internal/scheduler/preempting_queue_scheduler_test.go
+++ b/internal/scheduler/preempting_queue_scheduler_test.go
@@ -36,8 +36,8 @@ func TestEvictOversubscribed(t *testing.T) {
 	priorities := types.AllowedPriorities(config.PriorityClasses)
 
 	jobs := append(
-		testfixtures.N1Cpu4GiJobs("A", config.DefaultPriorityClass, 20),
-		testfixtures.N1Cpu4GiJobs("A", config.DefaultPriorityClass, 20)...,
+		testfixtures.N1Cpu4GiJobs("A", config.DefaultPriorityClassName, 20),
+		testfixtures.N1Cpu4GiJobs("A", config.DefaultPriorityClassName, 20)...,
 	)
 
 	node := testfixtures.Test32CpuNode(priorities)
@@ -47,7 +47,7 @@ func TestEvictOversubscribed(t *testing.T) {
 	err = nodeDb.CreateAndInsertWithJobDbJobsWithTxn(nodeDbTxn, jobs, node)
 	require.NoError(t, err)
 
-	jobDb := jobdb.NewJobDb(config.PriorityClasses, config.DefaultPriorityClass, 1024)
+	jobDb := jobdb.NewJobDb(config.PriorityClasses, config.DefaultPriorityClassName, 1024)
 	jobDbTxn := jobDb.WriteTxn()
 	err = jobDbTxn.Upsert(jobs)
 	require.NoError(t, err)
@@ -56,7 +56,7 @@ func TestEvictOversubscribed(t *testing.T) {
 		NewSchedulerJobRepositoryAdapter(jobDbTxn),
 		nodeDb,
 		config.PriorityClasses,
-		config.DefaultPriorityClass,
+		config.DefaultPriorityClassName,
 		1,
 		nil,
 	)
@@ -1493,7 +1493,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 						Preemptible: true,
 					},
 				}
-				config.DefaultPriorityClass = "armada-preemptible"
+				config.DefaultPriorityClassName = "armada-preemptible"
 				config.WellKnownNodeTypes = []configuration.WellKnownNodeType{
 					{
 						Name:   "gpu",
@@ -1559,7 +1559,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 						Preemptible: true,
 					},
 				}
-				config.DefaultPriorityClass = "armada-preemptible"
+				config.DefaultPriorityClassName = "armada-preemptible"
 				config.WellKnownNodeTypes = []configuration.WellKnownNodeType{
 					{
 						Name:   "gpu",
@@ -1625,7 +1625,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 						Preemptible: true,
 					},
 				}
-				config.DefaultPriorityClass = "armada-preemptible"
+				config.DefaultPriorityClassName = "armada-preemptible"
 				config.WellKnownNodeTypes = []configuration.WellKnownNodeType{
 					{
 						Name:   "gpu",
@@ -1692,7 +1692,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 						Preemptible: true,
 					},
 				}
-				config.DefaultPriorityClass = "armada-preemptible"
+				config.DefaultPriorityClassName = "armada-preemptible"
 				config.WellKnownNodeTypes = []configuration.WellKnownNodeType{
 					{
 						Name:   "gpu",
@@ -1758,7 +1758,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 
 			priorities := types.AllowedPriorities(tc.SchedulingConfig.PriorityClasses)
 
-			jobDb := jobdb.NewJobDb(tc.SchedulingConfig.PriorityClasses, tc.SchedulingConfig.DefaultPriorityClass, 1024)
+			jobDb := jobdb.NewJobDb(tc.SchedulingConfig.PriorityClasses, tc.SchedulingConfig.DefaultPriorityClassName, 1024)
 			jobDbTxn := jobDb.WriteTxn()
 
 			// Accounting across scheduling rounds.
@@ -1849,7 +1849,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 					"executor",
 					"pool",
 					tc.SchedulingConfig.PriorityClasses,
-					tc.SchedulingConfig.DefaultPriorityClass,
+					tc.SchedulingConfig.DefaultPriorityClassName,
 					fairnessCostProvider,
 					limiter,
 					tc.TotalResources,
@@ -2181,7 +2181,7 @@ func BenchmarkPreemptingQueueScheduler(b *testing.B) {
 			}
 			txn.Commit()
 
-			jobDb := jobdb.NewJobDb(tc.SchedulingConfig.PriorityClasses, tc.SchedulingConfig.DefaultPriorityClass, 1024)
+			jobDb := jobdb.NewJobDb(tc.SchedulingConfig.PriorityClasses, tc.SchedulingConfig.DefaultPriorityClassName, 1024)
 			jobDbTxn := jobDb.WriteTxn()
 			var queuedJobs []*jobdb.Job
 			for _, jobs := range jobsByQueue {
@@ -2213,7 +2213,7 @@ func BenchmarkPreemptingQueueScheduler(b *testing.B) {
 				"executor",
 				"pool",
 				tc.SchedulingConfig.PriorityClasses,
-				tc.SchedulingConfig.DefaultPriorityClass,
+				tc.SchedulingConfig.DefaultPriorityClassName,
 				fairnessCostProvider,
 				limiter,
 				nodeDb.TotalResources(),
@@ -2282,7 +2282,7 @@ func BenchmarkPreemptingQueueScheduler(b *testing.B) {
 					"executor",
 					"pool",
 					tc.SchedulingConfig.PriorityClasses,
-					tc.SchedulingConfig.DefaultPriorityClass,
+					tc.SchedulingConfig.DefaultPriorityClassName,
 					fairnessCostProvider,
 					limiter,
 					nodeDb.TotalResources(),

--- a/internal/scheduler/preempting_queue_scheduler_test.go
+++ b/internal/scheduler/preempting_queue_scheduler_test.go
@@ -33,11 +33,11 @@ import (
 func TestEvictOversubscribed(t *testing.T) {
 	config := testfixtures.TestSchedulingConfig()
 
-	priorities := types.AllowedPriorities(config.Preemption.PriorityClasses)
+	priorities := types.AllowedPriorities(config.PriorityClasses)
 
 	jobs := append(
-		testfixtures.N1Cpu4GiJobs("A", config.Preemption.DefaultPriorityClass, 20),
-		testfixtures.N1Cpu4GiJobs("A", config.Preemption.DefaultPriorityClass, 20)...,
+		testfixtures.N1Cpu4GiJobs("A", config.DefaultPriorityClass, 20),
+		testfixtures.N1Cpu4GiJobs("A", config.DefaultPriorityClass, 20)...,
 	)
 
 	node := testfixtures.Test32CpuNode(priorities)
@@ -47,7 +47,7 @@ func TestEvictOversubscribed(t *testing.T) {
 	err = nodeDb.CreateAndInsertWithJobDbJobsWithTxn(nodeDbTxn, jobs, node)
 	require.NoError(t, err)
 
-	jobDb := jobdb.NewJobDb(config.Preemption.PriorityClasses, config.Preemption.DefaultPriorityClass, 1024)
+	jobDb := jobdb.NewJobDb(config.PriorityClasses, config.DefaultPriorityClass, 1024)
 	jobDbTxn := jobDb.WriteTxn()
 	err = jobDbTxn.Upsert(jobs)
 	require.NoError(t, err)
@@ -55,8 +55,8 @@ func TestEvictOversubscribed(t *testing.T) {
 	evictor := NewOversubscribedEvictor(
 		NewSchedulerJobRepositoryAdapter(jobDbTxn),
 		nodeDb,
-		config.Preemption.PriorityClasses,
-		config.Preemption.DefaultPriorityClass,
+		config.PriorityClasses,
+		config.DefaultPriorityClass,
 		1,
 		nil,
 	)
@@ -1481,7 +1481,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 		"home-away preemption, away jobs first": {
 			SchedulingConfig: func() configuration.SchedulingConfig {
 				config := testfixtures.TestSchedulingConfig()
-				config.Preemption.PriorityClasses = map[string]types.PriorityClass{
+				config.PriorityClasses = map[string]types.PriorityClass{
 					"armada-preemptible-away": {
 						Priority:    30000,
 						Preemptible: true,
@@ -1493,7 +1493,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 						Preemptible: true,
 					},
 				}
-				config.Preemption.DefaultPriorityClass = "armada-preemptible"
+				config.DefaultPriorityClass = "armada-preemptible"
 				config.WellKnownNodeTypes = []configuration.WellKnownNodeType{
 					{
 						Name:   "gpu",
@@ -1547,7 +1547,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 		"home-away preemption, home jobs first": {
 			SchedulingConfig: func() configuration.SchedulingConfig {
 				config := testfixtures.TestSchedulingConfig()
-				config.Preemption.PriorityClasses = map[string]types.PriorityClass{
+				config.PriorityClasses = map[string]types.PriorityClass{
 					"armada-preemptible-away": {
 						Priority:    30000,
 						Preemptible: true,
@@ -1559,7 +1559,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 						Preemptible: true,
 					},
 				}
-				config.Preemption.DefaultPriorityClass = "armada-preemptible"
+				config.DefaultPriorityClass = "armada-preemptible"
 				config.WellKnownNodeTypes = []configuration.WellKnownNodeType{
 					{
 						Name:   "gpu",
@@ -1613,7 +1613,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 		"home-away preemption, mixed nodes, away jobs first": {
 			SchedulingConfig: func() configuration.SchedulingConfig {
 				config := testfixtures.TestSchedulingConfig()
-				config.Preemption.PriorityClasses = map[string]types.PriorityClass{
+				config.PriorityClasses = map[string]types.PriorityClass{
 					"armada-preemptible-away": {
 						Priority:    30000,
 						Preemptible: true,
@@ -1625,7 +1625,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 						Preemptible: true,
 					},
 				}
-				config.Preemption.DefaultPriorityClass = "armada-preemptible"
+				config.DefaultPriorityClass = "armada-preemptible"
 				config.WellKnownNodeTypes = []configuration.WellKnownNodeType{
 					{
 						Name:   "gpu",
@@ -1680,7 +1680,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 		"home-away preemption, mixed nodes, home jobs first": {
 			SchedulingConfig: func() configuration.SchedulingConfig {
 				config := testfixtures.TestSchedulingConfig()
-				config.Preemption.PriorityClasses = map[string]types.PriorityClass{
+				config.PriorityClasses = map[string]types.PriorityClass{
 					"armada-preemptible-away": {
 						Priority:    30000,
 						Preemptible: true,
@@ -1692,7 +1692,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 						Preemptible: true,
 					},
 				}
-				config.Preemption.DefaultPriorityClass = "armada-preemptible"
+				config.DefaultPriorityClass = "armada-preemptible"
 				config.WellKnownNodeTypes = []configuration.WellKnownNodeType{
 					{
 						Name:   "gpu",
@@ -1756,9 +1756,9 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 			}
 			nodeDbTxn.Commit()
 
-			priorities := types.AllowedPriorities(tc.SchedulingConfig.Preemption.PriorityClasses)
+			priorities := types.AllowedPriorities(tc.SchedulingConfig.PriorityClasses)
 
-			jobDb := jobdb.NewJobDb(tc.SchedulingConfig.Preemption.PriorityClasses, tc.SchedulingConfig.Preemption.DefaultPriorityClass, 1024)
+			jobDb := jobdb.NewJobDb(tc.SchedulingConfig.PriorityClasses, tc.SchedulingConfig.DefaultPriorityClass, 1024)
 			jobDbTxn := jobDb.WriteTxn()
 
 			// Accounting across scheduling rounds.
@@ -1813,7 +1813,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 							nodeId := nodeIdByJobId[job.GetId()]
 							node, err := nodeDb.GetNode(nodeId)
 							require.NoError(t, err)
-							node, err = nodeDb.UnbindJobFromNode(tc.SchedulingConfig.Preemption.PriorityClasses, job, node)
+							node, err = nodeDb.UnbindJobFromNode(tc.SchedulingConfig.PriorityClasses, job, node)
 							require.NoError(t, err)
 							err = nodeDb.Upsert(node)
 							require.NoError(t, err)
@@ -1848,8 +1848,8 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 				sctx := schedulercontext.NewSchedulingContext(
 					"executor",
 					"pool",
-					tc.SchedulingConfig.Preemption.PriorityClasses,
-					tc.SchedulingConfig.Preemption.DefaultPriorityClass,
+					tc.SchedulingConfig.PriorityClasses,
+					tc.SchedulingConfig.DefaultPriorityClass,
 					fairnessCostProvider,
 					limiter,
 					tc.TotalResources,
@@ -1876,9 +1876,9 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 				sch := NewPreemptingQueueScheduler(
 					sctx,
 					constraints,
-					tc.SchedulingConfig.Preemption.NodeEvictionProbability,
-					tc.SchedulingConfig.Preemption.NodeOversubscriptionEvictionProbability,
-					tc.SchedulingConfig.Preemption.ProtectedFractionOfFairShare,
+					tc.SchedulingConfig.NodeEvictionProbability,
+					tc.SchedulingConfig.NodeOversubscriptionEvictionProbability,
+					tc.SchedulingConfig.ProtectedFractionOfFairShare,
 					NewSchedulerJobRepositoryAdapter(jobDbTxn),
 					nodeDb,
 					nodeIdByJobId,
@@ -2181,7 +2181,7 @@ func BenchmarkPreemptingQueueScheduler(b *testing.B) {
 			}
 			txn.Commit()
 
-			jobDb := jobdb.NewJobDb(tc.SchedulingConfig.Preemption.PriorityClasses, tc.SchedulingConfig.Preemption.DefaultPriorityClass, 1024)
+			jobDb := jobdb.NewJobDb(tc.SchedulingConfig.PriorityClasses, tc.SchedulingConfig.DefaultPriorityClass, 1024)
 			jobDbTxn := jobDb.WriteTxn()
 			var queuedJobs []*jobdb.Job
 			for _, jobs := range jobsByQueue {
@@ -2212,8 +2212,8 @@ func BenchmarkPreemptingQueueScheduler(b *testing.B) {
 			sctx := schedulercontext.NewSchedulingContext(
 				"executor",
 				"pool",
-				tc.SchedulingConfig.Preemption.PriorityClasses,
-				tc.SchedulingConfig.Preemption.DefaultPriorityClass,
+				tc.SchedulingConfig.PriorityClasses,
+				tc.SchedulingConfig.DefaultPriorityClass,
 				fairnessCostProvider,
 				limiter,
 				nodeDb.TotalResources(),
@@ -2233,9 +2233,9 @@ func BenchmarkPreemptingQueueScheduler(b *testing.B) {
 			sch := NewPreemptingQueueScheduler(
 				sctx,
 				constraints,
-				tc.SchedulingConfig.Preemption.NodeEvictionProbability,
-				tc.SchedulingConfig.Preemption.NodeOversubscriptionEvictionProbability,
-				tc.SchedulingConfig.Preemption.ProtectedFractionOfFairShare,
+				tc.SchedulingConfig.NodeEvictionProbability,
+				tc.SchedulingConfig.NodeOversubscriptionEvictionProbability,
+				tc.SchedulingConfig.ProtectedFractionOfFairShare,
 				NewSchedulerJobRepositoryAdapter(jobDbTxn),
 				nodeDb,
 				nil,
@@ -2281,8 +2281,8 @@ func BenchmarkPreemptingQueueScheduler(b *testing.B) {
 				sctx := schedulercontext.NewSchedulingContext(
 					"executor",
 					"pool",
-					tc.SchedulingConfig.Preemption.PriorityClasses,
-					tc.SchedulingConfig.Preemption.DefaultPriorityClass,
+					tc.SchedulingConfig.PriorityClasses,
+					tc.SchedulingConfig.DefaultPriorityClass,
 					fairnessCostProvider,
 					limiter,
 					nodeDb.TotalResources(),
@@ -2295,9 +2295,9 @@ func BenchmarkPreemptingQueueScheduler(b *testing.B) {
 				sch := NewPreemptingQueueScheduler(
 					sctx,
 					constraints,
-					tc.SchedulingConfig.Preemption.NodeEvictionProbability,
-					tc.SchedulingConfig.Preemption.NodeOversubscriptionEvictionProbability,
-					tc.SchedulingConfig.Preemption.ProtectedFractionOfFairShare,
+					tc.SchedulingConfig.NodeEvictionProbability,
+					tc.SchedulingConfig.NodeOversubscriptionEvictionProbability,
+					tc.SchedulingConfig.ProtectedFractionOfFairShare,
 					NewSchedulerJobRepositoryAdapter(jobDbTxn),
 					nodeDb,
 					nil,

--- a/internal/scheduler/queue_scheduler.go
+++ b/internal/scheduler/queue_scheduler.go
@@ -97,7 +97,7 @@ func (sch *QueueScheduler) Schedule(ctx *armadacontext.Context) (*SchedulerResul
 				if pctx := jctx.PodSchedulingContext; pctx.IsSuccessful() {
 					scheduledJobs = append(scheduledJobs, jctx)
 					nodeIdByJobId[jctx.JobId] = pctx.NodeId
-					additionalAnnotationsByJobId[jctx.JobId] = map[string]string{configuration.RuntimeGangCardinality: strconv.Itoa(numScheduled)}
+					additionalAnnotationsByJobId[jctx.JobId] = map[string]string{configuration.GangNumJobsScheduledAnnotation: strconv.Itoa(numScheduled)}
 				} else if jctx.ShouldFail {
 					failedJobs = append(failedJobs, jctx)
 				}

--- a/internal/scheduler/queue_scheduler_test.go
+++ b/internal/scheduler/queue_scheduler_test.go
@@ -548,7 +548,7 @@ func TestQueueScheduler(t *testing.T) {
 			jobRepo := NewInMemoryJobRepository()
 			jobRepo.EnqueueMany(
 				schedulercontext.JobSchedulingContextsFromJobs(
-					tc.SchedulingConfig.Preemption.PriorityClasses,
+					tc.SchedulingConfig.PriorityClasses,
 					legacySchedulerJobs,
 				),
 			)
@@ -561,8 +561,8 @@ func TestQueueScheduler(t *testing.T) {
 			sctx := schedulercontext.NewSchedulingContext(
 				"executor",
 				"pool",
-				tc.SchedulingConfig.Preemption.PriorityClasses,
-				tc.SchedulingConfig.Preemption.DefaultPriorityClass,
+				tc.SchedulingConfig.PriorityClasses,
+				tc.SchedulingConfig.DefaultPriorityClass,
 				fairnessCostProvider,
 				rate.NewLimiter(
 					rate.Limit(tc.SchedulingConfig.MaximumSchedulingRate),
@@ -730,7 +730,7 @@ func TestQueueScheduler(t *testing.T) {
 
 func NewNodeDb(config configuration.SchedulingConfig) (*nodedb.NodeDb, error) {
 	nodeDb, err := nodedb.NewNodeDb(
-		config.Preemption.PriorityClasses,
+		config.PriorityClasses,
 		config.MaxExtraNodesToConsider,
 		config.IndexedResources,
 		config.IndexedTaints,

--- a/internal/scheduler/queue_scheduler_test.go
+++ b/internal/scheduler/queue_scheduler_test.go
@@ -562,7 +562,7 @@ func TestQueueScheduler(t *testing.T) {
 				"executor",
 				"pool",
 				tc.SchedulingConfig.PriorityClasses,
-				tc.SchedulingConfig.DefaultPriorityClass,
+				tc.SchedulingConfig.DefaultPriorityClassName,
 				fairnessCostProvider,
 				rate.NewLimiter(
 					rate.Limit(tc.SchedulingConfig.MaximumSchedulingRate),

--- a/internal/scheduler/schedulerapp.go
+++ b/internal/scheduler/schedulerapp.go
@@ -207,7 +207,7 @@ func Run(config schedulerconfig.Configuration) error {
 	}
 	jobDb := jobdb.NewJobDb(
 		config.Scheduling.PriorityClasses,
-		config.Scheduling.DefaultPriorityClass,
+		config.Scheduling.DefaultPriorityClassName,
 		config.InternedStringsCacheSize,
 	)
 	schedulingRoundMetrics := NewSchedulerMetrics(config.Metrics.Metrics)

--- a/internal/scheduler/schedulerapp.go
+++ b/internal/scheduler/schedulerapp.go
@@ -154,9 +154,9 @@ func Run(config schedulerconfig.Configuration) error {
 		jobRepository,
 		executorRepository,
 		legacyExecutorRepository,
-		types.AllowedPriorities(config.Scheduling.Preemption.PriorityClasses),
-		config.Scheduling.Preemption.NodeIdLabel,
-		config.Scheduling.Preemption.PriorityClassNameOverride,
+		types.AllowedPriorities(config.Scheduling.PriorityClasses),
+		config.Scheduling.NodeIdLabel,
+		config.Scheduling.PriorityClassNameOverride,
 		config.Pulsar.MaxAllowedMessageSize,
 	)
 	if err != nil {
@@ -206,8 +206,8 @@ func Run(config schedulerconfig.Configuration) error {
 		return errors.WithMessage(err, "error creating scheduling algo")
 	}
 	jobDb := jobdb.NewJobDb(
-		config.Scheduling.Preemption.PriorityClasses,
-		config.Scheduling.Preemption.DefaultPriorityClass,
+		config.Scheduling.PriorityClasses,
+		config.Scheduling.DefaultPriorityClass,
 		config.InternedStringsCacheSize,
 	)
 	schedulingRoundMetrics := NewSchedulerMetrics(config.Metrics.Metrics)
@@ -252,7 +252,7 @@ func Run(config schedulerconfig.Configuration) error {
 		config.SchedulePeriod,
 		config.ExecutorTimeout,
 		config.Scheduling.MaxRetries+1,
-		config.Scheduling.Preemption.NodeIdLabel,
+		config.Scheduling.NodeIdLabel,
 		schedulingRoundMetrics,
 		schedulerMetrics,
 		failureEstimator,

--- a/internal/scheduler/scheduling_algo.go
+++ b/internal/scheduler/scheduling_algo.go
@@ -68,8 +68,8 @@ func NewFairSchedulingAlgo(
 	queueRepository repository.QueueRepository,
 	schedulingContextRepository *SchedulingContextRepository,
 ) (*FairSchedulingAlgo, error) {
-	if _, ok := config.Preemption.PriorityClasses[config.Preemption.DefaultPriorityClass]; !ok {
-		return nil, errors.Errorf("default priority class %s is missing from priority class mapping %v", config.Preemption.DefaultPriorityClass, config.Preemption.PriorityClasses)
+	if _, ok := config.PriorityClasses[config.DefaultPriorityClass]; !ok {
+		return nil, errors.Errorf("default priority class %s is missing from priority class mapping %v", config.DefaultPriorityClass, config.PriorityClasses)
 	}
 	return &FairSchedulingAlgo{
 		schedulingConfig:            config,
@@ -338,7 +338,7 @@ func (l *FairSchedulingAlgo) scheduleOnExecutors(
 	executors []*schedulerobjects.Executor,
 ) (*SchedulerResult, *schedulercontext.SchedulingContext, error) {
 	nodeDb, err := nodedb.NewNodeDb(
-		l.schedulingConfig.Preemption.PriorityClasses,
+		l.schedulingConfig.PriorityClasses,
 		l.schedulingConfig.MaxExtraNodesToConsider,
 		l.schedulingConfig.IndexedResources,
 		l.schedulingConfig.IndexedTaints,
@@ -375,8 +375,8 @@ func (l *FairSchedulingAlgo) scheduleOnExecutors(
 	sctx := schedulercontext.NewSchedulingContext(
 		executorId,
 		pool,
-		l.schedulingConfig.Preemption.PriorityClasses,
-		l.schedulingConfig.Preemption.DefaultPriorityClass,
+		l.schedulingConfig.PriorityClasses,
+		l.schedulingConfig.DefaultPriorityClass,
 		fairnessCostProvider,
 		l.limiter,
 		totalResources,
@@ -417,9 +417,9 @@ func (l *FairSchedulingAlgo) scheduleOnExecutors(
 	scheduler := NewPreemptingQueueScheduler(
 		sctx,
 		constraints,
-		l.schedulingConfig.Preemption.NodeEvictionProbability,
-		l.schedulingConfig.Preemption.NodeOversubscriptionEvictionProbability,
-		l.schedulingConfig.Preemption.ProtectedFractionOfFairShare,
+		l.schedulingConfig.NodeEvictionProbability,
+		l.schedulingConfig.NodeOversubscriptionEvictionProbability,
+		l.schedulingConfig.ProtectedFractionOfFairShare,
 		NewSchedulerJobRepositoryAdapter(fsctx.txn),
 		nodeDb,
 		fsctx.nodeIdByJobId,

--- a/internal/scheduler/scheduling_algo.go
+++ b/internal/scheduler/scheduling_algo.go
@@ -68,8 +68,11 @@ func NewFairSchedulingAlgo(
 	queueRepository repository.QueueRepository,
 	schedulingContextRepository *SchedulingContextRepository,
 ) (*FairSchedulingAlgo, error) {
-	if _, ok := config.PriorityClasses[config.DefaultPriorityClass]; !ok {
-		return nil, errors.Errorf("default priority class %s is missing from priority class mapping %v", config.DefaultPriorityClass, config.PriorityClasses)
+	if _, ok := config.PriorityClasses[config.DefaultPriorityClassName]; !ok {
+		return nil, errors.Errorf(
+			"defaultPriorityClassName %s does not correspond to a priority class; priorityClasses is %v",
+			config.DefaultPriorityClassName, config.PriorityClasses,
+		)
 	}
 	return &FairSchedulingAlgo{
 		schedulingConfig:            config,
@@ -376,7 +379,7 @@ func (l *FairSchedulingAlgo) scheduleOnExecutors(
 		executorId,
 		pool,
 		l.schedulingConfig.PriorityClasses,
-		l.schedulingConfig.DefaultPriorityClass,
+		l.schedulingConfig.DefaultPriorityClassName,
 		fairnessCostProvider,
 		l.limiter,
 		totalResources,

--- a/internal/scheduler/scheduling_algo_test.go
+++ b/internal/scheduler/scheduling_algo_test.go
@@ -531,7 +531,7 @@ func BenchmarkNodeDbConstruction(b *testing.B) {
 				b.StartTimer()
 
 				nodeDb, err := nodedb.NewNodeDb(
-					schedulingConfig.Preemption.PriorityClasses,
+					schedulingConfig.PriorityClasses,
 					schedulingConfig.MaxExtraNodesToConsider,
 					schedulingConfig.IndexedResources,
 					schedulingConfig.IndexedTaints,

--- a/internal/scheduler/scheduling_algo_test.go
+++ b/internal/scheduler/scheduling_algo_test.go
@@ -452,9 +452,9 @@ func TestSchedule(t *testing.T) {
 			} else {
 				assert.Equal(t, tc.expectedScheduledIndices, actualScheduledIndices)
 			}
-			// Sanity check: we've set `RuntimeGangCardinality` for all scheduled jobs.
+			// Sanity check: we've set `GangNumJobsScheduledAnnotation` for all scheduled jobs.
 			for _, job := range scheduledJobs {
-				assert.Contains(t, schedulerResult.AdditionalAnnotationsByJobId[job.Id()], configuration.RuntimeGangCardinality)
+				assert.Contains(t, schedulerResult.AdditionalAnnotationsByJobId[job.Id()], configuration.GangNumJobsScheduledAnnotation)
 			}
 
 			// Check that we failed the correct number of excess jobs when a gang schedules >= minimum cardinality

--- a/internal/scheduler/simulator/simulator.go
+++ b/internal/scheduler/simulator/simulator.go
@@ -100,7 +100,7 @@ func NewSimulator(clusterSpec *ClusterSpec, workloadSpec *WorkloadSpec, scheduli
 	}
 	jobDb := jobdb.NewJobDb(
 		schedulingConfig.PriorityClasses,
-		schedulingConfig.DefaultPriorityClass,
+		schedulingConfig.DefaultPriorityClassName,
 		1024,
 	)
 	randomSeed := workloadSpec.RandomSeed
@@ -434,7 +434,7 @@ func (s *Simulator) handleScheduleEvent(ctx *armadacontext.Context) error {
 				fmt.Sprintf("%s-%d", pool.Name, i),
 				pool.Name,
 				s.schedulingConfig.PriorityClasses,
-				s.schedulingConfig.DefaultPriorityClass,
+				s.schedulingConfig.DefaultPriorityClassName,
 				fairnessCostProvider,
 				s.limiter,
 				totalResources,

--- a/internal/scheduler/simulator/simulator_test.go
+++ b/internal/scheduler/simulator/simulator_test.go
@@ -401,7 +401,7 @@ func TestSimulator(t *testing.T) {
 						Preemptible: true,
 					},
 				}
-				config.DefaultPriorityClass = "armada-preemptible"
+				config.DefaultPriorityClassName = "armada-preemptible"
 				config.WellKnownNodeTypes = []configuration.WellKnownNodeType{
 					{
 						Name:   "gpu-whale",

--- a/internal/scheduler/simulator/simulator_test.go
+++ b/internal/scheduler/simulator/simulator_test.go
@@ -389,7 +389,7 @@ func TestSimulator(t *testing.T) {
 			},
 			schedulingConfig: func() configuration.SchedulingConfig {
 				config := testfixtures.TestSchedulingConfig()
-				config.Preemption.PriorityClasses = map[string]types.PriorityClass{
+				config.PriorityClasses = map[string]types.PriorityClass{
 					"armada-preemptible-away": {
 						Priority:    30000,
 						Preemptible: true,
@@ -401,7 +401,7 @@ func TestSimulator(t *testing.T) {
 						Preemptible: true,
 					},
 				}
-				config.Preemption.DefaultPriorityClass = "armada-preemptible"
+				config.DefaultPriorityClass = "armada-preemptible"
 				config.WellKnownNodeTypes = []configuration.WellKnownNodeType{
 					{
 						Name:   "gpu-whale",

--- a/internal/scheduler/simulator/test_utils.go
+++ b/internal/scheduler/simulator/test_utils.go
@@ -45,17 +45,15 @@ func GetOneQueue10JobWorkload() *WorkloadSpec {
 
 func GetBasicSchedulingConfig() configuration.SchedulingConfig {
 	return configuration.SchedulingConfig{
-		Preemption: configuration.PreemptionConfig{
-			NodeEvictionProbability: 1.0,
-			PriorityClasses: map[string]types.PriorityClass{
-				"armada-default": {
-					Priority:    30000,
-					Preemptible: false,
-				},
-				"armada-preemptible": {
-					Priority:    30000,
-					Preemptible: true,
-				},
+		NodeEvictionProbability: 1.0,
+		PriorityClasses: map[string]types.PriorityClass{
+			"armada-default": {
+				Priority:    30000,
+				Preemptible: false,
+			},
+			"armada-preemptible": {
+				Priority:    30000,
+				Preemptible: true,
 			},
 		},
 		MaximumResourceFractionToSchedule: map[string]float64{

--- a/internal/scheduler/simulator/test_utils.go
+++ b/internal/scheduler/simulator/test_utils.go
@@ -56,6 +56,7 @@ func GetBasicSchedulingConfig() configuration.SchedulingConfig {
 				Preemptible: true,
 			},
 		},
+		DefaultPriorityClassName: "armada-default",
 		MaximumResourceFractionToSchedule: map[string]float64{
 			"memory": 0.025,
 			"cpu":    0.025,

--- a/internal/scheduler/simulator/testdata/configs/basicSchedulingConfig.yaml
+++ b/internal/scheduler/simulator/testdata/configs/basicSchedulingConfig.yaml
@@ -18,12 +18,12 @@ indexedResources:
     resolution: "1Mi"
   - name: "nvidia.com/gpu"
     resolution: "1"
-preemption:
-  nodeEvictionProbability: 1.0
-  priorityClasses:
-    armada-default:
-      priority: 30000
-      preemptible: false
-    armada-preemptible:
-      priority: 30000
-      preemptible: true
+nodeEvictionProbability: 1.0
+priorityClasses:
+  armada-default:
+    priority: 30000
+    preemptible: false
+  armada-preemptible:
+    priority: 30000
+    preemptible: true
+defaultPriorityClassName: "armada-default"

--- a/internal/scheduler/submitcheck.go
+++ b/internal/scheduler/submitcheck.go
@@ -43,8 +43,9 @@ type SubmitScheduleChecker interface {
 }
 
 type SubmitChecker struct {
-	executorTimeout           time.Duration
-	priorityClasses           map[string]types.PriorityClass
+	executorTimeout time.Duration
+	priorityClasses map[string]types.PriorityClass
+	// TODO(albin): Remove. Refer directly to const.
 	gangIdAnnotation          string
 	executorById              map[string]minimalExecutor
 	priorities                []int32

--- a/internal/scheduler/submitcheck.go
+++ b/internal/scheduler/submitcheck.go
@@ -43,10 +43,8 @@ type SubmitScheduleChecker interface {
 }
 
 type SubmitChecker struct {
-	executorTimeout time.Duration
-	priorityClasses map[string]types.PriorityClass
-	// TODO(albin): Remove. Refer directly to const.
-	gangIdAnnotation          string
+	executorTimeout           time.Duration
+	priorityClasses           map[string]types.PriorityClass
 	executorById              map[string]minimalExecutor
 	priorities                []int32
 	indexedResources          []configuration.IndexedResource
@@ -73,7 +71,6 @@ func NewSubmitChecker(
 	return &SubmitChecker{
 		executorTimeout:           executorTimeout,
 		priorityClasses:           schedulingConfig.PriorityClasses,
-		gangIdAnnotation:          configuration.GangIdAnnotation,
 		executorById:              map[string]minimalExecutor{},
 		priorities:                types.AllowedPriorities(schedulingConfig.PriorityClasses),
 		indexedResources:          schedulingConfig.IndexedResources,

--- a/internal/scheduler/submitcheck.go
+++ b/internal/scheduler/submitcheck.go
@@ -71,10 +71,10 @@ func NewSubmitChecker(
 	}
 	return &SubmitChecker{
 		executorTimeout:           executorTimeout,
-		priorityClasses:           schedulingConfig.Preemption.PriorityClasses,
+		priorityClasses:           schedulingConfig.PriorityClasses,
 		gangIdAnnotation:          configuration.GangIdAnnotation,
 		executorById:              map[string]minimalExecutor{},
-		priorities:                types.AllowedPriorities(schedulingConfig.Preemption.PriorityClasses),
+		priorities:                types.AllowedPriorities(schedulingConfig.PriorityClasses),
 		indexedResources:          schedulingConfig.IndexedResources,
 		indexedTaints:             schedulingConfig.IndexedTaints,
 		indexedNodeLabels:         schedulingConfig.IndexedNodeLabels,

--- a/internal/scheduler/testfixtures/testfixtures.go
+++ b/internal/scheduler/testfixtures/testfixtures.go
@@ -124,12 +124,10 @@ func Repeat[T any](v T, n int) []T {
 
 func TestSchedulingConfig() configuration.SchedulingConfig {
 	return configuration.SchedulingConfig{
-		Preemption: configuration.PreemptionConfig{
-			PriorityClasses:                         maps.Clone(TestPriorityClasses),
-			DefaultPriorityClass:                    TestDefaultPriorityClass,
-			NodeEvictionProbability:                 1.0,
-			NodeOversubscriptionEvictionProbability: 1.0,
-		},
+		PriorityClasses:                             maps.Clone(TestPriorityClasses),
+		DefaultPriorityClassName:                    TestDefaultPriorityClass,
+		NodeEvictionProbability:                     1.0,
+		NodeOversubscriptionEvictionProbability:     1.0,
 		MaximumSchedulingRate:                       math.Inf(1),
 		MaximumSchedulingBurst:                      math.MaxInt,
 		MaximumPerQueueSchedulingRate:               math.Inf(1),

--- a/internal/scheduler/testfixtures/testfixtures.go
+++ b/internal/scheduler/testfixtures/testfixtures.go
@@ -151,17 +151,17 @@ func WithMaxUnacknowledgedJobsPerExecutorConfig(v uint, config configuration.Sch
 }
 
 func WithProtectedFractionOfFairShareConfig(v float64, config configuration.SchedulingConfig) configuration.SchedulingConfig {
-	config.Preemption.ProtectedFractionOfFairShare = v
+	config.ProtectedFractionOfFairShare = v
 	return config
 }
 
 func WithNodeEvictionProbabilityConfig(p float64, config configuration.SchedulingConfig) configuration.SchedulingConfig {
-	config.Preemption.NodeEvictionProbability = p
+	config.NodeEvictionProbability = p
 	return config
 }
 
 func WithNodeOversubscriptionEvictionProbabilityConfig(p float64, config configuration.SchedulingConfig) configuration.SchedulingConfig {
-	config.Preemption.NodeOversubscriptionEvictionProbability = p
+	config.NodeOversubscriptionEvictionProbability = p
 	return config
 }
 
@@ -177,12 +177,12 @@ func WithRoundLimitsPoolConfig(limits map[string]map[string]float64, config conf
 
 func WithPerPriorityLimitsConfig(limits map[string]map[string]float64, config configuration.SchedulingConfig) configuration.SchedulingConfig {
 	for priorityClassName, limit := range limits {
-		priorityClass, ok := config.Preemption.PriorityClasses[priorityClassName]
+		priorityClass, ok := config.PriorityClasses[priorityClassName]
 		if !ok {
 			panic(fmt.Sprintf("no priority class with name %s", priorityClassName))
 		}
 		// We need to make a copy to avoid mutating the priorityClasses, which are used by other tests too.
-		config.Preemption.PriorityClasses[priorityClassName] = types.PriorityClass{
+		config.PriorityClasses[priorityClassName] = types.PriorityClass{
 			Priority:                              priorityClass.Priority,
 			Preemptible:                           priorityClass.Preemptible,
 			MaximumResourceFractionPerQueue:       limit,


### PR DESCRIPTION
Move config relating to job submission from `SchedulingConfig` into a new struct `SubmissionConfig`. Misc. other config refactoring and cleanup. Improved docstrings/comments.