### PR TITLE
Add Ability To Control Pool Scheduling Order In Config

### DIFF
--- a/config/scheduler/config.yaml
+++ b/config/scheduler/config.yaml
@@ -133,3 +133,5 @@ scheduling:
   queueQuarantining:
     quarantineFactorMultiplier: 0.5 # At most halve the scheduling rate of misbehaving queues.
     failureProbabilityEstimateTimeout: "10m"
+  poolSchedulePriority:
+  defaultPoolSchedulePriority: 0

--- a/config/scheduler/config.yaml
+++ b/config/scheduler/config.yaml
@@ -133,5 +133,3 @@ scheduling:
   queueQuarantining:
     quarantineFactorMultiplier: 0.5 # At most halve the scheduling rate of misbehaving queues.
     failureProbabilityEstimateTimeout: "10m"
-  poolSchedulePriority:
-  defaultPoolSchedulePriority: 0

--- a/internal/armada/configuration/types.go
+++ b/internal/armada/configuration/types.go
@@ -254,9 +254,9 @@ type SchedulingConfig struct {
 	// Controls queue quarantining, i.e., rate-limiting scheduling from misbehaving queues.
 	QueueQuarantining QueueQuarantinerConfig
 	// Defines the order in which pools will be scheduled. Higher priority pools will be scheduled first
-	PoolSchedulePriority map[string]int `validate:"required"`
+	PoolSchedulePriority map[string]int
 	// Default priority for pools that are not in the above list
-	DefaultPoolSchedulePriority int `validate:"required"`
+	DefaultPoolSchedulePriority int
 }
 
 const (

--- a/internal/armada/configuration/types.go
+++ b/internal/armada/configuration/types.go
@@ -253,6 +253,10 @@ type SchedulingConfig struct {
 	NodeQuarantining NodeQuarantinerConfig
 	// Controls queue quarantining, i.e., rate-limiting scheduling from misbehaving queues.
 	QueueQuarantining QueueQuarantinerConfig
+	// Defines the order in which pools will be scheduled. Higher priority pools will be scheduled first
+	PoolSchedulePriority map[string]int `validate:"required"`
+	// Default priority for pools that are not in the above list
+	DefaultPoolSchedulePriority int `validate:"required"`
 }
 
 const (

--- a/internal/scheduler/scheduling_algo.go
+++ b/internal/scheduler/scheduling_algo.go
@@ -663,6 +663,9 @@ func (l *FairSchedulingAlgo) aggregateAllocationByPoolAndQueueAndPriorityClass(
 // If a group's priority is not specified in the map, the defaultPriority is used. The groups are primarily
 // sorted by descending priority. If two groups have the same priority, they are sorted alphabetically by their names.
 func sortExecutorGroups(groups []string, groupToPriority map[string]int, defaultPriority int) {
+	if groupToPriority == nil {
+		groupToPriority = map[string]int{}
+	}
 	// Sort the groups using a custom comparison function
 	sort.Slice(groups, func(i, j int) bool {
 		// Retrieve or default the priority for the i-th group

--- a/internal/scheduler/scheduling_algo.go
+++ b/internal/scheduler/scheduling_algo.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"context"
 	"math/rand"
+	"sort"
 	"time"
 
 	"github.com/benbjohnson/immutable"
@@ -10,7 +11,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 	"golang.org/x/time/rate"
 	"k8s.io/apimachinery/pkg/util/clock"
 
@@ -135,7 +135,7 @@ func (l *FairSchedulingAlgo) Schedule(
 	if len(l.executorGroupsToSchedule) == 0 {
 		// Cycle over groups in a consistent order.
 		l.executorGroupsToSchedule = maps.Keys(executorGroups)
-		slices.Sort(l.executorGroupsToSchedule)
+		sortExecutorGroups(l.executorGroupsToSchedule, l.schedulingConfig.PoolSchedulePriority, l.schedulingConfig.DefaultPoolSchedulePriority)
 	}
 	for len(l.executorGroupsToSchedule) > 0 {
 		select {
@@ -657,4 +657,29 @@ func (l *FairSchedulingAlgo) aggregateAllocationByPoolAndQueueAndPriorityClass(
 		}
 	}
 	return rv
+}
+
+// sortExecutorGroups sorts the given list of groups based on priorities defined in groupToPriority map.
+// If a group's priority is not specified in the map, the defaultPriority is used. The groups are primarily
+// sorted by descending priority. If two groups have the same priority, they are sorted alphabetically by their names.
+func sortExecutorGroups(groups []string, groupToPriority map[string]int, defaultPriority int) {
+	// Sort the groups using a custom comparison function
+	sort.Slice(groups, func(i, j int) bool {
+		// Retrieve or default the priority for the i-th group
+		priI, okI := groupToPriority[groups[i]]
+		if !okI {
+			priI = defaultPriority
+		}
+		// Retrieve or default the priority for the j-th group
+		priJ, okJ := groupToPriority[groups[j]]
+		if !okJ {
+			priJ = defaultPriority
+		}
+		// Sort primarily by priority (descending)
+		if priI != priJ {
+			return priI > priJ
+		}
+		// If priorities are equal, sort by name (ascending)
+		return groups[i] < groups[j]
+	})
 }

--- a/internal/scheduler/scheduling_algo_test.go
+++ b/internal/scheduler/scheduling_algo_test.go
@@ -576,3 +576,46 @@ func BenchmarkNodeDbConstruction(b *testing.B) {
 		})
 	}
 }
+
+func TestSortExecutorGroups(t *testing.T) {
+
+	tests := map[string]struct {
+		groups          []string
+		groupToPriority map[string]int
+		defaultPriority int
+		expected        []string
+	}{
+		"All groups have defined priority": {
+			groups:          []string{"pool1", "pool2", "pool3"},
+			groupToPriority: map[string]int{"pool1": 3, "pool2": 1, "pool3": 2},
+			expected:        []string{"pool1", "pool3", "pool2"},
+		},
+		"Use default Priority": {
+			groups:          []string{"pool1", "pool2", "pool3"},
+			groupToPriority: map[string]int{"pool1": 3, "pool2": 1},
+			defaultPriority: 2,
+			expected:        []string{"pool1", "pool3", "pool2"},
+		},
+		"Tie break on alphabetical": {
+			groups:          []string{"pool1", "pool2", "pool3"},
+			groupToPriority: map[string]int{"pool1": 2, "pool2": 2, "pool3": 3},
+			defaultPriority: 2,
+			expected:        []string{"pool3", "pool1", "pool2"},
+		},
+		"Empty priority yields alphabetical": {
+			groups:   []string{"pool2", "pool3", "pool1"},
+			expected: []string{"pool1", "pool2", "pool3"},
+		},
+		"Empty input": {
+			groups:   []string{},
+			expected: []string{},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			sortExecutorGroups(tc.groups, tc.groupToPriority, tc.defaultPriority)
+			assert.Equal(t, tc.expected, tc.groups)
+		})
+	}
+}

--- a/internal/scheduler/scheduling_algo_test.go
+++ b/internal/scheduler/scheduling_algo_test.go
@@ -578,7 +578,6 @@ func BenchmarkNodeDbConstruction(b *testing.B) {
 }
 
 func TestSortExecutorGroups(t *testing.T) {
-
 	tests := map[string]struct {
 		groups          []string
 		groupToPriority map[string]int


### PR DESCRIPTION
Previously pools were scheduled in alphabetical order.  This had the effect of meaning that if a job was eligible for multiple pools it would always be scheduled on the pool that was alphabetically first, with no way of overriding this behaviour.

This change adds the following config options which allows control of the pool shceduling order:
```
// Defines the order in which pools will be scheduled. Higher priority pools will be scheduled first
PoolSchedulePriority map[string]int `validate:"required"`

// Default priority for pools that are not in the above list
DefaultPoolSchedulePriority int `validate:"required"`
```

If no config is supplied then the scheduler will fall back to alphabetical ordering and the behaviour will remain the same as before
