### PR TITLE
Queue cordoning in Armadactl (#187)

### DIFF
--- a/cmd/armadactl/cmd/commands.go
+++ b/cmd/armadactl/cmd/commands.go
@@ -54,10 +54,11 @@ func getCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get",
 		Short: "Retrieve information about armada resource",
-		Long:  "Retrieve information about armada resource. Supported: queue, scheduling-report, queue-report, job-report",
+		Long:  "Retrieve information about armada resource. Supported: queue, queues, scheduling-report, queue-report, job-report",
 	}
 	cmd.AddCommand(
 		queueGetCmd(),
+		queuesGetCmd(),
 		getSchedulingReportCmd(armadactl.New()),
 		getQueueSchedulingReportCmd(armadactl.New()),
 		getJobSchedulingReportCmd(armadactl.New()),

--- a/cmd/armadactl/cmd/cordon.go
+++ b/cmd/armadactl/cmd/cordon.go
@@ -1,0 +1,134 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/armadaproject/armada/internal/armadactl"
+	"github.com/armadaproject/armada/internal/common/slices"
+
+	"github.com/spf13/cobra"
+)
+
+func cordon() *cobra.Command {
+	a := armadactl.New()
+	cmd := &cobra.Command{
+		Use:   "cordon",
+		Short: "Pause scheduling by resource",
+		Long:  "Pause scheduling by resource. Supported: queue, queues",
+	}
+	cmd.AddCommand(cordonQueues(a))
+	return cmd
+}
+
+func uncordon() *cobra.Command {
+	a := armadactl.New()
+	cmd := &cobra.Command{
+		Use:   "uncordon",
+		Short: "Resume scheduling by resource",
+		Long:  "Resume scheduling by resource. Supported: queue, queues",
+	}
+	cmd.AddCommand(uncordonQueues(a))
+	return cmd
+}
+
+func cordonQueues(a *armadactl.App) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "queues <queue_1> <queue_2> <queue_3> ...",
+		Aliases: []string{"queue"},
+		Short:   "Pause scheduling for select queues",
+		Long:    "Pause scheduling for select queues. This can be achieved either by queue names or by labels.",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return initParams(cmd, a.Params)
+		},
+		RunE: func(cmd *cobra.Command, queues []string) error {
+			errs := slices.Filter(slices.Map(queues, queueNameValidation), func(err error) bool { return err != nil })
+			if len(errs) > 0 {
+				return fmt.Errorf("provided queue name invalid: %s", errs[0])
+			}
+
+			matchLabels, err := cmd.Flags().GetStringSlice("match-labels")
+			if err != nil {
+				return fmt.Errorf("error reading label selection: %s", err)
+			}
+
+			inverse, err := cmd.Flags().GetBool("inverse")
+			if err != nil {
+				return fmt.Errorf("error reading inverse flag: %s", err)
+			}
+
+			dryRun, err := cmd.Flags().GetBool("dry-run")
+			if err != nil {
+				return fmt.Errorf("error reading dry-run flag: %s", err)
+			}
+
+			if len(queues) == 0 && len(matchLabels) == 0 {
+				return fmt.Errorf("either queue names or match-labels must be set to determine queues to cordon")
+			} else if len(queues) > 0 && len(matchLabels) > 0 {
+				return fmt.Errorf("you can cordon by either a set of queue names or a set of queue labels, but not both")
+			}
+
+			return a.CordonQueues(&armadactl.QueueQueryArgs{
+				InQueueNames:      queues,
+				ContainsAllLabels: matchLabels,
+				InvertResult:      inverse,
+				OnlyCordoned:      false,
+			}, dryRun)
+		},
+	}
+	cmd.Flags().StringSliceP("match-labels", "l", []string{}, "Provide a comma separated list of labels. Queues matching all provided labels will have scheduling paused. Defaults to empty.")
+	cmd.Flags().Bool("inverse", false, "Select all queues which do not match the provided parameters")
+	cmd.Flags().Bool("dry-run", false, "Show selection of queues that will be modified in this operation")
+
+	return cmd
+}
+
+func uncordonQueues(a *armadactl.App) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "queues <queue_1> <queue_2> <queue_3> ...",
+		Aliases: []string{"queue"},
+		Short:   "Resume scheduling for select queues",
+		Long:    "Resume scheduling for select queues. This can be achieved either by queue names or by labels.",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return initParams(cmd, a.Params)
+		},
+		RunE: func(cmd *cobra.Command, queues []string) error {
+			errs := slices.Filter(slices.Map(queues, queueNameValidation), func(err error) bool { return err != nil })
+			if len(errs) > 0 {
+				return fmt.Errorf("provided queue name invalid: %s", errs[0])
+			}
+
+			matchLabels, err := cmd.Flags().GetStringSlice("match-labels")
+			if err != nil {
+				return fmt.Errorf("error reading label selection: %s", err)
+			}
+
+			inverse, err := cmd.Flags().GetBool("inverse")
+			if err != nil {
+				return fmt.Errorf("error reading inverse flag: %s", err)
+			}
+
+			dryRun, err := cmd.Flags().GetBool("dry-run")
+			if err != nil {
+				return fmt.Errorf("error reading dry-run flag: %s", err)
+			}
+
+			if len(queues) == 0 && len(matchLabels) == 0 {
+				return fmt.Errorf("either queue names or match-labels must be set to determine queues to uncordon")
+			} else if len(queues) > 0 && len(matchLabels) > 0 {
+				return fmt.Errorf("you can uncordon by either a set of queue names or a set of queue labels, but not both")
+			}
+
+			return a.UncordonQueues(&armadactl.QueueQueryArgs{
+				InQueueNames:      queues,
+				ContainsAllLabels: matchLabels,
+				InvertResult:      inverse,
+				OnlyCordoned:      false,
+			}, dryRun)
+		},
+	}
+	cmd.Flags().StringSliceP("match-labels", "l", []string{}, "Provide a comma separated list of labels. Queues matching all provided labels will have scheduling resumed. Defaults to empty.")
+	cmd.Flags().Bool("inverse", false, "Select all queues which do not match the provided parameters")
+	cmd.Flags().Bool("dry-run", false, "Show selection of queues that will be modified in this operation")
+
+	return cmd
+}

--- a/cmd/armadactl/cmd/params.go
+++ b/cmd/armadactl/cmd/params.go
@@ -24,7 +24,10 @@ func initParams(cmd *cobra.Command, params *armadactl.Params) error {
 	params.QueueAPI.Create = cq.Create(client.ExtractCommandlineArmadaApiConnectionDetails)
 	params.QueueAPI.Delete = cq.Delete(client.ExtractCommandlineArmadaApiConnectionDetails)
 	params.QueueAPI.Get = cq.Get(client.ExtractCommandlineArmadaApiConnectionDetails)
+	params.QueueAPI.GetAll = cq.GetAll(client.ExtractCommandlineArmadaApiConnectionDetails)
 	params.QueueAPI.Update = cq.Update(client.ExtractCommandlineArmadaApiConnectionDetails)
+	params.QueueAPI.Cordon = cq.Cordon(client.ExtractCommandlineArmadaApiConnectionDetails)
+	params.QueueAPI.Uncordon = cq.Uncordon(client.ExtractCommandlineArmadaApiConnectionDetails)
 
 	return nil
 }

--- a/cmd/armadactl/cmd/root.go
+++ b/cmd/armadactl/cmd/root.go
@@ -30,6 +30,8 @@ func RootCmd() *cobra.Command {
 		configCmd(armadactl.New()),
 		preemptCmd(),
 		docsCmd(),
+		cordon(),
+		uncordon(),
 	)
 
 	return cmd

--- a/cmd/armadactl/cmd/utils.go
+++ b/cmd/armadactl/cmd/utils.go
@@ -1,0 +1,10 @@
+package cmd
+
+import "fmt"
+
+func queueNameValidation(queueName string) error {
+	if queueName == "" {
+		return fmt.Errorf("cannot provide empty queue name")
+	}
+	return nil
+}

--- a/developer/config/insecure-armada.yaml
+++ b/developer/config/insecure-armada.yaml
@@ -6,6 +6,7 @@ auth:
     submit_any_jobs: ["everyone"]
     create_queue: ["everyone"]
     delete_queue: ["everyone"]
+    cordon_queue: ["everyone"]
     cancel_any_jobs: ["everyone"]
     reprioritize_any_jobs: ["everyone"]
     watch_all_events: ["everyone"]

--- a/internal/armadactl/cordon.go
+++ b/internal/armadactl/cordon.go
@@ -1,0 +1,69 @@
+package armadactl
+
+import (
+	"fmt"
+
+	"github.com/armadaproject/armada/internal/common/slices"
+	"github.com/armadaproject/armada/pkg/api"
+)
+
+func (a *App) cordonQueue(queueName string) error {
+	if err := a.Params.QueueAPI.Cordon(queueName); err != nil {
+		return fmt.Errorf("error updating queue %s: %s", queueName, err)
+	}
+	return nil
+}
+
+func (a *App) CordonQueues(queryArgs *QueueQueryArgs, dryRun bool) error {
+	selectedQueues, err := a.getAllQueuesAsAPIQueue(queryArgs)
+	if err != nil {
+		return fmt.Errorf("error retrieving queues: %s", err)
+	}
+
+	if dryRun {
+		fmt.Println("Cordoning the following queues: (DRY RUN)")
+		slices.Apply(selectedQueues, func(q *api.Queue) { fmt.Println(q.Name) })
+	} else {
+		fmt.Println("Cordoning the following queues:")
+		for _, q := range selectedQueues {
+			err = a.cordonQueue(q.Name)
+			if err != nil {
+				return fmt.Errorf("Could not cordon queue %s: %s", q.Name, err)
+			} else {
+				fmt.Printf("%s cordoned\n", q.Name)
+			}
+		}
+	}
+	return nil
+}
+
+func (a *App) uncordonQueue(queueName string) error {
+	if err := a.Params.QueueAPI.Uncordon(queueName); err != nil {
+		return fmt.Errorf("error updating queue %s: %s", queueName, err)
+	}
+	return nil
+}
+
+func (a *App) UncordonQueues(queryArgs *QueueQueryArgs, dryRun bool) error {
+	selectedQueues, err := a.getAllQueuesAsAPIQueue(queryArgs)
+	if err != nil {
+		return fmt.Errorf("error retrieving queues: %s", err)
+	}
+
+	if dryRun {
+		fmt.Println("Uncordoning the following queues: (DRY RUN)")
+		slices.Apply(selectedQueues, func(q *api.Queue) { fmt.Println(q.Name) })
+	} else {
+		fmt.Println("Uncordoning the following queues:")
+		for _, q := range selectedQueues {
+			err = a.uncordonQueue(q.Name)
+			if err != nil {
+				return fmt.Errorf("Could not uncordon queue %s: %s", q.Name, err)
+			} else {
+				fmt.Printf("%s uncordoned\n", q.Name)
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/armadactl/queue.go
+++ b/internal/armadactl/queue.go
@@ -2,14 +2,26 @@ package armadactl
 
 import (
 	"fmt"
+	"strings"
+
+	"github.com/armadaproject/armada/internal/common/slices"
+	"github.com/armadaproject/armada/pkg/api"
 
 	"github.com/pkg/errors"
+	goslices "golang.org/x/exp/slices"
 	"sigs.k8s.io/yaml"
 
 	"github.com/armadaproject/armada/pkg/client"
 	"github.com/armadaproject/armada/pkg/client/queue"
 	"github.com/armadaproject/armada/pkg/client/util"
 )
+
+type QueueQueryArgs struct {
+	InQueueNames      []string
+	ContainsAllLabels []string
+	InvertResult      bool
+	OnlyCordoned      bool
+}
 
 // CreateQueue calls app.QueueAPI.Create with the provided parameters.
 func (a *App) CreateQueue(queue queue.Queue) error {
@@ -63,6 +75,48 @@ func (a *App) GetQueue(name string) error {
 	b, err := yaml.Marshal(queue)
 	if err != nil {
 		return errors.Errorf("[armadactl.GetQueue] error unmarshalling queue %s: %s", name, err)
+	}
+	fmt.Fprintf(a.Out, headerYaml()+string(b))
+	return nil
+}
+
+func (a *App) getAllQueuesAsAPIQueue(args *QueueQueryArgs) ([]*api.Queue, error) {
+	queueFilters := func(q *api.Queue) bool {
+		containsAllLabels := slices.AllFunc(args.ContainsAllLabels, func(label string) bool {
+			// If the label is a key, map the labels slice to only keys
+			labelsToCompare := q.Labels
+			if len(strings.Split(label, "=")) == 1 {
+				labelsToCompare = slices.Map(q.Labels, func(queueLabel string) string { return strings.Split(queueLabel, "=")[0] })
+			}
+
+			return goslices.Contains(labelsToCompare, label)
+		})
+		inQueues := len(args.InQueueNames) == 0 || goslices.Contains(args.InQueueNames, q.Name)
+		invertedResult := args.InvertResult != (containsAllLabels && inQueues)
+		onlyCordonedCheck := (args.OnlyCordoned && q.Cordoned) || !args.OnlyCordoned
+		return invertedResult && onlyCordonedCheck
+	}
+	queuesToReturn, err := a.Params.QueueAPI.GetAll()
+	if err != nil {
+		return nil, errors.Errorf("error getting all queues: %s", err)
+	}
+
+	return slices.Filter(queuesToReturn, queueFilters), nil
+}
+
+// GetAllQueues calls app.QueueAPI.GetAll with the provided parameters. This method fetches all queues, and filters
+// for those where the queue name is in the provided queueNames and the queue contains all specified labels. If either
+// the labels or queueNames slices are empty, any checks on them are ignored. The inverse flag inverts the result,
+// returning all queues not matching the specified criteria.
+func (a *App) GetAllQueues(args *QueueQueryArgs) error {
+	queues, err := a.getAllQueuesAsAPIQueue(args)
+	if err != nil {
+		return errors.Errorf("error getting all queues: %s", err)
+	}
+
+	b, err := yaml.Marshal(queues)
+	if err != nil {
+		return errors.Errorf("error unmarshalling queues: %s", err)
 	}
 	fmt.Fprintf(a.Out, headerYaml()+string(b))
 	return nil

--- a/internal/common/slices/slices.go
+++ b/internal/common/slices/slices.go
@@ -109,6 +109,16 @@ func GroupByFuncUnique[S ~[]E, E any, K comparable](s S, keyFunc func(E) K) map[
 	return rv
 }
 
+// Apply applies the given function to all elements of the input slice
+func Apply[S ~[]E, E any](s S, f func(E)) {
+	if s == nil {
+		return
+	}
+	for _, s := range s {
+		f(s)
+	}
+}
+
 // Map Returns a slice consisting of the results of applying the given function to the elements of the input slice
 func Map[S ~[]E, E any, V any](s S, f func(E) V) []V {
 	if s == nil {
@@ -191,6 +201,18 @@ func AnyFunc[S ~[]T, T any](s S, predicate func(val T) bool) bool {
 		}
 	}
 	return false
+}
+
+// AllFunc returns true if predicate(v) returns true for all values v in s.
+func AllFunc[S ~[]T, T any](s S, predicate func(val T) bool) bool {
+	result := true
+	for _, v := range s {
+		result = predicate(v) && result
+		if !result {
+			return result
+		}
+	}
+	return result
 }
 
 // Zeros returns a slice T[] of length n with all elements equal to zero.

--- a/internal/common/slices/slices_test.go
+++ b/internal/common/slices/slices_test.go
@@ -88,6 +88,95 @@ func TestMap(t *testing.T) {
 	}
 }
 
+func TestAllFunc(t *testing.T) {
+	tests := map[string]struct {
+		input     []int
+		transform func(int) bool
+		expected  bool
+	}{
+		"returns constant false": {
+			input:     []int{1, 2, 3},
+			transform: func(i int) bool { return false },
+			expected:  false,
+		},
+		"returns constant true": {
+			input:     []int{1, 2, 3},
+			transform: func(i int) bool { return true },
+			expected:  true,
+		},
+		"simple function returns true": {
+			input:     []int{1, 2, 3},
+			transform: func(i int) bool { return i < 4 },
+			expected:  true,
+		},
+		"simple function returns false": {
+			input:     []int{1, 2, 3},
+			transform: func(i int) bool { return i > 3 },
+			expected:  false,
+		},
+		"simple function returns mixed": {
+			input:     []int{1, 2, 3},
+			transform: func(i int) bool { return i < 3 },
+			expected:  false,
+		},
+		"empty input": {
+			input:     []int{},
+			transform: func(i int) bool { return false },
+			expected:  true,
+		},
+		"nil input": {
+			input:     nil,
+			transform: func(i int) bool { return false },
+			expected:  true,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			output := AllFunc(tc.input, tc.transform)
+			assert.Equal(t, tc.expected, output)
+		})
+	}
+}
+
+func TestApply(t *testing.T) {
+	type testType struct {
+		val int
+	}
+	tests := map[string]struct {
+		input     []*testType
+		transform func(*testType)
+		expected  []*testType
+	}{
+		"identity": {
+			input:     []*testType{{1}, {2}, {3}},
+			transform: func(i *testType) { return },
+			expected:  []*testType{{1}, {2}, {3}},
+		},
+		"simple function": {
+			input:     []*testType{{1}, {2}, {3}},
+			transform: func(i *testType) { i.val += 1 },
+			expected:  []*testType{{2}, {3}, {4}},
+		},
+		"empty input": {
+			input:     []*testType{},
+			transform: func(i *testType) { i.val += 1 },
+			expected:  []*testType{},
+		},
+		"nil input": {
+			input:     nil,
+			transform: func(i *testType) { i.val += 1 },
+			expected:  nil,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			Apply(tc.input, tc.transform)
+			output := tc.input
+			assert.Equal(t, tc.expected, output)
+		})
+	}
+}
+
 func TestPartitionToMaxLen(t *testing.T) {
 	tests := map[string]struct {
 		input  []int


### PR DESCRIPTION
* Plumbing queue cordoning into armadactl

* Making armadactl cordoning commands more intuitive, some formatting changes

* Formatting

* Making queue get more intuitive

* Correcting comments and error messages

* Removing single queue cordoning code in favour of cobra alias. Adding only-cordoned flag when fetching queues

* Removing unused methods

* Removing method prefix from error messages

* Fixing import order

<!--  Thanks for sending a pull request!  Here are some tips for you:

#### What type of PR is this?

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Summary of changes:
- Adding `cordon` and `uncordon` commands to armadactl
  - Enabling cordoning and uncordoning of `queue` and `queues` resources
  - queues can be cordoned and uncordoned by name or by labels
- Enabling retrieval of multiple `queues` via armadactl
  - queues can be retrieved by name or by labels
- Adding functional slice operations, with tests

