### PR TITLE
Scheduler: move nodedb.Node to a new internaltypes package

### DIFF
--- a/internal/scheduler/internaltypes/node.go
+++ b/internal/scheduler/internaltypes/node.go
@@ -2,7 +2,7 @@ package internaltypes
 
 import (
 	"golang.org/x/exp/maps"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 
 	armadamaps "github.com/armadaproject/armada/internal/common/maps"
 	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"

--- a/internal/scheduler/internaltypes/node.go
+++ b/internal/scheduler/internaltypes/node.go
@@ -1,0 +1,64 @@
+package internaltypes
+
+import (
+	"golang.org/x/exp/maps"
+	"k8s.io/api/core/v1"
+
+	armadamaps "github.com/armadaproject/armada/internal/common/maps"
+	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
+)
+
+type Node struct {
+	// Unique id and index of this node.
+	// TODO(albin): Having both id and index is redundant.
+	//              Currently, the id is "cluster name" + "node name"  and index an integer assigned on node creation.
+	Id    string
+	Index uint64
+
+	// Executor this node belongs to and node name, which must be unique per executor.
+	Executor string
+	Name     string
+
+	// We need to store taints and labels separately from the node type: the latter only includes
+	// indexed taints and labels, but we need all of them when checking pod requirements.
+	Taints []v1.Taint
+	Labels map[string]string
+
+	TotalResources schedulerobjects.ResourceList
+
+	// This field is set when inserting the Node into a NodeDb.
+	Keys [][]byte
+
+	NodeTypeId uint64
+
+	AllocatableByPriority schedulerobjects.AllocatableByPriorityAndResourceType
+	AllocatedByQueue      map[string]schedulerobjects.ResourceList
+	AllocatedByJobId      map[string]schedulerobjects.ResourceList
+	EvictedJobRunIds      map[string]bool
+}
+
+// UnsafeCopy returns a pointer to a new value of type Node; it is unsafe because it only makes
+// shallow copies of fields that are not mutated by methods of NodeDb.
+func (node *Node) UnsafeCopy() *Node {
+	return &Node{
+		Id:    node.Id,
+		Index: node.Index,
+
+		Executor: node.Executor,
+		Name:     node.Name,
+
+		Taints: node.Taints,
+		Labels: node.Labels,
+
+		TotalResources: node.TotalResources,
+
+		Keys: nil,
+
+		NodeTypeId: node.NodeTypeId,
+
+		AllocatableByPriority: armadamaps.DeepCopy(node.AllocatableByPriority),
+		AllocatedByQueue:      armadamaps.DeepCopy(node.AllocatedByQueue),
+		AllocatedByJobId:      armadamaps.DeepCopy(node.AllocatedByJobId),
+		EvictedJobRunIds:      maps.Clone(node.EvictedJobRunIds),
+	}
+}

--- a/internal/scheduler/internaltypes/node_test.go
+++ b/internal/scheduler/internaltypes/node_test.go
@@ -1,0 +1,84 @@
+package internaltypes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
+)
+
+func TestNodeUnsafeCopy(t *testing.T) {
+	node := &Node{
+		Id:       "id",
+		Index:    1,
+		Executor: "executor",
+		Name:     "name",
+		Taints: []v1.Taint{
+			{
+				Key:   "foo",
+				Value: "bar",
+			},
+		},
+		Labels: map[string]string{
+			"key": "value",
+		},
+		TotalResources: schedulerobjects.ResourceList{
+			Resources: map[string]resource.Quantity{
+				"cpu":    resource.MustParse("16"),
+				"memory": resource.MustParse("32Gi"),
+			},
+		},
+		Keys: [][]byte{
+			{
+				0, 1, 255,
+			},
+		},
+		NodeTypeId: 123,
+		AllocatableByPriority: schedulerobjects.AllocatableByPriorityAndResourceType{
+			1: {
+				Resources: map[string]resource.Quantity{
+					"cpu":    resource.MustParse("0"),
+					"memory": resource.MustParse("0Gi"),
+				},
+			},
+			2: {
+				Resources: map[string]resource.Quantity{
+					"cpu":    resource.MustParse("8"),
+					"memory": resource.MustParse("16Gi"),
+				},
+			},
+			3: {
+				Resources: map[string]resource.Quantity{
+					"cpu":    resource.MustParse("16"),
+					"memory": resource.MustParse("32Gi"),
+				},
+			},
+		},
+		AllocatedByQueue: map[string]schedulerobjects.ResourceList{
+			"queue": {
+				Resources: map[string]resource.Quantity{
+					"cpu":    resource.MustParse("8"),
+					"memory": resource.MustParse("16Gi"),
+				},
+			},
+		},
+		AllocatedByJobId: map[string]schedulerobjects.ResourceList{
+			"jobId": {
+				Resources: map[string]resource.Quantity{
+					"cpu":    resource.MustParse("8"),
+					"memory": resource.MustParse("16Gi"),
+				},
+			},
+		},
+		EvictedJobRunIds: map[string]bool{
+			"jobId":        false,
+			"evictedJobId": true,
+		},
+	}
+	nodeCopy := node.UnsafeCopy()
+	// TODO(albin): Add more tests here.
+	assert.Equal(t, node.Id, nodeCopy.Id)
+}

--- a/internal/scheduler/internaltypes/node_test.go
+++ b/internal/scheduler/internaltypes/node_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"

--- a/internal/scheduler/nodedb/nodeiteration_test.go
+++ b/internal/scheduler/nodedb/nodeiteration_test.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	armadaslices "github.com/armadaproject/armada/internal/common/slices"
+	"github.com/armadaproject/armada/internal/scheduler/internaltypes"
 	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
 	"github.com/armadaproject/armada/internal/scheduler/testfixtures"
 )
@@ -76,7 +77,7 @@ func TestNodePairIterator(t *testing.T) {
 	}
 	nodeDb, err := newNodeDbWithNodes(nodes)
 	require.NoError(t, err)
-	entries := make([]*Node, len(nodes))
+	entries := make([]*internaltypes.Node, len(nodes))
 	for i, node := range nodes {
 		entry, err := nodeDb.GetNode(node.Id)
 		require.NoError(t, err)
@@ -420,7 +421,7 @@ func TestNodeTypeIterator(t *testing.T) {
 			nodeDb, err := newNodeDbWithNodes(nil)
 			require.NoError(t, err)
 
-			entries := make([]*Node, len(tc.nodes))
+			entries := make([]*internaltypes.Node, len(tc.nodes))
 			for i, node := range tc.nodes {
 				// Set monotonically increasing node IDs to ensure nodes appear in predictable order.
 				node.Id = fmt.Sprintf("%d", i)
@@ -811,7 +812,7 @@ func TestNodeTypesIterator(t *testing.T) {
 			nodeDb, err := newNodeDbWithNodes(nil)
 			require.NoError(t, err)
 
-			entries := make([]*Node, len(tc.nodes))
+			entries := make([]*internaltypes.Node, len(tc.nodes))
 			for i, node := range tc.nodes {
 				// Set monotonically increasing node IDs to ensure nodes appear in predictable order.
 				node.Id = fmt.Sprintf("%d", i)


### PR DESCRIPTION
The long term plan is to gradually refactor `Node` into a safe struct with immutable private fields accessed by getters, and some safe methods for modifying fields that return another instance of `Node`.

Anyway the first step is to move `Node` into its own package - if it stays in `nodedb`, `nodedb` will be able to access private fields.