### PR TITLE
[SubmitCheck] Don't reuse the Gang Context between executors

### DIFF
--- a/internal/scheduler/submitcheck.go
+++ b/internal/scheduler/submitcheck.go
@@ -186,15 +186,12 @@ func (srv *SubmitChecker) getIndividualSchedulingResult(jctx *context.JobSchedul
 // TODO: there are a number of things this won't catch:
 //   - Node Uniformity Label (although it will work if this is per cluster)
 //   - Gang jobs that will use more than the allowed capacity limit
-func (srv *SubmitChecker) getSchedulingResult(gctx *context.GangSchedulingContext, state *schedulerState) schedulingResult {
+func (srv *SubmitChecker) getSchedulingResult(originalGangCtx *context.GangSchedulingContext, state *schedulerState) schedulingResult {
 	sucessfulPools := map[string]bool{}
 	var sb strings.Builder
 
 poolStart:
 	for _, pool := range srv.schedulingConfig.Pools {
-
-		// copy the gctx here, as we are going to mutate it
-		gctx = copyGangContext(gctx)
 
 		if sucessfulPools[pool.Name] {
 			continue
@@ -212,6 +209,10 @@ poolStart:
 		}
 
 		for _, ex := range executors {
+
+			// copy the gctx here, as we are going to mutate it
+			gctx := copyGangContext(originalGangCtx)
+
 			txn := ex.nodeDb.Txn(true)
 			ok, err := ex.nodeDb.ScheduleManyWithTxn(txn, gctx)
 			txn.Abort()

--- a/internal/scheduler/submitcheck_test.go
+++ b/internal/scheduler/submitcheck_test.go
@@ -105,6 +105,18 @@ func TestSubmitChecker_CheckJobDbJobs(t *testing.T) {
 				smallAwayJob.Id(): {isSchedulable: true, pools: []string{"cpu", "cpu-away"}},
 			},
 		},
+		"One job schedulable, away pools, multiple executors": {
+			executorTimout: defaultTimeout,
+			executors: []*schedulerobjects.Executor{
+				Executor(SmallNode("cpu")),
+				Executor(GpuNode("gpu")),
+				Executor(GpuNode("gpu")),
+			},
+			jobs: []*jobdb.Job{smallAwayJob},
+			expectedResult: map[string]schedulingResult{
+				smallAwayJob.Id(): {isSchedulable: true, pools: []string{"cpu", "cpu-away"}},
+			},
+		},
 		"One job schedulable, multiple pools": {
 			executorTimout: defaultTimeout,
 			executors: []*schedulerobjects.Executor{


### PR DESCRIPTION
Previously we had an issue whereby we were reusing the gang context between different pools in the submit check.  This was fixed, but it didn't covert the case where we had multiple executors and so we still ended up reusing the context if there were multiple executors per pool.

This change ensures we make a separate copy of the gang context per executor, which should close the hole completely.