### PR TITLE
Update IsManagedPod to check for job run id and job id

### DIFF
--- a/internal/executor/util/pod_util.go
+++ b/internal/executor/util/pod_util.go
@@ -61,8 +61,9 @@ func IsInTerminalState(pod *v1.Pod) bool {
 }
 
 func IsManagedPod(pod *v1.Pod) bool {
-	_, ok := pod.Labels[domain.JobId]
-	return ok
+	_, jobRunIdOk := pod.Labels[domain.JobRunId]
+	_, jobIdOk := pod.Labels[domain.JobId]
+	return jobRunIdOk && jobIdOk
 }
 
 func GetManagedPodSelector() labels.Selector {

--- a/internal/executor/util/pod_util_test.go
+++ b/internal/executor/util/pod_util_test.go
@@ -71,7 +71,7 @@ func TestHasIngress_WhenAnnotationNotSetToTrue(t *testing.T) {
 	assert.False(t, HasIngress(pod))
 }
 
-func TestIsManagedPod_ReturnsTrueIfJobRunIdLabelPresent(t *testing.T) {
+func TestIsManagedPod_ReturnsTrueIfJobRunIdAndJobIdLabelPresent(t *testing.T) {
 	pod := v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{domain.JobRunId: "label", domain.JobId: "label"},
@@ -86,7 +86,19 @@ func TestIsManagedPod_ReturnsTrueIfJobRunIdLabelPresent(t *testing.T) {
 func TestIsManagedPod_ReturnsFalseIfJobIdLabelNotPresent(t *testing.T) {
 	pod := v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels: map[string]string{},
+			Labels: map[string]string{domain.JobRunId: "label"},
+		},
+	}
+
+	result := IsManagedPod(&pod)
+
+	assert.False(t, result)
+}
+
+func TestIsManagedPod_ReturnsFalseIfJobRunIdLabelNotPresent(t *testing.T) {
+	pod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{domain.JobId: "label"},
 		},
 	}
 

--- a/internal/executor/util/pod_util_test.go
+++ b/internal/executor/util/pod_util_test.go
@@ -71,10 +71,10 @@ func TestHasIngress_WhenAnnotationNotSetToTrue(t *testing.T) {
 	assert.False(t, HasIngress(pod))
 }
 
-func TestIsManagedPod_ReturnsTrueIfJobIdLabelPresent(t *testing.T) {
+func TestIsManagedPod_ReturnsTrueIfJobRunIdLabelPresent(t *testing.T) {
 	pod := v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels: map[string]string{domain.JobId: "label"},
+			Labels: map[string]string{domain.JobRunId: "label", domain.JobId: "label"},
 		},
 	}
 

--- a/internal/executor/utilisation/cluster_utilisation_test.go
+++ b/internal/executor/utilisation/cluster_utilisation_test.go
@@ -84,7 +84,7 @@ func TestGetAllPodsUsingResourceOnProcessingNodes_ShouldIncludeManagedPodsOnNode
 func TestGetAllPodsUsingResourceOnProcessingNodes_ShouldIncludeManagedPodNotAssignedToAnyNode(t *testing.T) {
 	podOnNode := v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels: map[string]string{domain.JobId: "label"},
+			Labels: map[string]string{domain.JobRunId: "label", domain.JobId: "label"},
 		},
 		Spec: v1.PodSpec{
 			NodeName: "",

--- a/internal/executor/utilisation/pod_utilisation_test.go
+++ b/internal/executor/utilisation/pod_utilisation_test.go
@@ -118,7 +118,8 @@ func createPod(phase v1.PodPhase, nodeName string, isManaged bool) *v1.Pod {
 	}
 	if isManaged {
 		pod.Labels = map[string]string{
-			domain.JobId: "jobid" + util2.NewULID(),
+			domain.JobRunId: "jobrunid" + util2.NewULID(),
+			domain.JobId:    "jobid" + util2.NewULID(),
 		}
 	}
 	return pod

--- a/internal/scheduler/api.go
+++ b/internal/scheduler/api.go
@@ -87,6 +87,10 @@ func (srv *ExecutorApi) LeaseJobRuns(stream executorapi.ExecutorApi_LeaseJobRuns
 
 	ctx := armadacontext.WithLogField(armadacontext.FromGrpcCtx(stream.Context()), "executor", req.ExecutorId)
 
+	if err := validateLeaseRequest(ctx, req); err != nil {
+		return err
+	}
+
 	executor := srv.executorFromLeaseRequest(ctx, req)
 	if err := srv.executorRepository.StoreExecutor(ctx, executor); err != nil {
 		return err

--- a/internal/scheduler/api_test.go
+++ b/internal/scheduler/api_test.go
@@ -2,10 +2,11 @@ package scheduler
 
 import (
 	"context"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"testing"
 	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/apache/pulsar-client-go/pulsar"
 	"github.com/gogo/protobuf/proto"

--- a/internal/scheduler/api_test.go
+++ b/internal/scheduler/api_test.go
@@ -377,7 +377,6 @@ func TestExecutorApi_LeaseJobRunsValidation(t *testing.T) {
 			mockPulsarProducer := mocks.NewMockProducer(ctrl)
 			mockJobRepository := schedulermocks.NewMockJobRepository(ctrl)
 			mockExecutorRepository := schedulermocks.NewMockExecutorRepository(ctrl)
-			mockLegacyExecutorRepository := schedulermocks.NewMockExecutorRepository(ctrl)
 			mockStream := schedulermocks.NewMockExecutorApi_LeaseJobRunsServer(ctrl)
 
 			// set up mocks
@@ -388,7 +387,6 @@ func TestExecutorApi_LeaseJobRunsValidation(t *testing.T) {
 				mockPulsarProducer,
 				mockJobRepository,
 				mockExecutorRepository,
-				mockLegacyExecutorRepository,
 				[]int32{1000, 2000},
 				"kubernetes.io/hostname",
 				nil,

--- a/internal/scheduler/api_validation.go
+++ b/internal/scheduler/api_validation.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"context"
 	"fmt"
+
 	"github.com/armadaproject/armada/pkg/executorapi"
 	"github.com/google/uuid"
 	"google.golang.org/grpc/codes"
@@ -11,7 +12,7 @@ import (
 
 func validateLeaseRequest(ctx context.Context, req *executorapi.LeaseRequest) error {
 	for _, node := range req.Nodes {
-		for runId, _ := range node.RunIdsByState {
+		for runId := range node.RunIdsByState {
 			_, err := uuid.Parse(runId)
 			if err != nil {
 				return status.Error(codes.InvalidArgument, fmt.Sprintf("runIdsByState for node %s includes invalid run id '%s'", node.Name, runId))

--- a/internal/scheduler/api_validation.go
+++ b/internal/scheduler/api_validation.go
@@ -1,0 +1,23 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"github.com/armadaproject/armada/pkg/executorapi"
+	"github.com/google/uuid"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func validateLeaseRequest(ctx context.Context, req *executorapi.LeaseRequest) error {
+	for _, node := range req.Nodes {
+		for runId, _ := range node.RunIdsByState {
+			_, err := uuid.Parse(runId)
+			if err != nil {
+				return status.Error(codes.InvalidArgument, fmt.Sprintf("runIdsByState for node %s includes invalid run id '%s'", node.Name, runId))
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/scheduler/api_validation.go
+++ b/internal/scheduler/api_validation.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/armadaproject/armada/pkg/executorapi"
 	"github.com/google/uuid"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/armadaproject/armada/pkg/executorapi"
 )
 
 func validateLeaseRequest(ctx context.Context, req *executorapi.LeaseRequest) error {


### PR DESCRIPTION
We had an issue where a v3 and v4 executor were running on the same cluster. The v4 executor was pulling empty job run ids from pods launched by the v3 executor. We realize that we shouldn't run two executors in the same cluster however it also feels like the filtering logic in the cluster utilization logic should just check for the job run id label if that is what it is ultimately going to pick out of the pod and assume is present. 

Fixes: https://github.com/armadaproject/armada/issues/3618
