### PR TITLE
Metrics to be driven from statically assigned pools

### DIFF
--- a/internal/scheduler/metrics.go
+++ b/internal/scheduler/metrics.go
@@ -165,7 +165,7 @@ func (c *MetricsCollector) updateQueueMetrics(ctx *armadacontext.Context) ([]pro
 			continue
 		}
 
-		pool, err := c.poolAssigner.AssignPool(job)
+		pools, err := c.poolAssigner.AssignPools(job)
 		if err != nil {
 			return nil, err
 		}
@@ -205,8 +205,10 @@ func (c *MetricsCollector) updateQueueMetrics(ctx *armadacontext.Context) ([]pro
 			recorder = qs.runningJobRecorder
 			timeInState = currentTime.Sub(time.Unix(0, run.Created()))
 		}
-		recorder.RecordJobRuntime(pool, priorityClass, timeInState)
-		recorder.RecordResources(pool, priorityClass, jobResources)
+		for _, pool := range pools {
+			recorder.RecordJobRuntime(pool, priorityClass, timeInState)
+			recorder.RecordResources(pool, priorityClass, jobResources)
+		}
 	}
 
 	queuedDistinctSchedulingKeysCount := armadamaps.MapValues(schedulingKeysByQueue, func(schedulingKeys map[schedulerobjects.SchedulingKey]bool) int {

--- a/internal/scheduler/metrics_test.go
+++ b/internal/scheduler/metrics_test.go
@@ -33,7 +33,7 @@ func TestMetricsCollector_TestCollect_QueueMetrics(t *testing.T) {
 	tests := map[string]struct {
 		initialJobs  []*jobdb.Job
 		defaultPool  string
-		poolMappings map[string]string
+		poolMappings map[string][]string
 		queues       []*api.Queue
 		expected     []prometheus.Metric
 	}{
@@ -250,7 +250,7 @@ func TestMetricsCollector_TestCollect_ClusterMetrics(t *testing.T) {
 
 			queueCache := schedulermocks.NewMockQueueCache(ctrl)
 			queueCache.EXPECT().GetAll(ctx).Return([]*api.Queue{}, nil).Times(1)
-			poolAssigner := &MockPoolAssigner{testfixtures.TestPool, map[string]string{}}
+			poolAssigner := &MockPoolAssigner{testfixtures.TestPool, map[string][]string{}}
 
 			executorRepository := schedulermocks.NewMockExecutorRepository(ctrl)
 			executorRepository.EXPECT().GetExecutors(ctx).Return(tc.executors, nil)
@@ -302,17 +302,17 @@ func createNode(nodeType string) *schedulerobjects.Node {
 
 type MockPoolAssigner struct {
 	defaultPool string
-	poolsById   map[string]string
+	poolsById   map[string][]string
 }
 
 func (m MockPoolAssigner) Refresh(_ *armadacontext.Context) error {
 	return nil
 }
 
-func (m MockPoolAssigner) AssignPool(j *jobdb.Job) (string, error) {
-	pool, ok := m.poolsById[j.Id()]
+func (m MockPoolAssigner) AssignPools(j *jobdb.Job) ([]string, error) {
+	pools, ok := m.poolsById[j.Id()]
 	if !ok {
-		pool = m.defaultPool
+		return []string{m.defaultPool}, nil
 	}
-	return pool, nil
+	return pools, nil
 }

--- a/internal/scheduler/pool_assigner.go
+++ b/internal/scheduler/pool_assigner.go
@@ -18,12 +18,11 @@ type DefaultPoolAssigner struct {
 	poolByExecutorId   map[string]string
 }
 
-func NewPoolAssigner(executorRepository database.ExecutorRepository,
-) (*DefaultPoolAssigner, error) {
+func NewPoolAssigner(executorRepository database.ExecutorRepository) *DefaultPoolAssigner {
 	return &DefaultPoolAssigner{
 		executorRepository: executorRepository,
 		poolByExecutorId:   map[string]string{},
-	}, nil
+	}
 }
 
 // Refresh updates executor state

--- a/internal/scheduler/pool_assigner.go
+++ b/internal/scheduler/pool_assigner.go
@@ -1,189 +1,52 @@
 package scheduler
 
 import (
-	"time"
-
-	"github.com/gogo/protobuf/proto"
-	lru "github.com/hashicorp/golang-lru"
-	"github.com/pkg/errors"
-	"k8s.io/apimachinery/pkg/util/clock"
-
 	"github.com/armadaproject/armada/internal/common/armadacontext"
-	"github.com/armadaproject/armada/internal/common/stringinterner"
-	"github.com/armadaproject/armada/internal/common/types"
-	"github.com/armadaproject/armada/internal/scheduler/configuration"
-	"github.com/armadaproject/armada/internal/scheduler/constraints"
-	schedulercontext "github.com/armadaproject/armada/internal/scheduler/context"
 	"github.com/armadaproject/armada/internal/scheduler/database"
-	"github.com/armadaproject/armada/internal/scheduler/internaltypes"
 	"github.com/armadaproject/armada/internal/scheduler/jobdb"
-	"github.com/armadaproject/armada/internal/scheduler/nodedb"
-	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
 )
 
-// PoolAssigner allows jobs to be assigned to a pool
+// PoolAssigner allows jobs to be assigned to one or more pools
 // Note that this is intended only for use with metrics calculation
 type PoolAssigner interface {
+	AssignPools(j *jobdb.Job) ([]string, error)
 	Refresh(ctx *armadacontext.Context) error
-	AssignPool(j *jobdb.Job) (string, error)
-}
-
-type executor struct {
-	nodeDb         *nodedb.NodeDb
-	minimumJobSize schedulerobjects.ResourceList
 }
 
 type DefaultPoolAssigner struct {
-	executorTimeout     time.Duration
-	priorityClasses     map[string]types.PriorityClass
-	priorities          []int32
-	indexedResources    []configuration.ResourceType
-	indexedTaints       []string
-	indexedNodeLabels   []string
-	wellKnownNodeTypes  []configuration.WellKnownNodeType
-	poolByExecutorId    map[string]string
-	executorsByPool     map[string][]*executor
-	executorRepository  database.ExecutorRepository
-	poolCache           *lru.Cache
-	clock               clock.Clock
-	resourceListFactory *internaltypes.ResourceListFactory
+	executorRepository database.ExecutorRepository
+	poolByExecutorId   map[string]string
 }
 
-func NewPoolAssigner(executorTimeout time.Duration,
-	schedulingConfig configuration.SchedulingConfig,
-	executorRepository database.ExecutorRepository,
-	resourceListFactory *internaltypes.ResourceListFactory,
+func NewPoolAssigner(executorRepository database.ExecutorRepository,
 ) (*DefaultPoolAssigner, error) {
-	poolCache, err := lru.New(10000)
-	if err != nil {
-		return nil, errors.Wrap(err, "error  creating PoolAssigner pool cache")
-	}
 	return &DefaultPoolAssigner{
-		executorTimeout:     executorTimeout,
-		priorityClasses:     schedulingConfig.PriorityClasses,
-		executorsByPool:     map[string][]*executor{},
-		poolByExecutorId:    map[string]string{},
-		priorities:          types.AllowedPriorities(schedulingConfig.PriorityClasses),
-		indexedResources:    schedulingConfig.IndexedResources,
-		indexedTaints:       schedulingConfig.IndexedTaints,
-		wellKnownNodeTypes:  schedulingConfig.WellKnownNodeTypes,
-		indexedNodeLabels:   schedulingConfig.IndexedNodeLabels,
-		executorRepository:  executorRepository,
-		poolCache:           poolCache,
-		clock:               clock.RealClock{},
-		resourceListFactory: resourceListFactory,
+		executorRepository: executorRepository,
+		poolByExecutorId:   map[string]string{},
 	}, nil
 }
 
 // Refresh updates executor state
 func (p *DefaultPoolAssigner) Refresh(ctx *armadacontext.Context) error {
 	executors, err := p.executorRepository.GetExecutors(ctx)
-	executorsByPool := map[string][]*executor{}
-	poolByExecutorId := map[string]string{}
 	if err != nil {
 		return err
 	}
+	poolByExecutorId := map[string]string{}
 	for _, e := range executors {
-		if p.clock.Since(e.LastUpdateTime) < p.executorTimeout {
-			poolByExecutorId[e.Id] = e.Pool
-			nodeDb, err := p.constructNodeDb(e.Nodes)
-			if err != nil {
-				return errors.WithMessagef(err, "could not construct node db for executor %s", e.Id)
-			}
-			executorsByPool[e.Pool] = append(executorsByPool[e.Pool], &executor{
-				nodeDb:         nodeDb,
-				minimumJobSize: e.MinimumJobSize,
-			})
-		}
+		poolByExecutorId[e.Id] = e.Pool
 	}
-	p.executorsByPool = executorsByPool
 	p.poolByExecutorId = poolByExecutorId
-	p.poolCache.Purge()
 	return nil
 }
 
-// AssignPool returns the pool associated with the job or the empty string if no pool is valid
-func (p *DefaultPoolAssigner) AssignPool(j *jobdb.Job) (string, error) {
-	// If Job is running then use the pool associated with the executor it was assigned to
+// AssignPools returns the pools associated with the job or the empty string if no pool is valid
+func (p *DefaultPoolAssigner) AssignPools(j *jobdb.Job) ([]string, error) {
+	// If Job has an active run then use the pool associated with the executor it was assigned to
 	if !j.Queued() && j.HasRuns() {
-		return p.poolByExecutorId[j.LatestRun().Executor()], nil
+		pool := p.poolByExecutorId[j.LatestRun().Executor()]
+		return []string{pool}, nil
 	}
-
-	// See if we have this set of reqs cached.
-	schedulingKey := j.SchedulingKey()
-	if cachedPool, ok := p.poolCache.Get(schedulingKey); ok {
-		return cachedPool.(string), nil
-	}
-
-	req := j.PodRequirements()
-	req = p.clearAnnotations(req)
-
-	// Otherwise iterate through each pool and detect the first one the job is potentially schedulable on.
-	// TODO: We should use the real scheduler instead since this check may go out of sync with the scheduler.
-	for pool, executors := range p.executorsByPool {
-		for _, e := range executors {
-			requests := req.GetResourceRequirements().Requests
-			if ok, _ := constraints.RequestsAreLargeEnough(schedulerobjects.ResourceListFromV1ResourceList(requests), e.minimumJobSize); !ok {
-				continue
-			}
-			nodeDb := e.nodeDb
-			txn := nodeDb.Txn(true)
-			jctx := &schedulercontext.JobSchedulingContext{
-				Created:         time.Now(),
-				JobId:           j.Id(),
-				Job:             j,
-				PodRequirements: j.PodRequirements(),
-				GangInfo:        schedulercontext.EmptyGangInfo(j),
-			}
-			node, err := nodeDb.SelectNodeForJobWithTxn(txn, jctx)
-			txn.Abort()
-			if err != nil {
-				return "", errors.WithMessagef(err, "error selecting node for job %s", j.Id())
-			}
-			if node != nil {
-				p.poolCache.Add(schedulingKey, pool)
-				return pool, nil
-			}
-		}
-	}
-	return "", nil
-}
-
-func (p *DefaultPoolAssigner) constructNodeDb(nodes []*schedulerobjects.Node) (*nodedb.NodeDb, error) {
-	// Nodes to be considered by the scheduler.
-	nodeDb, err := nodedb.NewNodeDb(
-		p.priorityClasses,
-		0,
-		p.indexedResources,
-		p.indexedTaints,
-		p.indexedNodeLabels,
-		p.wellKnownNodeTypes,
-		stringinterner.New(1024),
-		p.resourceListFactory,
-	)
-	if err != nil {
-		return nil, err
-	}
-	txn := nodeDb.Txn(true)
-	defer txn.Abort()
-	for _, node := range nodes {
-		if err := nodeDb.CreateAndInsertWithJobDbJobsWithTxn(txn, nil, node); err != nil {
-			return nil, err
-		}
-	}
-	txn.Commit()
-	err = nodeDb.ClearAllocated()
-	if err != nil {
-		return nil, err
-	}
-	return nodeDb, nil
-}
-
-// clearAnnotations
-func (p *DefaultPoolAssigner) clearAnnotations(reqs *schedulerobjects.PodRequirements) *schedulerobjects.PodRequirements {
-	reqsCopy := proto.Clone(reqs).(*schedulerobjects.PodRequirements)
-	for key := range reqsCopy.GetAnnotations() {
-		reqsCopy.Annotations[key] = "poolassigner"
-	}
-	return reqsCopy
+	// otherwise use the pools associated with the job
+	return j.Pools(), nil
 }

--- a/internal/scheduler/pool_assigner_test.go
+++ b/internal/scheduler/pool_assigner_test.go
@@ -55,10 +55,9 @@ func TestPoolAssigner_AssignPools(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockExecutorRepo := schedulermocks.NewMockExecutorRepository(ctrl)
 			mockExecutorRepo.EXPECT().GetExecutors(ctx).Return(tc.executors, nil).AnyTimes()
-			assigner, err := NewPoolAssigner(mockExecutorRepo)
-			require.NoError(t, err)
+			assigner := NewPoolAssigner(mockExecutorRepo)
 
-			err = assigner.Refresh(ctx)
+			err := assigner.Refresh(ctx)
 			require.NoError(t, err)
 			pools, err := assigner.AssignPools(tc.job)
 			require.NoError(t, err)

--- a/internal/scheduler/pool_assigner_test.go
+++ b/internal/scheduler/pool_assigner_test.go
@@ -7,42 +7,44 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/util/clock"
 
 	"github.com/armadaproject/armada/internal/common/armadacontext"
-	"github.com/armadaproject/armada/internal/common/util"
-	"github.com/armadaproject/armada/internal/scheduler/configuration"
 	"github.com/armadaproject/armada/internal/scheduler/jobdb"
 	schedulermocks "github.com/armadaproject/armada/internal/scheduler/mocks"
 	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
 	"github.com/armadaproject/armada/internal/scheduler/testfixtures"
 )
 
-func TestPoolAssigner_AssignPool(t *testing.T) {
-	executorTimeout := 15 * time.Minute
-	cpuJob := testfixtures.TestQueuedJobDbJob()
-	gpuJob := testfixtures.WithJobDbJobPodRequirements(testfixtures.TestQueuedJobDbJob(), testfixtures.Test1GpuPodReqs(testfixtures.TestQueue, util.ULID(), testfixtures.TestPriorities[0]))
+func TestPoolAssigner_AssignPools(t *testing.T) {
+	queuedJob := testfixtures.TestQueuedJobDbJob()
+	cpuExecutor := testfixtures.TestExecutor(testfixtures.BaseTime)
+	runningJob := queuedJob.
+		WithQueued(false).
+		WithNewRun(cpuExecutor.Id, "testNode", "testNode", 0)
 
 	tests := map[string]struct {
 		executorTimout time.Duration
-		config         configuration.SchedulingConfig
 		executors      []*schedulerobjects.Executor
 		job            *jobdb.Job
-		expectedPool   string
+		expectedPools  []string
 	}{
-		"matches pool": {
-			executorTimout: executorTimeout,
-			config:         testfixtures.TestSchedulingConfig(),
-			executors:      []*schedulerobjects.Executor{testfixtures.TestExecutor(testfixtures.BaseTime)},
-			job:            cpuJob,
-			expectedPool:   "cpu",
+		"queued job with single pool": {
+			job:           queuedJob.WithPools([]string{"cpu"}),
+			expectedPools: []string{"cpu"},
 		},
-		"doesn't match pool": {
-			executorTimout: executorTimeout,
-			config:         testfixtures.TestSchedulingConfig(),
-			executors:      []*schedulerobjects.Executor{testfixtures.TestExecutor(testfixtures.BaseTime)},
-			job:            gpuJob,
-			expectedPool:   "",
+		"queued job with multiple pools": {
+			job:           queuedJob.WithPools([]string{"cpu", "gpu"}),
+			expectedPools: []string{"cpu", "gpu"},
+		},
+		"running job matches pool": {
+			executors:     []*schedulerobjects.Executor{cpuExecutor},
+			job:           runningJob,
+			expectedPools: []string{"cpu"},
+		},
+		"running job doesn't match pool": {
+			executors:     []*schedulerobjects.Executor{},
+			job:           runningJob,
+			expectedPools: []string{""},
 		},
 	}
 	for name, tc := range tests {
@@ -53,17 +55,15 @@ func TestPoolAssigner_AssignPool(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockExecutorRepo := schedulermocks.NewMockExecutorRepository(ctrl)
 			mockExecutorRepo.EXPECT().GetExecutors(ctx).Return(tc.executors, nil).AnyTimes()
-			fakeClock := clock.NewFakeClock(testfixtures.BaseTime)
-			assigner, err := NewPoolAssigner(tc.executorTimout, tc.config, mockExecutorRepo, testfixtures.TestResourceListFactory)
+			assigner, err := NewPoolAssigner(mockExecutorRepo)
 			require.NoError(t, err)
-			assigner.clock = fakeClock
 
 			err = assigner.Refresh(ctx)
 			require.NoError(t, err)
-			pool, err := assigner.AssignPool(tc.job)
+			pools, err := assigner.AssignPools(tc.job)
 			require.NoError(t, err)
 
-			assert.Equal(t, tc.expectedPool, pool)
+			assert.Equal(t, tc.expectedPools, pools)
 		})
 	}
 }

--- a/internal/scheduler/schedulerapp.go
+++ b/internal/scheduler/schedulerapp.go
@@ -330,10 +330,7 @@ func Run(config schedulerconfig.Configuration) error {
 	// ////////////////////////////////////////////////////////////////////////
 	// Metrics
 	// ////////////////////////////////////////////////////////////////////////
-	poolAssigner, err := NewPoolAssigner(executorRepository)
-	if err != nil {
-		return errors.WithMessage(err, "error creating pool assigner")
-	}
+	poolAssigner := NewPoolAssigner(executorRepository)
 	metricsCollector := NewMetricsCollector(
 		scheduler.jobDb,
 		queueCache,

--- a/internal/scheduler/schedulerapp.go
+++ b/internal/scheduler/schedulerapp.go
@@ -329,7 +329,7 @@ func Run(config schedulerconfig.Configuration) error {
 	// ////////////////////////////////////////////////////////////////////////
 	// Metrics
 	// ////////////////////////////////////////////////////////////////////////
-	poolAssigner, err := NewPoolAssigner(config.Scheduling.ExecutorTimeout, config.Scheduling, executorRepository, resourceListFactory)
+	poolAssigner, err := NewPoolAssigner(executorRepository)
 	if err != nil {
 		return errors.WithMessage(err, "error creating pool assigner")
 	}


### PR DESCRIPTION
Metrics re now driven from the statically assigned pools.  This is much cheaper than running a  dummy scheduling cycle to assign them.