### PR TITLE
Log where we mutate containers with inconsistent requests/limits

### DIFF
--- a/internal/armada/server/applydefaults.go
+++ b/internal/armada/server/applydefaults.go
@@ -131,7 +131,6 @@ func applyDefaultActiveDeadlineSecondsToPodSpec(spec *v1.PodSpec, config configu
 // memory limit, but does not specify a memory request, assign a memory request that matches the limit.
 // Similarly, if a Container specifies its own CPU limit, but does not specify a CPU request, automatically
 // assigns a CPU request that matches the limit.
-//
 // 2024-03-18 chrisma: This seems suboptimal. return a string we can log out if people are submitting sparse requests.
 // If nobody is using this then remove this.
 func fillContainerRequestsAndLimits(containers []v1.Container) string {

--- a/internal/armada/server/applydefaults.go
+++ b/internal/armada/server/applydefaults.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"fmt"
 	"math"
 
 	v1 "k8s.io/api/core/v1"
@@ -132,7 +131,6 @@ func applyDefaultActiveDeadlineSecondsToPodSpec(spec *v1.PodSpec, config configu
 // Similarly, if a Container specifies its own CPU limit, but does not specify a CPU request, automatically
 // assigns a CPU request that matches the limit.
 func fillContainerRequestsAndLimits(containers []v1.Container) string {
-	var infoMsg = ""
 	for index := range containers {
 		if containers[index].Resources.Limits == nil {
 			containers[index].Resources.Limits = v1.ResourceList{}
@@ -144,21 +142,13 @@ func fillContainerRequestsAndLimits(containers []v1.Container) string {
 		for resourceName, quantity := range containers[index].Resources.Limits {
 			if _, ok := containers[index].Resources.Requests[resourceName]; !ok {
 				containers[index].Resources.Requests[resourceName] = quantity
-				if infoMsg == "" {
-					infoMsg = fmt.Sprintf(
-						"container %s had limits but not requests for %s", containers[index].Name, resourceName)
-				}
 			}
 		}
 		for resourceName, quantity := range containers[index].Resources.Requests {
 			if _, ok := containers[index].Resources.Limits[resourceName]; !ok {
 				containers[index].Resources.Limits[resourceName] = quantity
-				if infoMsg == "" {
-					infoMsg = fmt.Sprintf(
-						"container %s had requests but not limits for %s", containers[index].Name, resourceName)
-				}
 			}
 		}
 	}
-	return infoMsg
+	return ""
 }

--- a/internal/armada/server/applydefaults.go
+++ b/internal/armada/server/applydefaults.go
@@ -131,7 +131,7 @@ func applyDefaultActiveDeadlineSecondsToPodSpec(spec *v1.PodSpec, config configu
 // Similarly, if a Container specifies its own CPU limit, but does not specify a CPU request, automatically
 // assigns a CPU request that matches the limit.
 func fillContainerRequestsAndLimits(containers []v1.Container) string {
-	var infoMsg = ""
+	infoMsg := ""
 	for index := range containers {
 		if containers[index].Resources.Limits == nil {
 			containers[index].Resources.Limits = v1.ResourceList{}

--- a/internal/armada/server/applydefaults.go
+++ b/internal/armada/server/applydefaults.go
@@ -131,8 +131,6 @@ func applyDefaultActiveDeadlineSecondsToPodSpec(spec *v1.PodSpec, config configu
 // memory limit, but does not specify a memory request, assign a memory request that matches the limit.
 // Similarly, if a Container specifies its own CPU limit, but does not specify a CPU request, automatically
 // assigns a CPU request that matches the limit.
-// 2024-03-18 chrisma: This seems suboptimal. return a string we can log out if people are submitting
-// sparse requests. If nobody is using this then remove this.
 func fillContainerRequestsAndLimits(containers []v1.Container) string {
 	var infoMsg = ""
 	for index := range containers {

--- a/internal/armada/server/applydefaults.go
+++ b/internal/armada/server/applydefaults.go
@@ -131,6 +131,7 @@ func applyDefaultActiveDeadlineSecondsToPodSpec(spec *v1.PodSpec, config configu
 // Similarly, if a Container specifies its own CPU limit, but does not specify a CPU request, automatically
 // assigns a CPU request that matches the limit.
 func fillContainerRequestsAndLimits(containers []v1.Container) string {
+	var infoMsg = ""
 	for index := range containers {
 		if containers[index].Resources.Limits == nil {
 			containers[index].Resources.Limits = v1.ResourceList{}
@@ -150,5 +151,5 @@ func fillContainerRequestsAndLimits(containers []v1.Container) string {
 			}
 		}
 	}
-	return ""
+	return infoMsg
 }

--- a/internal/armada/server/applydefaults.go
+++ b/internal/armada/server/applydefaults.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"fmt"
 	"math"
 
 	v1 "k8s.io/api/core/v1"
@@ -130,6 +131,9 @@ func applyDefaultActiveDeadlineSecondsToPodSpec(spec *v1.PodSpec, config configu
 // memory limit, but does not specify a memory request, assign a memory request that matches the limit.
 // Similarly, if a Container specifies its own CPU limit, but does not specify a CPU request, automatically
 // assigns a CPU request that matches the limit.
+//
+// 2024-03-18 chrisma: This seems suboptimal. return a string we can log out if people are submitting sparse requests.
+// If nobody is using this then remove this.
 func fillContainerRequestsAndLimits(containers []v1.Container) string {
 	infoMsg := ""
 	for index := range containers {
@@ -143,11 +147,17 @@ func fillContainerRequestsAndLimits(containers []v1.Container) string {
 		for resourceName, quantity := range containers[index].Resources.Limits {
 			if _, ok := containers[index].Resources.Requests[resourceName]; !ok {
 				containers[index].Resources.Requests[resourceName] = quantity
+				if infoMsg == "" {
+					infoMsg = fmt.Sprintf("container %s had limits but not requests for %s", containers[index].Name, resourceName)
+				}
 			}
 		}
 		for resourceName, quantity := range containers[index].Resources.Requests {
 			if _, ok := containers[index].Resources.Limits[resourceName]; !ok {
 				containers[index].Resources.Limits[resourceName] = quantity
+				if infoMsg == "" {
+					infoMsg = fmt.Sprintf("container %s had requests but not limits for %s", containers[index].Name, resourceName)
+				}
 			}
 		}
 	}

--- a/internal/armada/server/applydefaults.go
+++ b/internal/armada/server/applydefaults.go
@@ -131,8 +131,8 @@ func applyDefaultActiveDeadlineSecondsToPodSpec(spec *v1.PodSpec, config configu
 // memory limit, but does not specify a memory request, assign a memory request that matches the limit.
 // Similarly, if a Container specifies its own CPU limit, but does not specify a CPU request, automatically
 // assigns a CPU request that matches the limit.
-// 2024-03-18 chrisma: This seems suboptimal. return a string we can log out if people are submitting sparse requests.
-// If nobody is using this then remove this.
+// 2024-03-18 chrisma: This seems suboptimal. return a string we can log out if people are submitting
+// sparse requests. If nobody is using this then remove this.
 func fillContainerRequestsAndLimits(containers []v1.Container) string {
 	var infoMsg = ""
 	for index := range containers {
@@ -147,7 +147,8 @@ func fillContainerRequestsAndLimits(containers []v1.Container) string {
 			if _, ok := containers[index].Resources.Requests[resourceName]; !ok {
 				containers[index].Resources.Requests[resourceName] = quantity
 				if infoMsg == "" {
-					infoMsg = fmt.Sprintf("container %s had limits but not requests for %s", containers[index].Name, resourceName)
+					infoMsg = fmt.Sprintf(
+						"container %s had limits but not requests for %s", containers[index].Name, resourceName)
 				}
 			}
 		}
@@ -155,7 +156,8 @@ func fillContainerRequestsAndLimits(containers []v1.Container) string {
 			if _, ok := containers[index].Resources.Limits[resourceName]; !ok {
 				containers[index].Resources.Limits[resourceName] = quantity
 				if infoMsg == "" {
-					infoMsg = fmt.Sprintf("container %s had requests but not limits for %s", containers[index].Name, resourceName)
+					infoMsg = fmt.Sprintf(
+						"container %s had requests but not limits for %s", containers[index].Name, resourceName)
 				}
 			}
 		}

--- a/internal/armada/server/applydefaults.go
+++ b/internal/armada/server/applydefaults.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"fmt"
 	"math"
 
 	v1 "k8s.io/api/core/v1"
@@ -130,7 +131,11 @@ func applyDefaultActiveDeadlineSecondsToPodSpec(spec *v1.PodSpec, config configu
 // memory limit, but does not specify a memory request, assign a memory request that matches the limit.
 // Similarly, if a Container specifies its own CPU limit, but does not specify a CPU request, automatically
 // assigns a CPU request that matches the limit.
-func fillContainerRequestsAndLimits(containers []v1.Container) {
+//
+// 2024-03-18 chrisma: This seems suboptimal. return a string we can log out if people are submitting sparse requests.
+// If nobody is using this then remove this.
+func fillContainerRequestsAndLimits(containers []v1.Container) string {
+	var infoMsg = ""
 	for index := range containers {
 		if containers[index].Resources.Limits == nil {
 			containers[index].Resources.Limits = v1.ResourceList{}
@@ -142,12 +147,19 @@ func fillContainerRequestsAndLimits(containers []v1.Container) {
 		for resourceName, quantity := range containers[index].Resources.Limits {
 			if _, ok := containers[index].Resources.Requests[resourceName]; !ok {
 				containers[index].Resources.Requests[resourceName] = quantity
+				if infoMsg == "" {
+					infoMsg = fmt.Sprintf("container %s had limits but not requests for %s", containers[index].Name, resourceName)
+				}
 			}
 		}
 		for resourceName, quantity := range containers[index].Resources.Requests {
 			if _, ok := containers[index].Resources.Limits[resourceName]; !ok {
 				containers[index].Resources.Limits[resourceName] = quantity
+				if infoMsg == "" {
+					infoMsg = fmt.Sprintf("container %s had requests but not limits for %s", containers[index].Name, resourceName)
+				}
 			}
 		}
 	}
+	return infoMsg
 }

--- a/internal/armada/server/submit_to_log.go
+++ b/internal/armada/server/submit_to_log.go
@@ -916,7 +916,10 @@ func (srv *PulsarSubmitServer) createJobsObjects(request *api.JobSubmitRequest, 
 		if namespace == "" {
 			namespace = "default"
 		}
-		fillContainerRequestsAndLimits(podSpec.Containers)
+		mutationMsg := fillContainerRequestsAndLimits(podSpec.Containers)
+		if mutationMsg != "" {
+			log.Infof("Inconsistent resources detected for job  %s: %s", jobId, mutationMsg)
+		}
 		applyDefaultsToAnnotations(item.Annotations, srv.SubmissionConfig)
 		applyDefaultsToPodSpec(podSpec, srv.SubmissionConfig)
 		if err := validation.ValidatePodSpec(podSpec, srv.SubmissionConfig); err != nil {

--- a/internal/armada/server/submit_to_log.go
+++ b/internal/armada/server/submit_to_log.go
@@ -918,7 +918,7 @@ func (srv *PulsarSubmitServer) createJobsObjects(request *api.JobSubmitRequest, 
 		}
 		mutationMsg := fillContainerRequestsAndLimits(podSpec.Containers)
 		if mutationMsg != "" {
-			log.Infof("Inconsistent resources detected for job  %s: %s", jobId, mutationMsg)
+			log.Infof("Inconsistent resources detected for job %s: %s", jobId, mutationMsg)
 		}
 		applyDefaultsToAnnotations(item.Annotations, srv.SubmissionConfig)
 		applyDefaultsToPodSpec(podSpec, srv.SubmissionConfig)


### PR DESCRIPTION
We have some code that looks to see if a user has specified a resource in requests but not limits or vice versa.  If they have then the missing resource value is automatically filled in.  A practical example here would be if a user has specified a 1 core cpu limit but does not specify a cpu request.  In  this case we would autopopulate a 1 core cpu request.

I'm largely against this logic because:
- It has a somewhat complex interaction with the other defaulting/checking we do
- It will hide mistakes from the user.

Ideally I think we'd either a) remove this completely, or b) replace with something simpler where we will populate an entire missing requests/limits section but not individual resources.

As this would be a breaking api change, I've added a log line so we can determine if this feature is actually being used.