### PR TITLE
Allow configuration for key operator parameters fix up logging around container logs

### DIFF
--- a/third_party/airflow/pyproject.toml
+++ b/third_party/airflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "armada_airflow"
-version = "1.0.8"
+version = "1.0.9"
 description = "Armada Airflow Operator"
 readme='README.md'
 authors = [{name = "Armada-GROSS", email = "armada@armadaproject.io"}]


### PR DESCRIPTION
* You can now configure defaults for: poll_interval, job_acknowledgement_timeout, dry_run via Airflow configuration.
* Operator will log an error in case of trying to fetch logs for container which doesn't exist, instead of throwing Kubernetes errors during log-fetching cycle.