### PR TITLE
Log warning on unused config keys

### DIFF
--- a/cmd/armada/main.go
+++ b/cmd/armada/main.go
@@ -39,8 +39,7 @@ func main() {
 	common.ConfigureLogging()
 	common.BindCommandlineArguments()
 
-	// TODO Load relevant config in one place: don't use viper here and in the config package
-	// (currently in common).
+	// TODO Load relevant config in one place: don't use viper here and in LoadConfig.
 	var config configuration.ArmadaConfig
 	userSpecifiedConfigs := viper.GetStringSlice(CustomConfigLocation)
 	common.LoadConfig(&config, "./config/armada", userSpecifiedConfigs)


### PR DESCRIPTION
This PR introduces a warning printed at startup if there are config keys in the yaml that don't match a config item in the struct the yaml is decoded into.

For example, adding the following unused keys to the server scheduling config:
```
  myUnusedField: "abc"
  myOtherUnusedField: 1.0
  myThirdUnusedField: true
  myMapUnusedField:
    - foo: "bar"
```

Results in a warning being printed at startup:
```
> go run .\cmd\armada\main.go
INFO[2024-03-13T11:12:41.828Z]startup.go:53 Read base config from C:\Users\albin\git\armada\config\armada\config.yaml
WARN[2024-03-13T11:12:41.83Z]startup.go:83 Unused keys: [Scheduling.mythirdunusedfield Scheduling.mymapunusedfield Scheduling.myunusedfield Scheduling.myotherunusedfield]
INFO[2024-03-13T11:12:41.83Z]main.go:47 Starting...
```

It also logs the set and unset config keys at a debug level.