### PR TITLE
Fix FairSchedulingAlgo.getCapacityForPool including the wrong nodes

### DIFF
--- a/internal/scheduler/scheduling/scheduling_algo.go
+++ b/internal/scheduler/scheduling/scheduling_algo.go
@@ -275,7 +275,9 @@ func (l *FairSchedulingAlgo) getCapacityForPool(pool string, executors []*schedu
 	totalCapacity := schedulerobjects.ResourceList{}
 	for _, executor := range executors {
 		for _, node := range executor.Nodes {
-			totalCapacity.Add(node.TotalResources)
+			if node.Pool == pool {
+				totalCapacity.Add(node.TotalResources)
+			}
 		}
 	}
 	totalCapacity.Add(l.floatingResourceTypes.GetTotalAvailableForPool(pool))


### PR DESCRIPTION
 FairSchedulingAlgo.getCapacityForPool  was including the nodes associated with all polls, not just the pool it was calculating capacity for.
 
 This change fixes that