### PR TITLE
Scheduler: when evicting don't normalise actualShare

### DIFF
--- a/internal/scheduler/context/scheduling.go
+++ b/internal/scheduler/context/scheduling.go
@@ -144,15 +144,6 @@ func (sctx *SchedulingContext) GetQueue(queue string) (fairness.Queue, bool) {
 	return qctx, ok
 }
 
-// TotalCost returns the sum of the costs across all queues.
-func (sctx *SchedulingContext) TotalCost() float64 {
-	var rv float64
-	for _, qctx := range sctx.QueueSchedulingContexts {
-		rv += sctx.FairnessCostProvider.UnweightedCostFromQueue(qctx)
-	}
-	return rv
-}
-
 // UpdateFairShares updates FairShare and AdjustedFairShare for every QueueSchedulingContext associated with the
 // SchedulingContext.  This works by calculating a far share as queue_weight/sum_of_all_queue_weights and an
 // AdjustedFairShare by resharing any unused capacity (as determined by a queue's demand)

--- a/internal/scheduler/preempting_queue_scheduler.go
+++ b/internal/scheduler/preempting_queue_scheduler.go
@@ -109,7 +109,6 @@ func (sch *PreemptingQueueScheduler) Schedule(ctx *armadacontext.Context) (*sche
 	snapshot := sch.nodeDb.Txn(false)
 
 	// Evict preemptible jobs.
-	totalCost := sch.schedulingContext.TotalCost()
 	ctx.WithField("stage", "scheduling-algo").Infof("Evicting preemptible jobs")
 	evictorResult, inMemoryJobRepo, err := sch.evict(
 		armadacontext.WithLogField(ctx, "stage", "evict for resource balancing"),
@@ -130,7 +129,7 @@ func (sch *PreemptingQueueScheduler) Schedule(ctx *armadacontext.Context) (*sche
 					return false
 				}
 				if qctx, ok := sch.schedulingContext.QueueSchedulingContexts[job.Queue()]; ok {
-					actualShare := sch.schedulingContext.FairnessCostProvider.UnweightedCostFromQueue(qctx) / totalCost
+					actualShare := sch.schedulingContext.FairnessCostProvider.UnweightedCostFromQueue(qctx)
 					fairShare := math.Max(qctx.AdjustedFairShare, qctx.FairShare)
 					fractionOfFairShare := actualShare / fairShare
 					if fractionOfFairShare <= sch.protectedFractionOfFairShare {


### PR DESCRIPTION
## Problem
There is currently a problem when `adjustedFairShare` is capped by demand.

The scheduler caps `adjustedFairShare` to `cost` at https://git.c3.zone/GR/armada/blob/69232402e78d1a420d56374415436fe15d2ebf0e/internal/scheduler/context/scheduling.go#L174

However, when deciding whether to evict a job, it compares fair share to `actualShare = cost / totalCost` at 
https://github.com/armadaproject/armada/blob/69232402e78d1a420d56374415436fe15d2ebf0e/internal/scheduler/preempting_queue_scheduler.go#L132

If `totalCost < 1` (which it often is for gpu clusters), dividing by `totalCost` inflates `actualShare` so that it thinks `actualShare` is above fair share even for fairly undemanding users. So it evicts many jobs well below fair share.

## Solution
Get rid of the `/ totalCost` at `preempting_queue_scheduler.go#L132`

This simplifies things, and makes it consistent between the two places. It also stops strange behavior for non-full clusters where totalCost may we well under 1, so actualShare gets inflated, and many jobs are evicted even though the cluster isn't full.