### PR TITLE
Add Monitoring To Ingesters

### DIFF
--- a/config/eventingester/config.yaml
+++ b/config/eventingester/config.yaml
@@ -17,3 +17,4 @@ batchDuration: 100ms
 batchMessages: 10000
 eventRetentionPolicy:
   retentionDuration: 336h
+metricsPort: 9001

--- a/config/lookoutingesterv2/config.yaml
+++ b/config/lookoutingesterv2/config.yaml
@@ -6,7 +6,7 @@ postgres:
     password: psw
     dbname: postgres
     sslmode: disable
-metricsPort: 9000
+metricsPort: 9002
 pulsar:
   URL: "pulsar://pulsar:6650"
   jobsetEventsTopic: "events"

--- a/deployment/event-ingester/templates/deployment.yaml
+++ b/deployment/event-ingester/templates/deployment.yaml
@@ -50,6 +50,9 @@ spec:
               protocol: TCP
               name: pprof
             {{- end }}
+            - containerPort: {{ .Values.applicationConfig.metricsPort }}
+              protocol: TCP
+              name: metrics
           volumeMounts:
             - name: user-config
               mountPath: /config/application_config.yaml

--- a/deployment/event-ingester/templates/servicemonitor.yaml
+++ b/deployment/event-ingester/templates/servicemonitor.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.prometheus.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "event_ingester.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "event_ingester.labels.all" . | nindent 4 -}}
+    {{- if .Values.prometheus.labels }}
+    {{- toYaml .Values.prometheus.labels | nindent 4 -}}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "event_ingester.labels.identity" . | nindent 6 }}
+  endpoints:
+    - port: metrics
+      interval: {{ .Values.prometheus.scrapeInterval }}
+      scrapeTimeout: {{ .Values.prometheus.scrapeTimeout }}
+{{- end }}

--- a/deployment/event-ingester/values.yaml
+++ b/deployment/event-ingester/values.yaml
@@ -9,7 +9,7 @@ resources:
     memory: 512Mi
     cpu: 200m
 # -- Tolerations
-tolerations: []    
+tolerations: []
 additionalLabels: {}
 additionalVolumeMounts: []
 additionalVolumes: []
@@ -27,3 +27,10 @@ applicationConfig:
     authenticationEnabled: false
   batchSize: 1048576  #1MB
   batchMessages: 10000
+  metricsPort: 9000
+
+prometheus:
+  enabled: false
+  labels: {}
+  scrapeInterval: 15s
+  scrapeTimeout: 10s

--- a/deployment/lookout-ingester-v2/templates/deployment.yaml
+++ b/deployment/lookout-ingester-v2/templates/deployment.yaml
@@ -50,6 +50,9 @@ spec:
               protocol: TCP
               name: pprof
             {{- end }}
+            - containerPort: {{ .Values.applicationConfig.metricsPort }}
+              protocol: TCP
+              name: metrics
           volumeMounts:
             - name: user-config
               mountPath: /config/application_config.yaml

--- a/deployment/lookout-ingester-v2/templates/servicemonitor.yaml
+++ b/deployment/lookout-ingester-v2/templates/servicemonitor.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.prometheus.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "lookout_ingester_v2.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lookout_ingester_v2.labels.all" . | nindent 4 -}}
+    {{- if .Values.prometheus.labels }}
+    {{- toYaml .Values.prometheus.labels | nindent 4 -}}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "lookout_ingester_v2.labels.identity" . | nindent 6 }}
+  endpoints:
+    - port: metrics
+      interval: {{ .Values.prometheus.scrapeInterval }}
+      scrapeTimeout: {{ .Values.prometheus.scrapeTimeout }}
+{{- end }}

--- a/deployment/lookout-ingester-v2/values.yaml
+++ b/deployment/lookout-ingester-v2/values.yaml
@@ -9,7 +9,7 @@ resources:
     memory: 512Mi
     cpu: 200m
 # -- Tolerations
-tolerations: []    
+tolerations: []
 additionalLabels: {}
 additionalVolumeMounts: []
 additionalVolumes: []
@@ -23,5 +23,12 @@ customServiceAccount: null
 serviceAccount: null
 
 applicationConfig:
+  metricsPort: 9000
   pulsar:
     authenticationEnabled: false
+
+prometheus:
+  enabled: false
+  labels: {}
+  scrapeInterval: 15s
+  scrapeTimeout: 10s

--- a/deployment/scheduler/templates/scheduler-ingester-deployment.yaml
+++ b/deployment/scheduler/templates/scheduler-ingester-deployment.yaml
@@ -44,6 +44,15 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.ingester.resources | nindent 12 }}
+          ports:
+            {{- if .Values.ingester.applicationConfig.pprofPort }}
+            - containerPort: {{ .Values.ingester.applicationConfig.pprofPort }}
+              protocol: TCP
+              name: pprof
+            {{- end }}
+            - containerPort: {{ .Values.ingester.applicationConfig.metricsPort }}
+              protocol: TCP
+              name: metrics
           volumeMounts:
             - name: user-config
               mountPath: /config/application_config.yaml

--- a/deployment/scheduler/templates/scheduler-ingester-servicemonitor.yaml
+++ b/deployment/scheduler/templates/scheduler-ingester-servicemonitor.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.ingester.prometheus.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "armada-scheduler.name" . }}-ingester
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "armada-scheduler-ingester.labels.all" . | nindent 4 -}}
+    {{- if .Values.prometheus.labels }}
+    {{- toYaml .Values.prometheus.labels | nindent 4 -}}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "armada-scheduler-ingester.labels.identity" . | nindent 6 }}
+  endpoints:
+    - port: metrics
+      interval: {{ .Values.ingester.prometheus.scrapeInterval }}
+      scrapeTimeout: {{ .Values.ingester.prometheus.scrapeTimeout }}
+{{- end }}

--- a/deployment/scheduler/values.yaml
+++ b/deployment/scheduler/values.yaml
@@ -58,8 +58,7 @@ ingester:
       memory: 512Mi
       cpu: 200m
   applicationConfig:
-    metrics:
-      port: 9003
+    metricsPort: 9003
     pulsar: {}
   strategy:
     rollingUpdate:
@@ -70,6 +69,11 @@ ingester:
   additionalVolumeMounts: []
   additionalVolumes: []
   terminationGracePeriodSeconds: 30
+  prometheus:
+    enabled: false
+    labels: { }
+    scrapeInterval: 15s
+    scrapeTimeout: 10s
 
 pruner:
   enabled: true


### PR DESCRIPTION
The code for this already exists, but we weren't passing it through the helm layer correctly.  This Change introduces a ServiceMonitor in the helm chart and exposes the metrics port in the container.