### PR TITLE
[Bug] Fix LimitSequenceByteSize function

### DIFF
--- a/internal/common/eventutil/eventutil.go
+++ b/internal/common/eventutil/eventutil.go
@@ -477,31 +477,16 @@ func LimitSequencesByteSize(sequences []*armadaevents.EventSequence, sizeInBytes
 
 // LimitSequenceByteSize returns a slice of sequences produced by breaking up sequence.Events
 // into separate sequences, each of which is at most MAX_SEQUENCE_SIZE_IN_BYTES bytes in size.
-func LimitSequenceByteSize(sequence *armadaevents.EventSequence, sizeInBytes uint, strict bool) ([]*armadaevents.EventSequence, error) {
+func LimitSequenceByteSize(sequence *armadaevents.EventSequence, maxSequenceSizeInBytes uint, strict bool) ([]*armadaevents.EventSequence, error) {
 	// Compute the size of the sequence without events.
 	events := sequence.Events
 	sequence.Events = make([]*armadaevents.EventSequence_Event, 0)
-	headerSize := uint(proto.Size(sequence))
 	sequence.Events = events
 
 	// var currentSequence *armadaevents.EventSequence
 	sequences := make([]*armadaevents.EventSequence, 0, 1)
-	lastSequenceEventSize := uint(0)
 	for _, event := range sequence.Events {
-		eventSize := uint(proto.Size(event))
-		if eventSize+headerSize > sizeInBytes && strict {
-			return nil, errors.WithStack(&armadaerrors.ErrInvalidArgument{
-				Name:  "sequence",
-				Value: sequence,
-				Message: fmt.Sprintf(
-					"sequence header is of size %d and sequence contains an event of size %d bytes, but the sequence size limit is %d",
-					headerSize,
-					eventSize,
-					sizeInBytes,
-				),
-			})
-		}
-		if len(sequences) == 0 || lastSequenceEventSize+eventSize+headerSize > sizeInBytes {
+		if len(sequences) == 0 {
 			sequences = append(sequences, &armadaevents.EventSequence{
 				Queue:      sequence.Queue,
 				JobSetName: sequence.JobSetName,
@@ -509,11 +494,39 @@ func LimitSequenceByteSize(sequence *armadaevents.EventSequence, sizeInBytes uin
 				Groups:     sequence.Groups,
 				Events:     nil,
 			})
-			lastSequenceEventSize = 0
 		}
 		lastSequence := sequences[len(sequences)-1]
 		lastSequence.Events = append(lastSequence.Events, event)
-		lastSequenceEventSize += eventSize
+		sequenceSizeInBytes := uint(proto.Size(lastSequence))
+
+		if sequenceSizeInBytes > maxSequenceSizeInBytes {
+			// Event makes sequence too large, remove event and make a new sequence
+			lastSequence.Events = lastSequence.Events[:len(lastSequence.Events)-1]
+			sequences = append(sequences, &armadaevents.EventSequence{
+				Queue:      sequence.Queue,
+				JobSetName: sequence.JobSetName,
+				UserId:     sequence.UserId,
+				Groups:     sequence.Groups,
+				Events:     nil,
+			})
+
+			lastSequence = sequences[len(sequences)-1]
+			lastSequence.Events = append(lastSequence.Events, event)
+			sequenceSizeInBytes = uint(proto.Size(lastSequence))
+
+			if sequenceSizeInBytes > maxSequenceSizeInBytes && strict {
+				eventSize := uint(proto.Size(event))
+				return nil, errors.WithStack(&armadaerrors.ErrInvalidArgument{
+					Name:  "sequence",
+					Value: sequence,
+					Message: fmt.Sprintf(
+						"event of %d bytes is too large, preventing the creation of a sequence with size limit %d",
+						eventSize,
+						maxSequenceSizeInBytes,
+					),
+				})
+			}
+		}
 	}
 	return sequences, nil
 }

--- a/internal/common/eventutil/eventutil_test.go
+++ b/internal/common/eventutil/eventutil_test.go
@@ -812,7 +812,7 @@ func TestLimitSequenceByteSize(t *testing.T) {
 			},
 		}
 	}
-	actual, err = LimitSequenceByteSize(sequence, 60, true)
+	actual, err = LimitSequenceByteSize(sequence, 65, true)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -847,7 +847,7 @@ func TestLimitSequencesByteSize(t *testing.T) {
 		sequences = append(sequences, sequence)
 	}
 
-	actual, err := LimitSequencesByteSize(sequences, 60, true)
+	actual, err := LimitSequencesByteSize(sequences, 65, true)
 	if !assert.NoError(t, err) {
 		return
 	}


### PR DESCRIPTION
This function can return sequences that are slightly largely than the byte limit

This is because it assumes that given 2 independent objects A and B

`Byte size of object A + B = byte size of A + byte size of B`

This is not true and is an underestimate (by a few bytes)

Now we check the byte size of the combined object, rather than rely on our computed size when enforcing the limit

