### PR TITLE
Disabling of leader-only cycle metrics when scheduler is follower

### DIFF
--- a/internal/scheduler/metrics/state_metrics.go
+++ b/internal/scheduler/metrics/state_metrics.go
@@ -11,11 +11,6 @@ import (
 	"github.com/armadaproject/armada/pkg/armadaevents"
 )
 
-type resettableMetric interface {
-	prometheus.Collector
-	Reset()
-}
-
 type jobStateMetrics struct {
 	errorRegexes         []*regexp.Regexp
 	resetInterval        time.Duration
@@ -267,11 +262,6 @@ func (m *jobStateMetrics) disable() {
 
 func (m *jobStateMetrics) enable() {
 	m.enabled = true
-}
-
-// isEnabled returns true if job state metrics are enabled
-func (m *jobStateMetrics) isEnabled() bool {
-	return m.enabled
 }
 
 // stateDuration returns:

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -240,10 +240,10 @@ func (s *Scheduler) cycle(ctx *armadacontext.Context, updateAll bool, leaderToke
 	// Only export metrics if leader.
 	if !s.leaderController.ValidateToken(leaderToken) {
 		ctx.Info("Not the leader so will not attempt to schedule")
-		s.metrics.DisableJobStateMetrics()
+		s.metrics.DisableLeaderMetrics()
 		return overallSchedulerResult, err
 	} else {
-		s.metrics.EnableJobStateMetrics()
+		s.metrics.EnableLeaderMetrics()
 	}
 
 	// If we've been asked to generate messages for all jobs, do so.
@@ -275,7 +275,7 @@ func (s *Scheduler) cycle(ctx *armadacontext.Context, updateAll bool, leaderToke
 	ctx.Infof("Fetched %d job run errors", len(jobRepoRunErrorsByRunId))
 
 	// Update metrics.
-	if s.metrics.JobStateMetricsEnabled() {
+	if s.metrics.LeaderMetricsEnabled() {
 		s.metrics.ReportStateTransitions(jsts, jobRepoRunErrorsByRunId)
 	}
 
@@ -344,7 +344,7 @@ func (s *Scheduler) cycle(ctx *armadacontext.Context, updateAll bool, leaderToke
 	txn.Commit()
 	ctx.Info("Completed committing cycle transaction")
 
-	if s.metrics.JobStateMetricsEnabled() {
+	if s.metrics.LeaderMetricsEnabled() {
 		for _, jctx := range overallSchedulerResult.ScheduledJobs {
 			s.metrics.ReportJobLeased(jctx.Job)
 		}


### PR DESCRIPTION
Currently, all of the scheduler's cycle metrics continue to be collected when the scheduler is in follower mode. This results in stale metrics. This change brings these metrics in line with the scheduler's state metrics, resetting and disabling the collection of these metrics when the scheduler is a follower, excluding the reconciliation cycle time metric which continues to be observed and collected.

 This PR also consolidates the disabling/enabling of both state and cycle metrics under Disable/EnableLeaderMetrics.


