### PR TITLE
Remove flaky test

### DIFF
--- a/internal/jobservice/eventstojobs/manage_subs_test.go
+++ b/internal/jobservice/eventstojobs/manage_subs_test.go
@@ -99,16 +99,6 @@ func TestJobSetSubscriptionSubscribe(t *testing.T) {
 			wantSubscriptionErr: true,
 		},
 		{
-			name:         "client errors and sets subscription error, enters reconnect loop, reconnects to continue on and exit normally",
-			ttlSecs:      time.Second * 10,
-			eventClients: []MockEventClient{{err: errors.New("some error 1")}, {err: errors.New("some error 2")}, {}},
-			isJobSetSubscribedFn: func(context.Context, string, string) (bool, string, error) {
-				return true, "", nil
-			},
-			wantErr:             false,
-			wantSubscriptionErr: true,
-		},
-		{
 			name:         "it exits without error when job unsubscribes",
 			ttlSecs:      time.Second,
 			eventClients: []MockEventClient{{}},


### PR DESCRIPTION
One of the jobservice tests is breaking the build. Looking at the test, it is non-deterministic because it's testing asynchronous code,but doesn't implement a pattern that would take this into account.

We want to delete the job service so we've agreed to delete this test for now.

