### PR TITLE
Add some more metics to the ingesters

### DIFF
--- a/internal/common/ingest/metrics/metrics.go
+++ b/internal/common/ingest/metrics/metrics.go
@@ -59,7 +59,7 @@ func NewMetrics(prefix string) *Metrics {
 		pulsarMessageError:      promauto.NewCounterVec(pulsarMessageErrorOpts, []string{"error"}),
 		pulsarConnectionError:   promauto.NewCounter(pulsarConnectionErrorOpts),
 		pulsarMessagesProcessed: promauto.NewCounter(pulsarMessagesProcessedOpts),
-		eventsProcessed:         promauto.NewCounterVec(eventsProcessedOpts, []string{"queue"}),
+		eventsProcessed:         promauto.NewCounterVec(eventsProcessedOpts, []string{"queue", "msgType"}),
 	}
 }
 

--- a/internal/common/ingest/metrics/metrics.go
+++ b/internal/common/ingest/metrics/metrics.go
@@ -28,7 +28,7 @@ type Metrics struct {
 	dbErrorsCounter         *prometheus.CounterVec
 	pulsarConnectionError   prometheus.Counter
 	pulsarMessageError      *prometheus.CounterVec
-	pulsarMessagesProcessed *prometheus.CounterVec
+	pulsarMessagesProcessed prometheus.Counter
 	eventsProcessed         *prometheus.CounterVec
 }
 
@@ -58,7 +58,7 @@ func NewMetrics(prefix string) *Metrics {
 		dbErrorsCounter:         promauto.NewCounterVec(dbErrorsCounterOpts, []string{"operation"}),
 		pulsarMessageError:      promauto.NewCounterVec(pulsarMessageErrorOpts, []string{"error"}),
 		pulsarConnectionError:   promauto.NewCounter(pulsarConnectionErrorOpts),
-		pulsarMessagesProcessed: promauto.NewCounterVec(pulsarMessagesProcessedOpts, []string{"queue"}),
+		pulsarMessagesProcessed: promauto.NewCounter(pulsarMessagesProcessedOpts),
 		eventsProcessed:         promauto.NewCounterVec(eventsProcessedOpts, []string{"queue"}),
 	}
 }
@@ -73,4 +73,12 @@ func (m *Metrics) RecordPulsarMessageError(error PulsarMessageError) {
 
 func (m *Metrics) RecordPulsarConnectionError() {
 	m.pulsarConnectionError.Inc()
+}
+
+func (m *Metrics) RecordPulsarMessageProcessed() {
+	m.pulsarMessagesProcessed.Inc()
+}
+
+func (m *Metrics) RecordEventSequenceProcessed(queue, msgTpe string) {
+	m.eventsProcessed.With(map[string]string{"queue": queue, "msgType": msgTpe}).Inc()
 }

--- a/internal/common/ingest/metrics/metrics.go
+++ b/internal/common/ingest/metrics/metrics.go
@@ -20,15 +20,16 @@ const (
 )
 
 const (
-	ArmadaLookoutIngesterMetricsPrefix   = "armada_lookout_ingester_"
 	ArmadaLookoutIngesterV2MetricsPrefix = "armada_lookout_ingester_v2_"
 	ArmadaEventIngesterMetricsPrefix     = "armada_event_ingester_"
 )
 
 type Metrics struct {
-	dbErrorsCounter       *prometheus.CounterVec
-	pulsarConnectionError prometheus.Counter
-	pulsarMessageError    *prometheus.CounterVec
+	dbErrorsCounter         *prometheus.CounterVec
+	pulsarConnectionError   prometheus.Counter
+	pulsarMessageError      *prometheus.CounterVec
+	pulsarMessagesProcessed *prometheus.CounterVec
+	eventsProcessed         *prometheus.CounterVec
 }
 
 func NewMetrics(prefix string) *Metrics {
@@ -44,10 +45,21 @@ func NewMetrics(prefix string) *Metrics {
 		Name: prefix + "pulsar_connection_errors",
 		Help: "Number of Pulsar connection errors",
 	}
+	pulsarMessagesProcessedOpts := prometheus.CounterOpts{
+		Name: prefix + "pulsar_messages_processed",
+		Help: "Number of pulsar messages processed",
+	}
+	eventsProcessedOpts := prometheus.CounterOpts{
+		Name: prefix + "pulsar_messages_processed",
+		Help: "Number of events processed",
+	}
+
 	return &Metrics{
-		dbErrorsCounter:       promauto.NewCounterVec(dbErrorsCounterOpts, []string{"operation"}),
-		pulsarMessageError:    promauto.NewCounterVec(pulsarMessageErrorOpts, []string{"error"}),
-		pulsarConnectionError: promauto.NewCounter(pulsarConnectionErrorOpts),
+		dbErrorsCounter:         promauto.NewCounterVec(dbErrorsCounterOpts, []string{"operation"}),
+		pulsarMessageError:      promauto.NewCounterVec(pulsarMessageErrorOpts, []string{"error"}),
+		pulsarConnectionError:   promauto.NewCounter(pulsarConnectionErrorOpts),
+		pulsarMessagesProcessed: promauto.NewCounterVec(pulsarMessagesProcessedOpts, []string{"queue"}),
+		eventsProcessed:         promauto.NewCounterVec(eventsProcessedOpts, []string{"queue"}),
 	}
 }
 

--- a/internal/common/ingest/metrics/metrics.go
+++ b/internal/common/ingest/metrics/metrics.go
@@ -50,7 +50,7 @@ func NewMetrics(prefix string) *Metrics {
 		Help: "Number of pulsar messages processed",
 	}
 	eventsProcessedOpts := prometheus.CounterOpts{
-		Name: prefix + "pulsar_messages_processed",
+		Name: prefix + "events_processed",
 		Help: "Number of events processed",
 	}
 

--- a/internal/lookoutingesterv2/ingester.go
+++ b/internal/lookoutingesterv2/ingester.go
@@ -60,7 +60,7 @@ func Run(config *configuration.LookoutIngesterV2Configuration) {
 		}()
 	}
 
-	converter := instructions.NewInstructionConverter(m, config.UserAnnotationPrefix, compressor)
+	converter := instructions.NewInstructionConverter(m.Metrics, config.UserAnnotationPrefix, compressor)
 
 	ingester := ingest.NewIngestionPipeline[*model.InstructionSet](
 		config.Pulsar,
@@ -71,7 +71,7 @@ func Run(config *configuration.LookoutIngesterV2Configuration) {
 		converter,
 		lookoutDb,
 		config.MetricsPort,
-		m,
+		m.Metrics,
 	)
 
 	if err := ingester.Run(app.CreateContextWithShutdown()); err != nil {

--- a/internal/lookoutingesterv2/instructions/instructions_test.go
+++ b/internal/lookoutingesterv2/instructions/instructions_test.go
@@ -476,7 +476,7 @@ func TestConvert(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			converter := NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{})
+			converter := NewInstructionConverter(metrics.Get().Metrics, userAnnotationPrefix, &compress.NoOpCompressor{})
 			decompressor := &compress.NoOpDecompressor{}
 			instructionSet := converter.Convert(armadacontext.TODO(), tc.events)
 			require.Equal(t, len(tc.expected.JobsToCreate), len(instructionSet.JobsToCreate))
@@ -542,7 +542,7 @@ func TestTruncatesStringsThatAreTooLong(t *testing.T) {
 		MessageIds: []pulsar.MessageID{pulsarutils.NewMessageId(1)},
 	}
 
-	converter := NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{})
+	converter := NewInstructionConverter(metrics.Get().Metrics, userAnnotationPrefix, &compress.NoOpCompressor{})
 	actual := converter.Convert(armadacontext.TODO(), events)
 
 	// String lengths obtained from database schema

--- a/internal/lookoutingesterv2/lookoutdb/insertion.go
+++ b/internal/lookoutingesterv2/lookoutdb/insertion.go
@@ -83,9 +83,8 @@ func (l *LookoutDb) CreateJobs(ctx *armadacontext.Context, instructions []*model
 		log.WithError(err).Warn("Creating jobs via batch failed, will attempt to insert serially (this might be slow).")
 		l.CreateJobsScalar(ctx, instructions)
 	}
-	taken := time.Since(start)
-	l.metrics.RecordRowsChange("job", "insert", len(instructions))
-	log.Infof("Inserted %d jobs in %s", len(instructions), taken)
+	l.metrics.RecordRowsChange("job", commonmetrics.DBOperationInsert, len(instructions))
+	log.Infof("Inserted %d jobs in %s", len(instructions), time.Since(start))
 }
 
 func (l *LookoutDb) UpdateJobs(ctx *armadacontext.Context, instructions []*model.UpdateJobInstruction) {
@@ -99,9 +98,8 @@ func (l *LookoutDb) UpdateJobs(ctx *armadacontext.Context, instructions []*model
 		log.WithError(err).Warn("Updating jobs via batch failed, will attempt to insert serially (this might be slow).")
 		l.UpdateJobsScalar(ctx, instructions)
 	}
-	taken := time.Since(start)
-	l.metrics.RecordRowsChange("job", "update", len(instructions))
-	log.Infof("Updated %d jobs in %s", len(instructions), taken)
+	l.metrics.RecordRowsChange("job", commonmetrics.DBOperationUpdate, len(instructions))
+	log.Infof("Updated %d jobs in %s", len(instructions), time.Since(start))
 }
 
 func (l *LookoutDb) CreateJobRuns(ctx *armadacontext.Context, instructions []*model.CreateJobRunInstruction) {
@@ -114,9 +112,8 @@ func (l *LookoutDb) CreateJobRuns(ctx *armadacontext.Context, instructions []*mo
 		log.WithError(err).Warn("Creating job runs via batch failed, will attempt to insert serially (this might be slow).")
 		l.CreateJobRunsScalar(ctx, instructions)
 	}
-	taken := time.Since(start)
-	l.metrics.RecordRowsChange("job_run", "insert", len(instructions))
-	log.Infof("Inserted %d job runs in %s", len(instructions), taken)
+	l.metrics.RecordRowsChange("job_run", commonmetrics.DBOperationInsert, len(instructions))
+	log.Infof("Inserted %d job runs in %s", len(instructions), time.Since(start))
 }
 
 func (l *LookoutDb) UpdateJobRuns(ctx *armadacontext.Context, instructions []*model.UpdateJobRunInstruction) {
@@ -129,9 +126,8 @@ func (l *LookoutDb) UpdateJobRuns(ctx *armadacontext.Context, instructions []*mo
 		log.WithError(err).Warn("Updating job runs via batch failed, will attempt to insert serially (this might be slow).")
 		l.UpdateJobRunsScalar(ctx, instructions)
 	}
-	taken := time.Since(start)
-	l.metrics.RecordRowsChange("job_run", "update", len(instructions))
-	log.Infof("Updated %d job runs in %s", len(instructions), taken)
+	l.metrics.RecordRowsChange("job_run", commonmetrics.DBOperationUpdate, len(instructions))
+	log.Infof("Updated %d job runs in %s", len(instructions), time.Since(start))
 }
 
 func (l *LookoutDb) CreateJobErrors(ctx *armadacontext.Context, instructions []*model.CreateJobErrorInstruction) {
@@ -144,9 +140,8 @@ func (l *LookoutDb) CreateJobErrors(ctx *armadacontext.Context, instructions []*
 		log.WithError(err).Warn("Creating job errors via batch failed, will attempt to insert serially (this might be slow).")
 		l.CreateJobErrorsScalar(ctx, instructions)
 	}
-	taken := time.Since(start)
-	l.metrics.RecordRowsChange("job_error", "insert", len(instructions))
-	log.Infof("Inserted %d job errors in %s", len(instructions), taken)
+	l.metrics.RecordRowsChange("job_error", commonmetrics.DBOperationInsert, len(instructions))
+	log.Infof("Inserted %d job errors in %s", len(instructions), time.Since(start))
 }
 
 func (l *LookoutDb) CreateJobsBatch(ctx *armadacontext.Context, instructions []*model.CreateJobInstruction) error {

--- a/internal/lookoutingesterv2/lookoutdb/insertion.go
+++ b/internal/lookoutingesterv2/lookoutdb/insertion.go
@@ -75,9 +75,9 @@ func (l *LookoutDb) Store(ctx *armadacontext.Context, instructions *model.Instru
 	// Finally, we can update the job runs
 	l.UpdateJobRuns(ctx, jobRunsToUpdate)
 
-	taken := time.Since(start).Microseconds()
+	taken := time.Since(start)
 	if numRowsToChange != 0 && taken != 0 {
-		l.metrics.RecordAvRowChangeTime(float64(numRowsToChange) / float64(taken))
+		l.metrics.RecordAvRowChangeTime(numRowsToChange, taken)
 	}
 	return nil
 }
@@ -92,8 +92,10 @@ func (l *LookoutDb) CreateJobs(ctx *armadacontext.Context, instructions []*model
 		log.WithError(err).Warn("Creating jobs via batch failed, will attempt to insert serially (this might be slow).")
 		l.CreateJobsScalar(ctx, instructions)
 	}
+	taken := time.Since(start)
+	l.metrics.RecordAvRowChangeTimeByOperation("job", commonmetrics.DBOperationInsert, len(instructions), taken)
 	l.metrics.RecordRowsChange("job", commonmetrics.DBOperationInsert, len(instructions))
-	log.Infof("Inserted %d jobs in %s", len(instructions), time.Since(start))
+	log.Infof("Inserted %d jobs in %s", len(instructions), taken)
 }
 
 func (l *LookoutDb) UpdateJobs(ctx *armadacontext.Context, instructions []*model.UpdateJobInstruction) {
@@ -107,8 +109,10 @@ func (l *LookoutDb) UpdateJobs(ctx *armadacontext.Context, instructions []*model
 		log.WithError(err).Warn("Updating jobs via batch failed, will attempt to insert serially (this might be slow).")
 		l.UpdateJobsScalar(ctx, instructions)
 	}
+	taken := time.Since(start)
+	l.metrics.RecordAvRowChangeTimeByOperation("job", commonmetrics.DBOperationUpdate, len(instructions), taken)
 	l.metrics.RecordRowsChange("job", commonmetrics.DBOperationUpdate, len(instructions))
-	log.Infof("Updated %d jobs in %s", len(instructions), time.Since(start))
+	log.Infof("Updated %d jobs in %s", len(instructions), taken)
 }
 
 func (l *LookoutDb) CreateJobRuns(ctx *armadacontext.Context, instructions []*model.CreateJobRunInstruction) {
@@ -121,8 +125,10 @@ func (l *LookoutDb) CreateJobRuns(ctx *armadacontext.Context, instructions []*mo
 		log.WithError(err).Warn("Creating job runs via batch failed, will attempt to insert serially (this might be slow).")
 		l.CreateJobRunsScalar(ctx, instructions)
 	}
+	taken := time.Since(start)
+	l.metrics.RecordAvRowChangeTimeByOperation("job_run", commonmetrics.DBOperationInsert, len(instructions), taken)
 	l.metrics.RecordRowsChange("job_run", commonmetrics.DBOperationInsert, len(instructions))
-	log.Infof("Inserted %d job runs in %s", len(instructions), time.Since(start))
+	log.Infof("Inserted %d job runs in %s", len(instructions), taken)
 }
 
 func (l *LookoutDb) UpdateJobRuns(ctx *armadacontext.Context, instructions []*model.UpdateJobRunInstruction) {
@@ -135,8 +141,10 @@ func (l *LookoutDb) UpdateJobRuns(ctx *armadacontext.Context, instructions []*mo
 		log.WithError(err).Warn("Updating job runs via batch failed, will attempt to insert serially (this might be slow).")
 		l.UpdateJobRunsScalar(ctx, instructions)
 	}
+	taken := time.Since(start)
+	l.metrics.RecordAvRowChangeTimeByOperation("job_run", commonmetrics.DBOperationUpdate, len(instructions), taken)
 	l.metrics.RecordRowsChange("job_run", commonmetrics.DBOperationUpdate, len(instructions))
-	log.Infof("Updated %d job runs in %s", len(instructions), time.Since(start))
+	log.Infof("Updated %d job runs in %s", len(instructions), taken)
 }
 
 func (l *LookoutDb) CreateJobErrors(ctx *armadacontext.Context, instructions []*model.CreateJobErrorInstruction) {
@@ -149,8 +157,10 @@ func (l *LookoutDb) CreateJobErrors(ctx *armadacontext.Context, instructions []*
 		log.WithError(err).Warn("Creating job errors via batch failed, will attempt to insert serially (this might be slow).")
 		l.CreateJobErrorsScalar(ctx, instructions)
 	}
+	taken := time.Since(start)
+	l.metrics.RecordAvRowChangeTimeByOperation("job_error", commonmetrics.DBOperationInsert, len(instructions), taken)
 	l.metrics.RecordRowsChange("job_error", commonmetrics.DBOperationInsert, len(instructions))
-	log.Infof("Inserted %d job errors in %s", len(instructions), time.Since(start))
+	log.Infof("Inserted %d job errors in %s", len(instructions), taken)
 }
 
 func (l *LookoutDb) CreateJobsBatch(ctx *armadacontext.Context, instructions []*model.CreateJobInstruction) error {

--- a/internal/lookoutingesterv2/metrics/metrics.go
+++ b/internal/lookoutingesterv2/metrics/metrics.go
@@ -45,8 +45,3 @@ func (m *Metrics) RecordRowsChange(table, operation string, numRows int) {
 		With(map[string]string{"table": table, "operation": operation}).
 		Add(float64(numRows))
 }
-
-// time taken per row change
-// rows change by table, operation (insert, update)
-// events processed by type and queue
-// pulsar messages processed

--- a/internal/lookoutingesterv2/metrics/metrics.go
+++ b/internal/lookoutingesterv2/metrics/metrics.go
@@ -18,7 +18,7 @@ var avRowChangeTimeHist = promauto.NewHistogram(
 
 var rowsChangedCounter = promauto.NewCounterVec(
 	prometheus.CounterOpts{
-		Name: metrics.ArmadaLookoutIngesterV2MetricsPrefix + "row_change_time",
+		Name: metrics.ArmadaLookoutIngesterV2MetricsPrefix + "rows_changed",
 		Help: "Number of rows changed in the database",
 	},
 	[]string{"table", "operation"},

--- a/internal/lookoutingesterv2/metrics/metrics.go
+++ b/internal/lookoutingesterv2/metrics/metrics.go
@@ -1,9 +1,10 @@
 package metrics
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"time"
 
 	"github.com/armadaproject/armada/internal/common/ingest/metrics"
 )

--- a/internal/lookoutingesterv2/metrics/metrics.go
+++ b/internal/lookoutingesterv2/metrics/metrics.go
@@ -40,8 +40,8 @@ func (m *Metrics) RecordAvRowChangeTime(duration float64) {
 	avRowChangeTimeHist.Observe(duration)
 }
 
-func (m *Metrics) RecordRowsChange(table, operation string, numRows int) {
+func (m *Metrics) RecordRowsChange(table string, operation metrics.DBOperation, numRows int) {
 	rowsChangedCounter.
-		With(map[string]string{"table": table, "operation": operation}).
+		With(map[string]string{"table": table, "operation": string(operation)}).
 		Add(float64(numRows))
 }

--- a/internal/lookoutingesterv2/metrics/metrics.go
+++ b/internal/lookoutingesterv2/metrics/metrics.go
@@ -1,16 +1,52 @@
 package metrics
 
 import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
 	"github.com/armadaproject/armada/internal/common/ingest/metrics"
 )
 
-type (
-	DBOperation        string
-	PulsarMessageError string
+// Lookout ingester specific metrics
+var avRowChangeTimeHist = promauto.NewHistogram(
+	prometheus.HistogramOpts{
+		Name:    metrics.ArmadaLookoutIngesterV2MetricsPrefix + "average_row_change_time",
+		Help:    "Average time take in microseconds to change one database row",
+		Buckets: []float64{1, 10, 100, 1000, 10000, 1e5, 1e6, 1e7, 1e8},
+	},
 )
 
-var m = metrics.NewMetrics(metrics.ArmadaLookoutIngesterV2MetricsPrefix)
+var rowsChangedCounter = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: metrics.ArmadaLookoutIngesterV2MetricsPrefix + "row_change_time",
+		Help: "Number of rows changed in the database",
+	},
+	[]string{"table", "operation"},
+)
 
-func Get() *metrics.Metrics {
+type Metrics struct {
+	*metrics.Metrics
+}
+
+var m = &Metrics{
+	metrics.NewMetrics(metrics.ArmadaLookoutIngesterV2MetricsPrefix),
+}
+
+func Get() *Metrics {
 	return m
 }
+
+func (m *Metrics) RecordAvRowChangeTime(duration float64) {
+	avRowChangeTimeHist.Observe(duration)
+}
+
+func (m *Metrics) RecordRowsChange(table, operation string, numRows int) {
+	rowsChangedCounter.
+		With(map[string]string{"table": table, "operation": operation}).
+		Add(float64(numRows))
+}
+
+// time taken per row change
+// rows change by table, operation (insert, update)
+// events processed by type and queue
+// pulsar messages processed

--- a/internal/lookoutv2/pruner/pruner_test.go
+++ b/internal/lookoutv2/pruner/pruner_test.go
@@ -129,7 +129,7 @@ func TestPruneDb(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.testName, func(t *testing.T) {
 			err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-				converter := instructions.NewInstructionConverter(metrics.Get(), "armadaproject.io/", &compress.NoOpCompressor{})
+				converter := instructions.NewInstructionConverter(metrics.Get().Metrics, "armadaproject.io/", &compress.NoOpCompressor{})
 				store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 
 				ctx, cancel := armadacontext.WithTimeout(armadacontext.Background(), 5*time.Minute)

--- a/internal/lookoutv2/repository/getjoberror_test.go
+++ b/internal/lookoutv2/repository/getjoberror_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestGetJobError(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{})
+		converter := instructions.NewInstructionConverter(metrics.Get().Metrics, userAnnotationPrefix, &compress.NoOpCompressor{})
 		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 		errMsg := "some bad error happened!"
 		_ = NewJobSimulator(converter, store).

--- a/internal/lookoutv2/repository/getjobrundebugmessage_test.go
+++ b/internal/lookoutv2/repository/getjobrundebugmessage_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestGetJobRunDebugMessage(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{})
+		converter := instructions.NewInstructionConverter(metrics.Get().Metrics, userAnnotationPrefix, &compress.NoOpCompressor{})
 		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 
 		debugMessageStrings := []string{

--- a/internal/lookoutv2/repository/getjobrunerror_test.go
+++ b/internal/lookoutv2/repository/getjobrunerror_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestGetJobRunError(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{})
+		converter := instructions.NewInstructionConverter(metrics.Get().Metrics, userAnnotationPrefix, &compress.NoOpCompressor{})
 		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 
 		errorStrings := []string{

--- a/internal/lookoutv2/repository/getjobs_test.go
+++ b/internal/lookoutv2/repository/getjobs_test.go
@@ -57,7 +57,7 @@ var (
 func withGetJobsSetup(f func(*instructions.InstructionConverter, *lookoutdb.LookoutDb, *SqlGetJobsRepository, *clock.FakeClock) error) error {
 	testClock := clock.NewFakeClock(time.Now())
 	return lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{})
+		converter := instructions.NewInstructionConverter(metrics.Get().Metrics, userAnnotationPrefix, &compress.NoOpCompressor{})
 		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 		repo := NewSqlGetJobsRepository(db)
 		repo.clock = testClock

--- a/internal/lookoutv2/repository/getjobspec_test.go
+++ b/internal/lookoutv2/repository/getjobspec_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestGetJobSpec(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{})
+		converter := instructions.NewInstructionConverter(metrics.Get().Metrics, userAnnotationPrefix, &compress.NoOpCompressor{})
 		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 
 		job := NewJobSimulator(converter, store).

--- a/internal/lookoutv2/repository/groupjobs_test.go
+++ b/internal/lookoutv2/repository/groupjobs_test.go
@@ -22,7 +22,7 @@ import (
 
 func withGroupJobsSetup(f func(*instructions.InstructionConverter, *lookoutdb.LookoutDb, *SqlGroupJobsRepository) error) error {
 	return lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		converter := instructions.NewInstructionConverter(metrics.Get(), userAnnotationPrefix, &compress.NoOpCompressor{})
+		converter := instructions.NewInstructionConverter(metrics.Get().Metrics, userAnnotationPrefix, &compress.NoOpCompressor{})
 		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10)
 		repo := NewSqlGroupJobsRepository(db)
 		return f(converter, store, repo)


### PR DESCRIPTION
Adds some more metrics to the ingesters relating to performance:
* `pulsar_messages_processed`: a counter recording how many pulsar messages the ingester has processed
* `events_processed`: a counter recording how many events the ingester has processed, broken down by message type and queue


Additionally the lookout ingester gets a couple of extra metrics
* `rows_changed`: a counter recording how many rows we've updated broken down by table and operation (insert/update)
* `average_row_change_time`: a histogram recording the average time to change a single row when processing a batch of messages.

I'm using promauto here which will be less efficient than the lower level prom client (e.g. it needs to create a map for every update), but in benchmarks on my 2018 intel mac I'm seeing > 1MM updates per second for our most expensive metric (2 labels), so I don't think this will be an issue in practise.
