### PR TITLE
Update ingesters to all use Failover subscription mode

### DIFF
--- a/internal/eventingester/ingester.go
+++ b/internal/eventingester/ingester.go
@@ -64,7 +64,7 @@ func Run(config *configuration.EventIngesterConfiguration) {
 		config.SubscriptionName,
 		config.BatchSize,
 		config.BatchDuration,
-		pulsar.KeyShared,
+		pulsar.Failover,
 		converter,
 		eventDb,
 		config.MetricsPort,

--- a/internal/lookoutingesterv2/ingester.go
+++ b/internal/lookoutingesterv2/ingester.go
@@ -60,7 +60,7 @@ func Run(config *configuration.LookoutIngesterV2Configuration) {
 		config.SubscriptionName,
 		config.BatchSize,
 		config.BatchDuration,
-		pulsar.KeyShared,
+		pulsar.Failover,
 		converter,
 		lookoutDb,
 		config.MetricsPort,


### PR DESCRIPTION
The scheduler ingester already uses Failover, swapping all to Failover so we are consistent

This will also allow us to get good latency metrics of processing delay by partition from pulsar:
 - When we use KeyShared, we may not process a partition strictly in order, so the metric isn't that useful


