### PR TITLE
Remove Repeatable Read From Lookout queries

### DIFF
--- a/internal/armada/queryapi/query_api.go
+++ b/internal/armada/queryapi/query_api.go
@@ -63,7 +63,7 @@ func (q *QueryApi) GetJobDetails(ctx context.Context, req *api.JobDetailsRequest
 	detailsById := make(map[string]*api.JobDetails)
 
 	err := pgx.BeginTxFunc(ctx, q.db, pgx.TxOptions{
-		IsoLevel:       pgx.RepeatableRead,
+		IsoLevel:       pgx.ReadCommitted,
 		AccessMode:     pgx.ReadOnly,
 		DeferrableMode: pgx.Deferrable,
 	}, func(tx pgx.Tx) error {

--- a/internal/lookoutv2/repository/groupjobs.go
+++ b/internal/lookoutv2/repository/groupjobs.go
@@ -61,18 +61,12 @@ func (r *SqlGroupJobsRepository) GroupBy(
 
 	var groups []*model.JobGroup
 
-	if err := pgx.BeginTxFunc(ctx, r.db, pgx.TxOptions{
-		IsoLevel:       pgx.RepeatableRead,
-		AccessMode:     pgx.ReadOnly,
-		DeferrableMode: pgx.Deferrable,
-	}, func(tx pgx.Tx) error {
-		groupRows, err := tx.Query(ctx, query.Sql, query.Args...)
-		if err != nil {
-			return err
-		}
-		groups, err = rowsToGroups(groupRows, groupedField, aggregates, filters)
-		return err
-	}); err != nil {
+	groupRows, err := r.db.Query(ctx, query.Sql, query.Args...)
+	if err != nil {
+		return nil, err
+	}
+	groups, err = rowsToGroups(groupRows, groupedField, aggregates, filters)
+	if err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
We currently use `RepeatableRead` for transaction isolation level when reading from lookout.  We used to need this because lookout would generally make several queries to fulfil a request, however now this is no longer the case and we generally just make a single query.

I've changed all the lookout-proper code to just not define an explicit transaction as we're just running a single query.  One of the query-api methods does make a couple of queries to serve a request, but there `ReadComitted` is probably sufficient.