### PR TITLE
Filter out invalid JST in ReconcileDifferences 

### DIFF
--- a/internal/scheduler/jobdb/reconciliation.go
+++ b/internal/scheduler/jobdb/reconciliation.go
@@ -83,7 +83,6 @@ func (jobDb *JobDb) ReconcileDifferences(txn *Txn, jobRepoJobs []database.Job, j
 			jobRepoJob,             // New or updated job from the jobRepo.
 			jobRepoRunsById[jobId], // New or updated runs associated with this job from the jobRepo.
 		)
-
 		if err != nil {
 			return nil, err
 		}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -373,11 +373,7 @@ func (s *Scheduler) syncState(ctx *armadacontext.Context) ([]*jobdb.Job, []jobdb
 	// Upsert updated jobs (including associated runs).
 	jobDbJobs := make([]*jobdb.Job, 0, len(jsts))
 	for _, jst := range jsts {
-		if jst.Job != nil {
-			// We receive nil jobs from jobDb.ReconcileDifferences if a run is updated after the associated job is deleted.
-			// These nil job must be sorted out.
-			jobDbJobs = append(jobDbJobs, jst.Job)
-		}
+		jobDbJobs = append(jobDbJobs, jst.Job)
 	}
 	if err := txn.Upsert(jobDbJobs); err != nil {
 		return nil, nil, err


### PR DESCRIPTION
ReconcileDifferences was generating invalid jobs state transitions containing a nil Job. The scheduler was filtering these out, however the metrics code wasn't, thus leading to panics when the metrics attempted to access the job.

Rather than make the metrics code also filter these out, I've modified ReconcileDifferences so that these are never returned in the first place. Ideally we would never even create such a transition, but that would be a bigger and more invasive change.