### PR TITLE
Filter out null values when grouping by annotation

### DIFF
--- a/internal/lookoutv2/repository/groupjobs_test.go
+++ b/internal/lookoutv2/repository/groupjobs_test.go
@@ -961,6 +961,13 @@ func TestGroupByAnnotation(t *testing.T) {
 				"test-annotation-1": "test-value-3",
 			},
 		}, converter, store)
+		manyJobs(3, &createJobsOpts{
+			queue:  queue,
+			jobSet: jobSet,
+			annotations: map[string]string{
+				// Note the absence of the key "test-annotation-1".
+			},
+		}, converter, store)
 
 		result, err := repo.GroupBy(
 			armadacontext.TODO(),

--- a/internal/lookoutv2/repository/groupjobs_test.go
+++ b/internal/lookoutv2/repository/groupjobs_test.go
@@ -962,8 +962,8 @@ func TestGroupByAnnotation(t *testing.T) {
 			},
 		}, converter, store)
 		manyJobs(3, &createJobsOpts{
-			queue:  queue,
-			jobSet: jobSet,
+			queue:       queue,
+			jobSet:      jobSet,
 			annotations: map[string]string{
 				// Note the absence of the key "test-annotation-1".
 			},


### PR DESCRIPTION
There is a general assumption in the Lookout UI and API that grouping by an annotation will only consider jobs which have a value associated with this key; I accidentally broke this assumption in the `jsonb` backend.