### PR TITLE
[process] update the current list of maintainers

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -9,6 +9,6 @@ pull_request_rules:
           - "#approved-reviews-by>=2"
           - and: 
             - "#approved-reviews-by>=1"
-            - "author~=^(JamesMurkin|severinson|d80tb7|carlocamurri|dejanzele|Sharpz7|ClifHouck|robertdavidsmith|theAntiYeti|richscott|suprjinx|zuqq|msumner91|MustafaI|mijovicmia|masipauskas)"
+            - "author~=^(d80tb7|dave[-]gantenbein|dejanzele|JamesMurkin|msumner91|masipauskas|mijovicmia|MustafaI|zuqq|richscott|robertdavidsmith|samclark)"
         title:
           Two are checks required.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,18 +4,28 @@
 
 | Maintainer           | GitHub ID                                               | Affiliation |
 | -------------------- | ------------------------------------------------------- | ----------- |
-| Carlo Camurri        | [carlocamurri](https://github.com/carlocamurri)         | G-Research  |
-| Sam Clark            | [samclark](https://github.com/samclark)                 | G-Research  |
-| Dave Gantenbein      | [dave-gantenbein](https://github.com/dave-gantenbein)   | G-Research  |
-| Kevin Hannon         | [kannon92](https://github.com/kannon92)                 | G-Research  |
-| Clifton Houck        | [ClifHouck](https://github.com/ClifHouck)               | G-Research  |
 | Chris Martin         | [d80tb7](https://github.com/d80tb7)                     | G-Research  |
-| James Murkin         | [JamesMurkin](https://github.com/JamesMurkin)           | G-Research  |
+| Dave Gantenbein      | [dave-gantenbein](https://github.com/dave-gantenbein)   | G-Research  |
 | Dejan Zele Pejchev   | [dejanzele](https://github.com/dejanzele)               | G-Research  |
-| Jamie Poole          | [jimbobby5](https://github.com/jimbobby5)               | G-Research  |
-| Daniel Rastelli      | [theAntiYeti](https://github.com/theAntiYeti)           | G-Research  |
-| Alex Scammon         | [stackedsax](https://github.com/stackedsax)             | G-Research  |
+| James Murkin         | [JamesMurkin](https://github.com/JamesMurkin)           | G-Research  |
+| Mark Sumner          | [msumner91](https://github.com/msumner91)               | G-Research  |
+| Martynas Asipauskas  | [masipauskas](https://github.com/masipauskas)           | G-Research  |
+| Mia Mijovic          | [mijovicmia](https://github.com/mijovicmia)             | G-Research  |
+| Mustafa Ilyas        | [MustafaI](https://github.com/MustafaI)                 | G-Research  |
+| Noah Held            | [zuqq](https://github.com/zuqq)                         | G-Research  |
 | Rich Scott           | [richscott](https://github.com/richscott)               | G-Research  |
-| Albin Severinson     | [severinson](https://github.com/severinson)             | G-Research  |
-| Geoffrey Wilson      | [suprjinx](https://github.com/suprjinx)                 | G-Research  |
+| Robert Smith         | [robertdavidsmith](https://github.com/robertdavidsmith) | G-Research  |
+| Sam Clark            | [samclark](https://github.com/samclark)                 | G-Research  |
 
+## Past
+
+| Maintainer           | GitHub ID                                               | Affiliation |
+| -------------------- | ------------------------------------------------------- | ----------- |
+| Albin Severinson     | [severinson](https://github.com/severinson)             | G-Research  |
+| Alex Scammon         | [stackedsax](https://github.com/stackedsax)             | G-Research  |
+| Carlo Camurri        | [carlocamurri](https://github.com/carlocamurri)         | G-Research  |
+| Clifton Houck        | [ClifHouck](https://github.com/ClifHouck)               | G-Research  |
+| Daniel Rastelli      | [theAntiYeti](https://github.com/theAntiYeti)           | G-Research  |
+| Geoffrey Wilson      | [suprjinx](https://github.com/suprjinx)                 | G-Research  |
+| Jamie Poole          | [jimbobby5](https://github.com/jimbobby5)               | G-Research  |
+| Kevin Hannon         | [kannon92](https://github.com/kannon92)                 | G-Research  |


### PR DESCRIPTION
Updates the current list of maintainers to be:
```
| Chris Martin         | [d80tb7](https://github.com/d80tb7)                     | G-Research  |
| Dave Gantenbein      | [dave-gantenbein](https://github.com/dave-gantenbein)   | G-Research  |
| Dejan Zele Pejchev   | [dejanzele](https://github.com/dejanzele)               | G-Research  |
| James Murkin         | [JamesMurkin](https://github.com/JamesMurkin)           | G-Research  |
| Mark Sumner          | [msumner91](https://github.com/msumner91)               | G-Research  |
| Martynas Asipauskas  | [masipauskas](https://github.com/masipauskas)           | G-Research  |
| Mia Mijovic          | [mijovicmia](https://github.com/mijovicmia)             | G-Research  |
| Mustafa Ilyas        | [MustafaI](https://github.com/MustafaI)                 | G-Research  |
| Noah Held            | [zuqq](https://github.com/zuqq)                         | G-Research  |
| Rich Scott           | [richscott](https://github.com/richscott)               | G-Research  |
| Robert Smith         | [robertdavidsmith](https://github.com/robertdavidsmith) | G-Research  |
| Sam Clark            | [samclark](https://github.com/samclark)                 | G-Research  |
```