### PR TITLE
Scheduler: make demand cap a share not a cost

### DIFF
--- a/internal/scheduler/context/scheduling.go
+++ b/internal/scheduler/context/scheduling.go
@@ -167,12 +167,17 @@ func (sctx *SchedulingContext) UpdateFairShares() {
 		cappedShare   float64
 	}
 
+	totalCost := sctx.TotalCost()
 	queueInfos := make([]*queueInfo, 0, len(sctx.QueueSchedulingContexts))
 	for queueName, qctx := range sctx.QueueSchedulingContexts {
 		cappedShare := 1.0
-		if !sctx.TotalResources.IsZero() {
-			cappedShare = sctx.FairnessCostProvider.UnweightedCostFromAllocation(qctx.CappedDemand)
+		if !sctx.TotalResources.IsZero() && totalCost > 0 {
+			cappedCost := sctx.FairnessCostProvider.UnweightedCostFromAllocation(qctx.CappedDemand)
+			cappedShare = cappedCost / totalCost
+		} else if qctx.CappedDemand.IsZero() {
+			cappedShare = 0
 		}
+
 		queueInfos = append(queueInfos, &queueInfo{
 			queueName:     queueName,
 			adjustedShare: 0,

--- a/internal/scheduler/context/scheduling_test.go
+++ b/internal/scheduler/context/scheduling_test.go
@@ -58,7 +58,6 @@ func TestSchedulingContextAccounting(t *testing.T) {
 }
 
 func TestCalculateFairShares(t *testing.T) {
-
 	zeroCpu := cpu("0")
 	oneCpu := cpu("1")
 	fortyCpu := cpu("40")


### PR DESCRIPTION
## Problem
There is currently a problem when `adjustedFairShare` is capped by demand.

The scheduler caps `adjustedFairShare` to `cost` at https://git.c3.zone/GR/armada/blob/69232402e78d1a420d56374415436fe15d2ebf0e/internal/scheduler/context/scheduling.go#L174

However, when deciding whether to evict a job, it compares fair share to `actualShare = cost / totalCost` at 
https://github.com/armadaproject/armada/blob/69232402e78d1a420d56374415436fe15d2ebf0e/internal/scheduler/preempting_queue_scheduler.go#L132

If `totalCost < 1` (which it often is in practice), dividing by `totalCost` inflates `actualShare` so that it thinks `actualShare` is above fair share even for fairly undemanding users. So it evicts many jobs well below fair share.

## Solution
Divide `cappedShare` by `totalCost` so the adjustedFairShare demand cap is consistent with the eviction logic.
