### PR TITLE
Add job submitted index

### DIFF
--- a/internal/lookoutv2/schema/migrations/012_add_job_submitted_index.sql
+++ b/internal/lookoutv2/schema/migrations/012_add_job_submitted_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_job_submitted ON job (submitted DESC);


### PR DESCRIPTION
#### What this PR does / why we need it:

This adds an index to the job table's `submitted` column which improves performance of browsing jobs when there are many jobs in the database.

Before
```
lookoutv2=>  EXPLAIN ANALYZE SELECT selected_jobs.job_id, selected_jobs.queue, selected_jobs.owner, selected_jobs.namespace, selected_jobs.jobset, selected_jobs.cpu, selected_jobs.memory, selected_jobs.ephemeral_storage, selected_jobs.gpu, selected_jobs.priority, selected_jobs.submitted, selected_jobs.cancelled, selected_jobs.state, selected_jobs.last_transition_time, selected_jobs.duplicate, selected_jobs.priority_class, selected_jobs.latest_run_id, selected_jobs.cancel_reason, selected_jobs.annotations, selected_runs.runs FROM ( SELECT * FROM job AS j  WHERE j.queue = 'compute' ORDER BY j.submitted DESC LIMIT 500 OFFSET 11500 ) AS selected_jobs CROSS JOIN LATERAL ( SELECT COALESCE( json_agg( json_strip_nulls( json_build_object( 'runId', run_id, 'cluster', cluster, 'node', node, 'leased', leased AT TIME ZONE 'UTC', 'pending', pending AT TIME ZONE 'UTC', 'started', started AT TIME ZONE 'UTC', 'finished', finished AT TIME ZONE 'UTC', 'jobRunState', job_run_state, 'exitCode', exit_code ) ) ORDER BY COALESCE(leased, pending) ) FILTER (WHERE run_id IS NOT NULL), '[]' ) AS runs FROM job_run WHERE job_id = selected_jobs.job_id ) AS selected_runs;
                                                                    QUERY PLAN                                                                     
---------------------------------------------------------------------------------------------------------------------------------------------------
 Nested Loop  (cost=896095.16..900449.43 rows=500 width=810) (actual time=5764.707..6064.367 rows=500 loops=1)
   ->  Limit  (cost=896086.59..896144.93 rows=500 width=818) (actual time=5764.503..6057.639 rows=500 loops=1)
         ->  Gather Merge  (cost=894744.83..1052054.68 rows=1348276 width=818) (actual time=5759.561..6057.200 rows=12000 loops=1)
               Workers Planned: 2
               Workers Launched: 2
               ->  Sort  (cost=893744.80..895430.15 rows=674138 width=818) (actual time=4455.785..4456.421 rows=4083 loops=3)
                     Sort Key: j.submitted DESC
                     Sort Method: top-N heapsort  Memory: 7101kB
                     Worker 0:  Sort Method: external merge  Disk: 70792kB
                     Worker 1:  Sort Method: external merge  Disk: 76952kB
                     ->  Parallel Seq Scan on job j  (cost=0.00..339991.20 rows=674138 width=818) (actual time=0.009..940.697 rows=540771 loops=3)
                           Filter: ((queue)::text = 'compute'::text)
                           Rows Removed by Filter: 135064
   ->  Aggregate  (cost=8.57..8.58 rows=1 width=32) (actual time=0.013..0.013 rows=1 loops=500)
         ->  Index Scan using idx_job_run_job_id on job_run  (cost=0.43..8.53 rows=2 width=135) (actual time=0.005..0.005 rows=1 loops=500)
               Index Cond: ((job_id)::text = (j.job_id)::text)
 Planning Time: 1.073 ms
 Execution Time: 6065.480 ms
```

After
```
lookoutv2=> CREATE INDEX CONCURRENTLY meow_idx ON job (submitted DESC);
CREATE INDEX
lookoutv2=> EXPLAIN ANALYZE SELECT selected_jobs.job_id, selected_jobs.queue, selected_jobs.owner, selected_jobs.namespace, selected_jobs.jobset, selected_jobs.cpu, selected_jobs.memory, selected_jobs.ephemeral_storage, selected_jobs.gpu, selected_jobs.priority, selected_jobs.submitted, selected_jobs.cancelled, selected_jobs.state, selected_jobs.last_transition_time, selected_jobs.duplicate, selected_jobs.priority_class, selected_jobs.latest_run_id, selected_jobs.cancel_reason, selected_jobs.annotations, selected_runs.runs FROM ( SELECT * FROM job AS j  WHERE j.queue = 'compute' ORDER BY j.submitted DESC LIMIT 500 OFFSET 11500 ) AS selected_jobs CROSS JOIN LATERAL ( SELECT COALESCE( json_agg( json_strip_nulls( json_build_object( 'runId', run_id, 'cluster', cluster, 'node', node, 'leased', leased AT TIME ZONE 'UTC', 'pending', pending AT TIME ZONE 'UTC', 'started', started AT TIME ZONE 'UTC', 'finished', finished AT TIME ZONE 'UTC', 'jobRunState', job_run_state, 'exitCode', exit_code ) ) ORDER BY COALESCE(leased, pending) ) FILTER (WHERE run_id IS NOT NULL), '[]' ) AS runs FROM job_run WHERE job_id = selected_jobs.job_id ) AS selected_runs;
                                                                  QUERY PLAN                                                                  
----------------------------------------------------------------------------------------------------------------------------------------------
 Nested Loop  (cost=3014.09..7440.68 rows=500 width=810) (actual time=16.486..24.159 rows=500 loops=1)
   ->  Limit  (cost=3005.53..3136.18 rows=500 width=818) (actual time=16.408..17.342 rows=500 loops=1)
         ->  Index Scan using meow_idx on job j  (cost=0.43..424555.24 rows=1624699 width=818) (actual time=0.024..16.897 rows=12000 loops=1)
               Filter: ((queue)::text = 'compute'::text)
               Rows Removed by Filter: 9411
   ->  Aggregate  (cost=8.57..8.58 rows=1 width=32) (actual time=0.013..0.013 rows=1 loops=500)
         ->  Index Scan using idx_job_run_job_id on job_run  (cost=0.43..8.53 rows=2 width=135) (actual time=0.005..0.005 rows=1 loops=500)
               Index Cond: ((job_id)::text = (j.job_id)::text)
 Planning Time: 0.907 ms
 Execution Time: 24.235 ms
(10 rows)
```

#### Which issue(s) this PR fixes:
Fixes https://github.com/armadaproject/armada/issues/3902

#### Special notes for your reviewer:

