### PR TITLE
[Lookout] Don't show negative runtime values

### DIFF
--- a/internal/lookout/ui/src/utils/jobsTableColumns.tsx
+++ b/internal/lookout/ui/src/utils/jobsTableColumns.tsx
@@ -434,7 +434,7 @@ export const JOB_COLUMNS: JobTableColumn[] = [
 ]
 
 export function formatSeconds(seconds: number | undefined): string {
-  if (seconds === undefined || seconds === 0) return ""
+  if (seconds === undefined || seconds <= 0) return ""
   const hours = Math.floor(seconds / 3600)
   const minutes = Math.floor((seconds % 3600) / 60)
   const remainingSeconds = seconds % 60

--- a/internal/lookout/ui/src/utils/jobsTableFormatters.ts
+++ b/internal/lookout/ui/src/utils/jobsTableFormatters.ts
@@ -59,6 +59,9 @@ export const formatTimeSince = (date?: string, now = Date.now()): string => {
     })
 
     const difference = now - parseISO(date).getTime()
+    if (difference < 0) {
+      return ""
+    }
     const days = Math.floor(difference / (1000 * 3600 * 24))
     const denominations = [
       { symbol: "d", value: days ?? 0 },


### PR DESCRIPTION
This is a "hack" to handle that we occasionally get events out of order - particularly due to preemption

Long term we should fix that issue - but that involves a fair amount of executor/scheduler work

For now, if we calculate a negative runtime, just show blank instead as this is invalid

