### PR TITLE
CI: Update paths for deploying GH pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,15 +6,16 @@ on:
       - master
     paths:
       - 'docs/*.md'
-      - 'docs/quickstart'
       - 'docs/developer'
-      - 'docs/design'
+      - 'docs/logo/**/*'
       - '*.md'
       - '.github/workflows/pages.yml'
 
 jobs:
   deploy-gh-pages:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout master
         uses: actions/checkout@v4
@@ -31,10 +32,7 @@ jobs:
         run: |
           cp master/docs/*.md gh-pages/
           rm gh-pages/docs-readme.md
-          cp -r master/docs/quickstart gh-pages/
-          cp master/docs/quickstart/index.md gh-pages/quickstart.md
           cp -r master/docs/developer gh-pages/
-          cp -r master/docs/design gh-pages/
           cp master/CODE_OF_CONDUCT.md master/CONTRIBUTING.md gh-pages/_pages/
 
       - name: Commit GH Pages


### PR DESCRIPTION
https://github.com/armadaproject/armada/issues/3709

- updated paths for the files which we are publishing to `gh-pages`
- add permissions required for `GITHUB_TOKEN` to push to `gh-pages`
- removed deleted folders from the workflow paths


Tests: https://github.com/gr-oss-devops/armada/actions/runs/9583455997
`gh-pages` updated: https://github.com/gr-oss-devops/armada/commits/gh-pages/