### PR TITLE
Improve scheduler logging

### DIFF
--- a/internal/common/grpc/grpc.go
+++ b/internal/common/grpc/grpc.go
@@ -37,6 +37,7 @@ func CreateGrpcServer(
 	keepaliveEnforcementPolicy keepalive.EnforcementPolicy,
 	authServices []authorization.AuthService,
 	tlsConfig configuration.TlsConfig,
+	logrusOptions ...grpc_logrus.Option,
 ) *grpc.Server {
 	// Logging, authentication, etc. are implemented via gRPC interceptors
 	// (i.e., via functions that are called before handling the actual request).
@@ -60,13 +61,13 @@ func CreateGrpcServer(
 		grpc_ctxtags.UnaryServerInterceptor(tagsExtractor),
 		requestid.UnaryServerInterceptor(false),
 		armadaerrors.UnaryServerInterceptor(2000),
-		grpc_logrus.UnaryServerInterceptor(messageDefault),
+		grpc_logrus.UnaryServerInterceptor(messageDefault, logrusOptions...),
 	)
 	streamInterceptors = append(streamInterceptors,
 		grpc_ctxtags.StreamServerInterceptor(tagsExtractor),
 		requestid.StreamServerInterceptor(false),
 		armadaerrors.StreamServerInterceptor(2000),
-		grpc_logrus.StreamServerInterceptor(messageDefault),
+		grpc_logrus.StreamServerInterceptor(messageDefault, logrusOptions...),
 	)
 
 	// Authentication

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -233,6 +233,7 @@ func (s *Scheduler) Run(ctx *armadacontext.Context) error {
 func (s *Scheduler) cycle(ctx *armadacontext.Context, updateAll bool, leaderToken leader.LeaderToken, shouldSchedule bool) (SchedulerResult, error) {
 	// TODO: Consider returning a slice of these instead.
 	overallSchedulerResult := SchedulerResult{}
+
 	// Update job state.
 	ctx.Info("Syncing internal state with database")
 	updatedJobs, jsts, err := s.syncState(ctx)

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -233,12 +233,13 @@ func (s *Scheduler) Run(ctx *armadacontext.Context) error {
 func (s *Scheduler) cycle(ctx *armadacontext.Context, updateAll bool, leaderToken leader.LeaderToken, shouldSchedule bool) (SchedulerResult, error) {
 	// TODO: Consider returning a slice of these instead.
 	overallSchedulerResult := SchedulerResult{}
-
 	// Update job state.
+	ctx.Infof("Syncing internal state with database")
 	updatedJobs, jsts, err := s.syncState(ctx)
 	if err != nil {
 		return overallSchedulerResult, err
 	}
+	ctx.Infof("Finished syncing state")
 
 	// Only the leader may make decisions; exit if not leader.
 	// Only export metrics if leader.
@@ -271,10 +272,12 @@ func (s *Scheduler) cycle(ctx *armadacontext.Context, updateAll bool, leaderToke
 			failedRunIds = append(failedRunIds, run.Id())
 		}
 	}
+	ctx.Infof("Fetching job run errors")
 	jobRepoRunErrorsByRunId, err := s.jobRepository.FetchJobRunErrors(ctx, failedRunIds)
 	if err != nil {
 		return overallSchedulerResult, err
 	}
+	ctx.Infof("Fetched %d job run errors", len(jobRepoRunErrorsByRunId))
 
 	// Update metrics.
 	if !s.schedulerMetrics.IsDisabled() {
@@ -310,23 +313,29 @@ func (s *Scheduler) cycle(ctx *armadacontext.Context, updateAll bool, leaderToke
 	}
 
 	// Generate any eventSequences that came out of synchronising the db state.
+	ctx.Infof("Generating update messages based on reconciliation changes")
 	events, err := s.generateUpdateMessages(ctx, txn, updatedJobs, jobRepoRunErrorsByRunId)
 	if err != nil {
 		return overallSchedulerResult, err
 	}
+	ctx.Infof("Finished generating updates messages, generating %d events", len(events))
 
 	// Expire any jobs running on clusters that haven't heartbeated within the configured deadline.
+	ctx.Infof("Looking for jobs to expire")
 	expirationEvents, err := s.expireJobsIfNecessary(ctx, txn)
 	if err != nil {
 		return overallSchedulerResult, err
 	}
+	ctx.Infof("Finished looking for jobs to expire, generating %d events", len(expirationEvents))
 	events = append(events, expirationEvents...)
 
 	// Request cancel for any jobs that exceed queueTtl
+	ctx.Infof("Cancelling queued jobs exceeding their queue ttl")
 	queueTtlCancelEvents, err := s.cancelQueuedJobsIfExpired(txn)
 	if err != nil {
 		return overallSchedulerResult, err
 	}
+	ctx.Infof("Finished cancelling queued jobs exceeding their queue ttl, generating %d events", len(queueTtlCancelEvents))
 	events = append(events, queueTtlCancelEvents...)
 
 	// Schedule jobs.
@@ -353,18 +362,22 @@ func (s *Scheduler) cycle(ctx *armadacontext.Context, updateAll bool, leaderToke
 		return s.leaderController.ValidateToken(leaderToken)
 	}
 	start := s.clock.Now()
+	ctx.Infof("Starting to publish %d eventSequences to pulsar", len(events))
 	if err = s.publisher.PublishMessages(ctx, events, isLeader); err != nil {
 		return overallSchedulerResult, err
 	}
-	ctx.Infof("published %d eventSequences to pulsar in %s", len(events), s.clock.Since(start))
+	ctx.Infof("Published %d eventSequences to pulsar in %s", len(events), s.clock.Since(start))
 
 	// Optionally assert that the jobDb is in a valid state and then commit.
 	if s.enableAssertions {
+		ctx.Infof("Performing assertions on current state")
 		if err := txn.Assert(false); err != nil {
 			return overallSchedulerResult, err
 		}
 	}
+	ctx.Infof("Committing cycle transaction")
 	txn.Commit()
+	ctx.Infof("Completed committing cycle transaction")
 
 	// Update metrics based on overallSchedulerResult.
 	if err := s.updateMetricsFromSchedulerResult(ctx, overallSchedulerResult); err != nil {

--- a/internal/scheduler/schedulerapp.go
+++ b/internal/scheduler/schedulerapp.go
@@ -392,9 +392,10 @@ func loadClusterConfig(ctx *armadacontext.Context) (*rest.Config, error) {
 
 // This changes the default logrus grpc logging to log OK messages at trace level
 // The reason for doing this are:
-// - Clearer logs
-// - Armada components are the only clients, so we don't need these logs to tell us who is calling the executor api
-// We could make this configurable in future - although is equivalently is via setting Trace level logging
+//   - Reduced logging
+//   - We only care about failures, so lets only log failures
+//   - We normally use these logs to work out who is calling us, however the Executor API is not public
+//     and is only called by other Armada components
 func createLogrusLoggingOption() grpc_logrus.Option {
 	return grpc_logrus.WithLevels(func(code codes.Code) log.Level {
 		switch code {

--- a/internal/scheduler/schedulerapp.go
+++ b/internal/scheduler/schedulerapp.go
@@ -10,9 +10,12 @@ import (
 
 	"github.com/apache/pulsar-client-go/pulsar"
 	"github.com/google/uuid"
+	grpc_logrus "github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/redis/go-redis/v9"
+	log "github.com/sirupsen/logrus"
+	"google.golang.org/grpc/codes"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -167,7 +170,7 @@ func Run(config schedulerconfig.Configuration) error {
 	if err != nil {
 		return errors.WithMessage(err, "error creating auth services")
 	}
-	grpcServer := grpcCommon.CreateGrpcServer(config.Grpc.KeepaliveParams, config.Grpc.KeepaliveEnforcementPolicy, authServices, config.Grpc.Tls)
+	grpcServer := grpcCommon.CreateGrpcServer(config.Grpc.KeepaliveParams, config.Grpc.KeepaliveEnforcementPolicy, authServices, config.Grpc.Tls, createLogrusLoggingOption())
 	defer grpcServer.GracefulStop()
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", config.Grpc.Port))
 	if err != nil {
@@ -385,4 +388,20 @@ func loadClusterConfig(ctx *armadacontext.Context) (*rest.Config, error) {
 	}
 	ctx.Info("Running with in cluster client configuration")
 	return config, err
+}
+
+// This changes the default logrus grpc logging to log OK messages at trace level
+// The reason for doing this are:
+// - Clearer logs
+// - Armada components are the only clients, so we don't need these logs to tell us who is calling the executor api
+// We could make this configurable in future - although is equivalently is via setting Trace level logging
+func createLogrusLoggingOption() grpc_logrus.Option {
+	return grpc_logrus.WithLevels(func(code codes.Code) log.Level {
+		switch code {
+		case codes.OK:
+			return log.TraceLevel
+		default:
+			return grpc_logrus.DefaultCodeToLevel(code)
+		}
+	})
 }


### PR DESCRIPTION
 - Remove noisy logs from successful grpc calls by default
   - These can be enabled by setting log level to trace
   - Generally we don't care about the successful calls and we already know who is calling us
   - Possibly we could make enabling these logs easier via config in future
 - More verbosely log where are in in scheduler.cycle
   - The motivation is to allow us to quickly hone in on where the scheduler is getting stuck / running slow



