### PR TITLE
Scheduler: refactor to make Node.Id immutable

### DIFF
--- a/internal/scheduler/internaltypes/node.go
+++ b/internal/scheduler/internaltypes/node.go
@@ -12,7 +12,7 @@ type Node struct {
 	// Unique id and index of this node.
 	// TODO(albin): Having both id and index is redundant.
 	//              Currently, the id is "cluster name" + "node name"  and index an integer assigned on node creation.
-	Id    string
+	id    string
 	Index uint64
 
 	// Executor this node belongs to and node name, which must be unique per executor.
@@ -37,11 +37,47 @@ type Node struct {
 	EvictedJobRunIds      map[string]bool
 }
 
+func CreateNode(
+	id string,
+	nodeTypeId uint64,
+	index uint64,
+	executor string,
+	name string,
+	taints []v1.Taint,
+	labels map[string]string,
+	totalResources schedulerobjects.ResourceList,
+	allocatableByPriority schedulerobjects.AllocatableByPriorityAndResourceType,
+	allocatedByQueue map[string]schedulerobjects.ResourceList,
+	allocatedByJobId map[string]schedulerobjects.ResourceList,
+	evictedJobRunIds map[string]bool,
+	keys [][]byte,
+) *Node {
+	return &Node{
+		id:                    id,
+		NodeTypeId:            nodeTypeId,
+		Index:                 index,
+		Executor:              executor,
+		Name:                  name,
+		Taints:                taints,
+		Labels:                labels,
+		TotalResources:        totalResources,
+		AllocatableByPriority: allocatableByPriority,
+		AllocatedByQueue:      allocatedByQueue,
+		AllocatedByJobId:      allocatedByJobId,
+		EvictedJobRunIds:      evictedJobRunIds,
+		Keys:                  keys,
+	}
+}
+
+func (node *Node) GetId() string {
+	return node.id
+}
+
 // UnsafeCopy returns a pointer to a new value of type Node; it is unsafe because it only makes
 // shallow copies of fields that are not mutated by methods of NodeDb.
 func (node *Node) UnsafeCopy() *Node {
 	return &Node{
-		Id:    node.Id,
+		id:    node.id,
 		Index: node.Index,
 
 		Executor: node.Executor,

--- a/internal/scheduler/internaltypes/node_test.go
+++ b/internal/scheduler/internaltypes/node_test.go
@@ -10,75 +10,103 @@ import (
 	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
 )
 
-func TestNodeUnsafeCopy(t *testing.T) {
-	node := &Node{
-		Id:       "id",
-		Index:    1,
-		Executor: "executor",
-		Name:     "name",
-		Taints: []v1.Taint{
-			{
-				Key:   "foo",
-				Value: "bar",
+func TestNode(t *testing.T) {
+	const id = "id"
+	const nodeTypeId = uint64(123)
+	const index = uint64(1)
+	const executor = "executor"
+	const name = "name"
+	taints := []v1.Taint{
+		{
+			Key:   "foo",
+			Value: "bar",
+		},
+	}
+	labels := map[string]string{
+		"key": "value",
+	}
+	totalResources := schedulerobjects.ResourceList{
+		Resources: map[string]resource.Quantity{
+			"cpu":    resource.MustParse("16"),
+			"memory": resource.MustParse("32Gi"),
+		},
+	}
+	allocatableByPriority := schedulerobjects.AllocatableByPriorityAndResourceType{
+		1: {
+			Resources: map[string]resource.Quantity{
+				"cpu":    resource.MustParse("0"),
+				"memory": resource.MustParse("0Gi"),
 			},
 		},
-		Labels: map[string]string{
-			"key": "value",
+		2: {
+			Resources: map[string]resource.Quantity{
+				"cpu":    resource.MustParse("8"),
+				"memory": resource.MustParse("16Gi"),
+			},
 		},
-		TotalResources: schedulerobjects.ResourceList{
+		3: {
 			Resources: map[string]resource.Quantity{
 				"cpu":    resource.MustParse("16"),
 				"memory": resource.MustParse("32Gi"),
 			},
 		},
-		Keys: [][]byte{
-			{
-				0, 1, 255,
+	}
+	allocatedByQueue := map[string]schedulerobjects.ResourceList{
+		"queue": {
+			Resources: map[string]resource.Quantity{
+				"cpu":    resource.MustParse("8"),
+				"memory": resource.MustParse("16Gi"),
 			},
-		},
-		NodeTypeId: 123,
-		AllocatableByPriority: schedulerobjects.AllocatableByPriorityAndResourceType{
-			1: {
-				Resources: map[string]resource.Quantity{
-					"cpu":    resource.MustParse("0"),
-					"memory": resource.MustParse("0Gi"),
-				},
-			},
-			2: {
-				Resources: map[string]resource.Quantity{
-					"cpu":    resource.MustParse("8"),
-					"memory": resource.MustParse("16Gi"),
-				},
-			},
-			3: {
-				Resources: map[string]resource.Quantity{
-					"cpu":    resource.MustParse("16"),
-					"memory": resource.MustParse("32Gi"),
-				},
-			},
-		},
-		AllocatedByQueue: map[string]schedulerobjects.ResourceList{
-			"queue": {
-				Resources: map[string]resource.Quantity{
-					"cpu":    resource.MustParse("8"),
-					"memory": resource.MustParse("16Gi"),
-				},
-			},
-		},
-		AllocatedByJobId: map[string]schedulerobjects.ResourceList{
-			"jobId": {
-				Resources: map[string]resource.Quantity{
-					"cpu":    resource.MustParse("8"),
-					"memory": resource.MustParse("16Gi"),
-				},
-			},
-		},
-		EvictedJobRunIds: map[string]bool{
-			"jobId":        false,
-			"evictedJobId": true,
 		},
 	}
+	allocatedByJobId := map[string]schedulerobjects.ResourceList{
+		"jobId": {
+			Resources: map[string]resource.Quantity{
+				"cpu":    resource.MustParse("8"),
+				"memory": resource.MustParse("16Gi"),
+			},
+		},
+	}
+	evictedJobRunIds := map[string]bool{
+		"jobId":        false,
+		"evictedJobId": true,
+	}
+	keys := [][]byte{
+		{
+			0, 1, 255,
+		},
+	}
+
+	node := CreateNode(
+		id,
+		nodeTypeId,
+		index,
+		executor,
+		name,
+		taints,
+		labels,
+		totalResources,
+		allocatableByPriority,
+		allocatedByQueue,
+		allocatedByJobId,
+		evictedJobRunIds,
+		keys,
+	)
+
+	assert.Equal(t, id, node.GetId())
+	assert.Equal(t, nodeTypeId, node.NodeTypeId)
+	assert.Equal(t, index, node.Index)
+	assert.Equal(t, executor, node.Executor)
+	assert.Equal(t, name, node.Name)
+	assert.Equal(t, taints, node.Taints)
+	assert.Equal(t, labels, node.Labels)
+	assert.Equal(t, totalResources, node.TotalResources)
+	assert.Equal(t, allocatableByPriority, node.AllocatableByPriority)
+	assert.Equal(t, allocatedByQueue, node.AllocatedByQueue)
+	assert.Equal(t, allocatedByJobId, node.AllocatedByJobId)
+	assert.Equal(t, keys, node.Keys)
+
 	nodeCopy := node.UnsafeCopy()
-	// TODO(albin): Add more tests here.
-	assert.Equal(t, node.Id, nodeCopy.Id)
+	node.Keys = nil // UnsafeCopy() sets Keys to nil
+	assert.Equal(t, node, nodeCopy)
 }

--- a/internal/scheduler/nodedb/nodedb_test.go
+++ b/internal/scheduler/nodedb/nodedb_test.go
@@ -83,7 +83,7 @@ func TestSelectNodeForPod_NodeIdLabel_Success(t *testing.T) {
 		require.NoError(t, err)
 		pctx := jctx.PodSchedulingContext
 		if assert.NotNil(t, node) {
-			assert.Equal(t, nodeId, node.Id)
+			assert.Equal(t, nodeId, node.GetId())
 		}
 		if assert.NotNil(t, pctx) {
 			assert.Equal(t, nodeId, pctx.NodeId)

--- a/internal/scheduler/nodedb/nodeidindex.go
+++ b/internal/scheduler/nodedb/nodeidindex.go
@@ -1,0 +1,49 @@
+package nodedb
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/armadaproject/armada/internal/scheduler/internaltypes"
+)
+
+// NodeIndex is an index for internaltypes.Node that indexes Node.GetId()
+type nodeIdIndex struct {
+}
+
+func createNodeIdIndex() *nodeIdIndex {
+	return &nodeIdIndex{}
+}
+
+func (nii *nodeIdIndex) FromObject(obj interface{}) (bool, []byte, error) {
+	node, ok := obj.(*internaltypes.Node)
+	if !ok {
+		return false, nil,
+			fmt.Errorf("Expected type *Node but got %v", reflect.TypeOf(obj))
+	}
+	val := node.GetId()
+	if val == "" {
+		return false, nil, nil
+	}
+
+	// Add the null character as a terminator
+	val += "\x00"
+	return true, []byte(val), nil
+}
+
+func (nii *nodeIdIndex) FromArgs(args ...interface{}) ([]byte, error) {
+	if len(args) != 1 {
+		return nil, fmt.Errorf("must provide only a single argument")
+	}
+	arg, ok := args[0].(string)
+	if !ok {
+		return nil, fmt.Errorf("argument must be a string: %#v", args[0])
+	}
+	// Add the null character as a terminator
+	arg += "\x00"
+	return []byte(arg), nil
+}
+
+func (nii *nodeIdIndex) PrefixFromArgs(args ...interface{}) ([]byte, error) {
+	panic("PrefixFromArgs not implemented")
+}

--- a/internal/scheduler/nodedb/nodeidindex.go
+++ b/internal/scheduler/nodedb/nodeidindex.go
@@ -8,8 +8,7 @@ import (
 )
 
 // NodeIndex is an index for internaltypes.Node that indexes Node.GetId()
-type nodeIdIndex struct {
-}
+type nodeIdIndex struct{}
 
 func createNodeIdIndex() *nodeIdIndex {
 	return &nodeIdIndex{}

--- a/internal/scheduler/nodedb/nodeidindex_test.go
+++ b/internal/scheduler/nodedb/nodeidindex_test.go
@@ -1,0 +1,60 @@
+package nodedb
+
+import (
+	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	"testing"
+
+	"github.com/armadaproject/armada/internal/scheduler/internaltypes"
+)
+
+func TestFromObjectValid(t *testing.T) {
+	sut := createNodeIdIndex()
+	node := makeTestNode("id")
+	ok, val, err := sut.FromObject(node)
+	assert.True(t, ok)
+	assert.Equal(t, []byte{'i', 'd', 0}, val)
+	assert.Nil(t, err)
+}
+
+func TestFromObjectEmptyId(t *testing.T) {
+	sut := createNodeIdIndex()
+	node := makeTestNode("")
+	ok, val, err := sut.FromObject(node)
+	assert.False(t, ok)
+	assert.Nil(t, val)
+	assert.Nil(t, err)
+}
+
+func TestFromObjectWrongType(t *testing.T) {
+	sut := createNodeIdIndex()
+	ok, val, err := sut.FromObject("this should not be a string")
+	assert.False(t, ok)
+	assert.Nil(t, val)
+	assert.NotNil(t, err)
+}
+
+func TestFromArgsValid(t *testing.T) {
+	sut := createNodeIdIndex()
+	val, err := sut.FromArgs("id")
+	assert.Equal(t, []byte{'i', 'd', 0}, val)
+	assert.Nil(t, err)
+}
+
+func makeTestNode(id string) *internaltypes.Node {
+	return internaltypes.CreateNode(id,
+		1,
+		1,
+		"executor",
+		"node_name",
+		[]v1.Taint{},
+		map[string]string{},
+		schedulerobjects.ResourceList{},
+		schedulerobjects.AllocatableByPriorityAndResourceType{},
+		map[string]schedulerobjects.ResourceList{},
+		map[string]schedulerobjects.ResourceList{},
+		map[string]bool{},
+		[][]byte{},
+	)
+}

--- a/internal/scheduler/nodedb/nodeidindex_test.go
+++ b/internal/scheduler/nodedb/nodeidindex_test.go
@@ -1,12 +1,13 @@
 package nodedb
 
 import (
-	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
-	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/api/core/v1"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+
 	"github.com/armadaproject/armada/internal/scheduler/internaltypes"
+	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
 )
 
 func TestFromObjectValid(t *testing.T) {

--- a/internal/scheduler/nodedb/nodeiteration.go
+++ b/internal/scheduler/nodedb/nodeiteration.go
@@ -105,7 +105,7 @@ func (it *NodePairIterator) NextItem() (rv *NodePairIteratorItem) {
 			NodeB: it.nodeB,
 		}
 	}
-	cmp := bytes.Compare([]byte(it.nodeA.Id), []byte(it.nodeB.Id))
+	cmp := bytes.Compare([]byte(it.nodeA.GetId()), []byte(it.nodeB.GetId()))
 	if cmp == 0 {
 		return &NodePairIteratorItem{
 			NodeA: it.nodeA,
@@ -126,7 +126,7 @@ func (it *NodePairIterator) Next() interface{} {
 	return it.NextItem()
 }
 
-// NodeIndex is an index for schedulerobjects.Node that returns node.NodeDbKeys[KeyIndex].
+// NodeIndex is an index for internaltypes.Node that returns node.NodeDbKeys[KeyIndex].
 type NodeIndex struct {
 	KeyIndex int
 }
@@ -259,7 +259,7 @@ func (it *nodeTypesIteratorPQ) less(a, b *internaltypes.Node) bool {
 		}
 	}
 	// Tie-break by id.
-	return a.Id < b.Id
+	return a.GetId() < b.GetId()
 }
 
 func (pq *nodeTypesIteratorPQ) Swap(i, j int) {
@@ -399,7 +399,7 @@ func (it *NodeTypeIterator) NextNode() (*internaltypes.Node, error) {
 		}
 		node := v.(*internaltypes.Node)
 		if it.keyIndex >= len(node.Keys) {
-			return nil, errors.Errorf("keyIndex is %d, but node %s has only %d keys", it.keyIndex, node.Id, len(node.Keys))
+			return nil, errors.Errorf("keyIndex is %d, but node %s has only %d keys", it.keyIndex, node.GetId(), len(node.Keys))
 		}
 		nodeKey := node.Keys[it.keyIndex]
 		if it.previousKey != nil && bytes.Compare(it.previousKey, nodeKey) != -1 {
@@ -416,7 +416,7 @@ func (it *NodeTypeIterator) NextNode() (*internaltypes.Node, error) {
 		}
 		allocatableByPriority := node.AllocatableByPriority[it.priority]
 		if len(allocatableByPriority.Resources) == 0 {
-			return nil, errors.Errorf("node %s has no resources registered at priority %d: %v", node.Id, it.priority, node.AllocatableByPriority)
+			return nil, errors.Errorf("node %s has no resources registered at priority %d: %v", node.GetId(), it.priority, node.AllocatableByPriority)
 		}
 		for i, t := range it.indexedResources {
 			nodeQuantity := allocatableByPriority.Get(t).DeepCopy()

--- a/internal/scheduler/nodedb/nodeiteration_test.go
+++ b/internal/scheduler/nodedb/nodeiteration_test.go
@@ -62,7 +62,7 @@ func TestNodesIterator(t *testing.T) {
 
 			actual := make([]int, 0)
 			for node := it.NextNode(); node != nil; node = it.NextNode() {
-				actual = append(actual, indexById[node.Id])
+				actual = append(actual, indexById[node.GetId()])
 			}
 
 			assert.Equal(t, expected, actual)
@@ -470,7 +470,7 @@ func TestNodeTypeIterator(t *testing.T) {
 				if node == nil {
 					break
 				}
-				actual = append(actual, node.Id)
+				actual = append(actual, node.GetId())
 			}
 			assert.Equal(t, expected, actual)
 
@@ -854,7 +854,7 @@ func TestNodeTypesIterator(t *testing.T) {
 				if node == nil {
 					break
 				}
-				actual = append(actual, node.Id)
+				actual = append(actual, node.GetId())
 			}
 			assert.Equal(t, expected, actual)
 

--- a/internal/scheduler/preempting_queue_scheduler.go
+++ b/internal/scheduler/preempting_queue_scheduler.go
@@ -647,16 +647,16 @@ func (sch *PreemptingQueueScheduler) assertions(
 	// and that jobs are preempted/scheduled on the nodes we expect them to.
 	for jobId, node := range preempted {
 		if expectedNodeId, ok := nodeIdByJobId[jobId]; ok {
-			if expectedNodeId != node.Id {
+			if expectedNodeId != node.GetId() {
 				return errors.Errorf(
 					"inconsistent NodeDb: expected job %s to be preempted from node %s, but got %s",
-					jobId, expectedNodeId, node.Id,
+					jobId, expectedNodeId, node.GetId(),
 				)
 			}
 		} else {
 			return errors.Errorf(
 				"inconsistent NodeDb: expected job %s to be mapped to node %s, but found none",
-				jobId, node.Id,
+				jobId, node.GetId(),
 			)
 		}
 		if _, ok := preemptedJobsById[jobId]; !ok {
@@ -665,16 +665,16 @@ func (sch *PreemptingQueueScheduler) assertions(
 	}
 	for jobId, node := range scheduled {
 		if expectedNodeId, ok := nodeIdByJobId[jobId]; ok {
-			if expectedNodeId != node.Id {
+			if expectedNodeId != node.GetId() {
 				return errors.Errorf(
 					"inconsistent NodeDb: expected job %s to be on node %s, but got %s",
-					jobId, expectedNodeId, node.Id,
+					jobId, expectedNodeId, node.GetId(),
 				)
 			}
 		} else {
 			return errors.Errorf(
 				"inconsistent NodeDb: expected job %s to be mapped to node %s, but found none",
-				jobId, node.Id,
+				jobId, node.GetId(),
 			)
 		}
 		if _, ok := scheduledJobsById[jobId]; !ok {
@@ -743,7 +743,7 @@ func NewFilteredEvictor(
 		nodeDb:          nodeDb,
 		priorityClasses: priorityClasses,
 		nodeFilter: func(_ *armadacontext.Context, node *internaltypes.Node) bool {
-			shouldEvict := nodeIdsToEvict[node.Id]
+			shouldEvict := nodeIdsToEvict[node.GetId()]
 			return shouldEvict
 		},
 		jobFilter: func(_ *armadacontext.Context, job interfaces.LegacySchedulerJob) bool {
@@ -863,16 +863,16 @@ func (evi *Evictor) Evict(ctx *armadacontext.Context, nodeDbTxn *memdb.Txn) (*Ev
 			// TODO(albin): We can remove the checkOnlyDynamicRequirements flag in the nodeDb now that we've added the tolerations.
 			jctx := schedulercontext.JobSchedulingContextFromJob(evi.priorityClasses, job)
 			jctx.IsEvicted = true
-			jctx.AddNodeSelector(schedulerconfig.NodeIdLabel, node.Id)
+			jctx.AddNodeSelector(schedulerconfig.NodeIdLabel, node.GetId())
 			evictedJctxsByJobId[job.GetId()] = jctx
 			for _, taint := range node.Taints {
 				jctx.AdditionalTolerations = append(jctx.AdditionalTolerations, v1.Toleration{Key: taint.Key, Value: taint.Value, Effect: taint.Effect})
 			}
 
-			nodeIdByJobId[job.GetId()] = node.Id
+			nodeIdByJobId[job.GetId()] = node.GetId()
 		}
 		if len(evictedJobs) > 0 {
-			affectedNodesById[node.Id] = node
+			affectedNodesById[node.GetId()] = node
 		}
 	}
 	result := &EvictorResult{

--- a/internal/scheduler/preempting_queue_scheduler_test.go
+++ b/internal/scheduler/preempting_queue_scheduler_test.go
@@ -2006,7 +2006,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 				for node := it.NextNode(); node != nil; node = it.NextNode() {
 					for _, p := range priorities {
 						for resourceType, q := range node.AllocatableByPriority[p].Resources {
-							assert.NotEqual(t, -1, q.Cmp(resource.Quantity{}), "resource %s oversubscribed by %s on node %s", resourceType, q.String(), node.Id)
+							assert.NotEqual(t, -1, q.Cmp(resource.Quantity{}), "resource %s oversubscribed by %s on node %s", resourceType, q.String(), node.GetId())
 						}
 					}
 				}
@@ -2056,7 +2056,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 						scheduledJobs,
 						job.WithQueuedVersion(job.QueuedVersion()+1).
 							WithQueued(false).
-							WithNewRun(node.Executor, node.Id, node.Name, priority),
+							WithNewRun(node.Executor, node.GetId(), node.Name, priority),
 					)
 				}
 				err = jobDbTxn.Upsert(scheduledJobs)

--- a/internal/scheduler/scheduling_algo.go
+++ b/internal/scheduler/scheduling_algo.go
@@ -483,7 +483,7 @@ func (l *FairSchedulingAlgo) scheduleOnExecutors(
 		result.ScheduledJobs[i].Job = jobDbJob.
 			WithQueuedVersion(jobDbJob.QueuedVersion()+1).
 			WithQueued(false).
-			WithNewRun(node.Executor, node.Id, node.Name, priority)
+			WithNewRun(node.Executor, node.GetId(), node.Name, priority)
 	}
 	for i, jctx := range result.FailedJobs {
 		jobDbJob := jctx.Job.(*jobdb.Job)

--- a/internal/scheduler/simulator/simulator.go
+++ b/internal/scheduler/simulator/simulator.go
@@ -539,7 +539,7 @@ func (s *Simulator) handleScheduleEvent(ctx *armadacontext.Context) error {
 					if !ok {
 						return errors.Errorf("job %s not mapped to a priority", job.Id())
 					}
-					scheduledJobs[i].Job = job.WithQueued(false).WithNewRun(node.Executor, node.Id, node.Name, priority)
+					scheduledJobs[i].Job = job.WithQueued(false).WithNewRun(node.Executor, node.GetId(), node.Name, priority)
 				}
 			}
 			for i, job := range failedJobs {


### PR DESCRIPTION
Next step towards making all of `internaltypes.Node` immutable - make `internaltypes.Node.Id` immutable.