### PR TITLE
[Lookout] Fix jobspec yaml to include job labels

### DIFF
--- a/internal/lookout/ui/src/components/lookoutV2/sidebar/SidebarTabJobYaml.tsx
+++ b/internal/lookout/ui/src/components/lookoutV2/sidebar/SidebarTabJobYaml.tsx
@@ -25,6 +25,7 @@ function toJobSubmissionYaml(jobSpec: Record<string, any>): string {
   job.priority = jobSpec.priority
   job.namespace = jobSpec.namespace
   job.annotations = jobSpec.annotations
+  job.labels = jobSpec.labels
   if (jobSpec.podSpec !== undefined) {
     job.podSpecs = [jobSpec.podSpec]
   }


### PR DESCRIPTION
Labels were unintentionally omitted from the yaml we display for a job.
 - This causes confusion and also prevents copy/pasting the job yaml to resubmit the same job

