### PR TITLE
Remove UserAnnotationLookup Insertion

### DIFF
--- a/config/lookoutv2/config.yaml
+++ b/config/lookoutv2/config.yaml
@@ -20,6 +20,7 @@ prunerConfig:
   timeout: 1h
   batchSize: 1000
 uiConfig:
+  backend: "jsonb"
   armadaApiBaseUrl: "http://armada-server:8080"
   userAnnotationPrefix: "armadaproject.io/"
   binocularsBaseUrlPattern: "http://armada-binoculars:8080"

--- a/internal/lookoutingesterv2/benchmark/benchmark.go
+++ b/internal/lookoutingesterv2/benchmark/benchmark.go
@@ -44,10 +44,9 @@ func withDbBenchmark(b *testing.B, config configuration.LookoutIngesterV2Configu
 func benchmarkSubmissions1000(b *testing.B, config configuration.LookoutIngesterV2Configuration) {
 	const n = 1000
 	jobIds := makeUlids(n)
-	jobsToCreate, userAnnotationsToCreate := createJobInstructions(jobIds, n, 10*n)
+	jobsToCreate := createJobInstructions(jobIds, n)
 	instructions := &model.InstructionSet{
-		JobsToCreate:            jobsToCreate,
-		UserAnnotationsToCreate: userAnnotationsToCreate,
+		JobsToCreate: jobsToCreate,
 	}
 	withDbBenchmark(b, config, func(b *testing.B, db *pgxpool.Pool) {
 		ldb := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
@@ -63,10 +62,9 @@ func benchmarkSubmissions1000(b *testing.B, config configuration.LookoutIngester
 func benchmarkSubmissions10000(b *testing.B, config configuration.LookoutIngesterV2Configuration) {
 	const n = 10000
 	jobIds := makeUlids(n)
-	jobsToCreate, userAnnotationsToCreate := createJobInstructions(jobIds, n, 10*n)
+	jobsToCreate := createJobInstructions(jobIds, n)
 	instructions := &model.InstructionSet{
-		JobsToCreate:            jobsToCreate,
-		UserAnnotationsToCreate: userAnnotationsToCreate,
+		JobsToCreate: jobsToCreate,
 	}
 	withDbBenchmark(b, config, func(b *testing.B, db *pgxpool.Pool) {
 		ldb := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
@@ -89,10 +87,9 @@ func benchmarkUpdates1000(b *testing.B, config configuration.LookoutIngesterV2Co
 	jobIds := makeUlids(n)
 	jobRunIds := makeUuids(runsPerJob * n)
 
-	jobsToCreate, userAnnotationsToCreate := createJobInstructions(jobIds, n, 10*n)
+	jobsToCreate := createJobInstructions(jobIds, n)
 	initialInstructions := &model.InstructionSet{
-		JobsToCreate:            jobsToCreate,
-		UserAnnotationsToCreate: userAnnotationsToCreate,
+		JobsToCreate: jobsToCreate,
 	}
 
 	instructions := &model.InstructionSet{
@@ -126,10 +123,9 @@ func benchmarkUpdates10000(b *testing.B, config configuration.LookoutIngesterV2C
 	jobIds := makeUlids(n)
 	jobRunIds := makeUuids(runsPerJob * n)
 
-	jobsToCreate, userAnnotationsToCreate := createJobInstructions(jobIds, n, 10*n)
+	jobsToCreate := createJobInstructions(jobIds, n)
 	initialInstructions := &model.InstructionSet{
-		JobsToCreate:            jobsToCreate,
-		UserAnnotationsToCreate: userAnnotationsToCreate,
+		JobsToCreate: jobsToCreate,
 	}
 
 	instructions := &model.InstructionSet{
@@ -169,7 +165,7 @@ func makeUuids(n int) []string {
 	return uuids
 }
 
-func createJobInstructions(jobIds []string, numJobs int, numUserAnnotations int) ([]*model.CreateJobInstruction, []*model.CreateUserAnnotationInstruction) {
+func createJobInstructions(jobIds []string, numJobs int) []*model.CreateJobInstruction {
 	createJobInstructions := make([]*model.CreateJobInstruction, numJobs)
 	jobBytes := make([]byte, 10000, 10000)
 	rand.Read(jobBytes)
@@ -194,21 +190,7 @@ func createJobInstructions(jobIds []string, numJobs int, numUserAnnotations int)
 			Annotations:               make(map[string]string),
 		}
 	}
-	createUserAnnotationInstructions := make([]*model.CreateUserAnnotationInstruction, numUserAnnotations)
-	for i := 0; i < numUserAnnotations; i++ {
-		job := createJobInstructions[i%len(createJobInstructions)]
-		k := uuid.NewString()
-		v := uuid.NewString()
-		job.Annotations[k] = v
-		createUserAnnotationInstructions[i] = &model.CreateUserAnnotationInstruction{
-			JobId:  job.JobId,
-			Key:    k,
-			Value:  v,
-			Queue:  job.Queue,
-			Jobset: job.JobSet,
-		}
-	}
-	return createJobInstructions, createUserAnnotationInstructions
+	return createJobInstructions
 }
 
 func createJobRunInstructions(n int, runIds []string) []*model.CreateJobRunInstruction {

--- a/internal/lookoutingesterv2/instructions/instructions_test.go
+++ b/internal/lookoutingesterv2/instructions/instructions_test.go
@@ -201,23 +201,6 @@ func TestConvert(t *testing.T) {
 		},
 	}
 
-	expectedCreateUserAnnotations := []*model.CreateUserAnnotationInstruction{
-		{
-			JobId:  testfixtures.JobIdString,
-			Key:    "a",
-			Value:  "0",
-			Queue:  testfixtures.Queue,
-			Jobset: testfixtures.JobSetName,
-		},
-		{
-			JobId:  testfixtures.JobIdString,
-			Key:    "b",
-			Value:  "1",
-			Queue:  testfixtures.Queue,
-			Jobset: testfixtures.JobSetName,
-		},
-	}
-
 	cancelledWithReason, err := testfixtures.DeepCopy(testfixtures.JobCancelled)
 	assert.NoError(t, err)
 	cancelledWithReason.GetCancelledJob().Reason = "some reason"
@@ -234,9 +217,8 @@ func TestConvert(t *testing.T) {
 				},
 			},
 			expected: &model.InstructionSet{
-				JobsToCreate:            []*model.CreateJobInstruction{expectedSubmit},
-				UserAnnotationsToCreate: expectedCreateUserAnnotations,
-				MessageIds:              []pulsar.MessageID{pulsarutils.NewMessageId(1)},
+				JobsToCreate: []*model.CreateJobInstruction{expectedSubmit},
+				MessageIds:   []pulsar.MessageID{pulsarutils.NewMessageId(1)},
 			},
 		},
 		"happy path single update": {
@@ -252,12 +234,11 @@ func TestConvert(t *testing.T) {
 				MessageIds: []pulsar.MessageID{pulsarutils.NewMessageId(1)},
 			},
 			expected: &model.InstructionSet{
-				JobsToCreate:            []*model.CreateJobInstruction{expectedSubmit},
-				JobsToUpdate:            []*model.UpdateJobInstruction{&expectedLeased, &expectedPending, &expectedRunning, &expectedJobSucceeded},
-				JobRunsToCreate:         []*model.CreateJobRunInstruction{&expectedLeasedRun},
-				JobRunsToUpdate:         []*model.UpdateJobRunInstruction{&expectedPendingRun, &expectedRunningRun, &expectedJobRunSucceeded},
-				UserAnnotationsToCreate: expectedCreateUserAnnotations,
-				MessageIds:              []pulsar.MessageID{pulsarutils.NewMessageId(1)},
+				JobsToCreate:    []*model.CreateJobInstruction{expectedSubmit},
+				JobsToUpdate:    []*model.UpdateJobInstruction{&expectedLeased, &expectedPending, &expectedRunning, &expectedJobSucceeded},
+				JobRunsToCreate: []*model.CreateJobRunInstruction{&expectedLeasedRun},
+				JobRunsToUpdate: []*model.UpdateJobRunInstruction{&expectedPendingRun, &expectedRunningRun, &expectedJobRunSucceeded},
+				MessageIds:      []pulsar.MessageID{pulsarutils.NewMessageId(1)},
 			},
 		},
 		"happy path multi update": {
@@ -279,11 +260,10 @@ func TestConvert(t *testing.T) {
 				},
 			},
 			expected: &model.InstructionSet{
-				JobsToCreate:            []*model.CreateJobInstruction{expectedSubmit},
-				JobsToUpdate:            []*model.UpdateJobInstruction{&expectedLeased, &expectedPending, &expectedRunning, &expectedJobSucceeded},
-				JobRunsToCreate:         []*model.CreateJobRunInstruction{&expectedLeasedRun},
-				JobRunsToUpdate:         []*model.UpdateJobRunInstruction{&expectedPendingRun, &expectedRunningRun, &expectedJobRunSucceeded},
-				UserAnnotationsToCreate: expectedCreateUserAnnotations,
+				JobsToCreate:    []*model.CreateJobInstruction{expectedSubmit},
+				JobsToUpdate:    []*model.UpdateJobInstruction{&expectedLeased, &expectedPending, &expectedRunning, &expectedJobSucceeded},
+				JobRunsToCreate: []*model.CreateJobRunInstruction{&expectedLeasedRun},
+				JobRunsToUpdate: []*model.UpdateJobRunInstruction{&expectedPendingRun, &expectedRunningRun, &expectedJobRunSucceeded},
 				MessageIds: []pulsar.MessageID{
 					pulsarutils.NewMessageId(1),
 					pulsarutils.NewMessageId(2),
@@ -435,8 +415,7 @@ func TestConvert(t *testing.T) {
 				},
 			},
 			expected: &model.InstructionSet{
-				JobsToCreate:            []*model.CreateJobInstruction{expectedSubmit},
-				UserAnnotationsToCreate: expectedCreateUserAnnotations,
+				JobsToCreate: []*model.CreateJobInstruction{expectedSubmit},
 				MessageIds: []pulsar.MessageID{
 					pulsarutils.NewMessageId(1),
 					pulsarutils.NewMessageId(2),
@@ -472,8 +451,7 @@ func TestConvert(t *testing.T) {
 				},
 			},
 			expected: &model.InstructionSet{
-				JobsToCreate:            []*model.CreateJobInstruction{expectedSubmit},
-				UserAnnotationsToCreate: expectedCreateUserAnnotations,
+				JobsToCreate: []*model.CreateJobInstruction{expectedSubmit},
 				MessageIds: []pulsar.MessageID{
 					pulsarutils.NewMessageId(1),
 					pulsarutils.NewMessageId(2),
@@ -510,7 +488,6 @@ func TestConvert(t *testing.T) {
 			assert.Equal(t, tc.expected.JobsToUpdate, instructionSet.JobsToUpdate)
 			assert.Equal(t, tc.expected.JobRunsToCreate, instructionSet.JobRunsToCreate)
 			assert.Equal(t, tc.expected.JobRunsToUpdate, instructionSet.JobRunsToUpdate)
-			assert.Equal(t, tc.expected.UserAnnotationsToCreate, instructionSet.UserAnnotationsToCreate)
 			assert.Equal(t, tc.expected.MessageIds, instructionSet.MessageIds)
 		})
 	}

--- a/internal/lookoutingesterv2/lookoutdb/insertion.go
+++ b/internal/lookoutingesterv2/lookoutdb/insertion.go
@@ -52,7 +52,7 @@ func (l *LookoutDb) Store(ctx *armadacontext.Context, instructions *model.Instru
 
 	// Now we can job updates, annotations and new job runs
 	wg := sync.WaitGroup{}
-	wg.Add(3)
+	wg.Add(2)
 	go func() {
 		defer wg.Done()
 		l.UpdateJobs(ctx, jobsToUpdate)

--- a/internal/lookoutingesterv2/lookoutdb/insertion_test.go
+++ b/internal/lookoutingesterv2/lookoutdb/insertion_test.go
@@ -598,7 +598,6 @@ func TestStoreWithEmptyInstructionSet(t *testing.T) {
 		assert.NoError(t, err)
 		assertNoRows(t, ldb.db, "job")
 		assertNoRows(t, ldb.db, "job_run")
-		assertNoRows(t, ldb.db, "user_annotation_lookup")
 		return nil
 	})
 	assert.NoError(t, err)

--- a/internal/lookoutingesterv2/lookoutdb/insertion_test.go
+++ b/internal/lookoutingesterv2/lookoutdb/insertion_test.go
@@ -129,13 +129,6 @@ func defaultInstructionSet() *model.InstructionSet {
 			JobRunState: pointer.Int32(lookout.JobRunSucceededOrdinal),
 			ExitCode:    pointer.Int32(0),
 		}},
-		UserAnnotationsToCreate: []*model.CreateUserAnnotationInstruction{{
-			JobId:  jobIdString,
-			Key:    "someKey",
-			Value:  "someValue",
-			Queue:  queue,
-			Jobset: jobSetName,
-		}},
 		MessageIds: []pulsar.MessageID{pulsarutils.NewMessageId(3)},
 	}
 }
@@ -198,14 +191,6 @@ var expectedJobRunAfterUpdate = JobRunRow{
 	Finished:    &finishedTime,
 	JobRunState: lookout.JobRunSucceededOrdinal,
 	ExitCode:    pointer.Int32(0),
-}
-
-var expectedUserAnnotation = UserAnnotationRow{
-	JobId:  jobIdString,
-	Key:    "someKey",
-	Value:  "someValue",
-	Queue:  queue,
-	JobSet: jobSetName,
 }
 
 func TestCreateJobsBatch(t *testing.T) {
@@ -604,39 +589,6 @@ func TestUpdateJobRunsScalar(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestCreateUserAnnotationsBatch(t *testing.T) {
-	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		ldb := NewLookoutDb(db, fatalErrors, m, 10)
-		// Need to make sure we have a job
-		err := ldb.CreateJobsBatch(armadacontext.Background(), defaultInstructionSet().JobsToCreate)
-		assert.Nil(t, err)
-
-		// Insert
-		err = ldb.CreateUserAnnotationsBatch(armadacontext.Background(), defaultInstructionSet().UserAnnotationsToCreate)
-		assert.Nil(t, err)
-		annotation := getUserAnnotationLookup(t, db, jobIdString)
-		assert.Equal(t, expectedUserAnnotation, annotation)
-
-		// Insert again and test that it's idempotent
-		err = ldb.CreateUserAnnotationsBatch(armadacontext.Background(), defaultInstructionSet().UserAnnotationsToCreate)
-		assert.Nil(t, err)
-		annotation = getUserAnnotationLookup(t, db, jobIdString)
-		assert.Equal(t, expectedUserAnnotation, annotation)
-
-		// If a row is bad then we should return an error and no updates should happen
-		_, err = ldb.db.Exec(armadacontext.Background(), "DELETE FROM user_annotation_lookup")
-		assert.NoError(t, err)
-		invalidAnnotation := &model.CreateUserAnnotationInstruction{
-			JobId: invalidId,
-		}
-		err = ldb.CreateUserAnnotationsBatch(armadacontext.Background(), append(defaultInstructionSet().UserAnnotationsToCreate, invalidAnnotation))
-		assert.Error(t, err)
-		assertNoRows(t, ldb.db, "user_annotation_lookup")
-		return nil
-	})
-	assert.NoError(t, err)
-}
-
 func TestStoreWithEmptyInstructionSet(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		ldb := NewLookoutDb(db, fatalErrors, m, 10)
@@ -652,37 +604,6 @@ func TestStoreWithEmptyInstructionSet(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestCreateUserAnnotationsScalar(t *testing.T) {
-	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		ldb := NewLookoutDb(db, fatalErrors, m, 10)
-		// Need to make sure we have a job
-		err := ldb.CreateJobsBatch(armadacontext.Background(), defaultInstructionSet().JobsToCreate)
-		assert.Nil(t, err)
-
-		// Insert
-		ldb.CreateUserAnnotationsScalar(armadacontext.Background(), defaultInstructionSet().UserAnnotationsToCreate)
-		annotation := getUserAnnotationLookup(t, db, jobIdString)
-		assert.Equal(t, expectedUserAnnotation, annotation)
-
-		// Insert again and test that it's idempotent
-		ldb.CreateUserAnnotationsScalar(armadacontext.Background(), defaultInstructionSet().UserAnnotationsToCreate)
-		annotation = getUserAnnotationLookup(t, db, jobIdString)
-		assert.Equal(t, expectedUserAnnotation, annotation)
-
-		// If a row is bad then we should update the rows we can
-		_, err = ldb.db.Exec(armadacontext.Background(), "DELETE FROM user_annotation_lookup")
-		assert.NoError(t, err)
-		invalidAnnotation := &model.CreateUserAnnotationInstruction{
-			JobId: invalidId,
-		}
-		ldb.CreateUserAnnotationsScalar(armadacontext.Background(), append(defaultInstructionSet().UserAnnotationsToCreate, invalidAnnotation))
-		annotation = getUserAnnotationLookup(t, ldb.db, jobIdString)
-		assert.Equal(t, expectedUserAnnotation, annotation)
-		return nil
-	})
-	assert.NoError(t, err)
-}
-
 func TestStore(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		ldb := NewLookoutDb(db, fatalErrors, m, 10)
@@ -692,11 +613,9 @@ func TestStore(t *testing.T) {
 
 		job := getJob(t, ldb.db, jobIdString)
 		jobRun := getJobRun(t, ldb.db, runIdString)
-		annotation := getUserAnnotationLookup(t, ldb.db, jobIdString)
 
 		assert.Equal(t, expectedJobAfterUpdate, job)
 		assert.Equal(t, expectedJobRunAfterUpdate, jobRun)
-		assert.Equal(t, expectedUserAnnotation, annotation)
 		return nil
 	})
 	assert.NoError(t, err)
@@ -1036,17 +955,6 @@ func getJobRun(t *testing.T, db *pgxpool.Pool, runId string) JobRunRow {
 	)
 	assert.NoError(t, err)
 	return run
-}
-
-func getUserAnnotationLookup(t *testing.T, db *pgxpool.Pool, jobId string) UserAnnotationRow {
-	annotation := UserAnnotationRow{}
-	r := db.QueryRow(
-		armadacontext.Background(),
-		`SELECT job_id, key, value, queue, jobset FROM user_annotation_lookup WHERE job_id = $1`,
-		jobId)
-	err := r.Scan(&annotation.JobId, &annotation.Key, &annotation.Value, &annotation.Queue, &annotation.JobSet)
-	assert.NoError(t, err)
-	return annotation
 }
 
 func assertNoRows(t *testing.T, db *pgxpool.Pool, table string) {

--- a/internal/lookoutingesterv2/model/model.go
+++ b/internal/lookoutingesterv2/model/model.go
@@ -40,15 +40,6 @@ type UpdateJobInstruction struct {
 	LatestRunId               *string
 }
 
-// CreateUserAnnotationInstruction is an instruction to create a new entry in the UserAnnotationInstruction table
-type CreateUserAnnotationInstruction struct {
-	JobId  string
-	Key    string
-	Value  string
-	Queue  string
-	Jobset string
-}
-
 // CreateJobRunInstruction is an instruction to update an existing row in the jobRuns table
 type CreateJobRunInstruction struct {
 	RunId       string
@@ -73,15 +64,14 @@ type UpdateJobRunInstruction struct {
 }
 
 // InstructionSet represents a set of instructions to apply to the database.  Each type of instruction is stored in its
-// own ordered list representign the order it was received.  We also store the original message ids corresponding to
+// own ordered list representing the order it was received.  We also store the original message ids corresponding to
 // these instructions so that when they are saved to the database, we can ACK the corresponding messages.
 type InstructionSet struct {
-	JobsToCreate            []*CreateJobInstruction
-	JobsToUpdate            []*UpdateJobInstruction
-	JobRunsToCreate         []*CreateJobRunInstruction
-	JobRunsToUpdate         []*UpdateJobRunInstruction
-	UserAnnotationsToCreate []*CreateUserAnnotationInstruction
-	MessageIds              []pulsar.MessageID
+	JobsToCreate    []*CreateJobInstruction
+	JobsToUpdate    []*UpdateJobInstruction
+	JobRunsToCreate []*CreateJobRunInstruction
+	JobRunsToUpdate []*UpdateJobRunInstruction
+	MessageIds      []pulsar.MessageID
 }
 
 func (i *InstructionSet) GetMessageIDs() []pulsar.MessageID {

--- a/internal/lookoutv2/pruner/pruner_test.go
+++ b/internal/lookoutv2/pruner/pruner_test.go
@@ -140,7 +140,6 @@ func TestPruneDb(t *testing.T) {
 				queriedJobIdsPerTable := []map[string]bool{
 					selectStringSet(t, db, "SELECT job_id FROM job"),
 					selectStringSet(t, db, "SELECT DISTINCT job_id FROM job_run"),
-					selectStringSet(t, db, "SELECT DISTINCT job_id FROM user_annotation_lookup"),
 				}
 				for _, queriedJobs := range queriedJobIdsPerTable {
 					assert.Equal(t, len(tc.jobIdsLeft), len(queriedJobs))

--- a/internal/lookoutv2/repository/getjobs_test.go
+++ b/internal/lookoutv2/repository/getjobs_test.go
@@ -55,15 +55,13 @@ var (
 )
 
 func withGetJobsSetup(f func(*instructions.InstructionConverter, *lookoutdb.LookoutDb, *SqlGetJobsRepository) error) error {
-	for _, useJsonbBackend := range []bool{false, true} {
-		if err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-			converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{})
-			store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
-			repo := NewSqlGetJobsRepository(db, useJsonbBackend)
-			return f(converter, store, repo)
-		}); err != nil {
-			return err
-		}
+	if err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
+		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{})
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
+		repo := NewSqlGetJobsRepository(db, true)
+		return f(converter, store, repo)
+	}); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/lookoutv2/repository/groupjobs_test.go
+++ b/internal/lookoutv2/repository/groupjobs_test.go
@@ -21,15 +21,13 @@ import (
 )
 
 func withGroupJobsSetup(f func(*instructions.InstructionConverter, *lookoutdb.LookoutDb, *SqlGroupJobsRepository) error) error {
-	for _, useJsonbBackend := range []bool{false, true} {
-		if err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-			converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{})
-			store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
-			repo := NewSqlGroupJobsRepository(db, useJsonbBackend)
-			return f(converter, store, repo)
-		}); err != nil {
-			return err
-		}
+	if err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
+		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{})
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
+		repo := NewSqlGroupJobsRepository(db, true)
+		return f(converter, store, repo)
+	}); err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
Now that we are using jsonb to store annotations in lookout  we can remove the old user_annotation_lookup code.  This PR removes all the insertion code form the lookout ingester which should improve insertion performance.

I've also added some log lines so that we can easily see how long insertion is taking. 