### PR TITLE
Fix Default Pool Config

### DIFF
--- a/config/scheduler/config.yaml
+++ b/config/scheduler/config.yaml
@@ -61,7 +61,7 @@ grpc:
 # You may want to configure indexedNodeLabels and indexedTaints to speed up scheduling.
 scheduling:
   pools:
-    name: default
+    - name: default
   supportedResourceTypes:
     - name: memory
       resolution: "1"


### PR DESCRIPTION
Pool config wasn't been specified as a list in the default yaml file, thus viper was never merging in extra values