### PR TITLE
Reduce Node copies in selectNodeForJobWithFairPreemption

### DIFF
--- a/internal/scheduler/nodedb/nodedb.go
+++ b/internal/scheduler/nodedb/nodedb.go
@@ -856,12 +856,14 @@ func (nodeDb *NodeDb) selectNodeForJobWithFairPreemption(txn *memdb.Txn, jctx *s
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
+			node = node.UnsafeCopy()
+			nodesById[nodeId] = node
 		}
-		node, err = nodeDb.UnbindJobFromNode(nodeDb.priorityClasses, evictedJctx.Job, node)
+
+		err = nodeDb.unbindJobFromNodeInPlace(nodeDb.priorityClasses, evictedJctx.Job, node)
 		if err != nil {
 			return nil, err
 		}
-		nodesById[nodeId] = node
 		evictedJobSchedulingContextsByNodeId[nodeId] = append(evictedJobSchedulingContextsByNodeId[nodeId], evictedJobSchedulingContext)
 
 		priority, ok := nodeDb.GetScheduledAtPriority(evictedJctx.JobId)


### PR DESCRIPTION
The call to `nodeDb.unbindJobFromNode` in `selectNodeForJobWithFairPreemption` is responsible for 25% of all cpu time spent in the scheduling cycles, almost all of which is spent in `node.UnsafeCopy()` making copies of the node.

This PR reduces the amount of time spent making copies of the node by making one copy per node per invocation `selectNodeForJobWithFairPreemption` rather than one copy per node per evicted job per invocation. This is safe because the node is not re-inserted into the db within the function which means that we are free to mutate its fields.

Note that there are several more optimisations we could do in this area, but this is by far the simplest and least impactful so I thought we'd get this one in first and see what difference it makes.