### PR TITLE
Add job APIs to armada client

### DIFF
--- a/client/python/armada_client/client.py
+++ b/client/python/armada_client/client.py
@@ -183,9 +183,7 @@ class ArmadaClient:
         response = self.submit_stub.SubmitJobs(request)
         return response
 
-    def get_job_status(
-        self, job_ids: Iterable[str]
-    ) -> job_pb2.JobStatusResponse:
+    def get_job_status(self, job_ids: Iterable[str]) -> job_pb2.JobStatusResponse:
         """Get the statuses of armada jobs.
 
         Uses GetJobStatus RPC to get the statuses of jobs.

--- a/client/python/armada_client/client.py
+++ b/client/python/armada_client/client.py
@@ -197,7 +197,9 @@ class ArmadaClient:
         )
         return self.jobs_stub.GetJobStatus(request)
 
-    def get_job_details(self, job_ids: Iterable[str], expand_job_spec: bool, expand_job_run: bool) -> job_pb2.JobDetailsResponse:
+    def get_job_details(
+        self, job_ids: Iterable[str], expand_job_spec: bool, expand_job_run: bool
+    ) -> job_pb2.JobDetailsResponse:
         """Get the details of armada jobs.
 
         Uses GetJobDetails RPC to get the details of jobs.
@@ -214,7 +216,9 @@ class ArmadaClient:
         )
         return self.jobs_stub.GetJobDetails(request)
 
-    def get_job_run_details(self, run_ids: Iterable[str]) -> job_pb2.JobRunDetailsResponse:
+    def get_job_run_details(
+        self, run_ids: Iterable[str]
+    ) -> job_pb2.JobRunDetailsResponse:
         """Get the details of armada job runs.
 
         Uses GetJobRunDetails RPC to get the details of job runs.

--- a/client/python/armada_client/client.py
+++ b/client/python/armada_client/client.py
@@ -223,7 +223,7 @@ class ArmadaClient:
 
         Uses GetJobRunDetails RPC to get the details of job runs.
 
-        :param run_ids: The job run ids to get the detials of.
+        :param run_ids: The job run ids to get the details of.
         :return: A JobRunDetailsResponse object.
         """
         request = job_pb2.JobRunDetailsRequest(

--- a/client/python/armada_client/client.py
+++ b/client/python/armada_client/client.py
@@ -197,6 +197,36 @@ class ArmadaClient:
         )
         return self.jobs_stub.GetJobStatus(request)
 
+    def get_job_details(self, job_ids: Iterable[str], expand_job_spec: bool, expand_job_run: bool) -> job_pb2.JobDetailsResponse:
+        """Get the details of armada jobs.
+
+        Uses GetJobDetails RPC to get the details of jobs.
+
+        :param job_ids: The job ids to get the details of.
+        :param expand_job_spec: Whether to include the job_spec field in the response.
+        :param expand_job_run: Whether to include the job_run field in the response.
+        :return: A JobDetailsResponse object.
+        """
+        request = job_pb2.JobDetailsRequest(
+            job_ids=job_ids,
+            expand_job_spec=expand_job_spec,
+            expand_job_run=expand_job_run,
+        )
+        return self.jobs_stub.GetJobDetails(request)
+
+    def get_job_run_details(self, run_ids: Iterable[str]) -> job_pb2.JobRunDetailsResponse:
+        """Get the details of armada job runs.
+
+        Uses GetJobRunDetails RPC to get the details of job runs.
+
+        :param run_ids: The job run ids to get the detials of.
+        :return: A JobRunDetailsResponse object.
+        """
+        request = job_pb2.JobRunDetailsRequest(
+            run_ids=run_ids,
+        )
+        return self.jobs_stub.GetJobRunDetails(request)
+
     def cancel_jobs(
         self,
         queue: str,

--- a/client/python/tests/unit/server_mock.py
+++ b/client/python/tests/unit/server_mock.py
@@ -112,3 +112,20 @@ class JobsService(job_pb2_grpc.JobsServicer):
             job_states[job_id] = submit_pb2.JobState.RUNNING
 
         return job_pb2.JobStatusResponse(job_states=job_states)
+
+    def GetJobDetails(self, request, context):
+        job_details = {}
+        for job_id in request.job_ids:
+            job_details[job_id] = job_pb2.JobDetails(
+                job_id=job_id, job_state=submit_pb2.JobState.RUNNING
+            )
+        return job_pb2.JobDetailsResponse(job_details=job_details)
+
+    def GetJobRunDetails(self, request, context):
+        job_run_details = {}
+        for run_id in request.run_ids:
+            job_run_details[run_id] = job_pb2.JobRunDetails(
+                run_id=run_id, state=job_pb2.JobRunState.RUN_STATE_RUNNING
+            )
+
+        return job_pb2.JobRunDetailsResponse()

--- a/client/python/tests/unit/server_mock.py
+++ b/client/python/tests/unit/server_mock.py
@@ -5,6 +5,8 @@ from armada_client.armada import (
     event_pb2,
     event_pb2_grpc,
     health_pb2,
+    job_pb2,
+    job_pb2_grpc,
 )
 
 
@@ -101,3 +103,12 @@ class EventService(event_pb2_grpc.EventServicer):
         return health_pb2.HealthCheckResponse(
             status=health_pb2.HealthCheckResponse.SERVING
         )
+
+
+class JobsService(job_pb2_grpc.JobsServicer):
+    def GetJobStatus(self, request, context):
+        job_states = {}
+        for job_id in request.job_ids:
+            job_states[job_id] = submit_pb2.JobState.RUNNING
+
+        return job_pb2.JobStatusResponse(job_states=job_states)

--- a/docs/python_armada_client.md
+++ b/docs/python_armada_client.md
@@ -335,7 +335,7 @@ Uses GetJobRunDetails RPC to get the details of job runs.
 
 * **Parameters**
 
-    **run_ids** (*Iterable**[**str**]*) – The job run ids to get the detials of.
+    **run_ids** (*Iterable**[**str**]*) – The job run ids to get the details of.
 
 
 

--- a/docs/python_armada_client.md
+++ b/docs/python_armada_client.md
@@ -255,6 +255,37 @@ Health check for Event Service.
 
 
 
+#### get_job_details(job_ids, expand_job_spec, expand_job_run)
+Get the details of armada jobs.
+
+Uses GetJobDetails RPC to get the details of jobs.
+
+
+* **Parameters**
+
+    
+    * **job_ids** (*Iterable**[**str**]*) – The job ids to get the details of.
+
+
+    * **expand_job_spec** (*bool*) – Whether to include the job_spec field in the response.
+
+
+    * **expand_job_run** (*bool*) – Whether to include the job_run field in the response.
+
+
+
+* **Returns**
+
+    A JobDetailsResponse object.
+
+
+
+* **Return type**
+
+    armada.job_pb2.JobDetailsResponse
+
+
+
 #### get_job_events_stream(queue, job_set_id, from_message_id=None)
 Get event stream for a job set.
 
@@ -293,6 +324,30 @@ for event in events:
 * **Return type**
 
     *Iterator*[armada.event_pb2.EventStreamMessage]
+
+
+
+#### get_job_run_details(run_ids)
+Get the details of armada job runs.
+
+Uses GetJobRunDetails RPC to get the details of job runs.
+
+
+* **Parameters**
+
+    **run_ids** (*Iterable**[**str**]*) – The job run ids to get the detials of.
+
+
+
+* **Returns**
+
+    A JobRunDetailsResponse object.
+
+
+
+* **Return type**
+
+    armada.job_pb2.JobRunDetailsResponse
 
 
 

--- a/docs/python_armada_client.md
+++ b/docs/python_armada_client.md
@@ -296,6 +296,30 @@ for event in events:
 
 
 
+#### get_job_status(job_ids)
+Get the statuses of armada jobs.
+
+Uses GetJobStatus RPC to get the statuses of jobs.
+
+
+* **Parameters**
+
+    **job_ids** (*Iterable**[**str**]*) – The job ids to get the statuses of.
+
+
+
+* **Returns**
+
+    A JobStatusResponse object.
+
+
+
+* **Return type**
+
+    armada.job_pb2.JobStatusResponse
+
+
+
 #### get_queue(name)
 Get the queue by name.
 


### PR DESCRIPTION
This pull request adds a `get_job_status` method to the armada python client. This is something that we'd like to use in order to migrate to the new query API. I figure the armada airflow operator will probably need to use this sooner or later as well as it migrates to the new query API.