### PR TITLE
[Bug] Fix ingestion pipeline event counting

### DIFF
--- a/internal/common/ingest/ingestion_pipeline.go
+++ b/internal/common/ingest/ingestion_pipeline.go
@@ -150,7 +150,13 @@ func (i *IngestionPipeline[T]) Run(ctx *armadacontext.Context) error {
 
 	// Batch up messages
 	batchedEventSequences := make(chan *EventSequencesWithIds)
-	eventCounterFunc := func(seq *EventSequencesWithIds) int { return len(seq.EventSequences) }
+	eventCounterFunc := func(seq *EventSequencesWithIds) int {
+		totalEvents := 0
+		for _, seq := range seq.EventSequences {
+			totalEvents += len(seq.Events)
+		}
+		return totalEvents
+	}
 	eventPublisherFunc := func(b []*EventSequencesWithIds) { batchedEventSequences <- combineEventSequences(b) }
 	batcher := NewBatcher[*EventSequencesWithIds](eventSequences, i.pulsarBatchSize, i.pulsarBatchDuration, eventCounterFunc, eventPublisherFunc)
 	go func() {


### PR DESCRIPTION
The function that counts the number of events per event sequence is wrong as it is actually counting the number of event sequences (each of which can contain many events)

This just makes us actually count all the events in all event sequences


