### PR TITLE
Remove msg filtering (read side)

### DIFF
--- a/internal/common/ingest/ingestion_pipeline.go
+++ b/internal/common/ingest/ingestion_pipeline.go
@@ -62,7 +62,6 @@ type IngestionPipeline[T HasPulsarMessageIds] struct {
 	pulsarBatchSize        int
 	pulsarBatchDuration    time.Duration
 	pulsarSubscriptionType pulsar.SubscriptionType
-	msgFilter              func(msg pulsar.Message) bool
 	converter              InstructionConverter[T]
 	sink                   Sink[T]
 	consumer               pulsar.Consumer // for test purposes only
@@ -80,34 +79,6 @@ func NewIngestionPipeline[T HasPulsarMessageIds](
 	metricsPort uint16,
 	metrics *commonmetrics.Metrics,
 ) *IngestionPipeline[T] {
-	return NewFilteredMsgIngestionPipeline[T](
-		pulsarConfig,
-		pulsarSubscriptionName,
-		pulsarBatchSize,
-		pulsarBatchDuration,
-		pulsarSubscriptionType,
-		func(_ pulsar.Message) bool { return true },
-		converter,
-		sink,
-		metricsPort,
-		metrics,
-	)
-}
-
-// NewFilteredMsgIngestionPipeline creates an IngestionPipeline that processes only messages corresponding to the
-// supplied message filter
-func NewFilteredMsgIngestionPipeline[T HasPulsarMessageIds](
-	pulsarConfig configuration.PulsarConfig,
-	pulsarSubscriptionName string,
-	pulsarBatchSize int,
-	pulsarBatchDuration time.Duration,
-	pulsarSubscriptionType pulsar.SubscriptionType,
-	msgFilter func(msg pulsar.Message) bool,
-	converter InstructionConverter[T],
-	sink Sink[T],
-	metricsPort uint16,
-	metrics *commonmetrics.Metrics,
-) *IngestionPipeline[T] {
 	return &IngestionPipeline[T]{
 		pulsarConfig:           pulsarConfig,
 		metricsPort:            metricsPort,
@@ -116,7 +87,6 @@ func NewFilteredMsgIngestionPipeline[T HasPulsarMessageIds](
 		pulsarBatchSize:        pulsarBatchSize,
 		pulsarBatchDuration:    pulsarBatchDuration,
 		pulsarSubscriptionType: pulsarSubscriptionType,
-		msgFilter:              msgFilter,
 		converter:              converter,
 		sink:                   sink,
 	}
@@ -172,7 +142,7 @@ func (ingester *IngestionPipeline[T]) Run(ctx *armadacontext.Context) error {
 	eventSequences := make(chan *EventSequencesWithIds)
 	go func() {
 		for msg := range batchedMsgs {
-			converted := unmarshalEventSequences(msg, ingester.msgFilter, ingester.metrics)
+			converted := unmarshalEventSequences(msg, ingester.metrics)
 			eventSequences <- converted
 		}
 		close(eventSequences)
@@ -251,7 +221,7 @@ func (ingester *IngestionPipeline[T]) subscribe() (pulsar.Consumer, func(), erro
 	}, nil
 }
 
-func unmarshalEventSequences(batch []pulsar.Message, msgFilter func(msg pulsar.Message) bool, metrics *commonmetrics.Metrics) *EventSequencesWithIds {
+func unmarshalEventSequences(batch []pulsar.Message, metrics *commonmetrics.Metrics) *EventSequencesWithIds {
 	sequences := make([]*armadaevents.EventSequence, 0, len(batch))
 	messageIds := make([]pulsar.MessageID, len(batch))
 	for i, msg := range batch {
@@ -259,11 +229,6 @@ func unmarshalEventSequences(batch []pulsar.Message, msgFilter func(msg pulsar.M
 		// Record the messageId- we need to record all message Ids, even if the event they contain is invalid
 		// As they must be acked at the end
 		messageIds[i] = msg.ID()
-
-		// If we're not interested in this then continue
-		if !msgFilter(msg) {
-			continue
-		}
 
 		// Try and unmarshall the proto
 		es, err := eventutil.UnmarshalEventSequence(armadacontext.Background(), msg.Payload())

--- a/internal/common/ingest/ingestion_pipeline_test.go
+++ b/internal/common/ingest/ingestion_pipeline_test.go
@@ -294,7 +294,6 @@ func testPipeline(consumer pulsar.Consumer, converter InstructionConverter[*simp
 		metricsPort:            8080,
 		metrics:                testMetrics,
 		consumer:               consumer,
-		msgFilter:              func(msg pulsar.Message) bool { return true },
 	}
 }
 

--- a/internal/common/schedulers/scheduler.go
+++ b/internal/common/schedulers/scheduler.go
@@ -48,15 +48,3 @@ func MsgPropertyFromScheduler(s Scheduler) string {
 	log.Warnf("Unknown scheduler [%d]. Defaulting to legacy scheduler", s)
 	return LegacySchedulerAttribute
 }
-
-// ForPulsarScheduler returns true if this message should be processed by the pulsar scheduler
-func ForPulsarScheduler(msg pulsar.Message) bool {
-	s := SchedulerFromMsg(msg)
-	return s == Pulsar || s == All
-}
-
-// ForLegacyScheduler returns true if this message should be processed by the legacy scheduler
-func ForLegacyScheduler(msg pulsar.Message) bool {
-	s := SchedulerFromMsg(msg)
-	return s == Legacy || s == All
-}

--- a/internal/scheduleringester/ingester.go
+++ b/internal/scheduleringester/ingester.go
@@ -16,7 +16,6 @@ import (
 	"github.com/armadaproject/armada/internal/common/database"
 	"github.com/armadaproject/armada/internal/common/ingest"
 	"github.com/armadaproject/armada/internal/common/ingest/metrics"
-	"github.com/armadaproject/armada/internal/common/schedulers"
 )
 
 // Run will create a pipeline that will take Armada event messages from Pulsar and update the schedulerDb.
@@ -47,13 +46,12 @@ func Run(config Configuration) error {
 		}()
 	}
 
-	ingester := ingest.NewFilteredMsgIngestionPipeline[*DbOperationsWithMessageIds](
+	ingester := ingest.NewIngestionPipeline[*DbOperationsWithMessageIds](
 		config.Pulsar,
 		config.SubscriptionName,
 		config.BatchSize,
 		config.BatchDuration,
 		pulsar.Failover,
-		schedulers.ForPulsarScheduler,
 		converter,
 		schedulerDb,
 		config.MetricsPort,


### PR DESCRIPTION
All pulsar messages are tagged as to which scheduler they pertain to.  This dates from a time when we planned to run new and legacy schedulers simultaneously.  As this no longer applies and all messages are now for the new scheduler we can remove this filtering from msg readers.  

Once this has been released we can remove the tagging of messages from message producers.