### PR TITLE
Adds Some Prometheus Metrics To Lookout

### DIFF
--- a/config/lookoutv2/config.yaml
+++ b/config/lookoutv2/config.yaml
@@ -1,4 +1,5 @@
 apiPort: 10000
+metricsPort: 9003
 corsAllowedOrigins:
   - "http://localhost:3000"
   - "http://localhost:8089"

--- a/deployment/lookout-v2/templates/servicemonitor.yaml
+++ b/deployment/lookout-v2/templates/servicemonitor.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.prometheus.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "lookout_v2.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lookout_v2.name.labels.all" . | nindent 4 -}}
+    {{- if .Values.prometheus.labels }}
+    {{- toYaml .Values.prometheus.labels | nindent 4 -}}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "lookout_v2.name.labels.identity" . | nindent 6 }}
+  endpoints:
+    - port: metrics
+      interval: {{ .Values.prometheus.scrapeInterval }}
+      scrapeTimeout: {{ .Values.prometheus.scrapeTimeout }}
+{{- end }}

--- a/go.mod
+++ b/go.mod
@@ -65,6 +65,7 @@ require (
 )
 
 require (
+	github.com/IBM/pgxpoolprometheus v1.1.1
 	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/benbjohnson/immutable v0.4.3
 	github.com/charmbracelet/glamour v0.7.0
@@ -97,7 +98,6 @@ require (
 	github.com/99designs/keyring v1.2.1 // indirect
 	github.com/AthenZ/athenz v1.10.39 // indirect
 	github.com/DataDog/zstd v1.5.0 // indirect
-	github.com/IBM/pgxpoolprometheus v1.1.1 // indirect
 	github.com/alecthomas/chroma/v2 v2.8.0 // indirect
 	github.com/apache/arrow/go/arrow v0.0.0-20200730104253-651201b0f516 // indirect
 	github.com/apache/thrift v0.14.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -97,6 +97,7 @@ require (
 	github.com/99designs/keyring v1.2.1 // indirect
 	github.com/AthenZ/athenz v1.10.39 // indirect
 	github.com/DataDog/zstd v1.5.0 // indirect
+	github.com/IBM/pgxpoolprometheus v1.1.1 // indirect
 	github.com/alecthomas/chroma/v2 v2.8.0 // indirect
 	github.com/apache/arrow/go/arrow v0.0.0-20200730104253-651201b0f516 // indirect
 	github.com/apache/thrift v0.14.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/zstd v1.5.0 h1:+K/VEwIAaPcHiMtQvpLD4lqW7f0Gk3xdYZmI1hD+CXo=
 github.com/DataDog/zstd v1.5.0/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
+github.com/IBM/pgxpoolprometheus v1.1.1 h1:xkWNUe87TIuBj/ypdSiDgNYktsuM7MoZCT8a+kjhh2s=
+github.com/IBM/pgxpoolprometheus v1.1.1/go.mod h1:GFJDkHbidFfB2APbhBTSy2X4PKH3bLWsEMBhmzK1ipo=
 github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
 github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/alecthomas/assert/v2 v2.2.1 h1:XivOgYcduV98QCahG8T5XTezV5bylXe+lBxLG2K2ink=

--- a/internal/lookoutv2/configuration/types.go
+++ b/internal/lookoutv2/configuration/types.go
@@ -7,7 +7,8 @@ import (
 )
 
 type LookoutV2Config struct {
-	ApiPort int
+	ApiPort     int
+	MetricsPort int
 	// If non-nil, net/http/pprof endpoints are exposed on localhost on this port.
 	PprofPort *uint16
 

--- a/internal/lookoutv2/metrics/metrics.go
+++ b/internal/lookoutv2/metrics/metrics.go
@@ -1,0 +1,23 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	requestDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "lookout_request_duration_ms",
+			Help:    "Request duration in milliseconds",
+			Buckets: []float64{1, 10, 100, 1000, 10000, 100000, 1000000},
+		},
+		[]string{"user", "endpoint"},
+	)
+)
+
+func RecordRequestDuration(user, endpoint string, duration float64) {
+	requestDuration.
+		With(map[string]string{"user": user, "endpoint": endpoint}).
+		Observe(duration)
+}

--- a/internal/lookoutv2/metrics/metrics.go
+++ b/internal/lookoutv2/metrics/metrics.go
@@ -5,15 +5,13 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-var (
-	requestDuration = promauto.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Name:    "lookout_request_duration_ms",
-			Help:    "Request duration in milliseconds",
-			Buckets: []float64{1, 10, 100, 1000, 10000, 100000, 1000000},
-		},
-		[]string{"user", "endpoint"},
-	)
+var requestDuration = promauto.NewHistogramVec(
+	prometheus.HistogramOpts{
+		Name:    "lookout_request_duration_ms",
+		Help:    "Request duration in milliseconds",
+		Buckets: []float64{1, 10, 100, 1000, 10000, 100000, 1000000},
+	},
+	[]string{"user", "endpoint"},
 )
 
 func RecordRequestDuration(user, endpoint string, duration float64) {


### PR DESCRIPTION
Previously lookout produced no metrics.  This change introduces some basic metrics, namely:
- PGX Pool metrics courtesy of http://github.com/IBM/pgxpoolprometheus
- Some basic api request duration metrics, which can also be used as a proxy for database query duration metrics