### PR TITLE
Fix slow ingestion of ReprioritiseJob events

### DIFF
--- a/internal/scheduleringester/dbops.go
+++ b/internal/scheduleringester/dbops.go
@@ -7,7 +7,6 @@ import (
 	"github.com/google/uuid"
 	"golang.org/x/exp/maps"
 
-	"github.com/armadaproject/armada/internal/common/slices"
 	schedulerdb "github.com/armadaproject/armada/internal/scheduler/database"
 )
 
@@ -239,7 +238,7 @@ func (a *UpdateJobPriorities) Merge(b DbOperation) bool {
 	switch op := b.(type) {
 	case *UpdateJobPriorities:
 		if a.key == op.key {
-			a.jobIds = slices.Unique(append(a.jobIds, op.jobIds...))
+			a.jobIds = append(a.jobIds, op.jobIds...)
 			return true
 		}
 	}

--- a/internal/scheduleringester/schedulerdb.go
+++ b/internal/scheduleringester/schedulerdb.go
@@ -14,6 +14,7 @@ import (
 	"github.com/armadaproject/armada/internal/common/database"
 	"github.com/armadaproject/armada/internal/common/ingest"
 	"github.com/armadaproject/armada/internal/common/ingest/metrics"
+	"github.com/armadaproject/armada/internal/common/slices"
 	schedulerdb "github.com/armadaproject/armada/internal/scheduler/database"
 )
 
@@ -230,7 +231,7 @@ func (s *SchedulerDb) WriteDbOp(ctx *armadacontext.Context, tx pgx.Tx, op DbOper
 			Queue:    o.key.queue,
 			JobSet:   o.key.jobSet,
 			Priority: o.key.Priority,
-			JobIds:   o.jobIds,
+			JobIds:   slices.Unique(o.jobIds),
 		})
 		if err != nil {
 			return errors.WithStack(err)


### PR DESCRIPTION
Call unique once per UpdateJobPriorities op, rather than once for every jobId added to the UpdateJobPriorities op



