### PR TITLE
Improvements To Fairness Metrics

### DIFF
--- a/internal/scheduler/scheduler_metrics.go
+++ b/internal/scheduler/scheduler_metrics.go
@@ -78,6 +78,23 @@ var actualSharePerQueueDesc = prometheus.NewDesc(
 	}, nil,
 )
 
+var demandPerQueueDesc = prometheus.NewDesc(
+	fmt.Sprintf("%s_%s_%s", NAMESPACE, SUBSYSTEM, "demand"),
+	"Demand of each queue and pool.",
+	[]string{
+		"queue",
+		"pool",
+	}, nil,
+)
+
+var fairnessErrorDesc = prometheus.NewDesc(
+	fmt.Sprintf("%s_%s_%s", NAMESPACE, SUBSYSTEM, "fairness_error"),
+	"Cumulative delta between adjusted fair share and actual share for all users who\n// are below their fair share",
+	[]string{
+		"pool",
+	}, nil,
+)
+
 func NewSchedulerMetrics(config configuration.SchedulerMetricsConfig) *SchedulerMetrics {
 	scheduleCycleTime := prometheus.NewHistogram(
 		prometheus.HistogramOpts{
@@ -123,10 +140,12 @@ func (m *SchedulerMetrics) ReportReconcileCycleTime(cycleTime time.Duration) {
 }
 
 func (m *SchedulerMetrics) ReportSchedulerResult(result SchedulerResult) {
+	qpd := m.calculateQueuePoolMetrics(result.SchedulingContexts)
 	currentSchedulingMetrics := schedulingRoundData{
-		queuePoolData:    m.calculateQueuePoolMetrics(result.SchedulingContexts),
+		queuePoolData:    qpd,
 		scheduledJobData: aggregateJobContexts(m.mostRecentSchedulingRoundData.scheduledJobData, result.ScheduledJobs),
 		preemptedJobData: aggregateJobContexts(m.mostRecentSchedulingRoundData.preemptedJobData, result.PreemptedJobs),
+		fairnessError:    calculateFairnessError(qpd),
 	}
 
 	m.mostRecentSchedulingRoundData = currentSchedulingMetrics
@@ -158,12 +177,17 @@ func generateSchedulerMetrics(schedulingRoundData schedulingRoundData) []prometh
 		result = append(result, prometheus.MustNewConstMetric(fairSharePerQueueDesc, prometheus.GaugeValue, float64(value.fairShare), key.queue, key.pool))
 		result = append(result, prometheus.MustNewConstMetric(adjustedFairSharePerQueueDesc, prometheus.GaugeValue, float64(value.adjustedFairShare), key.queue, key.pool))
 		result = append(result, prometheus.MustNewConstMetric(actualSharePerQueueDesc, prometheus.GaugeValue, float64(value.actualShare), key.queue, key.pool))
+		result = append(result, prometheus.MustNewConstMetric(demandPerQueueDesc, prometheus.GaugeValue, float64(value.demand), key.queue, key.pool))
 	}
 	for key, value := range schedulingRoundData.scheduledJobData {
 		result = append(result, prometheus.MustNewConstMetric(scheduledJobsDesc, prometheus.CounterValue, float64(value), key.queue, key.priorityClass))
 	}
 	for key, value := range schedulingRoundData.preemptedJobData {
 		result = append(result, prometheus.MustNewConstMetric(preemptedJobsDesc, prometheus.CounterValue, float64(value), key.queue, key.priorityClass))
+	}
+
+	for pool, fairnessError := range schedulingRoundData.fairnessError {
+		result = append(result, prometheus.MustNewConstMetric(fairnessErrorDesc, prometheus.CounterValue, fairnessError, pool))
 	}
 
 	return result
@@ -194,17 +218,18 @@ func aggregateJobContexts(previousSchedulingRoundData map[queuePriorityClassKey]
 func (metrics *SchedulerMetrics) calculateQueuePoolMetrics(schedulingContexts []*schedulercontext.SchedulingContext) map[queuePoolKey]queuePoolData {
 	result := make(map[queuePoolKey]queuePoolData)
 	for _, schedContext := range schedulingContexts {
-		totalCost := schedContext.TotalCost()
 		pool := schedContext.Pool
 
 		for queue, queueContext := range schedContext.QueueSchedulingContexts {
 			key := queuePoolKey{queue: queue, pool: pool}
-			actualShare := schedContext.FairnessCostProvider.UnweightedCostFromQueue(queueContext) / totalCost
+			actualShare := schedContext.FairnessCostProvider.UnweightedCostFromQueue(queueContext)
+			demand := schedContext.FairnessCostProvider.UnweightedCostFromAllocation(queueContext.Demand)
 			result[key] = queuePoolData{
 				numberOfJobsConsidered: len(queueContext.UnsuccessfulJobSchedulingContexts) + len(queueContext.SuccessfulJobSchedulingContexts),
 				fairShare:              queueContext.FairShare,
 				adjustedFairShare:      queueContext.AdjustedFairShare,
 				actualShare:            actualShare,
+				demand:                 demand,
 			}
 		}
 	}
@@ -212,7 +237,22 @@ func (metrics *SchedulerMetrics) calculateQueuePoolMetrics(schedulingContexts []
 	return result
 }
 
+// calculateFairnessError returns the cumulative delta between adjusted fair share and actual share for all users who
+// are below their fair share
+func calculateFairnessError(data map[queuePoolKey]queuePoolData) map[string]float64 {
+	errors := map[string]float64{}
+	for k, v := range data {
+		pool := k.pool
+		delta := v.adjustedFairShare - v.actualShare
+		if delta > 0 {
+			errors[pool] += delta
+		}
+	}
+	return errors
+}
+
 type schedulingRoundData struct {
+	fairnessError    map[string]float64
 	queuePoolData    map[queuePoolKey]queuePoolData
 	scheduledJobData map[queuePriorityClassKey]int
 	preemptedJobData map[queuePriorityClassKey]int
@@ -233,4 +273,5 @@ type queuePoolData struct {
 	actualShare            float64
 	fairShare              float64
 	adjustedFairShare      float64
+	demand                 float64
 }

--- a/internal/scheduler/scheduler_metrics.go
+++ b/internal/scheduler/scheduler_metrics.go
@@ -89,7 +89,7 @@ var demandPerQueueDesc = prometheus.NewDesc(
 
 var fairnessErrorDesc = prometheus.NewDesc(
 	fmt.Sprintf("%s_%s_%s", NAMESPACE, SUBSYSTEM, "fairness_error"),
-	"Cumulative delta between adjusted fair share and actual share for all users who\n// are below their fair share",
+	"Cumulative delta between adjusted fair share and actual share for all users who are below their fair share",
 	[]string{
 		"pool",
 	}, nil,

--- a/internal/scheduler/scheduler_metrics_test.go
+++ b/internal/scheduler/scheduler_metrics_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	schedulercontext "github.com/armadaproject/armada/internal/scheduler/context"
 	"github.com/armadaproject/armada/internal/scheduler/jobdb"
@@ -31,4 +32,61 @@ func TestAggregateJobs(t *testing.T) {
 	}
 
 	assert.Equal(t, expected, actual)
+}
+
+func TestCalculateFairnessError(t *testing.T) {
+	tests := map[string]struct {
+		input    map[queuePoolKey]queuePoolData
+		expected map[string]float64
+	}{
+		"empty": {
+			input:    map[queuePoolKey]queuePoolData{},
+			expected: map[string]float64{},
+		},
+		"one pool": {
+			input: map[queuePoolKey]queuePoolData{
+				{pool: "poolA", queue: "queueA"}: {actualShare: 0.5, adjustedFairShare: 0.6},
+			},
+			expected: map[string]float64{
+				"poolA": 0.1,
+			},
+		},
+		"one pool multiple values": {
+			input: map[queuePoolKey]queuePoolData{
+				{pool: "poolA", queue: "queueA"}: {actualShare: 0.5, adjustedFairShare: 0.6},
+				{pool: "poolA", queue: "queueB"}: {actualShare: 0.1, adjustedFairShare: 0.3},
+			},
+			expected: map[string]float64{
+				"poolA": 0.3,
+			},
+		},
+		"one pool one value above fair sahre": {
+			input: map[queuePoolKey]queuePoolData{
+				{pool: "poolA", queue: "queueA"}: {actualShare: 0.5, adjustedFairShare: 0.6},
+				{pool: "poolA", queue: "queueB"}: {actualShare: 0.3, adjustedFairShare: 0.1},
+			},
+			expected: map[string]float64{
+				"poolA": 0.1,
+			},
+		},
+		"two pools": {
+			input: map[queuePoolKey]queuePoolData{
+				{pool: "poolA", queue: "queueA"}: {actualShare: 0.5, adjustedFairShare: 0.6},
+				{pool: "poolB", queue: "queueB"}: {actualShare: 0.1, adjustedFairShare: 0.6},
+			},
+			expected: map[string]float64{
+				"poolA": 0.1,
+				"poolB": 0.5,
+			},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			fairnessErrors := calculateFairnessError(tc.input)
+			require.Equal(t, len(tc.expected), len(fairnessErrors))
+			for pool, err := range tc.expected {
+				assert.InDelta(t, err, fairnessErrors[pool], 0.0001, "error for pool %s", pool)
+			}
+		})
+	}
 }


### PR DESCRIPTION

* Adds a metric for `armada_scheduler_demand`  which is demand per queue per pool (in units of cost).  This helps us tell if `adjusted_fair_share` has been capped at demand.
* Adds a metric for `armada_scheduler_fairness_error` which is the sum of all deltas between `adjusted_fair_share`  and `actual_share` when `adjusted_fair_share` is greater than `actual_share`
* Chnages `actual_share` so that it is calculated as a percentage of available cluster capacity rather than as a percentage of running jobs.  