### PR TITLE
Armada Airflow Operator stability improvements

### DIFF
--- a/third_party/airflow/pyproject.toml
+++ b/third_party/airflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "armada_airflow"
-version = "1.0.4"
+version = "1.0.5"
 description = "Armada Airflow Operator"
 readme='README.md'
 authors = [{name = "Armada-GROSS", email = "armada@armadaproject.io"}]

--- a/third_party/airflow/test/unit/operators/test_armada.py
+++ b/third_party/airflow/test/unit/operators/test_armada.py
@@ -30,6 +30,7 @@ def default_hook() -> MagicMock:
     mock.cancel_job.return_value = dataclasses.replace(
         job_context, job_state=JobState.CANCELLED.name
     )
+    mock.context_from_xcom.return_value = None
 
     return mock
 
@@ -229,25 +230,14 @@ def test_publishes_xcom_state(context):
     op = operator(JobSubmitRequestItem())
     op.execute(context)
 
-    lookout_url = f"http://lookout.armadaproject.io/jobs?job_id={DEFAULT_JOB_ID}"
-    context["ti"].xcom_push.assert_called_once_with(
-        key="0",
-        value={
-            "armada_job_id": DEFAULT_JOB_ID,
-            "armada_job_set_id": DEFAULT_JOB_SET,
-            "armada_lookout_url": lookout_url,
-            "armada_queue": DEFAULT_QUEUE,
-        },
-    )
+    op.hook.context_to_xcom.assert_called_once()
 
 
 def test_reattaches_to_running_job(context):
     op = operator(JobSubmitRequestItem())
-    context["ti"].xcom_pull.return_value = {
-        "armada_job_id": DEFAULT_JOB_ID,
-        "armada_job_set_id": DEFAULT_JOB_SET,
-        "armada_queue": DEFAULT_QUEUE,
-    }
+    op.hook.context_from_xcom.return_value = running_job_context(
+        job_state=JobState.SUCCEEDED.name, cluster=DEFAULT_CLUSTER
+    )
 
     op.execute(context)
 


### PR DESCRIPTION
Fixes armada airflow operator:
* Retries, when templating tasks / talking to Armada. As jinja macros/ factory method might call out to 3rd party systems.
* Cache templated request within task, so it doesn't get re-rendered on each response from the Trigger.
* Use xcom to pass through connection string to the trigger + cache job configuration within the task.