### PR TITLE
Improve message on pod failed to start up

### DIFF
--- a/internal/executor/service/pod_issue_handler.go
+++ b/internal/executor/service/pod_issue_handler.go
@@ -440,9 +440,9 @@ func hasPodIssueSelfResolved(issue *issue) bool {
 
 func createStuckPodMessage(retryable bool, originalMessage string) string {
 	if retryable {
-		return fmt.Sprintf("Unable to schedule pod, Armada will return lease and retry.\n%s", originalMessage)
+		return fmt.Sprintf("Unable to start pod.\n%s", originalMessage)
 	}
-	return fmt.Sprintf("Unable to schedule pod with unrecoverable problem, Armada will not retry.\n%s", originalMessage)
+	return fmt.Sprintf("Unable to start pod - encountered an unrecoverable problem.\n%s", originalMessage)
 }
 
 func (p *IssueHandler) handleDeletedPod(pod *v1.Pod) {


### PR DESCRIPTION
- Remove reference to scheduling as this can cause confusion. Simplify to the more accurate "Unable to start pod"
- Remove message about retrying as this can cause confusion. The executor doesn't have full say over if a retry happens (fail fast, max retries both happen scheduler side and prevent a retry)
  - It is clearer to see if a retry will happen by looking at job state. If the job is in queued, it is being retried - this didn't used to happen so it was previously less obvious



