### PR TITLE
Reduce JobSummary logging

### DIFF
--- a/internal/scheduler/preempting_queue_scheduler.go
+++ b/internal/scheduler/preempting_queue_scheduler.go
@@ -240,11 +240,13 @@ func (sch *PreemptingQueueScheduler) Schedule(ctx *armadacontext.Context) (*Sche
 	); err != nil {
 		return nil, err
 	}
-	if s := JobsSummary(preemptedJobs); s != "" {
-		ctx.Infof("preempting running jobs; %s", s)
+	if s := JobsSummary(preemptedJobs); s != nil {
+		ctx.Infof("preempting running jobs; %s", s.Summary)
+		ctx.Debug("preempting running jobs; %s", s.Verbose)
 	}
-	if s := JobsSummary(scheduledJobs); s != "" {
-		ctx.Infof("scheduling new jobs; %s", s)
+	if s := JobsSummary(scheduledJobs); s != nil {
+		ctx.Infof("scheduling new jobs; %s", s.Summary)
+		ctx.Debug("scheduling new jobs; %s", s.Verbose)
 	}
 	// TODO: Show failed jobs.
 	if sch.enableAssertions {

--- a/internal/scheduler/preempting_queue_scheduler.go
+++ b/internal/scheduler/preempting_queue_scheduler.go
@@ -241,12 +241,12 @@ func (sch *PreemptingQueueScheduler) Schedule(ctx *armadacontext.Context) (*Sche
 		return nil, err
 	}
 	if s := JobsSummary(preemptedJobs); s != nil {
-		ctx.Infof("preempting running jobs; %s", s.Summary)
-		ctx.Debug("preempting running jobs; %s", s.Verbose)
+		ctx.Infof("Preempting running jobs; %s", s.Summary)
+		ctx.Debug("Preempting running jobs; %s", s.Verbose)
 	}
 	if s := JobsSummary(scheduledJobs); s != nil {
-		ctx.Infof("scheduling new jobs; %s", s.Summary)
-		ctx.Debug("scheduling new jobs; %s", s.Verbose)
+		ctx.Infof("Scheduling new jobs; %s", s.Summary)
+		ctx.Debug("Scheduling new jobs; %s", s.Verbose)
 	}
 	// TODO: Show failed jobs.
 	if sch.enableAssertions {

--- a/internal/scheduler/preempting_queue_scheduler.go
+++ b/internal/scheduler/preempting_queue_scheduler.go
@@ -240,15 +240,11 @@ func (sch *PreemptingQueueScheduler) Schedule(ctx *armadacontext.Context) (*Sche
 	); err != nil {
 		return nil, err
 	}
-	if s := JobsSummary(preemptedJobs); s != nil {
-		ctx.Infof("Preempting running jobs; %s", s.Summary)
-		ctx.Debug("Preempting running jobs; %s", s.Verbose)
-	}
-	if s := JobsSummary(scheduledJobs); s != nil {
-		ctx.Infof("Scheduling new jobs; %s", s.Summary)
-		ctx.Debug("Scheduling new jobs; %s", s.Verbose)
-	}
+
+	PrintJobSummary(ctx, "Preempting running jobs;", preemptedJobs)
+	PrintJobSummary(ctx, "Scheduling new jobs;", scheduledJobs)
 	// TODO: Show failed jobs.
+
 	if sch.enableAssertions {
 		err := sch.assertions(
 			snapshot,


### PR DESCRIPTION
Currently this logs every job id scheduled, which can lead to massive log lines
 - Many thousand job ids

Now we only log that at debug level, and instead log the number of jobs scheduler per queue at info level

