### PR TITLE
Separate Job Spec to its own table to improve performance

### DIFF
--- a/internal/lookoutingesterv2/lookoutdb/insertion.go
+++ b/internal/lookoutingesterv2/lookoutdb/insertion.go
@@ -52,7 +52,18 @@ func (l *LookoutDb) Store(ctx *armadacontext.Context, instructions *model.Instru
 
 	start := time.Now()
 	// Jobs need to be ingested first as other updates may reference these
-	l.CreateJobs(ctx, instructions.JobsToCreate)
+	wgJobIngestion := sync.WaitGroup{}
+	wgJobIngestion.Add(2)
+	go func() {
+		defer wgJobIngestion.Done()
+		l.CreateJobs(ctx, instructions.JobsToCreate)
+	}()
+	go func() {
+		defer wgJobIngestion.Done()
+		l.CreateJobSpecs(ctx, instructions.JobsToCreate)
+	}()
+
+	wgJobIngestion.Wait()
 
 	// Now we can job updates, annotations and new job runs
 	wg := sync.WaitGroup{}
@@ -96,6 +107,22 @@ func (l *LookoutDb) CreateJobs(ctx *armadacontext.Context, instructions []*model
 	l.metrics.RecordAvRowChangeTimeByOperation("job", commonmetrics.DBOperationInsert, len(instructions), taken)
 	l.metrics.RecordRowsChange("job", commonmetrics.DBOperationInsert, len(instructions))
 	log.Infof("Inserted %d jobs in %s", len(instructions), taken)
+}
+
+func (l *LookoutDb) CreateJobSpecs(ctx *armadacontext.Context, instructions []*model.CreateJobInstruction) {
+	if len(instructions) == 0 {
+		return
+	}
+	start := time.Now()
+	err := l.CreateJobSpecsBatch(ctx, instructions)
+	if err != nil {
+		log.WithError(err).Warn("Creating job specs via batch failed, will attempt to insert serially (this might be slow).")
+		l.CreateJobSpecsScalar(ctx, instructions)
+	}
+	taken := time.Since(start)
+	l.metrics.RecordAvRowChangeTimeByOperation("job_spec", commonmetrics.DBOperationInsert, len(instructions), taken)
+	l.metrics.RecordRowsChange("job_spec", commonmetrics.DBOperationInsert, len(instructions))
+	log.Infof("Inserted %d job specs in %s", len(instructions), taken)
 }
 
 func (l *LookoutDb) UpdateJobs(ctx *armadacontext.Context, instructions []*model.UpdateJobInstruction) {
@@ -185,7 +212,6 @@ func (l *LookoutDb) CreateJobsBatch(ctx *armadacontext.Context, instructions []*
 					state                        smallint,
 					last_transition_time         timestamp,
 					last_transition_time_seconds bigint,
-					job_spec                     bytea,
 					priority_class               varchar(63),
 					annotations                  jsonb
 				) ON COMMIT DROP;`, tmpTable))
@@ -213,7 +239,6 @@ func (l *LookoutDb) CreateJobsBatch(ctx *armadacontext.Context, instructions []*
 					"state",
 					"last_transition_time",
 					"last_transition_time_seconds",
-					"job_spec",
 					"priority_class",
 					"annotations",
 				},
@@ -233,7 +258,6 @@ func (l *LookoutDb) CreateJobsBatch(ctx *armadacontext.Context, instructions []*
 						instructions[i].State,
 						instructions[i].LastTransitionTime,
 						instructions[i].LastTransitionTimeSeconds,
-						instructions[i].JobProto,
 						instructions[i].PriorityClass,
 						instructions[i].Annotations,
 					}, nil
@@ -261,7 +285,6 @@ func (l *LookoutDb) CreateJobsBatch(ctx *armadacontext.Context, instructions []*
 						state,
 						last_transition_time,
 						last_transition_time_seconds,
-						job_spec,
 						priority_class,
 						annotations
 					) SELECT * from %s
@@ -294,11 +317,10 @@ func (l *LookoutDb) CreateJobsScalar(ctx *armadacontext.Context, instructions []
 			state,
 			last_transition_time,
 			last_transition_time_seconds,
-			job_spec,
 			priority_class,
 			annotations
 		)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
 		ON CONFLICT DO NOTHING`
 	for _, i := range instructions {
 		err := l.withDatabaseRetryInsert(func() error {
@@ -317,7 +339,6 @@ func (l *LookoutDb) CreateJobsScalar(ctx *armadacontext.Context, instructions []
 				i.State,
 				i.LastTransitionTime,
 				i.LastTransitionTimeSeconds,
-				i.JobProto,
 				i.PriorityClass,
 				i.Annotations,
 			)
@@ -442,6 +463,83 @@ func (l *LookoutDb) UpdateJobsScalar(ctx *armadacontext.Context, instructions []
 		})
 		if err != nil {
 			log.WithError(err).Warnf("Updating job %s failed", i.JobId)
+		}
+	}
+}
+
+func (l *LookoutDb) CreateJobSpecsBatch(ctx *armadacontext.Context, instructions []*model.CreateJobInstruction) error {
+	return l.withDatabaseRetryInsert(func() error {
+		tmpTable := "job_spec_create_tmp"
+
+		createTmp := func(tx pgx.Tx) error {
+			_, err := tx.Exec(ctx, fmt.Sprintf(`
+				CREATE TEMPORARY TABLE %s (
+					job_id varchar(32),
+					job_spec bytea
+				) ON COMMIT DROP;`, tmpTable))
+			if err != nil {
+				l.metrics.RecordDBError(commonmetrics.DBOperationCreateTempTable)
+			}
+			return err
+		}
+
+		insertTmp := func(tx pgx.Tx) error {
+			_, err := tx.CopyFrom(ctx,
+				pgx.Identifier{tmpTable},
+				[]string{
+					"job_id",
+					"job_spec",
+				},
+				pgx.CopyFromSlice(len(instructions), func(i int) ([]interface{}, error) {
+					return []interface{}{
+						instructions[i].JobId,
+						instructions[i].JobProto,
+					}, nil
+				}),
+			)
+			return err
+		}
+
+		copyToDest := func(tx pgx.Tx) error {
+			_, err := tx.Exec(
+				ctx,
+				fmt.Sprintf(`
+					INSERT INTO job_spec (
+						job_id,
+						job_spec
+					) SELECT * from %s
+					ON CONFLICT DO NOTHING`, tmpTable),
+			)
+			if err != nil {
+				l.metrics.RecordDBError(commonmetrics.DBOperationInsert)
+			}
+			return err
+		}
+
+		return batchInsert(ctx, l.db, createTmp, insertTmp, copyToDest)
+	})
+}
+
+func (l *LookoutDb) CreateJobSpecsScalar(ctx *armadacontext.Context, instructions []*model.CreateJobInstruction) {
+	sqlStatement := `INSERT INTO job_spec (
+			job_id,
+			job_spec
+		)
+		VALUES ($1, $2)
+		ON CONFLICT DO NOTHING`
+	for _, i := range instructions {
+		err := l.withDatabaseRetryInsert(func() error {
+			_, err := l.db.Exec(ctx, sqlStatement,
+				i.JobId,
+				i.JobProto,
+			)
+			if err != nil {
+				l.metrics.RecordDBError(commonmetrics.DBOperationInsert)
+			}
+			return err
+		})
+		if err != nil {
+			log.WithError(err).Warnf("Create job spec for job %s, jobset %s failed", i.JobId, i.JobSet)
 		}
 	}
 }

--- a/internal/lookoutv2/pruner/pruner.go
+++ b/internal/lookoutv2/pruner/pruner.go
@@ -132,6 +132,7 @@ func deleteBatch(ctx *armadacontext.Context, tx pgx.Tx, batchLimit int) (int, er
 	}
 	_, err = tx.Exec(ctx, `
 		DELETE FROM job WHERE job_id in (SELECT job_id from batch);
+		DELETE FROM job_spec WHERE job_id in (SELECT job_id from batch);
 		DELETE FROM job_run WHERE job_id in (SELECT job_id from batch);
 		DELETE FROM job_ids_to_delete WHERE job_id in (SELECT job_id from batch);
 		TRUNCATE TABLE batch;`)

--- a/internal/lookoutv2/pruner/pruner_test.go
+++ b/internal/lookoutv2/pruner/pruner_test.go
@@ -145,6 +145,7 @@ func TestPruneDb(t *testing.T) {
 
 				queriedJobIdsPerTable := []map[string]bool{
 					selectStringSet(t, db, "SELECT job_id FROM job"),
+					selectStringSet(t, db, "SELECT job_id FROM job_spec"),
 					selectStringSet(t, db, "SELECT DISTINCT job_id FROM job_run"),
 				}
 				for _, queriedJobs := range queriedJobIdsPerTable {

--- a/internal/lookoutv2/repository/getjobspec.go
+++ b/internal/lookoutv2/repository/getjobspec.go
@@ -30,10 +30,17 @@ func NewSqlGetJobSpecRepository(db *pgxpool.Pool, decompressor compress.Decompre
 
 func (r *SqlGetJobSpecRepository) GetJobSpec(ctx *armadacontext.Context, jobId string) (*api.Job, error) {
 	var rawBytes []byte
-	err := r.db.QueryRow(ctx, "SELECT job_spec FROM job WHERE job_id = $1", jobId).Scan(&rawBytes)
+
+	err := r.db.QueryRow(
+		ctx, `
+			SELECT
+				COALESCE(job_spec.job_spec, job.job_spec)
+			FROM job LEFT JOIN job_spec
+				ON job.job_id = job_spec.job_id
+			WHERE job.job_id = $1`, jobId).Scan(&rawBytes)
 	if err != nil {
 		if err == pgx.ErrNoRows {
-			return nil, errors.Errorf("job with id %s not found", jobId)
+			return nil, errors.Errorf("job_spec with job id %s not found", jobId)
 		}
 		return nil, err
 	}

--- a/internal/lookoutv2/schema/migrations/013_add_job_spec_table.sql
+++ b/internal/lookoutv2/schema/migrations/013_add_job_spec_table.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS job_spec (
+  job_id           varchar(32)   NOT NULL PRIMARY KEY,
+  job_spec         bytea         NOT NULL
+  );
+ALTER TABLE job_spec ALTER COLUMN job_spec SET STORAGE EXTERNAL;
+ALTER TABLE job ALTER COLUMN job_spec DROP NOT NULL;


### PR DESCRIPTION
Moves job spec to it's own table, allowing job_spec in the job table to be null. Also changes lookout to use a different query to pull job_spec, working for both old and migrated table structure.