### PR TITLE
[Executor] Allow specifying node-type via label

### DIFF
--- a/config/executor/config.yaml
+++ b/config/executor/config.yaml
@@ -34,6 +34,7 @@ kubernetes:
   QPS: 10000
   Burst: 10000
   nodeIdLabel: kubernetes.io/hostname
+  nodeTypeLabel: armadaproject.io/node-type
   minimumPodAge: 3m
   failedPodExpiry: 10m
   maxTerminatedPods: 1000 # Should be lower than kube-controller-managed terminated-pod-gc-threshold (default 12500)

--- a/internal/executor/application.go
+++ b/internal/executor/application.go
@@ -124,7 +124,7 @@ func StartUpWithContext(
 	taskManager *task.BackgroundTaskManager,
 	wg *sync.WaitGroup,
 ) (func(), *sync.WaitGroup) {
-	nodeInfoService := node.NewKubernetesNodeInfoService(clusterContext, config.Kubernetes.ToleratedTaints)
+	nodeInfoService := node.NewKubernetesNodeInfoService(clusterContext, config.Kubernetes.NodeTypeLabel, config.Kubernetes.ToleratedTaints)
 	podUtilisationService := utilisation.NewPodUtilisationService(
 		clusterContext,
 		nodeInfoService,

--- a/internal/executor/configuration/types.go
+++ b/internal/executor/configuration/types.go
@@ -56,6 +56,7 @@ type KubernetesConfiguration struct {
 	QPS                       float32
 	Burst                     int
 	Etcd                      EtcdConfiguration
+	NodeTypeLabel             string
 	NodeIdLabel               string
 	TrackedNodeLabels         []string
 	AvoidNodeLabelsOnRetry    []string

--- a/internal/executor/node/node_group_test.go
+++ b/internal/executor/node/node_group_test.go
@@ -12,10 +12,11 @@ import (
 )
 
 var testAppConfig = configuration.ApplicationConfiguration{ClusterId: "test", Pool: "pool"}
+var nodeTypeLabel = "node-type"
 
 func TestGetType_WhenNodeHasNoTaint(t *testing.T) {
 	context := fakeContext.NewFakeClusterContext(testAppConfig, "kubernetes.io/hostname", nil)
-	nodeInfoService := NewKubernetesNodeInfoService(context, []string{"tolerated1", "tolerated2"})
+	nodeInfoService := NewKubernetesNodeInfoService(context, nodeTypeLabel, []string{"tolerated1", "tolerated2"})
 	node := createNodeWithTaints("node1")
 
 	result := nodeInfoService.GetType(node)
@@ -25,7 +26,7 @@ func TestGetType_WhenNodeHasNoTaint(t *testing.T) {
 
 func TestGetType_WhenNodeHasUntoleratedTaint(t *testing.T) {
 	context := fakeContext.NewFakeClusterContext(testAppConfig, "kubernetes.io/hostname", nil)
-	nodeInfoService := NewKubernetesNodeInfoService(context, []string{"tolerated1", "tolerated2"})
+	nodeInfoService := NewKubernetesNodeInfoService(context, nodeTypeLabel, []string{"tolerated1", "tolerated2"})
 	node := createNodeWithTaints("node1", "untolerated")
 
 	result := nodeInfoService.GetType(node)
@@ -35,7 +36,7 @@ func TestGetType_WhenNodeHasUntoleratedTaint(t *testing.T) {
 
 func TestGetType_WhenNodeHasToleratedTaint(t *testing.T) {
 	context := fakeContext.NewFakeClusterContext(testAppConfig, "kubernetes.io/hostname", nil)
-	nodeInfoService := NewKubernetesNodeInfoService(context, []string{"tolerated1", "tolerated2"})
+	nodeInfoService := NewKubernetesNodeInfoService(context, nodeTypeLabel, []string{"tolerated1", "tolerated2"})
 
 	node := createNodeWithTaints("node1", "tolerated1")
 	result := nodeInfoService.GetType(node)
@@ -52,7 +53,7 @@ func TestGetType_WhenNodeHasToleratedTaint(t *testing.T) {
 
 func TestGetType_WhenSomeNodeTaintsTolerated(t *testing.T) {
 	context := fakeContext.NewFakeClusterContext(testAppConfig, "kubernetes.io/hostname", nil)
-	nodeInfoService := NewKubernetesNodeInfoService(context, []string{"tolerated1", "tolerated2"})
+	nodeInfoService := NewKubernetesNodeInfoService(context, nodeTypeLabel, []string{"tolerated1", "tolerated2"})
 
 	node := createNodeWithTaints("node1", "tolerated1", "untolerated")
 	result := nodeInfoService.GetType(node)
@@ -63,7 +64,7 @@ func TestGetType_WhenSomeNodeTaintsTolerated(t *testing.T) {
 
 func TestGroupNodesByType(t *testing.T) {
 	context := fakeContext.NewFakeClusterContext(testAppConfig, "kubernetes.io/hostname", nil)
-	nodeInfoService := NewKubernetesNodeInfoService(context, []string{"tolerated1", "tolerated2"})
+	nodeInfoService := NewKubernetesNodeInfoService(context, nodeTypeLabel, []string{"tolerated1", "tolerated2"})
 
 	node1 := createNodeWithTaints("node1")
 	node2 := createNodeWithTaints("node2", "untolerated")
@@ -89,7 +90,7 @@ func TestGroupNodesByType(t *testing.T) {
 
 func TestFilterAvailableProcessingNodes(t *testing.T) {
 	context := fakeContext.NewFakeClusterContext(testAppConfig, "kubernetes.io/hostname", nil)
-	nodeInfoService := NewKubernetesNodeInfoService(context, []string{})
+	nodeInfoService := NewKubernetesNodeInfoService(context, nodeTypeLabel, []string{})
 
 	node := v1.Node{
 		Spec: v1.NodeSpec{
@@ -104,7 +105,7 @@ func TestFilterAvailableProcessingNodes(t *testing.T) {
 
 func TestIsAvailableProcessingNode_IsFalse_UnschedulableNode(t *testing.T) {
 	context := fakeContext.NewFakeClusterContext(testAppConfig, "kubernetes.io/hostname", nil)
-	nodeInfoService := NewKubernetesNodeInfoService(context, []string{})
+	nodeInfoService := NewKubernetesNodeInfoService(context, nodeTypeLabel, []string{})
 
 	node := v1.Node{
 		Spec: v1.NodeSpec{
@@ -119,7 +120,7 @@ func TestIsAvailableProcessingNode_IsFalse_UnschedulableNode(t *testing.T) {
 
 func TestFilterAvailableProcessingNodes_IsFalse_NodeWithNoScheduleTaint(t *testing.T) {
 	context := fakeContext.NewFakeClusterContext(testAppConfig, "kubernetes.io/hostname", nil)
-	nodeInfoService := NewKubernetesNodeInfoService(context, []string{})
+	nodeInfoService := NewKubernetesNodeInfoService(context, nodeTypeLabel, []string{})
 
 	taint := v1.Taint{
 		Key:    "taint",
@@ -138,7 +139,7 @@ func TestFilterAvailableProcessingNodes_IsFalse_NodeWithNoScheduleTaint(t *testi
 
 func TestFilterAvailableProcessingNodes_IsTrue_NodeWithToleratedTaint(t *testing.T) {
 	context := fakeContext.NewFakeClusterContext(testAppConfig, "kubernetes.io/hostname", nil)
-	nodeInfoService := NewKubernetesNodeInfoService(context, []string{"taint"})
+	nodeInfoService := NewKubernetesNodeInfoService(context, nodeTypeLabel, []string{"taint"})
 
 	taint := v1.Taint{
 		Key:    "taint",


### PR DESCRIPTION
Currently node-type is calculated by combining all the taints on a node.

While this typically results in unique node-types that accurately describe the node, it is very hard to read

Now we'll check for a label on the node (configurable) and if present, the node-type will be set to the value of that label

This allows human readable node-types to be set
 - It does mean that you can incorrectly label a nodes type, but that is now on the admin to configure properly

