### PR TITLE
[scheduleringester] Fix merging UpdateJobPriorities

### DIFF
--- a/internal/scheduleringester/dbops.go
+++ b/internal/scheduleringester/dbops.go
@@ -235,9 +235,9 @@ func (a MarkJobsFailed) Merge(b DbOperation) bool {
 	return mergeInMap(a, b)
 }
 
-func (a UpdateJobPriorities) Merge(b DbOperation) bool {
+func (a *UpdateJobPriorities) Merge(b DbOperation) bool {
 	switch op := b.(type) {
-	case UpdateJobPriorities:
+	case *UpdateJobPriorities:
 		if a.key == op.key {
 			a.jobIds = slices.Unique(append(a.jobIds, op.jobIds...))
 			return true
@@ -353,7 +353,7 @@ func (a InsertRuns) CanBeAppliedBefore(b DbOperation) bool {
 }
 
 func (a UpdateJobSetPriorities) CanBeAppliedBefore(b DbOperation) bool {
-	_, isUpdateJobPriorities := b.(UpdateJobPriorities)
+	_, isUpdateJobPriorities := b.(*UpdateJobPriorities)
 	return !isUpdateJobPriorities && !definesJobInSet(a, b)
 }
 
@@ -389,9 +389,9 @@ func (a UpdateJobQueuedState) CanBeAppliedBefore(b DbOperation) bool {
 	return !definesJob(a, b)
 }
 
-func (a UpdateJobPriorities) CanBeAppliedBefore(b DbOperation) bool {
+func (a *UpdateJobPriorities) CanBeAppliedBefore(b DbOperation) bool {
 	_, isUpdateJobSetPriorities := b.(UpdateJobSetPriorities)
-	_, isUpdateJobPriorities := b.(UpdateJobPriorities)
+	_, isUpdateJobPriorities := b.(*UpdateJobPriorities)
 	return !isUpdateJobPriorities && !isUpdateJobSetPriorities &&
 		!definesJobInSet(map[JobSetKey]bool{a.key.JobSetKey: true}, b) &&
 		!definesRunInSet(map[JobSetKey]bool{a.key.JobSetKey: true}, b)

--- a/internal/scheduleringester/instructions.go
+++ b/internal/scheduleringester/instructions.go
@@ -344,7 +344,7 @@ func (c *InstructionConverter) handleReprioritiseJob(reprioritiseJob *armadaeven
 	if err != nil {
 		return nil, err
 	}
-	return []DbOperation{UpdateJobPriorities{
+	return []DbOperation{&UpdateJobPriorities{
 		key: JobReprioritiseKey{
 			JobSetKey: JobSetKey{
 				queue:  meta.queue,

--- a/internal/scheduleringester/instructions_test.go
+++ b/internal/scheduleringester/instructions_test.go
@@ -129,7 +129,7 @@ func TestConvertSequence(t *testing.T) {
 		"reprioritise job": {
 			events: []*armadaevents.EventSequence_Event{f.JobReprioritiseRequested},
 			expected: []DbOperation{
-				UpdateJobPriorities{
+				&UpdateJobPriorities{
 					key: JobReprioritiseKey{
 						JobSetKey: JobSetKey{queue: f.Queue, jobSet: f.JobSetName},
 						Priority:  f.NewPriority,

--- a/internal/scheduleringester/schedulerdb.go
+++ b/internal/scheduleringester/schedulerdb.go
@@ -225,7 +225,7 @@ func (s *SchedulerDb) WriteDbOp(ctx *armadacontext.Context, tx pgx.Tx, op DbOper
 		if err != nil {
 			return errors.WithStack(err)
 		}
-	case UpdateJobPriorities:
+	case *UpdateJobPriorities:
 		err := queries.UpdateJobPriorityById(ctx, schedulerdb.UpdateJobPriorityByIdParams{
 			Queue:    o.key.queue,
 			JobSet:   o.key.jobSet,

--- a/internal/scheduleringester/schedulerdb_test.go
+++ b/internal/scheduleringester/schedulerdb_test.go
@@ -94,7 +94,7 @@ func TestWriteOps(t *testing.T) {
 				jobIds[2]: &schedulerdb.Job{JobID: jobIds[2], Queue: testQueueName, JobSet: "set1"},
 				jobIds[3]: &schedulerdb.Job{JobID: jobIds[3], Queue: testQueueName, JobSet: "set2"},
 			},
-			UpdateJobPriorities{
+			&UpdateJobPriorities{
 				key: JobReprioritiseKey{
 					JobSetKey: JobSetKey{
 						queue:  testQueueName,
@@ -367,7 +367,7 @@ func addDefaultValues(op DbOperation) DbOperation {
 	case MarkJobsCancelRequested:
 	case MarkJobsSucceeded:
 	case MarkJobsFailed:
-	case UpdateJobPriorities:
+	case *UpdateJobPriorities:
 	case MarkRunsSucceeded:
 	case MarkRunsFailed:
 	case MarkRunsRunning:
@@ -598,7 +598,7 @@ func assertOpSuccess(t *testing.T, schedulerDb *SchedulerDb, serials map[string]
 			}
 		}
 		assert.Equal(t, len(expected), numChanged)
-	case UpdateJobPriorities:
+	case *UpdateJobPriorities:
 		jobs, err := selectNewJobs(ctx, serials["jobs"])
 		if err != nil {
 			return errors.WithStack(err)


### PR DESCRIPTION
As we were not using a pointer, our merging was "working" but the change would be lost once the Merge function returned.

Now we operate on a pointer to UpdateJobPriorities, so the update to JobIds is not lost once the Merge function returns
 - Added a unit test to confirm


