### PR TITLE
[Lookout] Make pruner removed rejected jobs

### DIFF
--- a/internal/lookoutv2/pruner/pruner.go
+++ b/internal/lookoutv2/pruner/pruner.go
@@ -103,7 +103,8 @@ func createJobIdsToDeleteTempTable(ctx *armadacontext.Context, db *pgx.Conn, cut
 				4, -- Succeeded
 		   		5, -- Failed
 		   		6, -- Cancelled
-		   		7  -- Preempted
+		   		7, -- Preempted
+		   		9  -- Rejected
 		    )
 		)`, cutOffTime)
 	if err != nil {

--- a/internal/lookoutv2/pruner/pruner_test.go
+++ b/internal/lookoutv2/pruner/pruner_test.go
@@ -110,6 +110,11 @@ func TestPruneDb(t *testing.T) {
 					ts:    baseTime.Add(-(10*time.Hour + 1*time.Minute)),
 					state: lookout.JobPreempted,
 				},
+				{
+					jobId: sampleJobIds[4],
+					ts:    baseTime.Add(-(10*time.Hour + 1*time.Minute)),
+					state: lookout.JobRejected,
+				},
 			},
 			jobIdsLeft: []string{},
 		},
@@ -195,6 +200,9 @@ func storeJob(job testJob, db *lookoutdb.LookoutDb, converter *instructions.Inst
 		simulator.
 			Preempted(job.ts).
 			Build()
+	case lookout.JobRejected:
+		simulator.
+			Rejected("invalid", job.ts)
 	case lookout.JobRunning:
 		simulator.
 			Build()


### PR DESCRIPTION
We have added a new terminal job state but we didn't update the Lookout pruner to remove jobs in this state

This leads to a build up of jobs in Rejected state

This PR addresses this by making it so we now clean up jobs in Rejected state


