### PR TITLE
Add Prometheus Stats For the Redis Client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,6 @@ require (
 	github.com/go-openapi/swag v0.22.6
 	github.com/go-openapi/validate v0.22.6
 	github.com/go-playground/validator/v10 v10.15.4
-	github.com/go-redis/redis v6.15.9+incompatible
 	github.com/gogo/status v1.1.1
 	github.com/golang/mock v1.6.0
 	github.com/goreleaser/goreleaser v1.15.2

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/go-openapi/loads v0.21.5
 	github.com/go-openapi/runtime v0.26.0
 	github.com/go-openapi/spec v0.20.14
-	github.com/go-redis/redis v6.15.9+incompatible
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/protobuf v1.5.3
 	github.com/google/go-cmp v0.5.9
@@ -84,7 +83,7 @@ require (
 	github.com/magefile/mage v1.14.0
 	github.com/minio/highwayhash v1.0.2
 	github.com/openconfig/goyang v1.2.0
-	github.com/prometheus/common v0.37.0
+	github.com/prometheus/common v0.39.0
 	github.com/sanity-io/litter v1.5.5
 	github.com/segmentio/fasthash v1.0.3
 	github.com/xitongsys/parquet-go v1.6.2
@@ -111,6 +110,7 @@ require (
 	github.com/charmbracelet/lipgloss v0.9.1 // indirect
 	github.com/danieljoos/wincred v1.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/dvsekhvalnov/jose2go v1.6.0 // indirect
@@ -158,7 +158,7 @@ require (
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.18 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
-	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mtibben/percent v0.2.1 // indirect
@@ -170,7 +170,9 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/pquerna/cachecontrol v0.1.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
-	github.com/prometheus/procfs v0.8.0 // indirect
+	github.com/prometheus/procfs v0.9.0 // indirect
+	github.com/redis/go-redis/extra/redisprometheus/v9 v9.0.5 // indirect
+	github.com/redis/go-redis/v9 v9.5.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.4.2 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -75,6 +75,7 @@ require (
 	github.com/go-openapi/swag v0.22.6
 	github.com/go-openapi/validate v0.22.6
 	github.com/go-playground/validator/v10 v10.15.4
+	github.com/go-redis/redis v6.15.9+incompatible
 	github.com/gogo/status v1.1.1
 	github.com/golang/mock v1.6.0
 	github.com/goreleaser/goreleaser v1.15.2
@@ -84,6 +85,8 @@ require (
 	github.com/minio/highwayhash v1.0.2
 	github.com/openconfig/goyang v1.2.0
 	github.com/prometheus/common v0.39.0
+	github.com/redis/go-redis/extra/redisprometheus/v9 v9.0.5
+	github.com/redis/go-redis/v9 v9.5.1
 	github.com/sanity-io/litter v1.5.5
 	github.com/segmentio/fasthash v1.0.3
 	github.com/xitongsys/parquet-go v1.6.2
@@ -171,8 +174,6 @@ require (
 	github.com/pquerna/cachecontrol v0.1.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect
-	github.com/redis/go-redis/extra/redisprometheus/v9 v9.0.5 // indirect
-	github.com/redis/go-redis/v9 v9.5.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.4.2 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -109,6 +109,8 @@ github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJm
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/boynton/repl v0.0.0-20170116235056-348863958e3e/go.mod h1:Crc/GCZ3NXDVCio7Yr0o+SSrytpcFhLmVCIzi0s49t4=
+github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
+github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
 github.com/caarlos0/log v0.4.4 h1:LnvgBz/ofsJ00AupP/cEfksJSZglb1L69g4Obk/sdAc=
 github.com/caarlos0/log v0.4.4/go.mod h1:+AmCI9Liv5LKXmzFmFI1htuHdTTj/0R3KuoP9DMY7Mo=
 github.com/caarlos0/testfs v0.4.4 h1:3PHvzHi5Lt+g332CiShwS8ogTgS3HjrmzZxCm6JCDr8=
@@ -117,7 +119,6 @@ github.com/cenkalti/backoff/v4 v4.0.0/go.mod h1:eEew/i+1Q6OrCDZh3WiXYv3+nJwBASZ8
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/charmbracelet/lipgloss v0.9.1 h1:PNyd3jvaJbg4jRHKWXnCj1akQm4rh8dbEzN1p/u1KWg=
@@ -199,11 +200,9 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
-github.com/go-kit/log v0.2.0/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
-github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -567,7 +566,6 @@ github.com/mattn/go-sqlite3 v1.14.16 h1:yOQRA0RpS5PFz/oikGwBEqvAWhWg5ufRz4ETLjwp
 github.com/mattn/go-zglob v0.0.4 h1:LQi2iOm0/fGgu80AioIJ/1j9w9Oh+9DZ39J4VAGzHQM=
 github.com/mattn/go-zglob v0.0.4/go.mod h1:MxxjyoXXnMxfIpxTK2GAkw1w8glPsQILx3N5wrKakiY=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
@@ -656,7 +654,6 @@ github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDf
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
 github.com/prometheus/client_golang v1.11.0/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
-github.com/prometheus/client_golang v1.12.1/go.mod h1:3Z9XVyYiZYEO+YQWt3RD2R3jrbd179Rt297l4aS6nDY=
 github.com/prometheus/client_golang v1.14.0 h1:nJdhIvne2eSX/XRAFV9PcvFFRbrjbcTUj0VP62TMhnw=
 github.com/prometheus/client_golang v1.14.0/go.mod h1:8vpkKitgIVNcqrRBWh1C4TIUQgYNtG/XQE4E/Zae36Y=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
@@ -670,9 +667,6 @@ github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
 github.com/prometheus/common v0.26.0/go.mod h1:M7rCNAaPfAosfx8veZJCuw84e35h3Cfd9VFqTh1DIvc=
-github.com/prometheus/common v0.32.1/go.mod h1:vu+V0TpY+O6vW9J44gczi3Ap/oXXR10b+M/gUGO4Hls=
-github.com/prometheus/common v0.37.0 h1:ccBbHCgIiT9uSoFY0vX8H3zsNR5eLt17/RQLUvn8pXE=
-github.com/prometheus/common v0.37.0/go.mod h1:phzohg0JFMnBEFGxTDbfu3QyL5GI8gTQJFhYO5B3mfA=
 github.com/prometheus/common v0.39.0 h1:oOyhkDq05hPZKItWVBkJ6g6AtGxi+fy7F4JvUV8uhsI=
 github.com/prometheus/common v0.39.0/go.mod h1:6XBZ7lYdLCbkAVhwRsWTZn+IN5AB9F/NXd5w0BbEX0Y=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
@@ -680,9 +674,6 @@ github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7z
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
-github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
-github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5mo=
-github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
 github.com/prometheus/procfs v0.9.0 h1:wzCHvIvM5SxWqYvwgVL7yJY8Lz3PKn49KQtpgMYJfhI=
 github.com/prometheus/procfs v0.9.0/go.mod h1:+pB4zwohETzFnmlpe6yd2lSc+0/46IYZRB/chUwxUZY=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
@@ -690,8 +681,6 @@ github.com/rakyll/statik v0.1.7 h1:OF3QCZUuyPxuGEP7B4ypUa7sB/iHtqOTDYZXGM8KOdQ=
 github.com/rakyll/statik v0.1.7/go.mod h1:AlZONWzMtEnMs7W4e/1LURLiI49pIMmp6V9Unghqrcc=
 github.com/redis/go-redis/extra/redisprometheus/v9 v9.0.5 h1:kvl0LOTQD23VR1R7A9vDti9msfV6mOE2+j6ngYkFsfg=
 github.com/redis/go-redis/extra/redisprometheus/v9 v9.0.5/go.mod h1:VhyLk7MdSTKbJCx6+wXlj3/ebh49gTq3yBiXymYrG7w=
-github.com/redis/go-redis/v9 v9.0.5 h1:CuQcn5HIEeK7BgElubPP8CGtE0KakrnbBSTLjathl5o=
-github.com/redis/go-redis/v9 v9.0.5/go.mod h1:WqMKv5vnQbRuZstUwxQI195wHy+t4PuXDOjzMvcuQHk=
 github.com/redis/go-redis/v9 v9.5.1 h1:H1X4D3yHPaYrkL5X06Wh6xNVM/pX0Ft4RV0vMGvLBh8=
 github.com/redis/go-redis/v9 v9.5.1/go.mod h1:hdY0cQFCN4fnSYT6TkisLufl/4W5UIXyv0b/CLO2V2M=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
@@ -959,10 +948,7 @@ golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210520170846-37e1c6afe023/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
-golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.22.0 h1:9sGLhx7iRIHEiX0oAJ3MRZMUCElJgy7Br1nO+AMN3Tc=
 golang.org/x/net v0.22.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
@@ -975,8 +961,6 @@ golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20201109201403-9fd604954f58/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20201208152858-08078c50e5b5/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
-golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
-golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
 golang.org/x/oauth2 v0.18.0 h1:09qnuIAgzdx1XplqJvW6CQqMCtGZykZWcXzPMPUusvI=
 golang.org/x/oauth2 v0.18.0/go.mod h1:Wf7knwG0MPoWIMMBgFlEaSUDaKskp0dCfrlJRJXbBi8=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -1060,8 +1044,6 @@ golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210819135213-f52c844e1c1c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/go.sum
+++ b/go.sum
@@ -238,8 +238,6 @@ github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJn
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
 github.com/go-playground/validator/v10 v10.15.4 h1:zMXza4EpOdooxPel5xDqXEdXG5r+WggpvnAKMsalBjs=
 github.com/go-playground/validator/v10 v10.15.4/go.mod h1:9iXMNT7sEkjXb0I+enO7QXmzG6QCsPWY4zveKFVRSyU=
-github.com/go-redis/redis v6.15.9+incompatible h1:K0pv1D7EQUjfyoMql+r/jZqCLizCGKFlFgcHWWmHQjg=
-github.com/go-redis/redis v6.15.9+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=

--- a/go.sum
+++ b/go.sum
@@ -152,6 +152,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dimfeld/httptreemux v5.0.1+incompatible h1:Qj3gVcDNoOthBAqftuD596rm4wg/adLLz5xh5CmpiCA=
 github.com/dimfeld/httptreemux v5.0.1+incompatible/go.mod h1:rbUlSV+CCpv/SuqUTP/8Bk2O3LyUV436/yaRGkhP6Z0=
@@ -567,6 +569,8 @@ github.com/mattn/go-zglob v0.0.4/go.mod h1:MxxjyoXXnMxfIpxTK2GAkw1w8glPsQILx3N5w
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
+github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/minio/highwayhash v1.0.2 h1:Aak5U0nElisjDCfPSG79Tgzkn2gl66NxOMspRrKnA/g=
 github.com/minio/highwayhash v1.0.2/go.mod h1:BQskDq+xkJ12lmlUUi7U0M5Swg3EWR+dLTk+kldvVxY=
@@ -669,6 +673,8 @@ github.com/prometheus/common v0.26.0/go.mod h1:M7rCNAaPfAosfx8veZJCuw84e35h3Cfd9
 github.com/prometheus/common v0.32.1/go.mod h1:vu+V0TpY+O6vW9J44gczi3Ap/oXXR10b+M/gUGO4Hls=
 github.com/prometheus/common v0.37.0 h1:ccBbHCgIiT9uSoFY0vX8H3zsNR5eLt17/RQLUvn8pXE=
 github.com/prometheus/common v0.37.0/go.mod h1:phzohg0JFMnBEFGxTDbfu3QyL5GI8gTQJFhYO5B3mfA=
+github.com/prometheus/common v0.39.0 h1:oOyhkDq05hPZKItWVBkJ6g6AtGxi+fy7F4JvUV8uhsI=
+github.com/prometheus/common v0.39.0/go.mod h1:6XBZ7lYdLCbkAVhwRsWTZn+IN5AB9F/NXd5w0BbEX0Y=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
@@ -677,9 +683,17 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5mo=
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
+github.com/prometheus/procfs v0.9.0 h1:wzCHvIvM5SxWqYvwgVL7yJY8Lz3PKn49KQtpgMYJfhI=
+github.com/prometheus/procfs v0.9.0/go.mod h1:+pB4zwohETzFnmlpe6yd2lSc+0/46IYZRB/chUwxUZY=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rakyll/statik v0.1.7 h1:OF3QCZUuyPxuGEP7B4ypUa7sB/iHtqOTDYZXGM8KOdQ=
 github.com/rakyll/statik v0.1.7/go.mod h1:AlZONWzMtEnMs7W4e/1LURLiI49pIMmp6V9Unghqrcc=
+github.com/redis/go-redis/extra/redisprometheus/v9 v9.0.5 h1:kvl0LOTQD23VR1R7A9vDti9msfV6mOE2+j6ngYkFsfg=
+github.com/redis/go-redis/extra/redisprometheus/v9 v9.0.5/go.mod h1:VhyLk7MdSTKbJCx6+wXlj3/ebh49gTq3yBiXymYrG7w=
+github.com/redis/go-redis/v9 v9.0.5 h1:CuQcn5HIEeK7BgElubPP8CGtE0KakrnbBSTLjathl5o=
+github.com/redis/go-redis/v9 v9.0.5/go.mod h1:WqMKv5vnQbRuZstUwxQI195wHy+t4PuXDOjzMvcuQHk=
+github.com/redis/go-redis/v9 v9.5.1 h1:H1X4D3yHPaYrkL5X06Wh6xNVM/pX0Ft4RV0vMGvLBh8=
+github.com/redis/go-redis/v9 v9.5.1/go.mod h1:hdY0cQFCN4fnSYT6TkisLufl/4W5UIXyv0b/CLO2V2M=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=

--- a/internal/armada/configuration/types.go
+++ b/internal/armada/configuration/types.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/apache/pulsar-client-go/pulsar"
 	"github.com/go-playground/validator/v10"
-	"github.com/go-redis/redis"
+	"github.com/redis/go-redis/v9"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 

--- a/internal/armada/repository/event_test.go
+++ b/internal/armada/repository/event_test.go
@@ -1,7 +1,6 @@
 package repository
 
 import (
-	"github.com/armadaproject/armada/internal/common/armadacontext"
 	"testing"
 	"time"
 
@@ -11,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/armadaproject/armada/internal/armada/repository/sequence"
+	"github.com/armadaproject/armada/internal/common/armadacontext"
 	"github.com/armadaproject/armada/internal/common/compress"
 	"github.com/armadaproject/armada/pkg/api"
 	"github.com/armadaproject/armada/pkg/armadaevents"

--- a/internal/armada/repository/event_test.go
+++ b/internal/armada/repository/event_test.go
@@ -1,12 +1,13 @@
 package repository
 
 import (
+	"github.com/armadaproject/armada/internal/common/armadacontext"
 	"testing"
 	"time"
 
-	"github.com/go-redis/redis"
 	"github.com/gogo/protobuf/proto"
 	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/armadaproject/armada/internal/armada/repository/sequence"
@@ -140,24 +141,26 @@ var expectedRunning = api.EventMessage{
 }
 
 func TestRead(t *testing.T) {
-	withRedisEventRepository(func(r *RedisEventRepository) {
-		err := storeEvents(r, assigned, running)
+	ctx, cancel := armadacontext.WithTimeout(armadacontext.Background(), 10*time.Second)
+	defer cancel()
+	withRedisEventRepository(ctx, func(r *RedisEventRepository) {
+		err := storeEvents(ctx, r, assigned, running)
 		assert.NoError(t, err)
 
 		// Fetch from beginning
-		events, lastMessageId, err := r.ReadEvents(testQueue, jobSetName, "", 500, 1*time.Second)
+		events, lastMessageId, err := r.ReadEvents(ctx, testQueue, jobSetName, "", 500, 1*time.Second)
 		assert.NoError(t, err)
 		assertExpected(t, events, lastMessageId, &expectedPending, &expectedRunning)
 
 		// Fetch from offset in the middle
 		offset := events[0].Id
-		events, lastMessageId, err = r.ReadEvents(testQueue, jobSetName, offset, 500, 1*time.Second)
+		events, lastMessageId, err = r.ReadEvents(ctx, testQueue, jobSetName, offset, 500, 1*time.Second)
 		assert.NoError(t, err)
 		assertExpected(t, events, lastMessageId, &expectedRunning)
 
 		// Fetch from offset after
 		offset = events[0].Id
-		events, lastMessageId, err = r.ReadEvents(testQueue, jobSetName, offset, 500, 1*time.Second)
+		events, lastMessageId, err = r.ReadEvents(ctx, testQueue, jobSetName, offset, 500, 1*time.Second)
 		assert.NoError(t, err)
 		assert.Nil(t, lastMessageId)
 		assert.Equal(t, 0, len(events))
@@ -166,11 +169,11 @@ func TestRead(t *testing.T) {
 		// JobRunSucceeded doesn't result in an api event, so expect:
 		// - No events
 		// - Last message Id to be non-nil
-		err = storeEvents(r, runSucceeded)
+		err = storeEvents(ctx, r, runSucceeded)
 		assert.NoError(t, err)
 		offSetId, err := sequence.Parse(offset)
 		assert.NoError(t, err)
-		events, lastMessageId, err = r.ReadEvents(testQueue, jobSetName, offSetId.String(), 500, 1*time.Second)
+		events, lastMessageId, err = r.ReadEvents(ctx, testQueue, jobSetName, offSetId.String(), 500, 1*time.Second)
 		assert.NoError(t, err)
 		assert.NotNil(t, lastMessageId)
 		assert.True(t, lastMessageId.IsAfter(offSetId))
@@ -179,47 +182,51 @@ func TestRead(t *testing.T) {
 }
 
 func TestGetLastId(t *testing.T) {
-	withRedisEventRepository(func(r *RedisEventRepository) {
+	ctx, cancel := armadacontext.WithTimeout(armadacontext.Background(), 10*time.Second)
+	defer cancel()
+	withRedisEventRepository(ctx, func(r *RedisEventRepository) {
 		// Event doesn't exist- should be "0"
-		retrievedLastId, err := r.GetLastMessageId(testQueue, jobSetName)
+		retrievedLastId, err := r.GetLastMessageId(ctx, testQueue, jobSetName)
 		assert.NoError(t, err)
 		assert.Equal(t, "0", retrievedLastId)
 
 		// Now create the stream and fetch the events to manually determine the last id
-		err = storeEvents(r, assigned, running)
+		err = storeEvents(ctx, r, assigned, running)
 		assert.NoError(t, err)
-		events, _, err := r.ReadEvents(testQueue, jobSetName, "", 500, 1*time.Second)
+		events, _, err := r.ReadEvents(ctx, testQueue, jobSetName, "", 500, 1*time.Second)
 		assert.NoError(t, err)
 		actualLastId := events[1].Id
 
 		// Assert that the test id matches
-		retrievedLastId, err = r.GetLastMessageId(testQueue, jobSetName)
+		retrievedLastId, err = r.GetLastMessageId(ctx, testQueue, jobSetName)
 		assert.NoError(t, err)
 		assert.Equal(t, actualLastId, retrievedLastId)
 	})
 }
 
 func TestStreamExists(t *testing.T) {
-	withRedisEventRepository(func(r *RedisEventRepository) {
-		exists, err := r.CheckStreamExists(testQueue, jobSetName)
+	ctx, cancel := armadacontext.WithTimeout(armadacontext.Background(), 10*time.Second)
+	defer cancel()
+	withRedisEventRepository(ctx, func(r *RedisEventRepository) {
+		exists, err := r.CheckStreamExists(ctx, testQueue, jobSetName)
 		assert.NoError(t, err)
 		assert.False(t, exists)
 
-		err = storeEvents(r, assigned, running)
+		err = storeEvents(ctx, r, assigned, running)
 		assert.NoError(t, err)
 
-		exists, err = r.CheckStreamExists(testQueue, jobSetName)
+		exists, err = r.CheckStreamExists(ctx, testQueue, jobSetName)
 		assert.NoError(t, err)
 		assert.True(t, exists)
 	})
 }
 
-func withRedisEventRepository(action func(r *RedisEventRepository)) {
+func withRedisEventRepository(ctx *armadacontext.Context, action func(r *RedisEventRepository)) {
 	client := redis.NewClient(&redis.Options{Addr: "localhost:6379", DB: 10})
-	defer client.FlushDB()
+	defer client.FlushDB(ctx)
 	defer client.Close()
 
-	client.FlushDB()
+	client.FlushDB(ctx)
 
 	repo := NewEventRepository(client)
 	action(repo)
@@ -234,7 +241,7 @@ func assertExpected(t *testing.T, actual []*api.EventStreamMessage, lastMessageI
 	assert.Equal(t, actual[len(actual)-1].Id, lastMessageId.String())
 }
 
-func storeEvents(r *RedisEventRepository, events ...*armadaevents.EventSequence_Event) error {
+func storeEvents(ctx *armadacontext.Context, r *RedisEventRepository, events ...*armadaevents.EventSequence_Event) error {
 	// create an eventSequence
 	es := &armadaevents.EventSequence{Events: events}
 
@@ -251,7 +258,7 @@ func storeEvents(r *RedisEventRepository, events ...*armadaevents.EventSequence_
 		return err
 	}
 
-	r.db.XAdd(&redis.XAddArgs{
+	r.db.XAdd(ctx, &redis.XAddArgs{
 		Stream: eventStreamPrefix + testQueue + ":" + jobSetName,
 		Values: map[string]interface{}{
 			dataKey: compressed,

--- a/internal/armada/repository/health_redis.go
+++ b/internal/armada/repository/health_redis.go
@@ -1,9 +1,10 @@
 package repository
 
 import (
+	"context"
 	"fmt"
 
-	"github.com/go-redis/redis"
+	"github.com/redis/go-redis/v9"
 )
 
 type RedisHealth struct {
@@ -15,7 +16,7 @@ func NewRedisHealth(db redis.UniversalClient) *RedisHealth {
 }
 
 func (r *RedisHealth) Check() error {
-	_, err := r.db.Ping().Result()
+	_, err := r.db.Ping(context.Background()).Result()
 	if err == nil {
 		return nil
 	} else {

--- a/internal/armada/repository/job.go
+++ b/internal/armada/repository/job.go
@@ -2,13 +2,13 @@ package repository
 
 import (
 	"fmt"
-	"github.com/armadaproject/armada/internal/common/armadacontext"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 	"github.com/redis/go-redis/v9"
 
+	"github.com/armadaproject/armada/internal/common/armadacontext"
 	protoutil "github.com/armadaproject/armada/internal/common/proto"
 	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
 )

--- a/internal/armada/repository/job.go
+++ b/internal/armada/repository/job.go
@@ -2,11 +2,12 @@ package repository
 
 import (
 	"fmt"
+	"github.com/armadaproject/armada/internal/common/armadacontext"
 	"time"
 
-	"github.com/go-redis/redis"
 	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
+	"github.com/redis/go-redis/v9"
 
 	protoutil "github.com/armadaproject/armada/internal/common/proto"
 	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
@@ -17,9 +18,9 @@ const (
 )
 
 type JobRepository interface {
-	StorePulsarSchedulerJobDetails(jobDetails []*schedulerobjects.PulsarSchedulerJobDetails) error
-	GetPulsarSchedulerJobDetails(jobIds string) (*schedulerobjects.PulsarSchedulerJobDetails, error)
-	ExpirePulsarSchedulerJobDetails(jobId []string) error
+	StorePulsarSchedulerJobDetails(ctx *armadacontext.Context, jobDetails []*schedulerobjects.PulsarSchedulerJobDetails) error
+	GetPulsarSchedulerJobDetails(ctx *armadacontext.Context, jobIds string) (*schedulerobjects.PulsarSchedulerJobDetails, error)
+	ExpirePulsarSchedulerJobDetails(ctx *armadacontext.Context, jobId []string) error
 }
 
 type RedisJobRepository struct {
@@ -32,7 +33,7 @@ func NewRedisJobRepository(
 	return &RedisJobRepository{db: db}
 }
 
-func (repo *RedisJobRepository) StorePulsarSchedulerJobDetails(jobDetails []*schedulerobjects.PulsarSchedulerJobDetails) error {
+func (repo *RedisJobRepository) StorePulsarSchedulerJobDetails(ctx *armadacontext.Context, jobDetails []*schedulerobjects.PulsarSchedulerJobDetails) error {
 	pipe := repo.db.Pipeline()
 	for _, job := range jobDetails {
 		key := fmt.Sprintf("%s%s", pulsarJobPrefix, job.JobId)
@@ -40,17 +41,17 @@ func (repo *RedisJobRepository) StorePulsarSchedulerJobDetails(jobDetails []*sch
 		if err != nil {
 			return errors.WithStack(err)
 		}
-		pipe.Set(key, jobData, 375*24*time.Hour) // expire after a year
+		pipe.Set(ctx, key, jobData, 375*24*time.Hour) // expire after a year
 	}
-	_, err := pipe.Exec()
+	_, err := pipe.Exec(ctx)
 	if err != nil {
 		return errors.Wrapf(err, "error storing pulsar job details in redis")
 	}
 	return nil
 }
 
-func (repo *RedisJobRepository) GetPulsarSchedulerJobDetails(jobId string) (*schedulerobjects.PulsarSchedulerJobDetails, error) {
-	cmd := repo.db.Get(pulsarJobPrefix + jobId)
+func (repo *RedisJobRepository) GetPulsarSchedulerJobDetails(ctx *armadacontext.Context, jobId string) (*schedulerobjects.PulsarSchedulerJobDetails, error) {
+	cmd := repo.db.Get(ctx, pulsarJobPrefix+jobId)
 
 	bytes, err := cmd.Bytes()
 	if err != nil && err != redis.Nil {
@@ -67,7 +68,7 @@ func (repo *RedisJobRepository) GetPulsarSchedulerJobDetails(jobId string) (*sch
 	return details, nil
 }
 
-func (repo *RedisJobRepository) ExpirePulsarSchedulerJobDetails(jobIds []string) error {
+func (repo *RedisJobRepository) ExpirePulsarSchedulerJobDetails(ctx *armadacontext.Context, jobIds []string) error {
 	if len(jobIds) == 0 {
 		return nil
 	}
@@ -75,9 +76,9 @@ func (repo *RedisJobRepository) ExpirePulsarSchedulerJobDetails(jobIds []string)
 	for _, jobId := range jobIds {
 		key := fmt.Sprintf("%s%s", pulsarJobPrefix, jobId)
 		// Expire as opposed to delete so that we are permissive of race conditions.
-		pipe.Expire(key, 1*time.Hour)
+		pipe.Expire(ctx, key, 1*time.Hour)
 	}
-	if _, err := pipe.Exec(); err != nil {
+	if _, err := pipe.Exec(ctx); err != nil {
 		return errors.Wrap(err, "failed to delete pulsar job details in Redis")
 	}
 	return nil

--- a/internal/armada/repository/job_test.go
+++ b/internal/armada/repository/job_test.go
@@ -1,7 +1,6 @@
 package repository
 
 import (
-	"github.com/armadaproject/armada/internal/common/armadacontext"
 	"testing"
 	"time"
 
@@ -9,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/armadaproject/armada/internal/common/armadacontext"
 	"github.com/armadaproject/armada/internal/common/util"
 	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
 )

--- a/internal/armada/repository/job_test.go
+++ b/internal/armada/repository/job_test.go
@@ -1,9 +1,11 @@
 package repository
 
 import (
+	"github.com/armadaproject/armada/internal/common/armadacontext"
 	"testing"
+	"time"
 
-	"github.com/go-redis/redis"
+	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -12,30 +14,32 @@ import (
 )
 
 func TestStoreAndGetPulsarSchedulerJobDetails(t *testing.T) {
-	withRepository(func(r *RedisJobRepository) {
+	ctx, cancel := armadacontext.WithTimeout(armadacontext.Background(), 5*time.Second)
+	defer cancel()
+	withRepository(ctx, func(r *RedisJobRepository) {
 		details := &schedulerobjects.PulsarSchedulerJobDetails{
 			JobId:  util.NewULID(),
 			Queue:  "testQueue",
 			JobSet: "testJobset",
 		}
-		err := r.StorePulsarSchedulerJobDetails([]*schedulerobjects.PulsarSchedulerJobDetails{details})
+		err := r.StorePulsarSchedulerJobDetails(ctx, []*schedulerobjects.PulsarSchedulerJobDetails{details})
 		require.NoError(t, err)
 
-		retrievedDetails, err := r.GetPulsarSchedulerJobDetails(details.JobId)
+		retrievedDetails, err := r.GetPulsarSchedulerJobDetails(ctx, details.JobId)
 		require.NoError(t, err)
 		assert.Equal(t, details, retrievedDetails)
 
-		nonExistantDetails, err := r.GetPulsarSchedulerJobDetails("not a valid details key")
+		nonExistantDetails, err := r.GetPulsarSchedulerJobDetails(ctx, "not a valid details key")
 		require.NoError(t, err)
 		assert.Nil(t, nonExistantDetails)
 	})
 }
 
-func withRepository(action func(r *RedisJobRepository)) {
+func withRepository(ctx *armadacontext.Context, action func(r *RedisJobRepository)) {
 	client := redis.NewClient(&redis.Options{Addr: "localhost:6379", DB: 10})
-	defer client.FlushDB()
+	defer client.FlushDB(ctx)
 	defer client.Close()
-	client.FlushDB()
+	client.FlushDB(ctx)
 	repo := NewRedisJobRepository(client)
 	action(repo)
 }

--- a/internal/armada/repository/queue.go
+++ b/internal/armada/repository/queue.go
@@ -2,10 +2,11 @@ package repository
 
 import (
 	"fmt"
+	"github.com/armadaproject/armada/internal/common/armadacontext"
 
-	"github.com/go-redis/redis"
 	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
+	"github.com/redis/go-redis/v9"
 
 	"github.com/armadaproject/armada/pkg/api"
 	"github.com/armadaproject/armada/pkg/client/queue"
@@ -30,11 +31,11 @@ func (err *ErrQueueAlreadyExists) Error() string {
 }
 
 type QueueRepository interface {
-	GetAllQueues() ([]queue.Queue, error)
-	GetQueue(name string) (queue.Queue, error)
-	CreateQueue(queue.Queue) error
-	UpdateQueue(queue.Queue) error
-	DeleteQueue(name string) error
+	GetAllQueues(ctx *armadacontext.Context) ([]queue.Queue, error)
+	GetQueue(ctx *armadacontext.Context, name string) (queue.Queue, error)
+	CreateQueue(*armadacontext.Context, queue.Queue) error
+	UpdateQueue(*armadacontext.Context, queue.Queue) error
+	DeleteQueue(ctx *armadacontext.Context, name string) error
 }
 
 type RedisQueueRepository struct {
@@ -45,8 +46,8 @@ func NewRedisQueueRepository(db redis.UniversalClient) *RedisQueueRepository {
 	return &RedisQueueRepository{db: db}
 }
 
-func (r *RedisQueueRepository) GetAllQueues() ([]queue.Queue, error) {
-	result, err := r.db.HGetAll(queueHashKey).Result()
+func (r *RedisQueueRepository) GetAllQueues(ctx *armadacontext.Context) ([]queue.Queue, error) {
+	result, err := r.db.HGetAll(ctx, queueHashKey).Result()
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -68,8 +69,8 @@ func (r *RedisQueueRepository) GetAllQueues() ([]queue.Queue, error) {
 	return queues, nil
 }
 
-func (r *RedisQueueRepository) GetQueue(name string) (queue.Queue, error) {
-	result, err := r.db.HGet(queueHashKey, name).Result()
+func (r *RedisQueueRepository) GetQueue(ctx *armadacontext.Context, name string) (queue.Queue, error) {
+	result, err := r.db.HGet(ctx, queueHashKey, name).Result()
 	if err == redis.Nil {
 		return queue.Queue{}, &ErrQueueNotFound{QueueName: name}
 	} else if err != nil {
@@ -85,7 +86,7 @@ func (r *RedisQueueRepository) GetQueue(name string) (queue.Queue, error) {
 	return queue.NewQueue(apiQueue)
 }
 
-func (r *RedisQueueRepository) CreateQueue(queue queue.Queue) error {
+func (r *RedisQueueRepository) CreateQueue(ctx *armadacontext.Context, queue queue.Queue) error {
 	data, err := proto.Marshal(queue.ToAPI())
 	if err != nil {
 		return fmt.Errorf("[RedisQueueRepository.CreateQueue] error marshalling queue: %s", err)
@@ -93,7 +94,7 @@ func (r *RedisQueueRepository) CreateQueue(queue queue.Queue) error {
 
 	// HSetNX sets a key-value pair if the key doesn't already exist.
 	// If the key exists, this is a no-op, and result is false.
-	result, err := r.db.HSetNX(queueHashKey, queue.Name, data).Result()
+	result, err := r.db.HSetNX(ctx, queueHashKey, queue.Name, data).Result()
 	if err != nil {
 		return fmt.Errorf("[RedisQueueRepository.CreateQueue] error writing to database: %s", err)
 	}
@@ -107,8 +108,8 @@ func (r *RedisQueueRepository) CreateQueue(queue queue.Queue) error {
 // TODO If the queue to be updated is deleted between this method checking if the queue exists and
 // making the update, the deleted queue is re-added to Redis. There's no "update if exists"
 // operation in Redis, so we need to do this with a script or transaction.
-func (r *RedisQueueRepository) UpdateQueue(queue queue.Queue) error {
-	existsResult, err := r.db.HExists(queueHashKey, queue.Name).Result()
+func (r *RedisQueueRepository) UpdateQueue(ctx *armadacontext.Context, queue queue.Queue) error {
+	existsResult, err := r.db.HExists(ctx, queueHashKey, queue.Name).Result()
 	if err != nil {
 		return fmt.Errorf("[RedisQueueRepository.UpdateQueue] error reading from database: %s", err)
 	} else if !existsResult {
@@ -120,7 +121,7 @@ func (r *RedisQueueRepository) UpdateQueue(queue queue.Queue) error {
 		return fmt.Errorf("[RedisQueueRepository.UpdateQueue] error marshalling queue: %s", err)
 	}
 
-	result := r.db.HSet(queueHashKey, queue.Name, data)
+	result := r.db.HSet(ctx, queueHashKey, queue.Name, data)
 	if err := result.Err(); err != nil {
 		return fmt.Errorf("[RedisQueueRepository.UpdateQueue] error writing to database: %s", err)
 	}
@@ -128,8 +129,8 @@ func (r *RedisQueueRepository) UpdateQueue(queue queue.Queue) error {
 	return nil
 }
 
-func (r *RedisQueueRepository) DeleteQueue(name string) error {
-	result := r.db.HDel(queueHashKey, name)
+func (r *RedisQueueRepository) DeleteQueue(ctx *armadacontext.Context, name string) error {
+	result := r.db.HDel(ctx, queueHashKey, name)
 	if err := result.Err(); err != nil {
 		return fmt.Errorf("[RedisQueueRepository.DeleteQueue] error deleting queue: %s", err)
 	}

--- a/internal/armada/repository/queue.go
+++ b/internal/armada/repository/queue.go
@@ -2,12 +2,12 @@ package repository
 
 import (
 	"fmt"
-	"github.com/armadaproject/armada/internal/common/armadacontext"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 	"github.com/redis/go-redis/v9"
 
+	"github.com/armadaproject/armada/internal/common/armadacontext"
 	"github.com/armadaproject/armada/pkg/api"
 	"github.com/armadaproject/armada/pkg/client/queue"
 )

--- a/internal/armada/server.go
+++ b/internal/armada/server.go
@@ -3,9 +3,6 @@ package armada
 import (
 	"context"
 	"fmt"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/redis/go-redis/extra/redisprometheus/v9"
-	"github.com/redis/go-redis/v9"
 	"math"
 	"net"
 	"time"
@@ -16,6 +13,9 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	pool "github.com/jolestar/go-commons-pool"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/redis/go-redis/extra/redisprometheus/v9"
+	"github.com/redis/go-redis/v9"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 

--- a/internal/armada/server.go
+++ b/internal/armada/server.go
@@ -103,7 +103,7 @@ func Serve(ctx *armadacontext.Context, config *configuration.ArmadaConfig, healt
 		}
 	}()
 	prometheus.MustRegister(
-		redisprometheus.NewCollector("armada", "events-redis", eventDb))
+		redisprometheus.NewCollector("armada", "events_redis", eventDb))
 
 	jobRepository := repository.NewRedisJobRepository(db)
 	queueRepository := repository.NewRedisQueueRepository(db)

--- a/internal/armada/server.go
+++ b/internal/armada/server.go
@@ -3,12 +3,14 @@ package armada
 import (
 	"context"
 	"fmt"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/redis/go-redis/extra/redisprometheus/v9"
+	"github.com/redis/go-redis/v9"
 	"math"
 	"net"
 	"time"
 
 	"github.com/apache/pulsar-client-go/pulsar"
-	"github.com/go-redis/redis"
 	"github.com/google/uuid"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -91,6 +93,8 @@ func Serve(ctx *armadacontext.Context, config *configuration.ArmadaConfig, healt
 			log.WithError(err).Error("failed to close Redis client")
 		}
 	}()
+	prometheus.MustRegister(
+		redisprometheus.NewCollector("armada", "redis", db))
 
 	eventDb := createRedisClient(&config.EventsApiRedis)
 	defer func() {
@@ -98,6 +102,8 @@ func Serve(ctx *armadacontext.Context, config *configuration.ArmadaConfig, healt
 			log.WithError(err).Error("failed to close events api Redis client")
 		}
 	}()
+	prometheus.MustRegister(
+		redisprometheus.NewCollector("armada", "events-redis", eventDb))
 
 	jobRepository := repository.NewRedisJobRepository(db)
 	queueRepository := repository.NewRedisQueueRepository(db)

--- a/internal/armada/server/event_test.go
+++ b/internal/armada/server/event_test.go
@@ -358,7 +358,6 @@ func TestEventServer_GetJobSetEvents_Permissions(t *testing.T) {
 }
 
 func reportPulsarEvent(ctx *armadacontext.Context, es *armadaevents.EventSequence) error {
-
 	bytes, err := proto.Marshal(es)
 	if err != nil {
 		return err

--- a/internal/armada/server/event_test.go
+++ b/internal/armada/server/event_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-redis/redis"
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
 	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -28,7 +28,10 @@ import (
 )
 
 func TestEventServer_Health(t *testing.T) {
+	ctx, cancel := armadacontext.WithTimeout(armadacontext.Background(), 5*time.Second)
+	defer cancel()
 	withEventServer(
+		ctx,
 		t,
 		func(s *EventServer) {
 			health, err := s.Health(armadacontext.Background(), &types.Empty{})
@@ -39,7 +42,10 @@ func TestEventServer_Health(t *testing.T) {
 }
 
 func TestEventServer_ForceNew(t *testing.T) {
+	ctx, cancel := armadacontext.WithTimeout(armadacontext.Background(), 5*time.Second)
+	defer cancel()
 	withEventServer(
+		ctx,
 		t,
 		func(s *EventServer) {
 			jobSetId := "set1"
@@ -62,7 +68,7 @@ func TestEventServer_ForceNew(t *testing.T) {
 				},
 			}
 
-			err := reportPulsarEvent(&armadaevents.EventSequence{
+			err := reportPulsarEvent(ctx, &armadaevents.EventSequence{
 				Queue:      queue,
 				JobSetName: jobSetId,
 				Events:     []*armadaevents.EventSequence_Event{assigned},
@@ -84,7 +90,10 @@ func TestEventServer_ForceNew(t *testing.T) {
 }
 
 func TestEventServer_GetJobSetEvents_EmptyStreamShouldNotFail(t *testing.T) {
+	ctx, cancel := armadacontext.WithTimeout(armadacontext.Background(), 5*time.Second)
+	defer cancel()
 	withEventServer(
+		ctx,
 		t,
 		func(s *EventServer) {
 			stream := &eventStreamMock{}
@@ -96,7 +105,10 @@ func TestEventServer_GetJobSetEvents_EmptyStreamShouldNotFail(t *testing.T) {
 }
 
 func TestEventServer_GetJobSetEvents_QueueDoNotExist(t *testing.T) {
+	ctx, cancel := armadacontext.WithTimeout(armadacontext.Background(), 5*time.Second)
+	defer cancel()
 	withEventServer(
+		ctx,
 		t,
 		func(s *EventServer) {
 			stream := &eventStreamMock{}
@@ -115,6 +127,8 @@ func TestEventServer_GetJobSetEvents_QueueDoNotExist(t *testing.T) {
 }
 
 func TestEventServer_GetJobSetEvents_ErrorIfMissing(t *testing.T) {
+	ctx, cancel := armadacontext.WithTimeout(armadacontext.Background(), 5*time.Second)
+	defer cancel()
 	q := queue.Queue{
 		Name:           "test-queue",
 		PriorityFactor: 1,
@@ -122,9 +136,10 @@ func TestEventServer_GetJobSetEvents_ErrorIfMissing(t *testing.T) {
 
 	t.Run("job set non existent ErrorIfMissing true", func(t *testing.T) {
 		withEventServer(
+			ctx,
 			t,
 			func(s *EventServer) {
-				err := s.queueRepository.CreateQueue(q)
+				err := s.queueRepository.CreateQueue(ctx, q)
 				assert.NoError(t, err)
 				stream := &eventStreamMock{}
 
@@ -143,9 +158,10 @@ func TestEventServer_GetJobSetEvents_ErrorIfMissing(t *testing.T) {
 
 	t.Run("job set non existent ErrorIfMissing false", func(t *testing.T) {
 		withEventServer(
+			ctx,
 			t,
 			func(s *EventServer) {
-				err := s.queueRepository.CreateQueue(q)
+				err := s.queueRepository.CreateQueue(ctx, q)
 				assert.NoError(t, err)
 				stream := &eventStreamMock{}
 				err = s.GetJobSetEvents(&api.JobSetRequest{
@@ -161,9 +177,10 @@ func TestEventServer_GetJobSetEvents_ErrorIfMissing(t *testing.T) {
 
 	t.Run("job set exists ErrorIfMissing true", func(t *testing.T) {
 		withEventServer(
+			ctx,
 			t,
 			func(s *EventServer) {
-				err := s.queueRepository.CreateQueue(q)
+				err := s.queueRepository.CreateQueue(ctx, q)
 				assert.NoError(t, err)
 				stream := &eventStreamMock{}
 
@@ -183,7 +200,7 @@ func TestEventServer_GetJobSetEvents_ErrorIfMissing(t *testing.T) {
 					},
 				}
 
-				err = reportPulsarEvent(&armadaevents.EventSequence{
+				err = reportPulsarEvent(ctx, &armadaevents.EventSequence{
 					Queue:      "test-queue",
 					JobSetName: "job-set-1",
 					Events:     []*armadaevents.EventSequence_Event{assigned},
@@ -204,9 +221,10 @@ func TestEventServer_GetJobSetEvents_ErrorIfMissing(t *testing.T) {
 
 	t.Run("job set exists ErrorIfMissing false", func(t *testing.T) {
 		withEventServer(
+			ctx,
 			t,
 			func(s *EventServer) {
-				err := s.queueRepository.CreateQueue(q)
+				err := s.queueRepository.CreateQueue(ctx, q)
 				require.NoError(t, err)
 				stream := &eventStreamMock{}
 
@@ -226,7 +244,7 @@ func TestEventServer_GetJobSetEvents_ErrorIfMissing(t *testing.T) {
 					},
 				}
 
-				err = reportPulsarEvent(&armadaevents.EventSequence{
+				err = reportPulsarEvent(ctx, &armadaevents.EventSequence{
 					Queue:      "test-queue",
 					JobSetName: "job-set-1",
 					Events:     []*armadaevents.EventSequence_Event{assigned},
@@ -247,6 +265,8 @@ func TestEventServer_GetJobSetEvents_ErrorIfMissing(t *testing.T) {
 }
 
 func TestEventServer_GetJobSetEvents_Permissions(t *testing.T) {
+	ctx, cancel := armadacontext.WithTimeout(armadacontext.Background(), 5*time.Second)
+	defer cancel()
 	emptyPerms := make(map[permission.Permission][]string)
 	perms := map[permission.Permission][]string{
 		permissions.WatchAllEvents: {"watch-all-events-group"},
@@ -267,10 +287,11 @@ func TestEventServer_GetJobSetEvents_Permissions(t *testing.T) {
 
 	t.Run("no permissions", func(t *testing.T) {
 		withEventServer(
+			ctx,
 			t,
 			func(s *EventServer) {
 				s.authorizer = NewAuthorizer(authorization.NewPrincipalPermissionChecker(perms, emptyPerms, emptyPerms))
-				err := s.queueRepository.CreateQueue(q)
+				err := s.queueRepository.CreateQueue(ctx, q)
 				assert.NoError(t, err)
 
 				principal := authorization.NewStaticPrincipal("alice", []string{})
@@ -291,10 +312,11 @@ func TestEventServer_GetJobSetEvents_Permissions(t *testing.T) {
 
 	t.Run("global permissions", func(t *testing.T) {
 		withEventServer(
+			ctx,
 			t,
 			func(s *EventServer) {
 				s.authorizer = NewAuthorizer(authorization.NewPrincipalPermissionChecker(perms, emptyPerms, emptyPerms))
-				err := s.queueRepository.CreateQueue(q)
+				err := s.queueRepository.CreateQueue(ctx, q)
 				assert.NoError(t, err)
 
 				principal := authorization.NewStaticPrincipal("alice", []string{"watch-all-events-group"})
@@ -314,9 +336,9 @@ func TestEventServer_GetJobSetEvents_Permissions(t *testing.T) {
 	})
 
 	t.Run("queue permission", func(t *testing.T) {
-		withEventServer(t, func(s *EventServer) {
+		withEventServer(ctx, t, func(s *EventServer) {
 			s.authorizer = NewAuthorizer(authorization.NewPrincipalPermissionChecker(perms, emptyPerms, emptyPerms))
-			err := s.queueRepository.CreateQueue(q)
+			err := s.queueRepository.CreateQueue(ctx, q)
 			assert.NoError(t, err)
 
 			principal := authorization.NewStaticPrincipal("alice", []string{"watch-events-group", "watch-queue-group"})
@@ -335,7 +357,8 @@ func TestEventServer_GetJobSetEvents_Permissions(t *testing.T) {
 	})
 }
 
-func reportPulsarEvent(es *armadaevents.EventSequence) error {
+func reportPulsarEvent(ctx *armadacontext.Context, es *armadaevents.EventSequence) error {
+
 	bytes, err := proto.Marshal(es)
 	if err != nil {
 		return err
@@ -351,7 +374,7 @@ func reportPulsarEvent(es *armadaevents.EventSequence) error {
 
 	client := redis.NewClient(&redis.Options{Addr: "localhost:6379", DB: 11})
 
-	client.XAdd(&redis.XAddArgs{
+	client.XAdd(ctx, &redis.XAddArgs{
 		Stream: "Events:" + es.Queue + ":" + es.JobSetName,
 		Values: map[string]interface{}{
 			"message": compressed,
@@ -360,7 +383,7 @@ func reportPulsarEvent(es *armadaevents.EventSequence) error {
 	return nil
 }
 
-func withEventServer(t *testing.T, action func(s *EventServer)) {
+func withEventServer(ctx *armadacontext.Context, t *testing.T, action func(s *EventServer)) {
 	t.Helper()
 
 	// using real redis instance as miniredis does not support streams
@@ -372,11 +395,11 @@ func withEventServer(t *testing.T, action func(s *EventServer)) {
 	jobRepo := repository.NewRedisJobRepository(client)
 	server := NewEventServer(&FakeActionAuthorizer{}, eventRepo, queueRepo, jobRepo)
 
-	client.FlushDB()
-	legacyClient.FlushDB()
+	client.FlushDB(ctx)
+	legacyClient.FlushDB(ctx)
 
 	// Create test queue
-	err := queueRepo.CreateQueue(queue.Queue{
+	err := queueRepo.CreateQueue(ctx, queue.Queue{
 		Name:           "",
 		Permissions:    nil,
 		PriorityFactor: 1,
@@ -384,8 +407,8 @@ func withEventServer(t *testing.T, action func(s *EventServer)) {
 	require.NoError(t, err)
 	action(server)
 
-	client.FlushDB()
-	legacyClient.FlushDB()
+	client.FlushDB(ctx)
+	legacyClient.FlushDB(ctx)
 }
 
 type eventStreamMock struct {

--- a/internal/armada/server/job_expiration.go
+++ b/internal/armada/server/job_expiration.go
@@ -71,7 +71,7 @@ func (srv *PulsarJobExpirer) handlePulsarSchedulerEventSequence(ctx *armadaconte
 		}
 		idsOfJobsToExpireMappingFor = append(idsOfJobsToExpireMappingFor, jobId)
 	}
-	return srv.JobRepository.ExpirePulsarSchedulerJobDetails(idsOfJobsToExpireMappingFor)
+	return srv.JobRepository.ExpirePulsarSchedulerJobDetails(ctx, idsOfJobsToExpireMappingFor)
 }
 
 func (srv *PulsarJobExpirer) ack(ctx *armadacontext.Context, msg pulsar.Message) {

--- a/internal/armada/server/submit_to_log.go
+++ b/internal/armada/server/submit_to_log.go
@@ -201,7 +201,7 @@ func (srv *PulsarSubmitServer) SubmitJobs(grpcCtx context.Context, req *api.JobS
 	}
 
 	if len(pulsarJobDetails) > 0 {
-		err = srv.JobRepository.StorePulsarSchedulerJobDetails(pulsarJobDetails)
+		err = srv.JobRepository.StorePulsarSchedulerJobDetails(ctx, pulsarJobDetails)
 		if err != nil {
 			log.WithError(err).Error("failed store pulsar job details")
 			return nil, status.Error(codes.Internal, "failed store pulsar job details")
@@ -259,7 +259,7 @@ func (srv *PulsarSubmitServer) CancelJobs(grpcCtx context.Context, req *api.JobC
 	}
 
 	// resolve the queue and jobset of the job: we can't trust what the user has given us
-	resolvedQueue, resolvedJobset, err := srv.resolveQueueAndJobsetForJob(req.JobId)
+	resolvedQueue, resolvedJobset, err := srv.resolveQueueAndJobsetForJob(ctx, req.JobId)
 	if err != nil {
 		return nil, err
 	}
@@ -466,7 +466,7 @@ func (srv *PulsarSubmitServer) ReprioritizeJobs(grpcCtx context.Context, req *ap
 	if len(req.JobIds) > 0 && (req.Queue == "" || req.JobSetId == "") {
 		firstJobId := req.JobIds[0]
 
-		resolvedQueue, resolvedJobset, err := srv.resolveQueueAndJobsetForJob(firstJobId)
+		resolvedQueue, resolvedJobset, err := srv.resolveQueueAndJobsetForJob(ctx, firstJobId)
 		if err != nil {
 			return nil, err
 		}
@@ -585,7 +585,7 @@ func (srv *PulsarSubmitServer) Authorize(
 	principal := authorization.GetPrincipal(ctx)
 	userId := principal.GetName()
 	groups := principal.GetGroupNames()
-	q, err := srv.QueueRepository.GetQueue(queueName)
+	q, err := srv.QueueRepository.GetQueue(ctx, queueName)
 	if err != nil {
 		return userId, groups, err
 	}
@@ -618,7 +618,7 @@ func (srv *PulsarSubmitServer) CreateQueue(grpcCtx context.Context, req *api.Que
 		return nil, status.Errorf(codes.InvalidArgument, "[CreateQueue] error validating queue: %s", err)
 	}
 
-	err = srv.QueueRepository.CreateQueue(queue)
+	err = srv.QueueRepository.CreateQueue(ctx, queue)
 	var eq *repository.ErrQueueAlreadyExists
 	if errors.As(err, &eq) {
 		return nil, status.Errorf(codes.AlreadyExists, "[CreateQueue] error creating queue: %s", err)
@@ -663,7 +663,7 @@ func (srv *PulsarSubmitServer) UpdateQueue(grpcCtx context.Context, req *api.Que
 		return nil, status.Errorf(codes.InvalidArgument, "[UpdateQueue] error: %s", err)
 	}
 
-	err = srv.QueueRepository.UpdateQueue(queue)
+	err = srv.QueueRepository.UpdateQueue(ctx, queue)
 	var e *repository.ErrQueueNotFound
 	if errors.As(err, &e) {
 		return nil, status.Errorf(codes.NotFound, "[UpdateQueue] error: %s", err)
@@ -703,15 +703,16 @@ func (srv *PulsarSubmitServer) DeleteQueue(grpcCtx context.Context, req *api.Que
 	} else if err != nil {
 		return nil, status.Errorf(codes.Unavailable, "[DeleteQueue] error checking permissions: %s", err)
 	}
-	err = srv.QueueRepository.DeleteQueue(req.Name)
+	err = srv.QueueRepository.DeleteQueue(ctx, req.Name)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "[DeleteQueue] error deleting queue %s: %s", req.Name, err)
 	}
 	return &types.Empty{}, nil
 }
 
-func (srv *PulsarSubmitServer) GetQueue(ctx context.Context, req *api.QueueGetRequest) (*api.Queue, error) {
-	queue, err := srv.QueueRepository.GetQueue(req.Name)
+func (srv *PulsarSubmitServer) GetQueue(grpcCtx context.Context, req *api.QueueGetRequest) (*api.Queue, error) {
+	ctx := armadacontext.FromGrpcCtx(grpcCtx)
+	queue, err := srv.QueueRepository.GetQueue(ctx, req.Name)
 	var e *repository.ErrQueueNotFound
 	if errors.As(err, &e) {
 		return nil, status.Errorf(codes.NotFound, "[GetQueue] error: %s", err)
@@ -727,8 +728,8 @@ func (srv *PulsarSubmitServer) GetQueues(req *api.StreamingQueueGetRequest, stre
 	if numToReturn < 1 {
 		numToReturn = math.MaxUint32
 	}
-
-	queues, err := srv.QueueRepository.GetAllQueues()
+	ctx := armadacontext.FromGrpcCtx(stream.Context())
+	queues, err := srv.QueueRepository.GetAllQueues(ctx)
 	if err != nil {
 		return err
 	}
@@ -753,7 +754,7 @@ func (srv *PulsarSubmitServer) GetQueues(req *api.StreamingQueueGetRequest, stre
 	return nil
 }
 
-func (srv *PulsarSubmitServer) Health(ctx context.Context, _ *types.Empty) (*api.HealthCheckResponse, error) {
+func (srv *PulsarSubmitServer) Health(_ context.Context, _ *types.Empty) (*api.HealthCheckResponse, error) {
 	// For now, lets make the health check really simple.
 	return &api.HealthCheckResponse{Status: api.HealthCheckResponse_SERVING}, nil
 }
@@ -836,8 +837,8 @@ func (srv *PulsarSubmitServer) storeOriginalJobIds(ctx *armadacontext.Context, a
 
 // resolveQueueAndJobsetForJob returns the queue and jobset for a job.
 // If no job can be retrieved then an error is returned.
-func (srv *PulsarSubmitServer) resolveQueueAndJobsetForJob(jobId string) (string, string, error) {
-	jobDetails, err := srv.JobRepository.GetPulsarSchedulerJobDetails(jobId)
+func (srv *PulsarSubmitServer) resolveQueueAndJobsetForJob(ctx *armadacontext.Context, jobId string) (string, string, error) {
+	jobDetails, err := srv.JobRepository.GetPulsarSchedulerJobDetails(ctx, jobId)
 	if err != nil {
 		return "", "", err
 	}

--- a/internal/common/armadaerrors/errors_test.go
+++ b/internal/common/armadaerrors/errors_test.go
@@ -9,9 +9,9 @@ import (
 	"time"
 
 	"github.com/apache/pulsar-client-go/pulsar"
-	"github.com/go-redis/redis"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	"github.com/pkg/errors"
+	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -181,7 +181,7 @@ func TestIsNetworkErrorRedis(t *testing.T) {
 	client := redis.NewClient(&redis.Options{
 		Addr: "localhost:637", // Assume nothing is listening on this port
 	})
-	cmd := client.Ping()
+	cmd := client.Ping(context.TODO())
 
 	err := errors.Wrap(cmd.Err(), "foo")
 	assert.True(t, IsNetworkError(err))

--- a/internal/common/config/redis.go
+++ b/internal/common/config/redis.go
@@ -3,46 +3,44 @@ package config
 import (
 	"time"
 
-	"github.com/go-redis/redis"
+	"github.com/redis/go-redis/v9"
 )
 
 type RedisConfig struct {
 	// Either a single address or a seed list of host:port addresses
-	Addrs              []string `validate:"required"`
-	DB                 int      `validate:"gte=0,lte=16"`
-	Password           string
-	MaxRetries         int
-	MinRetryBackoff    time.Duration
-	MaxRetryBackoff    time.Duration
-	DialTimeout        time.Duration
-	ReadTimeout        time.Duration
-	WriteTimeout       time.Duration
-	PoolSize           int `validate:"required"`
-	MinIdleConns       int
-	MaxConnAge         time.Duration
-	PoolTimeout        time.Duration
-	IdleTimeout        time.Duration
-	IdleCheckFrequency time.Duration
-	MasterName         string
+	Addrs           []string `validate:"required"`
+	DB              int      `validate:"gte=0,lte=16"`
+	Password        string
+	MaxRetries      int
+	MinRetryBackoff time.Duration
+	MaxRetryBackoff time.Duration
+	DialTimeout     time.Duration
+	ReadTimeout     time.Duration
+	WriteTimeout    time.Duration
+	PoolSize        int `validate:"required"`
+	MinIdleConns    int
+	MaxConnAge      time.Duration
+	PoolTimeout     time.Duration
+	IdleTimeout     time.Duration
+	MasterName      string
 }
 
 func (rc RedisConfig) AsUniversalOptions() *redis.UniversalOptions {
 	return &redis.UniversalOptions{
-		Addrs:              rc.Addrs,
-		DB:                 rc.DB,
-		Password:           rc.Password,
-		MaxRetries:         rc.MaxRetries,
-		MinRetryBackoff:    rc.MaxRetryBackoff,
-		MaxRetryBackoff:    rc.MinRetryBackoff,
-		DialTimeout:        rc.DialTimeout,
-		ReadTimeout:        rc.ReadTimeout,
-		WriteTimeout:       rc.WriteTimeout,
-		PoolSize:           rc.PoolSize,
-		MinIdleConns:       rc.MinIdleConns,
-		MaxConnAge:         rc.MaxConnAge,
-		PoolTimeout:        rc.PoolTimeout,
-		IdleTimeout:        rc.IdleTimeout,
-		IdleCheckFrequency: rc.IdleCheckFrequency,
-		MasterName:         rc.MasterName,
+		Addrs:           rc.Addrs,
+		DB:              rc.DB,
+		Password:        rc.Password,
+		MaxRetries:      rc.MaxRetries,
+		MinRetryBackoff: rc.MaxRetryBackoff,
+		MaxRetryBackoff: rc.MinRetryBackoff,
+		DialTimeout:     rc.DialTimeout,
+		ReadTimeout:     rc.ReadTimeout,
+		WriteTimeout:    rc.WriteTimeout,
+		PoolSize:        rc.PoolSize,
+		MinIdleConns:    rc.MinIdleConns,
+		ConnMaxLifetime: rc.MaxConnAge,
+		PoolTimeout:     rc.PoolTimeout,
+		ConnMaxIdleTime: rc.IdleTimeout,
+		MasterName:      rc.MasterName,
 	}
 }

--- a/internal/eventingester/configuration/types.go
+++ b/internal/eventingester/configuration/types.go
@@ -3,7 +3,7 @@ package configuration
 import (
 	"time"
 
-	"github.com/go-redis/redis"
+	"github.com/redis/go-redis/v9"
 
 	"github.com/armadaproject/armada/internal/armada/configuration"
 )

--- a/internal/eventingester/ingester.go
+++ b/internal/eventingester/ingester.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	"github.com/apache/pulsar-client-go/pulsar"
-	"github.com/go-redis/redis"
 	"github.com/pkg/errors"
+	"github.com/redis/go-redis/v9"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/armadaproject/armada/internal/common/app"

--- a/internal/scheduler/metrics.go
+++ b/internal/scheduler/metrics.go
@@ -129,7 +129,7 @@ func (c *MetricsCollector) refresh(ctx *armadacontext.Context) error {
 }
 
 func (c *MetricsCollector) updateQueueMetrics(ctx *armadacontext.Context) ([]prometheus.Metric, error) {
-	queues, err := c.queueRepository.GetAllQueues()
+	queues, err := c.queueRepository.GetAllQueues(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/scheduler/metrics_test.go
+++ b/internal/scheduler/metrics_test.go
@@ -98,7 +98,7 @@ func TestMetricsCollector_TestCollect_QueueMetrics(t *testing.T) {
 			txn.Commit()
 
 			queueRepository := schedulermocks.NewMockQueueRepository(ctrl)
-			queueRepository.EXPECT().GetAllQueues().Return(tc.queues, nil).Times(1)
+			queueRepository.EXPECT().GetAllQueues(ctx).Return(tc.queues, nil).Times(1)
 			poolAssigner := &MockPoolAssigner{tc.defaultPool, tc.poolMappings}
 
 			executorRepository := schedulermocks.NewMockExecutorRepository(ctrl)
@@ -248,7 +248,7 @@ func TestMetricsCollector_TestCollect_ClusterMetrics(t *testing.T) {
 			txn.Commit()
 
 			queueRepository := schedulermocks.NewMockQueueRepository(ctrl)
-			queueRepository.EXPECT().GetAllQueues().Return([]queue.Queue{}, nil).Times(1)
+			queueRepository.EXPECT().GetAllQueues(ctx).Return([]queue.Queue{}, nil).Times(1)
 			poolAssigner := &MockPoolAssigner{testfixtures.TestPool, map[string]string{}}
 
 			executorRepository := schedulermocks.NewMockExecutorRepository(ctrl)

--- a/internal/scheduler/mocks/queue_repository.go
+++ b/internal/scheduler/mocks/queue_repository.go
@@ -7,6 +7,7 @@ package schedulermocks
 import (
 	reflect "reflect"
 
+	armadacontext "github.com/armadaproject/armada/internal/common/armadacontext"
 	queue "github.com/armadaproject/armada/pkg/client/queue"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -35,73 +36,73 @@ func (m *MockQueueRepository) EXPECT() *MockQueueRepositoryMockRecorder {
 }
 
 // CreateQueue mocks base method.
-func (m *MockQueueRepository) CreateQueue(arg0 queue.Queue) error {
+func (m *MockQueueRepository) CreateQueue(arg0 *armadacontext.Context, arg1 queue.Queue) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateQueue", arg0)
+	ret := m.ctrl.Call(m, "CreateQueue", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateQueue indicates an expected call of CreateQueue.
-func (mr *MockQueueRepositoryMockRecorder) CreateQueue(arg0 interface{}) *gomock.Call {
+func (mr *MockQueueRepositoryMockRecorder) CreateQueue(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateQueue", reflect.TypeOf((*MockQueueRepository)(nil).CreateQueue), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateQueue", reflect.TypeOf((*MockQueueRepository)(nil).CreateQueue), arg0, arg1)
 }
 
 // DeleteQueue mocks base method.
-func (m *MockQueueRepository) DeleteQueue(arg0 string) error {
+func (m *MockQueueRepository) DeleteQueue(arg0 *armadacontext.Context, arg1 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteQueue", arg0)
+	ret := m.ctrl.Call(m, "DeleteQueue", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteQueue indicates an expected call of DeleteQueue.
-func (mr *MockQueueRepositoryMockRecorder) DeleteQueue(arg0 interface{}) *gomock.Call {
+func (mr *MockQueueRepositoryMockRecorder) DeleteQueue(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteQueue", reflect.TypeOf((*MockQueueRepository)(nil).DeleteQueue), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteQueue", reflect.TypeOf((*MockQueueRepository)(nil).DeleteQueue), arg0, arg1)
 }
 
 // GetAllQueues mocks base method.
-func (m *MockQueueRepository) GetAllQueues() ([]queue.Queue, error) {
+func (m *MockQueueRepository) GetAllQueues(arg0 *armadacontext.Context) ([]queue.Queue, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllQueues")
+	ret := m.ctrl.Call(m, "GetAllQueues", arg0)
 	ret0, _ := ret[0].([]queue.Queue)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetAllQueues indicates an expected call of GetAllQueues.
-func (mr *MockQueueRepositoryMockRecorder) GetAllQueues() *gomock.Call {
+func (mr *MockQueueRepositoryMockRecorder) GetAllQueues(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllQueues", reflect.TypeOf((*MockQueueRepository)(nil).GetAllQueues))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllQueues", reflect.TypeOf((*MockQueueRepository)(nil).GetAllQueues), arg0)
 }
 
 // GetQueue mocks base method.
-func (m *MockQueueRepository) GetQueue(arg0 string) (queue.Queue, error) {
+func (m *MockQueueRepository) GetQueue(arg0 *armadacontext.Context, arg1 string) (queue.Queue, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetQueue", arg0)
+	ret := m.ctrl.Call(m, "GetQueue", arg0, arg1)
 	ret0, _ := ret[0].(queue.Queue)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetQueue indicates an expected call of GetQueue.
-func (mr *MockQueueRepositoryMockRecorder) GetQueue(arg0 interface{}) *gomock.Call {
+func (mr *MockQueueRepositoryMockRecorder) GetQueue(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetQueue", reflect.TypeOf((*MockQueueRepository)(nil).GetQueue), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetQueue", reflect.TypeOf((*MockQueueRepository)(nil).GetQueue), arg0, arg1)
 }
 
 // UpdateQueue mocks base method.
-func (m *MockQueueRepository) UpdateQueue(arg0 queue.Queue) error {
+func (m *MockQueueRepository) UpdateQueue(arg0 *armadacontext.Context, arg1 queue.Queue) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateQueue", arg0)
+	ret := m.ctrl.Call(m, "UpdateQueue", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateQueue indicates an expected call of UpdateQueue.
-func (mr *MockQueueRepositoryMockRecorder) UpdateQueue(arg0 interface{}) *gomock.Call {
+func (mr *MockQueueRepositoryMockRecorder) UpdateQueue(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateQueue", reflect.TypeOf((*MockQueueRepository)(nil).UpdateQueue), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateQueue", reflect.TypeOf((*MockQueueRepository)(nil).UpdateQueue), arg0, arg1)
 }

--- a/internal/scheduler/schedulerapp.go
+++ b/internal/scheduler/schedulerapp.go
@@ -9,10 +9,10 @@ import (
 	"time"
 
 	"github.com/apache/pulsar-client-go/pulsar"
-	"github.com/go-redis/redis"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/redis/go-redis/v9"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"

--- a/internal/scheduler/scheduling_algo.go
+++ b/internal/scheduler/scheduling_algo.go
@@ -256,7 +256,7 @@ func (l *FairSchedulingAlgo) newFairSchedulingAlgoContext(ctx *armadacontext.Con
 	executors = l.filterStaleExecutors(executors)
 
 	// TODO(albin): Skip queues with a high failure rate.
-	queues, err := l.queueRepository.GetAllQueues()
+	queues, err := l.queueRepository.GetAllQueues(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/scheduler/scheduling_algo_test.go
+++ b/internal/scheduler/scheduling_algo_test.go
@@ -380,7 +380,7 @@ func TestSchedule(t *testing.T) {
 			mockExecutorRepo := schedulermocks.NewMockExecutorRepository(ctrl)
 			mockExecutorRepo.EXPECT().GetExecutors(ctx).Return(tc.executors, nil).AnyTimes()
 			mockQueueRepo := schedulermocks.NewMockQueueRepository(ctrl)
-			mockQueueRepo.EXPECT().GetAllQueues().Return(tc.queues, nil).AnyTimes()
+			mockQueueRepo.EXPECT().GetAllQueues(ctx).Return(tc.queues, nil).AnyTimes()
 
 			schedulingContextRepo := NewSchedulingContextRepository()
 			sch, err := NewFairSchedulingAlgo(


### PR DESCRIPTION
We want to alert when the Redis client connection pool.  To do this we need to export Prometheus metrics about the size of the pool, which requires us to update the Redis client lib we use and add a bit of boilerplate to expose the metrics.  Essentially this boils down to:

* Add a dependency on `github.com/redis/go-redis/extra/redisprometheus/v9 v9.0.5` and `github.com/redis/go-redis/v9 v9.5.1`
* Update all the client code to be compatible with the new client. Unfortunately this is a lot of changes as the new client requires a `context` to be passed in for every call.
* Update `server.go` to register prometheus metrics for the redis clients

The new Redis Client *should* be compatible with both Redis 6 and Redis 7.