### PR TITLE
 Remove Legacy Scheduler Job 

### DIFF
--- a/internal/scheduler/common.go
+++ b/internal/scheduler/common.go
@@ -9,7 +9,7 @@ import (
 	armadamaps "github.com/armadaproject/armada/internal/common/maps"
 	armadaslices "github.com/armadaproject/armada/internal/common/slices"
 	schedulercontext "github.com/armadaproject/armada/internal/scheduler/context"
-	"github.com/armadaproject/armada/internal/scheduler/interfaces"
+	"github.com/armadaproject/armada/internal/scheduler/jobdb"
 	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
 )
 
@@ -24,13 +24,13 @@ func PrintJobSummary(ctx *armadacontext.Context, prefix string, jctxs []*schedul
 		func(jctx *schedulercontext.JobSchedulingContext) string {
 			return jctx.Job.GetQueue()
 		},
-		func(jctx *schedulercontext.JobSchedulingContext) interfaces.LegacySchedulerJob {
+		func(jctx *schedulercontext.JobSchedulingContext) *jobdb.Job {
 			return jctx.Job
 		},
 	)
 	resourcesByQueue := armadamaps.MapValues(
 		jobsByQueue,
-		func(jobs []interfaces.LegacySchedulerJob) schedulerobjects.ResourceList {
+		func(jobs []*jobdb.Job) schedulerobjects.ResourceList {
 			rv := schedulerobjects.NewResourceListWithDefaultSize()
 			for _, job := range jobs {
 				rv.AddV1ResourceList(job.GetResourceRequirements().Requests)
@@ -40,13 +40,13 @@ func PrintJobSummary(ctx *armadacontext.Context, prefix string, jctxs []*schedul
 	)
 	jobCountPerQueue := armadamaps.MapValues(
 		jobsByQueue,
-		func(jobs []interfaces.LegacySchedulerJob) int {
+		func(jobs []*jobdb.Job) int {
 			return len(jobs)
 		},
 	)
 	jobIdsByQueue := armadamaps.MapValues(
 		jobsByQueue,
-		func(jobs []interfaces.LegacySchedulerJob) []string {
+		func(jobs []*jobdb.Job) []string {
 			rv := make([]string, len(jobs))
 			for i, job := range jobs {
 				rv[i] = job.GetId()

--- a/internal/scheduler/gang_scheduler.go
+++ b/internal/scheduler/gang_scheduler.go
@@ -10,7 +10,7 @@ import (
 	"github.com/armadaproject/armada/internal/common/util"
 	schedulerconstraints "github.com/armadaproject/armada/internal/scheduler/constraints"
 	schedulercontext "github.com/armadaproject/armada/internal/scheduler/context"
-	"github.com/armadaproject/armada/internal/scheduler/interfaces"
+	"github.com/armadaproject/armada/internal/scheduler/jobdb"
 	"github.com/armadaproject/armada/internal/scheduler/nodedb"
 	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
 )
@@ -63,7 +63,7 @@ func (sch *GangScheduler) updateGangSchedulingContextOnSuccess(gctx *schedulerco
 func (sch *GangScheduler) updateGangSchedulingContextOnFailure(gctx *schedulercontext.GangSchedulingContext, gangAddedToSchedulingContext bool, unschedulableReason string) error {
 	// If the job was added to the context, remove it first.
 	if gangAddedToSchedulingContext {
-		failedJobs := util.Map(gctx.JobSchedulingContexts, func(jctx *schedulercontext.JobSchedulingContext) interfaces.LegacySchedulerJob { return jctx.Job })
+		failedJobs := util.Map(gctx.JobSchedulingContexts, func(jctx *schedulercontext.JobSchedulingContext) *jobdb.Job { return jctx.Job })
 		if _, err := sch.schedulingContext.EvictGang(failedJobs); err != nil {
 			return err
 		}

--- a/internal/scheduler/interfaces/interfaces.go
+++ b/internal/scheduler/interfaces/interfaces.go
@@ -1,64 +1,6 @@
 package interfaces
 
-import (
-	"time"
-
-	v1 "k8s.io/api/core/v1"
-
-	"github.com/armadaproject/armada/internal/common/types"
-	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
-)
-
 type MinimalJob interface {
 	GetAnnotations() map[string]string
 	GetPriorityClassName() string
-}
-
-// LegacySchedulerJob is the job interface used throughout the scheduler.
-type LegacySchedulerJob interface {
-	GetId() string
-	GetQueue() string
-	GetJobSet() string
-	GetPerQueuePriority() uint32
-	GetSubmitTime() time.Time
-	GetAnnotations() map[string]string
-	GetPodRequirements(priorityClasses map[string]types.PriorityClass) *schedulerobjects.PodRequirements
-	GetPriorityClassName() string
-	GetScheduledAtPriority() (int32, bool)
-	GetNodeSelector() map[string]string
-	GetAffinity() *v1.Affinity
-	GetTolerations() []v1.Toleration
-	GetResourceRequirements() v1.ResourceRequirements
-	GetQueueTtlSeconds() int64
-	// GetSchedulingKey returns (schedulingKey, true) if the job has a scheduling key associated with it and
-	// (emptySchedulingKey, false) otherwise, where emptySchedulingKey is the zero value of the SchedulingKey type.
-	GetSchedulingKey() (schedulerobjects.SchedulingKey, bool)
-	// SchedulingOrderCompare defines the order in which jobs in a queue should be scheduled
-	// (both when scheduling new jobs and when re-scheduling evicted jobs).
-	// Specifically, compare returns
-	//   - 0 if the jobs have equal job id,
-	//   - -1 if job should be scheduled before other,
-	//   - +1 if other should be scheduled before other.
-	SchedulingOrderCompare(other LegacySchedulerJob) int
-}
-
-func PriorityClassFromLegacySchedulerJob(priorityClasses map[string]types.PriorityClass, defaultPriorityClassName string, job LegacySchedulerJob) types.PriorityClass {
-	priorityClassName := job.GetPriorityClassName()
-	if priorityClass, ok := priorityClasses[priorityClassName]; ok {
-		return priorityClass
-	}
-	// We could return (types.PriorityClass{}, false) here, but then callers
-	// might handle this situation in different ways; return the default
-	// priority class in order to enforce uniformity.
-	return priorityClasses[defaultPriorityClassName]
-}
-
-func SchedulingKeyFromLegacySchedulerJob(skg *schedulerobjects.SchedulingKeyGenerator, job LegacySchedulerJob) schedulerobjects.SchedulingKey {
-	return skg.Key(
-		job.GetNodeSelector(),
-		job.GetAffinity(),
-		job.GetTolerations(),
-		job.GetResourceRequirements().Requests,
-		job.GetPriorityClassName(),
-	)
 }

--- a/internal/scheduler/jobdb/comparison.go
+++ b/internal/scheduler/jobdb/comparison.go
@@ -2,8 +2,6 @@ package jobdb
 
 import (
 	"time"
-
-	"github.com/armadaproject/armada/internal/scheduler/interfaces"
 )
 
 type (
@@ -60,10 +58,10 @@ func (JobPriorityComparer) Compare(job, other *Job) int {
 }
 
 // SchedulingOrderCompare defines the order in which jobs in a particular queue should be scheduled,
-func (job *Job) SchedulingOrderCompare(other interfaces.LegacySchedulerJob) int {
+func (job *Job) SchedulingOrderCompare(other *Job) int {
 	// We need this cast for now to expose this method via an interface.
 	// This is safe since we only ever compare jobs of the same type.
-	return SchedulingOrderCompare(job, other.(*Job))
+	return SchedulingOrderCompare(job, other)
 }
 
 // SchedulingOrderCompare defines the order in which jobs in a queue should be scheduled

--- a/internal/scheduler/jobdb/jobdb.go
+++ b/internal/scheduler/jobdb/jobdb.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/armadaproject/armada/internal/common/stringinterner"
 	"github.com/armadaproject/armada/internal/common/types"
-	"github.com/armadaproject/armada/internal/scheduler/interfaces"
 	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
 )
 
@@ -149,7 +148,7 @@ func (jobDb *JobDb) NewJob(
 		runsById:                map[uuid.UUID]*JobRun{},
 	}
 	job.ensureJobSchedulingInfoFieldsInitialised()
-	job.schedulingKey = interfaces.SchedulingKeyFromLegacySchedulerJob(jobDb.schedulingKeyGenerator, job)
+	job.schedulingKey = SchedulingKeyFromJob(jobDb.schedulingKeyGenerator, job)
 	return job
 }
 

--- a/internal/scheduler/jobdb/jobdb_test.go
+++ b/internal/scheduler/jobdb/jobdb_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/armadaproject/armada/internal/common/stringinterner"
 	"github.com/armadaproject/armada/internal/common/types"
 	"github.com/armadaproject/armada/internal/common/util"
-	"github.com/armadaproject/armada/internal/scheduler/interfaces"
 	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
 )
 
@@ -250,7 +249,7 @@ func TestJobDb_SchedulingKeyIsPopulated(t *testing.T) {
 
 	actualSchedulingKey, ok := job.GetSchedulingKey()
 	require.True(t, ok)
-	assert.Equal(t, interfaces.SchedulingKeyFromLegacySchedulerJob(jobDb.schedulingKeyGenerator, job), actualSchedulingKey)
+	assert.Equal(t, SchedulingKeyFromJob(jobDb.schedulingKeyGenerator, job), actualSchedulingKey)
 }
 
 func TestJobDb_SchedulingKey(t *testing.T) {
@@ -1244,13 +1243,13 @@ func TestJobDb_SchedulingKey(t *testing.T) {
 			jobSchedulingInfoB.ObjectRequirements[0].Requirements = &schedulerobjects.ObjectRequirements_PodRequirements{PodRequirements: tc.podRequirementsB}
 			jobB := baseJob.WithJobSchedulingInfo(jobSchedulingInfoB)
 
-			schedulingKeyA := interfaces.SchedulingKeyFromLegacySchedulerJob(skg, jobA)
-			schedulingKeyB := interfaces.SchedulingKeyFromLegacySchedulerJob(skg, jobB)
+			schedulingKeyA := SchedulingKeyFromJob(skg, jobA)
+			schedulingKeyB := SchedulingKeyFromJob(skg, jobB)
 
 			// Generate the keys several times to check their consistency.
 			for i := 1; i < 10; i++ {
-				assert.Equal(t, interfaces.SchedulingKeyFromLegacySchedulerJob(skg, jobA), schedulingKeyA)
-				assert.Equal(t, interfaces.SchedulingKeyFromLegacySchedulerJob(skg, jobB), schedulingKeyB)
+				assert.Equal(t, SchedulingKeyFromJob(skg, jobA), schedulingKeyA)
+				assert.Equal(t, SchedulingKeyFromJob(skg, jobB), schedulingKeyB)
 			}
 
 			if tc.equal {

--- a/internal/scheduler/jobiteration.go
+++ b/internal/scheduler/jobiteration.go
@@ -9,7 +9,7 @@ import (
 	"github.com/armadaproject/armada/internal/common/types"
 	"github.com/armadaproject/armada/internal/common/util"
 	schedulercontext "github.com/armadaproject/armada/internal/scheduler/context"
-	"github.com/armadaproject/armada/internal/scheduler/interfaces"
+	"github.com/armadaproject/armada/internal/scheduler/jobdb"
 )
 
 type JobIterator interface {
@@ -18,7 +18,7 @@ type JobIterator interface {
 
 type JobRepository interface {
 	GetQueueJobIds(queueName string) []string
-	GetExistingJobsByIds(ids []string) []interfaces.LegacySchedulerJob
+	GetExistingJobsByIds(ids []string) []*jobdb.Job
 }
 
 type InMemoryJobIterator struct {
@@ -86,10 +86,10 @@ func (repo *InMemoryJobRepository) GetQueueJobIds(queue string) []string {
 	)
 }
 
-func (repo *InMemoryJobRepository) GetExistingJobsByIds(jobIds []string) []interfaces.LegacySchedulerJob {
+func (repo *InMemoryJobRepository) GetExistingJobsByIds(jobIds []string) []*jobdb.Job {
 	repo.mu.Lock()
 	defer repo.mu.Unlock()
-	rv := make([]interfaces.LegacySchedulerJob, 0, len(jobIds))
+	rv := make([]*jobdb.Job, 0, len(jobIds))
 	for _, jobId := range jobIds {
 		if jctx, ok := repo.jctxsById[jobId]; ok {
 			rv = append(rv, jctx.Job)

--- a/internal/scheduler/metrics/metrics.go
+++ b/internal/scheduler/metrics/metrics.go
@@ -279,7 +279,7 @@ func (m *Metrics) UpdateSucceeded(job *jobdb.Job) error {
 }
 
 func (m *Metrics) UpdateLeased(jctx *schedulercontext.JobSchedulingContext) error {
-	job := jctx.Job.(*jobdb.Job)
+	job := jctx.Job
 	latestRun := job.LatestRun()
 	duration, priorState := stateDuration(job, latestRun, &jctx.Created)
 	labels := m.buffer[0:0]
@@ -381,7 +381,7 @@ func appendLabelsFromJob(labels []string, job *jobdb.Job) []string {
 }
 
 func appendLabelsFromJobSchedulingContext(labels []string, jctx *schedulercontext.JobSchedulingContext) []string {
-	job := jctx.Job.(*jobdb.Job)
+	job := jctx.Job
 	executor, nodeName := executorAndNodeNameFromRun(job.LatestRun())
 	labels = append(labels, job.GetQueue())
 	labels = append(labels, executor)

--- a/internal/scheduler/pool_assigner.go
+++ b/internal/scheduler/pool_assigner.go
@@ -15,7 +15,6 @@ import (
 	"github.com/armadaproject/armada/internal/scheduler/constraints"
 	schedulercontext "github.com/armadaproject/armada/internal/scheduler/context"
 	"github.com/armadaproject/armada/internal/scheduler/database"
-	"github.com/armadaproject/armada/internal/scheduler/interfaces"
 	"github.com/armadaproject/armada/internal/scheduler/jobdb"
 	"github.com/armadaproject/armada/internal/scheduler/nodedb"
 	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
@@ -112,7 +111,7 @@ func (p *DefaultPoolAssigner) AssignPool(j *jobdb.Job) (string, error) {
 	// See if we have this set of reqs cached.
 	schedulingKey, ok := j.GetSchedulingKey()
 	if !ok {
-		schedulingKey = interfaces.SchedulingKeyFromLegacySchedulerJob(p.schedulingKeyGenerator, j)
+		schedulingKey = jobdb.SchedulingKeyFromJob(p.schedulingKeyGenerator, j)
 	}
 	if cachedPool, ok := p.poolCache.Get(schedulingKey); ok {
 		return cachedPool.(string), nil

--- a/internal/scheduler/preempting_queue_scheduler_test.go
+++ b/internal/scheduler/preempting_queue_scheduler_test.go
@@ -2020,7 +2020,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 
 				var preemptedJobs []*jobdb.Job
 				for _, jctx := range result.PreemptedJobs {
-					job := jctx.Job.(*jobdb.Job)
+					job := jctx.Job
 					preemptedJobs = append(
 						preemptedJobs,
 						job.
@@ -2049,7 +2049,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 				)
 				var scheduledJobs []*jobdb.Job
 				for _, jctx := range result.ScheduledJobs {
-					job := jctx.Job.(*jobdb.Job)
+					job := jctx.Job
 					jobId := job.GetId()
 					node, err := nodeDb.GetNode(result.NodeIdByJobId[jobId])
 					require.NotNil(t, node)
@@ -2265,7 +2265,7 @@ func BenchmarkPreemptingQueueScheduler(b *testing.B) {
 			require.NoError(b, err)
 
 			jobsByNodeId := make(map[string][]*jobdb.Job)
-			for _, job := range ScheduledJobsFromSchedulerResult[*jobdb.Job](result) {
+			for _, job := range ScheduledJobsFromSchedulerResult(result) {
 				nodeId := result.NodeIdByJobId[job.GetId()]
 				jobsByNodeId[nodeId] = append(jobsByNodeId[nodeId], job)
 			}

--- a/internal/scheduler/queue_scheduler_test.go
+++ b/internal/scheduler/queue_scheduler_test.go
@@ -22,7 +22,6 @@ import (
 	schedulerconstraints "github.com/armadaproject/armada/internal/scheduler/constraints"
 	schedulercontext "github.com/armadaproject/armada/internal/scheduler/context"
 	"github.com/armadaproject/armada/internal/scheduler/fairness"
-	"github.com/armadaproject/armada/internal/scheduler/interfaces"
 	"github.com/armadaproject/armada/internal/scheduler/jobdb"
 	"github.com/armadaproject/armada/internal/scheduler/nodedb"
 	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
@@ -541,7 +540,7 @@ func TestQueueScheduler(t *testing.T) {
 				}
 				indexByJobId[job.GetId()] = i
 			}
-			legacySchedulerJobs := make([]interfaces.LegacySchedulerJob, len(tc.Jobs))
+			legacySchedulerJobs := make([]*jobdb.Job, len(tc.Jobs))
 			for i, job := range tc.Jobs {
 				legacySchedulerJobs[i] = job
 			}

--- a/internal/scheduler/result.go
+++ b/internal/scheduler/result.go
@@ -2,7 +2,7 @@ package scheduler
 
 import (
 	schedulercontext "github.com/armadaproject/armada/internal/scheduler/context"
-	"github.com/armadaproject/armada/internal/scheduler/interfaces"
+	"github.com/armadaproject/armada/internal/scheduler/jobdb"
 )
 
 // SchedulerResult is returned by Rescheduler.Schedule().
@@ -26,29 +26,29 @@ type SchedulerResult struct {
 	AdditionalAnnotationsByJobId map[string]map[string]string
 }
 
-// PreemptedJobsFromSchedulerResult returns the slice of preempted jobs in the result cast to type T.
-func PreemptedJobsFromSchedulerResult[T interfaces.LegacySchedulerJob](sr *SchedulerResult) []T {
-	rv := make([]T, len(sr.PreemptedJobs))
+// PreemptedJobsFromSchedulerResult returns the slice of preempted jobs in the result.
+func PreemptedJobsFromSchedulerResult(sr *SchedulerResult) []*jobdb.Job {
+	rv := make([]*jobdb.Job, len(sr.PreemptedJobs))
 	for i, jctx := range sr.PreemptedJobs {
-		rv[i] = jctx.Job.(T)
+		rv[i] = jctx.Job
 	}
 	return rv
 }
 
-// ScheduledJobsFromSchedulerResult returns the slice of scheduled jobs in the result cast to type T.
-func ScheduledJobsFromSchedulerResult[T interfaces.LegacySchedulerJob](sr *SchedulerResult) []T {
-	rv := make([]T, len(sr.ScheduledJobs))
+// ScheduledJobsFromSchedulerResult returns the slice of scheduled jobs in the result.
+func ScheduledJobsFromSchedulerResult(sr *SchedulerResult) []*jobdb.Job {
+	rv := make([]*jobdb.Job, len(sr.ScheduledJobs))
 	for i, jctx := range sr.ScheduledJobs {
-		rv[i] = jctx.Job.(T)
+		rv[i] = jctx.Job
 	}
 	return rv
 }
 
-// FailedJobsFromSchedulerResult returns the slice of scheduled jobs in the result cast to type T.
-func FailedJobsFromSchedulerResult[T interfaces.LegacySchedulerJob](sr *SchedulerResult) []T {
-	rv := make([]T, len(sr.FailedJobs))
+// FailedJobsFromSchedulerResult returns the slice of scheduled jobs in the result.
+func FailedJobsFromSchedulerResult(sr *SchedulerResult) []*jobdb.Job {
+	rv := make([]*jobdb.Job, len(sr.FailedJobs))
 	for i, jctx := range sr.FailedJobs {
-		rv[i] = jctx.Job.(T)
+		rv[i] = jctx.Job
 	}
 	return rv
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -398,7 +398,7 @@ func (s *Scheduler) updateMetricsFromSchedulerResult(ctx *armadacontext.Context,
 		}
 	}
 	for _, jctx := range overallSchedulerResult.FailedJobs {
-		if err := s.schedulerMetrics.UpdateFailed(ctx, jctx.Job.(*jobdb.Job), nil); err != nil {
+		if err := s.schedulerMetrics.UpdateFailed(ctx, jctx.Job, nil); err != nil {
 			return err
 		}
 	}
@@ -503,7 +503,7 @@ func (s *Scheduler) eventsFromSchedulerResult(result *SchedulerResult) ([]*armad
 // EventsFromSchedulerResult generates necessary EventSequences from the provided SchedulerResult.
 func EventsFromSchedulerResult(result *SchedulerResult, time time.Time) ([]*armadaevents.EventSequence, error) {
 	eventSequences := make([]*armadaevents.EventSequence, 0, len(result.PreemptedJobs)+len(result.ScheduledJobs)+len(result.FailedJobs))
-	eventSequences, err := AppendEventSequencesFromPreemptedJobs(eventSequences, PreemptedJobsFromSchedulerResult[*jobdb.Job](result), time)
+	eventSequences, err := AppendEventSequencesFromPreemptedJobs(eventSequences, PreemptedJobsFromSchedulerResult(result), time)
 	if err != nil {
 		return nil, err
 	}
@@ -511,7 +511,7 @@ func EventsFromSchedulerResult(result *SchedulerResult, time time.Time) ([]*arma
 	if err != nil {
 		return nil, err
 	}
-	eventSequences, err = AppendEventSequencesFromUnschedulableJobs(eventSequences, FailedJobsFromSchedulerResult[*jobdb.Job](result), time)
+	eventSequences, err = AppendEventSequencesFromUnschedulableJobs(eventSequences, FailedJobsFromSchedulerResult(result), time)
 	if err != nil {
 		return nil, err
 	}
@@ -586,7 +586,7 @@ func createEventsForPreemptedJob(jobId *armadaevents.Uuid, runId *armadaevents.U
 
 func AppendEventSequencesFromScheduledJobs(eventSequences []*armadaevents.EventSequence, jctxs []*schedulercontext.JobSchedulingContext, additionalAnnotationsByJobId map[string]map[string]string) ([]*armadaevents.EventSequence, error) {
 	for _, jctx := range jctxs {
-		job := jctx.Job.(*jobdb.Job)
+		job := jctx.Job
 		jobId, err := armadaevents.ProtoUuidFromUlidString(job.Id())
 		if err != nil {
 			return nil, err

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -24,7 +24,6 @@ import (
 	schedulercontext "github.com/armadaproject/armada/internal/scheduler/context"
 	"github.com/armadaproject/armada/internal/scheduler/database"
 	schedulerdb "github.com/armadaproject/armada/internal/scheduler/database"
-	"github.com/armadaproject/armada/internal/scheduler/interfaces"
 	"github.com/armadaproject/armada/internal/scheduler/jobdb"
 	"github.com/armadaproject/armada/internal/scheduler/kubernetesobjects/affinity"
 	"github.com/armadaproject/armada/internal/scheduler/leader"
@@ -1485,7 +1484,7 @@ func (t *testSchedulingAlgo) Persist() {
 	return
 }
 
-func NewSchedulerResultForTest[S ~[]T, T interfaces.LegacySchedulerJob](
+func NewSchedulerResultForTest[S ~[]T, T *jobdb.Job](
 	preemptedJobs S,
 	scheduledJobs S,
 	failedJobs S,

--- a/internal/scheduler/scheduling_algo.go
+++ b/internal/scheduler/scheduling_algo.go
@@ -25,7 +25,6 @@ import (
 	schedulercontext "github.com/armadaproject/armada/internal/scheduler/context"
 	"github.com/armadaproject/armada/internal/scheduler/database"
 	"github.com/armadaproject/armada/internal/scheduler/fairness"
-	"github.com/armadaproject/armada/internal/scheduler/interfaces"
 	"github.com/armadaproject/armada/internal/scheduler/jobdb"
 	"github.com/armadaproject/armada/internal/scheduler/nodedb"
 	"github.com/armadaproject/armada/internal/scheduler/quarantine"
@@ -199,9 +198,9 @@ func (l *FairSchedulingAlgo) Schedule(
 			l.schedulingContextRepository.StoreSchedulingContext(sctx)
 		}
 
-		preemptedJobs := PreemptedJobsFromSchedulerResult[*jobdb.Job](schedulerResult)
-		scheduledJobs := ScheduledJobsFromSchedulerResult[*jobdb.Job](schedulerResult)
-		failedJobs := FailedJobsFromSchedulerResult[*jobdb.Job](schedulerResult)
+		preemptedJobs := PreemptedJobsFromSchedulerResult(schedulerResult)
+		scheduledJobs := ScheduledJobsFromSchedulerResult(schedulerResult)
+		failedJobs := FailedJobsFromSchedulerResult(schedulerResult)
 		if err := txn.Upsert(preemptedJobs); err != nil {
 			return nil, err
 		}
@@ -243,7 +242,7 @@ type JobQueueIteratorAdapter struct {
 	it *immutable.SortedSetIterator[*jobdb.Job]
 }
 
-func (it *JobQueueIteratorAdapter) Next() (interfaces.LegacySchedulerJob, error) {
+func (it *JobQueueIteratorAdapter) Next() (*jobdb.Job, error) {
 	if it.it.Done() {
 		return nil, nil
 	}
@@ -476,7 +475,7 @@ func (l *FairSchedulingAlgo) scheduleOnExecutors(
 		return nil, nil, err
 	}
 	for i, jctx := range result.PreemptedJobs {
-		jobDbJob := jctx.Job.(*jobdb.Job)
+		jobDbJob := jctx.Job
 		if run := jobDbJob.LatestRun(); run != nil {
 			jobDbJob = jobDbJob.WithUpdatedRun(run.WithFailed(true))
 		} else {
@@ -485,7 +484,7 @@ func (l *FairSchedulingAlgo) scheduleOnExecutors(
 		result.PreemptedJobs[i].Job = jobDbJob.WithQueued(false).WithFailed(true)
 	}
 	for i, jctx := range result.ScheduledJobs {
-		jobDbJob := jctx.Job.(*jobdb.Job)
+		jobDbJob := jctx.Job
 		jobId := jobDbJob.GetId()
 		nodeId := result.NodeIdByJobId[jobId]
 		if nodeId == "" {
@@ -505,7 +504,7 @@ func (l *FairSchedulingAlgo) scheduleOnExecutors(
 			WithNewRun(node.GetExecutor(), node.GetId(), node.GetName(), priority)
 	}
 	for i, jctx := range result.FailedJobs {
-		jobDbJob := jctx.Job.(*jobdb.Job)
+		jobDbJob := jctx.Job
 		result.FailedJobs[i].Job = jobDbJob.WithQueued(false).WithFailed(true)
 	}
 	return result, sctx, nil
@@ -537,8 +536,8 @@ func (repo *SchedulerJobRepositoryAdapter) GetQueueJobIds(queue string) []string
 
 // GetExistingJobsByIds is necessary to implement the JobRepository interface which we need while transitioning from the
 // old to new scheduler.
-func (repo *SchedulerJobRepositoryAdapter) GetExistingJobsByIds(ids []string) []interfaces.LegacySchedulerJob {
-	rv := make([]interfaces.LegacySchedulerJob, 0, len(ids))
+func (repo *SchedulerJobRepositoryAdapter) GetExistingJobsByIds(ids []string) []*jobdb.Job {
+	rv := make([]*jobdb.Job, 0, len(ids))
 	for _, id := range ids {
 		if job := repo.txn.GetById(id); job != nil {
 			rv = append(rv, job)

--- a/internal/scheduler/scheduling_algo_test.go
+++ b/internal/scheduler/scheduling_algo_test.go
@@ -441,7 +441,7 @@ func TestSchedule(t *testing.T) {
 			require.NoError(t, err)
 
 			// Check that the expected preemptions took place.
-			preemptedJobs := PreemptedJobsFromSchedulerResult[*jobdb.Job](schedulerResult)
+			preemptedJobs := PreemptedJobsFromSchedulerResult(schedulerResult)
 			actualPreemptedJobsByExecutorIndexAndNodeIndex := make(map[int]map[int][]int)
 			for _, job := range preemptedJobs {
 				executorIndex := executorIndexByJobId[job.Id()]
@@ -466,7 +466,7 @@ func TestSchedule(t *testing.T) {
 			}
 
 			// Check that jobs were scheduled as expected.
-			scheduledJobs := ScheduledJobsFromSchedulerResult[*jobdb.Job](schedulerResult)
+			scheduledJobs := ScheduledJobsFromSchedulerResult(schedulerResult)
 			actualScheduledIndices := make([]int, 0)
 			for _, job := range scheduledJobs {
 				actualScheduledIndices = append(actualScheduledIndices, queueIndexByJobId[job.Id()])
@@ -483,7 +483,7 @@ func TestSchedule(t *testing.T) {
 			}
 
 			// Check that we failed the correct number of excess jobs when a gang schedules >= minimum cardinality
-			failedJobs := FailedJobsFromSchedulerResult[*jobdb.Job](schedulerResult)
+			failedJobs := FailedJobsFromSchedulerResult(schedulerResult)
 			assert.Equal(t, tc.expectedFailedJobCount, len(failedJobs))
 
 			// Check that preempted jobs are marked as such consistently.

--- a/internal/scheduler/submitcheck.go
+++ b/internal/scheduler/submitcheck.go
@@ -20,7 +20,6 @@ import (
 	"github.com/armadaproject/armada/internal/scheduler/adapters"
 	schedulercontext "github.com/armadaproject/armada/internal/scheduler/context"
 	"github.com/armadaproject/armada/internal/scheduler/database"
-	"github.com/armadaproject/armada/internal/scheduler/interfaces"
 	"github.com/armadaproject/armada/internal/scheduler/jobdb"
 	"github.com/armadaproject/armada/internal/scheduler/nodedb"
 	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
@@ -200,7 +199,7 @@ func (srv *SubmitChecker) getIndividualSchedulingResult(jctx *schedulercontext.J
 	schedulingKey, ok := jctx.Job.GetSchedulingKey()
 	if !ok {
 		srv.mu.Lock()
-		schedulingKey = interfaces.SchedulingKeyFromLegacySchedulerJob(srv.schedulingKeyGenerator, jctx.Job)
+		schedulingKey = jobdb.SchedulingKeyFromJob(srv.schedulingKeyGenerator, jctx.Job)
 		srv.mu.Unlock()
 	}
 

--- a/pkg/api/util.go
+++ b/pkg/api/util.go
@@ -14,7 +14,6 @@ import (
 	"github.com/armadaproject/armada/internal/common/logging"
 	armadaresource "github.com/armadaproject/armada/internal/common/resource"
 	"github.com/armadaproject/armada/internal/common/types"
-	"github.com/armadaproject/armada/internal/scheduler/interfaces"
 	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
 )
 
@@ -205,46 +204,6 @@ func (job *Job) GetResourceRequirements() v1.ResourceRequirements {
 // The second return value is always false since scheduling keys are not pre-computed for these jobs.
 func (job *Job) GetSchedulingKey() (schedulerobjects.SchedulingKey, bool) {
 	return schedulerobjects.SchedulingKey{}, false
-}
-
-// SchedulingOrderCompare defines the order in which jobs in a particular queue should be scheduled,
-func (job *Job) SchedulingOrderCompare(other interfaces.LegacySchedulerJob) int {
-	// We need this cast for now to expose this method via an interface.
-	// This is safe since we only ever compare jobs of the same type.
-	return SchedulingOrderCompare(job, other.(*Job))
-}
-
-// SchedulingOrderCompare defines the order in which jobs in a queue should be scheduled
-// (both when scheduling new jobs and when re-scheduling evicted jobs).
-// Specifically, compare returns
-//   - 0 if the jobs have equal job id,
-//   - -1 if job should be scheduled before other,
-//   - +1 if other should be scheduled before other.
-func SchedulingOrderCompare(job, other *Job) int {
-	if job.Id == other.Id {
-		return 0
-	}
-
-	// Jobs with higher in queue-priority come first.
-	if job.Priority < other.Priority {
-		return -1
-	} else if job.Priority > other.Priority {
-		return 1
-	}
-
-	// Jobs that have been queuing for longer are scheduled first.
-	if cmp := job.Created.Compare(other.Created); cmp != 0 {
-		return cmp
-	}
-
-	// Tie-break by jobId, which must be unique.
-	// This ensure there is a total order between jobs, i.e., no jobs are equal from an ordering point of view.
-	if job.Id < other.Id {
-		return -1
-	} else if job.Id > other.Id {
-		return 1
-	}
-	panic("We should never get here. Since we check for job id equality at the top of this function.")
 }
 
 func (job *Job) GetJobSet() string {


### PR DESCRIPTION
We used to need to schedule based on one of two job structs: `jobdb.Job` (for the new in-memory scheduler) and `api.Job` (for the old Redis Scheduler).  To manage this we defined a `LegacySchedulerJob` interface that defined the basic functionality we needed.  Now that the  Redis Scheduler is no more  we can  remove this interface and simplify the code a bit.