### PR TITLE
Change default node-type from pool name to none

### DIFF
--- a/internal/executor/node/node_group.go
+++ b/internal/executor/node/node_group.go
@@ -11,6 +11,8 @@ import (
 	util2 "github.com/armadaproject/armada/internal/executor/util"
 )
 
+const defaultNodeType = "none"
+
 type NodeInfoService interface {
 	IsAvailableProcessingNode(*v1.Node) bool
 	GetAllAvailableProcessingNodes() ([]*v1.Node, error)
@@ -61,7 +63,7 @@ func (kubernetesNodeInfoService *KubernetesNodeInfoService) GroupNodesByType(nod
 }
 
 func (kubernetesNodeInfoService *KubernetesNodeInfoService) GetType(node *v1.Node) string {
-	nodeType := kubernetesNodeInfoService.clusterContext.GetClusterPool()
+	nodeType := defaultNodeType
 
 	if labelValue, ok := node.Labels[kubernetesNodeInfoService.nodeTypeLabel]; ok {
 		nodeType = labelValue

--- a/internal/executor/node/node_group_test.go
+++ b/internal/executor/node/node_group_test.go
@@ -22,7 +22,7 @@ func TestGetType_WhenNodeHasNoTaint(t *testing.T) {
 	node := createNodeWithTaints("node1")
 
 	result := nodeInfoService.GetType(node)
-	assert.Equal(t, result, context.GetClusterPool())
+	assert.Equal(t, result, defaultNodeType)
 }
 
 func TestGetType_WhenNodeHasNodeTypeLabel(t *testing.T) {
@@ -42,7 +42,7 @@ func TestGetType_WhenNodeHasUntoleratedTaint(t *testing.T) {
 	node := createNodeWithTaints("node1", "untolerated")
 
 	result := nodeInfoService.GetType(node)
-	assert.Equal(t, result, context.GetClusterPool())
+	assert.Equal(t, result, defaultNodeType)
 }
 
 func TestGetType_WhenNodeHasToleratedTaint(t *testing.T) {
@@ -81,9 +81,9 @@ func TestGroupNodesByType(t *testing.T) {
 	assert.Equal(t, len(groupedNodes), 3)
 
 	expected := map[string][]*v1.Node{
-		context.GetClusterPool(): {node1, node2},
-		"tolerated1":             {node3, node4},
-		"tolerated1,tolerated2":  {node5},
+		defaultNodeType:         {node1, node2},
+		"tolerated1":            {node3, node4},
+		"tolerated1,tolerated2": {node5},
 	}
 
 	for _, nodeGroup := range groupedNodes {


### PR DESCRIPTION
Explicitly set nodes without a node-type configured to node-type = "none"

It was previously set to the pool name, however metrics already include the pool the node is in, making this information redundant

It is more useful to explicitly see the nodes without a node-type
 - Typically this will be non-armada nodes (master nodes)

