### PR TITLE
Return error if no longer leader when publishing

### DIFF
--- a/internal/scheduler/publisher.go
+++ b/internal/scheduler/publisher.go
@@ -125,7 +125,7 @@ func (p *PulsarPublisher) PublishMessages(ctx *armadacontext.Context, events []*
 			return errors.New("One or more messages failed to send to Pulsar")
 		}
 	} else {
-		ctx.Debugf("No longer leader so not publishing")
+		return errors.New("Failed to publish as no longer leader")
 	}
 	return nil
 }

--- a/internal/scheduler/publisher_test.go
+++ b/internal/scheduler/publisher_test.go
@@ -53,6 +53,7 @@ func TestPulsarPublisher_TestPublish(t *testing.T) {
 		"Don't publish if not leader": {
 			amLeader:               false,
 			numSuccessfulPublishes: math.MaxInt,
+			expectedError:          true,
 			eventSequences: []*armadaevents.EventSequence{
 				{
 					JobSetName: "jobset1",


### PR DESCRIPTION
Previously we silently ignored this condition (well we logged at debug which is much the same thing!).  Now we return an error so that we correctly roll back the transaction.  This means that the in-memory state is consistent with what is on Pulsar.