### PR TITLE
JobContext Should Not Report Leased Returned Jobs As Away

### DIFF
--- a/internal/scheduler/scheduling/context/job.go
+++ b/internal/scheduler/scheduling/context/job.go
@@ -63,9 +63,9 @@ type JobSchedulingContext struct {
 }
 
 func (jctx *JobSchedulingContext) IsHomeJob(currentPool string) bool {
-	// Away jobs will only even be evicted in this round - and by definition have a run
-	// Therefore any job without a run we can assume is a home job
-	if jctx.Job.LatestRun() == nil {
+	// Away jobs  can never have been scheduled in this round
+	// and therefore must have an active run
+	if jctx.Job.Queued() || jctx.Job.LatestRun() == nil {
 		return true
 	}
 	return jctx.Job.LatestRun().Pool() == currentPool

--- a/internal/scheduler/scheduling/context/job_test.go
+++ b/internal/scheduler/scheduling/context/job_test.go
@@ -41,4 +41,9 @@ func TestJobSchedulingContext_IsHomePool(t *testing.T) {
 	job = job.WithNewRun("executor", "node-id", "node", "other", 1)
 	jctx = &JobSchedulingContext{Job: job}
 	assert.False(t, jctx.IsHomeJob(testfixtures.TestPool))
+
+	// Add returned run for a different pool
+	job = job.WithNewRun("executor", "node-id", "node", "other", 1).WithQueued(true)
+	jctx = &JobSchedulingContext{Job: job}
+	assert.True(t, jctx.IsHomeJob(testfixtures.TestPool))
 }


### PR DESCRIPTION
JobContext was reporting jobs as an away job if the lease for an away pool had been returned.  Fix this by always returning home if the job is queued