### PR TITLE
Move lookback limit into the QueuedJobsIterator 

### DIFF
--- a/internal/scheduler/scheduling/jobiteration.go
+++ b/internal/scheduler/scheduling/jobiteration.go
@@ -1,6 +1,7 @@
 package scheduling
 
 import (
+	"math"
 	"sync"
 
 	"golang.org/x/exp/slices"
@@ -118,6 +119,9 @@ type QueuedJobsIterator struct {
 }
 
 func NewQueuedJobsIterator(ctx *armadacontext.Context, queue string, pool string, maxLookback uint, repo JobRepository) *QueuedJobsIterator {
+	if maxLookback == 0 {
+		maxLookback = math.MaxUint
+	}
 	return &QueuedJobsIterator{
 		jobIter:     repo.QueuedJobs(queue),
 		pool:        pool,
@@ -133,7 +137,7 @@ func (it *QueuedJobsIterator) Next() (*schedulercontext.JobSchedulingContext, er
 		case <-it.ctx.Done():
 			return nil, it.ctx.Err()
 		default:
-			if it.jobsSeen > it.maxLookback {
+			if it.jobsSeen >= it.maxLookback {
 				return nil, nil
 			}
 			job, _ := it.jobIter.Next()

--- a/internal/scheduler/scheduling/jobiteration_test.go
+++ b/internal/scheduler/scheduling/jobiteration_test.go
@@ -2,6 +2,7 @@ package scheduling
 
 import (
 	"context"
+	"math"
 	"testing"
 	"time"
 
@@ -64,7 +65,7 @@ func TestMultiJobsIterator_TwoQueues(t *testing.T) {
 	ctx := armadacontext.Background()
 	its := make([]JobContextIterator, 3)
 	for i, queue := range []string{"A", "B", "C"} {
-		it := NewQueuedJobsIterator(ctx, queue, testfixtures.TestPool, repo)
+		it := NewQueuedJobsIterator(ctx, queue, testfixtures.TestPool, math.MaxUint, repo)
 		its[i] = it
 	}
 	it := NewMultiJobsIterator(its...)
@@ -93,7 +94,7 @@ func TestQueuedJobsIterator_OneQueue(t *testing.T) {
 		expected = append(expected, job.Id())
 	}
 	ctx := armadacontext.Background()
-	it := NewQueuedJobsIterator(ctx, "A", testfixtures.TestPool, repo)
+	it := NewQueuedJobsIterator(ctx, "A", testfixtures.TestPool, math.MaxUint, repo)
 	actual := make([]string, 0)
 	for {
 		jctx, err := it.Next()
@@ -115,7 +116,7 @@ func TestQueuedJobsIterator_ExceedsBufferSize(t *testing.T) {
 		expected = append(expected, job.Id())
 	}
 	ctx := armadacontext.Background()
-	it := NewQueuedJobsIterator(ctx, "A", testfixtures.TestPool, repo)
+	it := NewQueuedJobsIterator(ctx, "A", testfixtures.TestPool, math.MaxUint, repo)
 	actual := make([]string, 0)
 	for {
 		jctx, err := it.Next()
@@ -137,7 +138,7 @@ func TestQueuedJobsIterator_ManyJobs(t *testing.T) {
 		expected = append(expected, job.Id())
 	}
 	ctx := armadacontext.Background()
-	it := NewQueuedJobsIterator(ctx, "A", testfixtures.TestPool, repo)
+	it := NewQueuedJobsIterator(ctx, "A", testfixtures.TestPool, math.MaxUint, repo)
 	actual := make([]string, 0)
 	for {
 		jctx, err := it.Next()
@@ -164,7 +165,7 @@ func TestCreateQueuedJobsIterator_TwoQueues(t *testing.T) {
 		repo.Enqueue(job)
 	}
 	ctx := armadacontext.Background()
-	it := NewQueuedJobsIterator(ctx, "A", testfixtures.TestPool, repo)
+	it := NewQueuedJobsIterator(ctx, "A", testfixtures.TestPool, math.MaxUint, repo)
 	actual := make([]string, 0)
 	for {
 		jctx, err := it.Next()
@@ -187,7 +188,7 @@ func TestCreateQueuedJobsIterator_RespectsTimeout(t *testing.T) {
 	ctx, cancel := armadacontext.WithTimeout(armadacontext.Background(), time.Millisecond)
 	time.Sleep(20 * time.Millisecond)
 	defer cancel()
-	it := NewQueuedJobsIterator(ctx, "A", testfixtures.TestPool, repo)
+	it := NewQueuedJobsIterator(ctx, "A", testfixtures.TestPool, math.MaxUint, repo)
 	job, err := it.Next()
 	assert.Nil(t, job)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
@@ -205,7 +206,7 @@ func TestCreateQueuedJobsIterator_NilOnEmpty(t *testing.T) {
 		repo.Enqueue(job)
 	}
 	ctx := armadacontext.Background()
-	it := NewQueuedJobsIterator(ctx, "A", testfixtures.TestPool, repo)
+	it := NewQueuedJobsIterator(ctx, "A", testfixtures.TestPool, math.MaxUint, repo)
 	for job, err := it.Next(); job != nil; job, err = it.Next() {
 		require.NoError(t, err)
 	}
@@ -266,7 +267,7 @@ func (repo *mockJobRepository) Enqueue(job *jobdb.Job) {
 }
 
 func (repo *mockJobRepository) GetJobIterator(ctx *armadacontext.Context, queue string) JobContextIterator {
-	return NewQueuedJobsIterator(ctx, queue, testfixtures.TestPool, repo)
+	return NewQueuedJobsIterator(ctx, queue, testfixtures.TestPool, math.MaxUint, repo)
 }
 
 func jobFromPodSpec(queue string, req *schedulerobjects.PodRequirements) *jobdb.Job {

--- a/internal/scheduler/scheduling/preempting_queue_scheduler.go
+++ b/internal/scheduler/scheduling/preempting_queue_scheduler.go
@@ -469,7 +469,6 @@ func addEvictedJobsToNodeDb(_ *armadacontext.Context, sctx *schedulercontext.Sch
 		gangItByQueue[qctx.Queue] = NewQueuedGangIterator(
 			sctx,
 			inMemoryJobRepo.GetJobIterator(qctx.Queue),
-			0,
 			false,
 		)
 	}
@@ -511,7 +510,7 @@ func (sch *PreemptingQueueScheduler) schedule(ctx *armadacontext.Context, inMemo
 		if jobRepo == nil || reflect.ValueOf(jobRepo).IsNil() {
 			jobIteratorByQueue[qctx.Queue] = evictedIt
 		} else {
-			queueIt := NewQueuedJobsIterator(ctx, qctx.Queue, sch.schedulingContext.Pool, jobRepo)
+			queueIt := NewQueuedJobsIterator(ctx, qctx.Queue, sch.schedulingContext.Pool, sch.constraints.GetMaxQueueLookBack(), jobRepo)
 			jobIteratorByQueue[qctx.Queue] = NewMultiJobsIterator(evictedIt, queueIt)
 		}
 	}

--- a/internal/scheduler/scheduling/queue_scheduler_test.go
+++ b/internal/scheduler/scheduling/queue_scheduler_test.go
@@ -358,18 +358,6 @@ func TestQueueScheduler(t *testing.T) {
 			Queues:                   testfixtures.SingleQueuePriorityOne("A"),
 			ExpectedScheduledIndices: []int{0},
 		},
-		"MaxQueueLookback": {
-			SchedulingConfig: testfixtures.WithMaxQueueLookbackConfig(3, testfixtures.TestSchedulingConfig()),
-			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
-			Jobs: armadaslices.Concatenate(
-				testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 1),
-				testfixtures.N32Cpu256GiJobs("A", testfixtures.PriorityClass0, 3),
-				testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 1),
-			),
-			Queues:                        testfixtures.SingleQueuePriorityOne("A"),
-			ExpectedScheduledIndices:      []int{0},
-			ExpectedNeverAttemptedIndices: []int{3, 4},
-		},
 		"gang success": {
 			SchedulingConfig:         testfixtures.TestSchedulingConfig(),
 			Nodes:                    testfixtures.N32CpuNodes(2, testfixtures.TestPriorities),


### PR DESCRIPTION
Move the lookback limit up the stack from the `QueuedGangIterator` to the `QueuedJobsIterator`.  This has a couple of benefits:

- Simplifies the `QueuedGangIterator`, which is already fairly complex
- Means we can get rid of all the logic about when "Evicted" jobs need to contribute to the lookback.  `QueuedJobsIterator` only ever contains queued jobs (as opposed to evicted jobs) so the lookback always applies.