### PR TITLE
Test case submit_random_clientid: smaller batch size

### DIFF
--- a/testsuite/testcases/basic/submit_random_clientid.yaml
+++ b/testsuite/testcases/basic/submit_random_clientid.yaml
@@ -1,5 +1,5 @@
 numBatches: 1
-batchSize: 10
+batchSize: 3
 queue: e2e-test-queue
 randomClientId: true
 jobs:


### PR DESCRIPTION
This test is prone to random OOMing, let's submit less jobs, we don't really need 10.

e.g. https://github.com/armadaproject/armada/actions/runs/9282807184/job/25541744347

```
test case submit_random_clientid failed: unexpected event for job 01hz1qy2acr0vyw0g520rvywjy: expected event of type *api.EventMessage_Succeeded, but got &EventMessage_Failed{Failed:&JobFailedEvent{JobId:01hz1qy2acr0vyw0g520rvywjy,JobSetId:submit_random_clientid-GTYjzvpgHhRBCEok6EgpZQ,Queue:e2e-test-queue,Created:2024-05-29 08:37:36.800701261 +0000 UTC,ClusterId:Cluster1,Reason:Container ls failed with exit code 128 because StartError: failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: container init was OOM-killed (memory limit too low?): unknown
```