### PR TITLE
Relax Constraint on  release branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           echo "Validating ref: $ref, sha: $sha"
 
           # Check if it's a valid tag format
-          if [[ ! $ref =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-patch[0-9]+)?$ ]]; then
+          if [[ ! $ref =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             echo "::error::Invalid tag format: $ref"
             exit 1
           fi
@@ -48,7 +48,7 @@ jobs:
           git fetch --all
 
           # Check if it's from master branch or a patch branch
-          if [ $(git branch -r --contains=$sha | grep -E "origin/(master|patch/v[0-9]+\.[0-9]+\.[0-9]+-patch[0-9]+)$" | wc -l) -eq 0 ]; then
+          if [ $(git branch -r --contains=$sha | grep -E "origin/(master|patch/v[0-9]+\.[0-9]+\.[0-9]+-patch[0-9]+.*)$" | wc -l) -eq 0 ]; then
             echo "::error::$sha is not in master or any patch branch"
             echo "Branches containing this SHA:"
             git branch -r --contains=$sha

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           git fetch --all
 
           # Check if it's from master branch or a patch branch
-          if [ $(git branch -r --contains=$sha | grep -E "origin/(master|patch/v[0-9]+\.[0-9]+\.[0-9]+-patch[0-9]+.*)$" | wc -l) -eq 0 ]; then
+          if [ $(git branch -r --contains=$sha | grep -E "origin/(master|patch/v[0-9]+\.[0-9]+\.[0-9]+.*)$" | wc -l) -eq 0 ]; then
             echo "::error::$sha is not in master or any patch branch"
             echo "Branches containing this SHA:"
             git branch -r --contains=$sha


### PR DESCRIPTION
Previously patch release branches had to match the regex `^patch/v[0-9]+\.[0-9]+\.[0-9]+-patch[0-9]+$` which essentially meant a separate release branch for each patch release (`patch/v0.9.0-patch1`, `patch/v0.9.0-patch2` etc).  We've now relaxed this to be `^patch/v[0-9]+\.[0-9]+\.[0-9]+.*` which means that we can just create a single release release branch for a given release (e.g. `patch/v0.9.0`) and then create as many patches off it as we want.  Note that the release *tag* regex hasn't changed and so the tag itself must contain the patch version.

Note that this regex is a security control as it ensures we can only created official releases from protected branches. This change is safe because all branches under `patch/*` are protected. 