### PR TITLE
Fix Issues Arising from Confusing Weighted Costs

### DIFF
--- a/internal/scheduler/context/context.go
+++ b/internal/scheduler/context/context.go
@@ -187,7 +187,7 @@ func (sctx *SchedulingContext) UpdateFairShares() {
 	for queueName, qctx := range sctx.QueueSchedulingContexts {
 		cappedShare := 1.0
 		if !sctx.TotalResources.IsZero() {
-			cappedShare = sctx.FairnessCostProvider.WeightedCostFromAllocation(qctx.Demand, qctx.Weight) * qctx.Weight
+			cappedShare = sctx.FairnessCostProvider.UnweightedCostFromAllocation(qctx.Demand)
 		}
 		queueInfos = append(queueInfos, &queueInfo{
 			queueName:     queueName,

--- a/internal/scheduler/context/context.go
+++ b/internal/scheduler/context/context.go
@@ -164,7 +164,7 @@ func (sctx *SchedulingContext) GetQueue(queue string) (fairness.Queue, bool) {
 func (sctx *SchedulingContext) TotalCost() float64 {
 	var rv float64
 	for _, qctx := range sctx.QueueSchedulingContexts {
-		rv += sctx.FairnessCostProvider.CostFromQueue(qctx)
+		rv += sctx.FairnessCostProvider.UnweightedCostFromQueue(qctx)
 	}
 	return rv
 }
@@ -187,7 +187,7 @@ func (sctx *SchedulingContext) UpdateFairShares() {
 	for queueName, qctx := range sctx.QueueSchedulingContexts {
 		cappedShare := 1.0
 		if !sctx.TotalResources.IsZero() {
-			cappedShare = sctx.FairnessCostProvider.CostFromAllocationAndWeight(qctx.Demand, qctx.Weight) * qctx.Weight
+			cappedShare = sctx.FairnessCostProvider.WeightedCostFromAllocation(qctx.Demand, qctx.Weight) * qctx.Weight
 		}
 		queueInfos = append(queueInfos, &queueInfo{
 			queueName:     queueName,

--- a/internal/scheduler/fairness/fairness_test.go
+++ b/internal/scheduler/fairness/fairness_test.go
@@ -156,12 +156,12 @@ func TestDominantResourceFairness(t *testing.T) {
 			assert.Equal(
 				t,
 				tc.expectedCost,
-				f.CostFromAllocationAndWeight(tc.allocation, tc.weight),
+				f.WeightedCostFromAllocation(tc.allocation, tc.weight),
 			)
 			assert.Equal(
 				t,
-				f.CostFromAllocationAndWeight(tc.allocation, tc.weight),
-				f.CostFromQueue(MinimalQueue{allocation: tc.allocation, weight: tc.weight}),
+				f.WeightedCostFromAllocation(tc.allocation, tc.weight),
+				f.WeightedCostFromQueue(MinimalQueue{allocation: tc.allocation, weight: tc.weight}),
 			)
 		})
 	}

--- a/internal/scheduler/preempting_queue_scheduler.go
+++ b/internal/scheduler/preempting_queue_scheduler.go
@@ -137,7 +137,6 @@ func (sch *PreemptingQueueScheduler) Schedule(ctx *armadacontext.Context) (*Sche
 						fairShare = math.Max(qctx.AdjustedFairShare, fairShare)
 					}
 					fractionOfFairShare := actualShare / fairShare
-					ctx.Infof("queue=%s, fairShare=%.2f, actualShare=%.2f", qctx.Queue, fairShare, actualShare)
 					if fractionOfFairShare <= sch.protectedFractionOfFairShare {
 						return false
 					}

--- a/internal/scheduler/preempting_queue_scheduler.go
+++ b/internal/scheduler/preempting_queue_scheduler.go
@@ -131,12 +131,13 @@ func (sch *PreemptingQueueScheduler) Schedule(ctx *armadacontext.Context) (*Sche
 					return false
 				}
 				if qctx, ok := sch.schedulingContext.QueueSchedulingContexts[job.Queue()]; ok {
-					actualShare := sch.schedulingContext.FairnessCostProvider.CostFromQueue(qctx) / totalCost
+					actualShare := sch.schedulingContext.FairnessCostProvider.UnweightedCostFromQueue(qctx) / totalCost
 					fairShare := qctx.FairShare
 					if sch.useAdjustedFairShareProtection {
 						fairShare = math.Max(qctx.AdjustedFairShare, fairShare)
 					}
 					fractionOfFairShare := actualShare / fairShare
+					ctx.Infof("queue=%s, fairShare=%.2f, actualShare=%.2f", qctx.Queue, fairShare, actualShare)
 					if fractionOfFairShare <= sch.protectedFractionOfFairShare {
 						return false
 					}

--- a/internal/scheduler/preempting_queue_scheduler_test.go
+++ b/internal/scheduler/preempting_queue_scheduler_test.go
@@ -1321,19 +1321,26 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
-						"A": testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 16),
-						"B": testfixtures.N1Cpu4GiJobs("B", testfixtures.PriorityClass0, 16),
+						"A": testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass2NonPreemptible, 24),
+						"B": testfixtures.N1Cpu4GiJobs("B", testfixtures.PriorityClass0, 8),
 					},
 					ExpectedScheduledIndices: map[string][]int{
-						"A": testfixtures.IntRange(0, 15),
-						"B": testfixtures.IntRange(0, 15),
+						"A": testfixtures.IntRange(0, 23),
+						"B": testfixtures.IntRange(0, 7),
+					},
+				},
+				{
+					// D submits one more job. No preemption occurs because B is below adjusted fair share
+					JobsByQueue: map[string][]*jobdb.Job{
+						"C": testfixtures.N1Cpu4GiJobs("C", testfixtures.PriorityClass0, 1),
 					},
 				},
 				{}, // Empty round to make sure nothing changes.
 			},
 			PriorityFactorByQueue: map[string]float64{
 				"A": 1,
-				"B": 10,
+				"B": 2,
+				"c": 1,
 			},
 		},
 		"DominantResourceFairness": {

--- a/internal/scheduler/preempting_queue_scheduler_test.go
+++ b/internal/scheduler/preempting_queue_scheduler_test.go
@@ -1312,6 +1312,30 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 				"D": 1,
 			},
 		},
+		"ProtectedFractionOfFairShare non equal weights": {
+			SchedulingConfig: testfixtures.WithProtectedFractionOfFairShareConfig(
+				1.0,
+				testfixtures.TestSchedulingConfig(),
+			),
+			Nodes: testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
+			Rounds: []SchedulingRound{
+				{
+					JobsByQueue: map[string][]*jobdb.Job{
+						"A": testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 16),
+						"B": testfixtures.N1Cpu4GiJobs("B", testfixtures.PriorityClass0, 16),
+					},
+					ExpectedScheduledIndices: map[string][]int{
+						"A": testfixtures.IntRange(0, 15),
+						"B": testfixtures.IntRange(0, 15),
+					},
+				},
+				{}, // Empty round to make sure nothing changes.
+			},
+			PriorityFactorByQueue: map[string]float64{
+				"A": 1,
+				"B": 10,
+			},
+		},
 		"DominantResourceFairness": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
 			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),

--- a/internal/scheduler/preempting_queue_scheduler_test.go
+++ b/internal/scheduler/preempting_queue_scheduler_test.go
@@ -1340,7 +1340,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 			PriorityFactorByQueue: map[string]float64{
 				"A": 1,
 				"B": 2,
-				"c": 1,
+				"C": 1,
 			},
 		},
 		"DominantResourceFairness": {

--- a/internal/scheduler/queue_scheduler.go
+++ b/internal/scheduler/queue_scheduler.go
@@ -465,7 +465,7 @@ func (it *CandidateGangIterator) queueCostWithGctx(gctx *schedulercontext.GangSc
 	it.buffer.Zero()
 	it.buffer.Add(queue.GetAllocation())
 	it.buffer.Add(gctx.TotalResourceRequests)
-	return it.fairnessCostProvider.CostFromAllocationAndWeight(it.buffer, queue.GetWeight()), nil
+	return it.fairnessCostProvider.WeightedCostFromAllocation(it.buffer, queue.GetWeight()), nil
 }
 
 // Priority queue used by CandidateGangIterator to determine from which queue to schedule the next job.

--- a/internal/scheduler/scheduler_metrics.go
+++ b/internal/scheduler/scheduler_metrics.go
@@ -199,7 +199,7 @@ func (metrics *SchedulerMetrics) calculateQueuePoolMetrics(schedulingContexts []
 
 		for queue, queueContext := range schedContext.QueueSchedulingContexts {
 			key := queuePoolKey{queue: queue, pool: pool}
-			actualShare := schedContext.FairnessCostProvider.CostFromQueue(queueContext) / totalCost
+			actualShare := schedContext.FairnessCostProvider.UnweightedCostFromQueue(queueContext) / totalCost
 			result[key] = queuePoolData{
 				numberOfJobsConsidered: len(queueContext.UnsuccessfulJobSchedulingContexts) + len(queueContext.SuccessfulJobSchedulingContexts),
 				fairShare:              queueContext.FairShare,


### PR DESCRIPTION
The cost provider returned weighted costs, this caused issues iin a couple of places where an unweighted cost was expected.

- protected fair share
- actual_share metric

I've modified the cost provider to also return unweighted costs and have renamed the existing methods soo that it's clear they are weighted.

