### PR TITLE
LookoutV2 config: fix deduplicationExpireAfter

### DIFF
--- a/config/lookoutv2/config.yaml
+++ b/config/lookoutv2/config.yaml
@@ -16,8 +16,8 @@ postgres:
     dbname: lookout
     sslmode: disable
 prunerConfig:
-  expireAfter: 1008h  # 42 days, 6 weeks
-  deduplicationExpireAfter: 168 # 7 days
+  expireAfter: 1008h  # 42 days / 6 weeks
+  deduplicationExpireAfter: 168h # 7 days
   timeout: 1h
   batchSize: 1000
 uiConfig:


### PR DESCRIPTION
Fix units in config - currently it's interpreting `deduplicationExpireAfter` as 0 and expiring them straight away.