### PR TITLE
Relax Patch Release Regex

### DIFF
--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -34,7 +34,7 @@ jobs:
           if [[ "$ref" == "master" ]]; then
             [ $(git branch --contains=$sha master | wc -l) -eq 1 ] &&
             [ $(git rev-list --count $sha..master) -le 2 ]
-          elif [[ "$ref" =~ ^patch/v[0-9]+\.[0-9]+\.[0-9]+-patch[0-9]+$ ]]; then
+          elif [[ "$ref" =~ ^patch/v[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
             [ $(git branch --contains=$sha "$ref" | wc -l) -eq 1 ] &&
             base_tag=${ref#patch/}
             base_tag=${base_tag%-*}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           git fetch --all
 
           # Check if it's from master branch or a patch branch
-          if [ $(git branch -r --contains=$sha | grep -E "origin/(master|patch/v[0-9]+\.[0-9]+\.[0-9]+-patch[0-9]+)$" | wc -l) -eq 0 ]; then
+          if [ $(git branch -r --contains=$sha | grep -E "origin/(master|patch/v[0-9]+\.[0-9]+\.[0-9]+.*)$" | wc -l) -eq 0 ]; then
             echo "::error::$sha is not in master or any patch branch"
             echo "Branches containing this SHA:"
             git branch -r --contains=$sha


### PR DESCRIPTION
Previously patch release branches had to match the regex `^patch/v[0-9]+\.[0-9]+\.[0-9]+-patch[0-9]+$` which essentially meant a separate release branch for each patch release (`patch/v0.9.0-patch1`, `patch/v0.9.0-patch2` etc). We've now relaxed this to be `^patch/v[0-9]+\.[0-9]+\.[0-9]+.*` which means that we can just create a single release release branch for a given release (e.g. `patch/v0.9.0`) and then create as many patches off it as we want. Note that the release tag regex hasn't changed and so the tag itself must contain the patch version.

Note that this regex is a security control as it ensures we can only created official releases from protected branches. This change is safe because all branches under `patch/*` are protected.
