### PR TITLE
Support overwriting connection string for lookout DB pruner

### DIFF
--- a/cmd/lookoutv2/main.go
+++ b/cmd/lookoutv2/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/viper"
 	"k8s.io/apimachinery/pkg/util/clock"
 
+	armada_config "github.com/armadaproject/armada/internal/armada/configuration"
 	"github.com/armadaproject/armada/internal/common"
 	"github.com/armadaproject/armada/internal/common/armadacontext"
 	"github.com/armadaproject/armada/internal/common/database"
@@ -79,9 +80,11 @@ func migrate(ctx *armadacontext.Context, config configuration.LookoutV2Config) {
 }
 
 func prune(ctx *armadacontext.Context, config configuration.LookoutV2Config) {
-	dbConfig := config.PrunerConfig.Postgres
-	if dbConfig == &configuration.PostgresConfig{} {
-		dbConfig := config.Postgres
+	var dbConfig armada_config.PostgresConfig
+	if config.PrunerConfig.Postgres.Connection != nil {
+		dbConfig = config.PrunerConfig.Postgres
+	} else {
+		dbConfig = config.Postgres
 	}
 
 	db, err := database.OpenPgxConn(dbConfig)

--- a/cmd/lookoutv2/main.go
+++ b/cmd/lookoutv2/main.go
@@ -79,7 +79,12 @@ func migrate(ctx *armadacontext.Context, config configuration.LookoutV2Config) {
 }
 
 func prune(ctx *armadacontext.Context, config configuration.LookoutV2Config) {
-	db, err := database.OpenPgxConn(config.Postgres)
+	dbConfig := config.PrunerConfig.Postgres
+	if dbConfig == &configuration.PostgresConfig{} {
+		dbConfig := config.Postgres
+	}
+
+	db, err := database.OpenPgxConn(dbConfig)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/lookoutv2/configuration/types.go
+++ b/internal/lookoutv2/configuration/types.go
@@ -32,6 +32,7 @@ type PrunerConfig struct {
 	DeduplicationExpireAfter time.Duration
 	Timeout                  time.Duration
 	BatchSize                int
+	Postgres                 configuration.PostgresConfig
 }
 
 type CommandSpec struct {


### PR DESCRIPTION
Enables setting independent connection string to lookout DB pruner, separately from lookout. Enabling support of pointing LookoutV2 to read-only replicas for LookoutDB, while pruner could still use read-write master for clean up operations. 

Longer term, lookout DB pruner will likely move to lookout ingester, as both are responsible for actual lookout data management.

