### PR TITLE
Move scheduling key check into the QueuedJobsIterator

### DIFF
--- a/internal/scheduler/scheduling/context/job.go
+++ b/internal/scheduler/scheduling/context/job.go
@@ -83,16 +83,6 @@ func (jctx *JobSchedulingContext) String() string {
 	return sb.String()
 }
 
-// SchedulingKey returns the scheduling key of the embedded job.
-// If the jctx contains additional node selectors or tolerations,
-// the key is invalid and the second return value is false.
-func (jctx *JobSchedulingContext) SchedulingKey() (schedulerobjects.SchedulingKey, bool) {
-	if len(jctx.AdditionalNodeSelectors) != 0 || len(jctx.AdditionalTolerations) != 0 {
-		return schedulerobjects.EmptySchedulingKey, false
-	}
-	return jctx.Job.SchedulingKey(), true
-}
-
 func (jctx *JobSchedulingContext) IsSuccessful() bool {
 	return jctx.UnschedulableReason == ""
 }

--- a/internal/scheduler/scheduling/context/scheduling.go
+++ b/internal/scheduler/scheduling/context/scheduling.go
@@ -84,10 +84,6 @@ func NewSchedulingContext(
 	}
 }
 
-func (sctx *SchedulingContext) ClearUnfeasibleSchedulingKeys() {
-	sctx.UnfeasibleSchedulingKeys = make(map[schedulerobjects.SchedulingKey]*JobSchedulingContext)
-}
-
 func (sctx *SchedulingContext) AddQueueSchedulingContext(
 	queue string, weight float64,
 	initialAllocatedByPriorityClass schedulerobjects.QuantityByTAndResourceType[string],

--- a/internal/scheduler/scheduling/gang_scheduler.go
+++ b/internal/scheduler/scheduling/gang_scheduler.go
@@ -30,14 +30,12 @@ func NewGangScheduler(
 	constraints schedulerconstraints.SchedulingConstraints,
 	floatingResourceTypes *floatingresources.FloatingResourceTypes,
 	nodeDb *nodedb.NodeDb,
-	skipUnsuccessfulSchedulingKeyCheck bool,
 ) (*GangScheduler, error) {
 	return &GangScheduler{
-		constraints:                        constraints,
-		floatingResourceTypes:              floatingResourceTypes,
-		schedulingContext:                  sctx,
-		nodeDb:                             nodeDb,
-		skipUnsuccessfulSchedulingKeyCheck: skipUnsuccessfulSchedulingKeyCheck,
+		constraints:           constraints,
+		floatingResourceTypes: floatingResourceTypes,
+		schedulingContext:     sctx,
+		nodeDb:                nodeDb,
 	}, nil
 }
 

--- a/internal/scheduler/scheduling/gang_scheduler_test.go
+++ b/internal/scheduler/scheduling/gang_scheduler_test.go
@@ -576,10 +576,7 @@ func TestGangScheduler(t *testing.T) {
 				jctxs := context.JobSchedulingContextsFromJobs(gang)
 				require.Equal(t, 1, len(jctxs), fmt.Sprintf("gangs with cardinality greater than 1 don't have a single scheduling key: %v", gang))
 				jctx := jctxs[0]
-				key, _ := jctx.SchedulingKey()
-				require.NotEqual(t, key, schedulerobjects.EmptySchedulingKey, "expected unfeasible scheduling key cannot be the empty key")
-
-				expectedUnfeasibleJobSchedulingKeys = append(expectedUnfeasibleJobSchedulingKeys, key)
+				expectedUnfeasibleJobSchedulingKeys = append(expectedUnfeasibleJobSchedulingKeys, jctx.Job.SchedulingKey())
 			}
 
 			nodesById := make(map[string]*schedulerobjects.Node, len(tc.Nodes))

--- a/internal/scheduler/scheduling/gang_scheduler_test.go
+++ b/internal/scheduler/scheduling/gang_scheduler_test.go
@@ -645,7 +645,7 @@ func TestGangScheduler(t *testing.T) {
 			constraints := schedulerconstraints.NewSchedulingConstraints("pool", tc.TotalResources, tc.SchedulingConfig, nil)
 			floatingResourceTypes, err := floatingresources.NewFloatingResourceTypes(tc.SchedulingConfig.ExperimentalFloatingResources)
 			require.NoError(t, err)
-			sch, err := NewGangScheduler(sctx, constraints, floatingResourceTypes, nodeDb, false)
+			sch, err := NewGangScheduler(sctx, constraints, floatingResourceTypes, nodeDb)
 			require.NoError(t, err)
 
 			var actualScheduledIndices []int

--- a/internal/scheduler/scheduling/jobiteration.go
+++ b/internal/scheduler/scheduling/jobiteration.go
@@ -1,6 +1,7 @@
 package scheduling
 
 import (
+	"math"
 	"sync"
 
 	"golang.org/x/exp/slices"
@@ -118,6 +119,9 @@ type QueuedJobsIterator struct {
 }
 
 func NewQueuedJobsIterator(ctx *armadacontext.Context, queue string, pool string, maxLookback uint, repo JobRepository) *QueuedJobsIterator {
+	if maxLookback == 0 {
+		maxLookback = math.MaxUint
+	}
 	return &QueuedJobsIterator{
 		jobIter:     repo.QueuedJobs(queue),
 		pool:        pool,
@@ -133,7 +137,7 @@ func (it *QueuedJobsIterator) Next() (*schedulercontext.JobSchedulingContext, er
 		case <-it.ctx.Done():
 			return nil, it.ctx.Err()
 		default:
-			if it.jobsSeen > it.maxLookback {
+			if it.jobsSeen >= it.maxLookback {
 				return nil, nil
 			}
 			job, _ := it.jobIter.Next()

--- a/internal/scheduler/scheduling/jobiteration_test.go
+++ b/internal/scheduler/scheduling/jobiteration_test.go
@@ -2,6 +2,7 @@ package scheduling
 
 import (
 	"context"
+	"math"
 	"testing"
 	"time"
 
@@ -64,7 +65,7 @@ func TestMultiJobsIterator_TwoQueues(t *testing.T) {
 	ctx := armadacontext.Background()
 	its := make([]JobContextIterator, 3)
 	for i, queue := range []string{"A", "B", "C"} {
-		it := NewQueuedJobsIterator(ctx, queue, testfixtures.TestPool, repo)
+		it := NewQueuedJobsIterator(ctx, queue, testfixtures.TestPool, math.MaxUint, repo)
 		its[i] = it
 	}
 	it := NewMultiJobsIterator(its...)
@@ -93,7 +94,7 @@ func TestQueuedJobsIterator_OneQueue(t *testing.T) {
 		expected = append(expected, job.Id())
 	}
 	ctx := armadacontext.Background()
-	it := NewQueuedJobsIterator(ctx, "A", testfixtures.TestPool, repo)
+	it := NewQueuedJobsIterator(ctx, "A", testfixtures.TestPool, math.MaxUint, repo)
 	actual := make([]string, 0)
 	for {
 		jctx, err := it.Next()
@@ -115,7 +116,7 @@ func TestQueuedJobsIterator_ExceedsBufferSize(t *testing.T) {
 		expected = append(expected, job.Id())
 	}
 	ctx := armadacontext.Background()
-	it := NewQueuedJobsIterator(ctx, "A", testfixtures.TestPool, repo)
+	it := NewQueuedJobsIterator(ctx, "A", testfixtures.TestPool, math.MaxUint, repo)
 	actual := make([]string, 0)
 	for {
 		jctx, err := it.Next()
@@ -137,7 +138,7 @@ func TestQueuedJobsIterator_ManyJobs(t *testing.T) {
 		expected = append(expected, job.Id())
 	}
 	ctx := armadacontext.Background()
-	it := NewQueuedJobsIterator(ctx, "A", testfixtures.TestPool, repo)
+	it := NewQueuedJobsIterator(ctx, "A", testfixtures.TestPool, math.MaxUint, repo)
 	actual := make([]string, 0)
 	for {
 		jctx, err := it.Next()
@@ -164,7 +165,7 @@ func TestCreateQueuedJobsIterator_TwoQueues(t *testing.T) {
 		repo.Enqueue(job)
 	}
 	ctx := armadacontext.Background()
-	it := NewQueuedJobsIterator(ctx, "A", testfixtures.TestPool, repo)
+	it := NewQueuedJobsIterator(ctx, "A", testfixtures.TestPool, math.MaxUint, repo)
 	actual := make([]string, 0)
 	for {
 		jctx, err := it.Next()
@@ -187,7 +188,7 @@ func TestCreateQueuedJobsIterator_RespectsTimeout(t *testing.T) {
 	ctx, cancel := armadacontext.WithTimeout(armadacontext.Background(), time.Millisecond)
 	time.Sleep(20 * time.Millisecond)
 	defer cancel()
-	it := NewQueuedJobsIterator(ctx, "A", testfixtures.TestPool, repo)
+	it := NewQueuedJobsIterator(ctx, "A", testfixtures.TestPool, math.MaxUint, repo)
 	job, err := it.Next()
 	assert.Nil(t, job)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
@@ -205,7 +206,7 @@ func TestCreateQueuedJobsIterator_NilOnEmpty(t *testing.T) {
 		repo.Enqueue(job)
 	}
 	ctx := armadacontext.Background()
-	it := NewQueuedJobsIterator(ctx, "A", testfixtures.TestPool, repo)
+	it := NewQueuedJobsIterator(ctx, "A", testfixtures.TestPool, math.MaxUint, repo)
 	for job, err := it.Next(); job != nil; job, err = it.Next() {
 		require.NoError(t, err)
 	}
@@ -266,7 +267,7 @@ func (repo *mockJobRepository) Enqueue(job *jobdb.Job) {
 }
 
 func (repo *mockJobRepository) GetJobIterator(ctx *armadacontext.Context, queue string) JobContextIterator {
-	return NewQueuedJobsIterator(ctx, queue, testfixtures.TestPool, repo)
+	return NewQueuedJobsIterator(ctx, queue, testfixtures.TestPool, math.MaxUint, repo)
 }
 
 func jobFromPodSpec(queue string, req *schedulerobjects.PodRequirements) *jobdb.Job {

--- a/internal/scheduler/scheduling/jobiteration_test.go
+++ b/internal/scheduler/scheduling/jobiteration_test.go
@@ -65,7 +65,7 @@ func TestMultiJobsIterator_TwoQueues(t *testing.T) {
 	ctx := armadacontext.Background()
 	its := make([]JobContextIterator, 3)
 	for i, queue := range []string{"A", "B", "C"} {
-		it := NewQueuedJobsIterator(ctx, queue, testfixtures.TestPool, math.MaxUint, repo)
+		it := NewQueuedJobsIterator(ctx, queue, testfixtures.TestPool, math.MaxUint, &schedulercontext.SchedulingContext{}, repo)
 		its[i] = it
 	}
 	it := NewMultiJobsIterator(its...)
@@ -94,7 +94,7 @@ func TestQueuedJobsIterator_OneQueue(t *testing.T) {
 		expected = append(expected, job.Id())
 	}
 	ctx := armadacontext.Background()
-	it := NewQueuedJobsIterator(ctx, "A", testfixtures.TestPool, math.MaxUint, repo)
+	it := NewQueuedJobsIterator(ctx, "A", testfixtures.TestPool, math.MaxUint, &schedulercontext.SchedulingContext{}, repo)
 	actual := make([]string, 0)
 	for {
 		jctx, err := it.Next()
@@ -116,7 +116,7 @@ func TestQueuedJobsIterator_ExceedsBufferSize(t *testing.T) {
 		expected = append(expected, job.Id())
 	}
 	ctx := armadacontext.Background()
-	it := NewQueuedJobsIterator(ctx, "A", testfixtures.TestPool, math.MaxUint, repo)
+	it := NewQueuedJobsIterator(ctx, "A", testfixtures.TestPool, math.MaxUint, &schedulercontext.SchedulingContext{}, repo)
 	actual := make([]string, 0)
 	for {
 		jctx, err := it.Next()
@@ -138,7 +138,7 @@ func TestQueuedJobsIterator_ManyJobs(t *testing.T) {
 		expected = append(expected, job.Id())
 	}
 	ctx := armadacontext.Background()
-	it := NewQueuedJobsIterator(ctx, "A", testfixtures.TestPool, math.MaxUint, repo)
+	it := NewQueuedJobsIterator(ctx, "A", testfixtures.TestPool, math.MaxUint, &schedulercontext.SchedulingContext{}, repo)
 	actual := make([]string, 0)
 	for {
 		jctx, err := it.Next()
@@ -165,7 +165,7 @@ func TestCreateQueuedJobsIterator_TwoQueues(t *testing.T) {
 		repo.Enqueue(job)
 	}
 	ctx := armadacontext.Background()
-	it := NewQueuedJobsIterator(ctx, "A", testfixtures.TestPool, math.MaxUint, repo)
+	it := NewQueuedJobsIterator(ctx, "A", testfixtures.TestPool, math.MaxUint, &schedulercontext.SchedulingContext{}, repo)
 	actual := make([]string, 0)
 	for {
 		jctx, err := it.Next()
@@ -188,7 +188,7 @@ func TestCreateQueuedJobsIterator_RespectsTimeout(t *testing.T) {
 	ctx, cancel := armadacontext.WithTimeout(armadacontext.Background(), time.Millisecond)
 	time.Sleep(20 * time.Millisecond)
 	defer cancel()
-	it := NewQueuedJobsIterator(ctx, "A", testfixtures.TestPool, math.MaxUint, repo)
+	it := NewQueuedJobsIterator(ctx, "A", testfixtures.TestPool, math.MaxUint, &schedulercontext.SchedulingContext{}, repo)
 	job, err := it.Next()
 	assert.Nil(t, job)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
@@ -206,7 +206,7 @@ func TestCreateQueuedJobsIterator_NilOnEmpty(t *testing.T) {
 		repo.Enqueue(job)
 	}
 	ctx := armadacontext.Background()
-	it := NewQueuedJobsIterator(ctx, "A", testfixtures.TestPool, math.MaxUint, repo)
+	it := NewQueuedJobsIterator(ctx, "A", testfixtures.TestPool, math.MaxUint, &schedulercontext.SchedulingContext{}, repo)
 	for job, err := it.Next(); job != nil; job, err = it.Next() {
 		require.NoError(t, err)
 	}
@@ -267,7 +267,7 @@ func (repo *mockJobRepository) Enqueue(job *jobdb.Job) {
 }
 
 func (repo *mockJobRepository) GetJobIterator(ctx *armadacontext.Context, queue string) JobContextIterator {
-	return NewQueuedJobsIterator(ctx, queue, testfixtures.TestPool, math.MaxUint, repo)
+	return NewQueuedJobsIterator(ctx, queue, testfixtures.TestPool, math.MaxUint, &schedulercontext.SchedulingContext{}, repo)
 }
 
 func jobFromPodSpec(queue string, req *schedulerobjects.PodRequirements) *jobdb.Job {

--- a/internal/scheduler/scheduling/preempting_queue_scheduler.go
+++ b/internal/scheduler/scheduling/preempting_queue_scheduler.go
@@ -469,7 +469,6 @@ func addEvictedJobsToNodeDb(_ *armadacontext.Context, sctx *schedulercontext.Sch
 		gangItByQueue[qctx.Queue] = NewQueuedGangIterator(
 			sctx,
 			inMemoryJobRepo.GetJobIterator(qctx.Queue),
-			0,
 			false,
 		)
 	}
@@ -511,7 +510,7 @@ func (sch *PreemptingQueueScheduler) schedule(ctx *armadacontext.Context, inMemo
 		if jobRepo == nil || reflect.ValueOf(jobRepo).IsNil() {
 			jobIteratorByQueue[qctx.Queue] = evictedIt
 		} else {
-			queueIt := NewQueuedJobsIterator(ctx, qctx.Queue, sch.schedulingContext.Pool, jobRepo)
+			queueIt := NewQueuedJobsIterator(ctx, qctx.Queue, sch.schedulingContext.Pool, sch.constraints.GetMaxQueueLookBack(), jobRepo)
 			jobIteratorByQueue[qctx.Queue] = NewMultiJobsIterator(evictedIt, queueIt)
 		}
 	}

--- a/internal/scheduler/scheduling/preempting_queue_scheduler.go
+++ b/internal/scheduler/scheduling/preempting_queue_scheduler.go
@@ -467,9 +467,7 @@ func addEvictedJobsToNodeDb(_ *armadacontext.Context, sctx *schedulercontext.Sch
 	gangItByQueue := make(map[string]*QueuedGangIterator)
 	for _, qctx := range sctx.QueueSchedulingContexts {
 		gangItByQueue[qctx.Queue] = NewQueuedGangIterator(
-			sctx,
 			inMemoryJobRepo.GetJobIterator(qctx.Queue),
-			false,
 		)
 	}
 	qr := NewMinimalQueueRepositoryFromSchedulingContext(sctx)
@@ -510,7 +508,7 @@ func (sch *PreemptingQueueScheduler) schedule(ctx *armadacontext.Context, inMemo
 		if jobRepo == nil || reflect.ValueOf(jobRepo).IsNil() {
 			jobIteratorByQueue[qctx.Queue] = evictedIt
 		} else {
-			queueIt := NewQueuedJobsIterator(ctx, qctx.Queue, sch.schedulingContext.Pool, sch.constraints.GetMaxQueueLookBack(), jobRepo)
+			queueIt := NewQueuedJobsIterator(ctx, qctx.Queue, sch.schedulingContext.Pool, sch.constraints.GetMaxQueueLookBack(), sch.schedulingContext, jobRepo)
 			jobIteratorByQueue[qctx.Queue] = NewMultiJobsIterator(evictedIt, queueIt)
 		}
 	}

--- a/internal/scheduler/scheduling/preempting_queue_scheduler.go
+++ b/internal/scheduler/scheduling/preempting_queue_scheduler.go
@@ -513,16 +513,12 @@ func (sch *PreemptingQueueScheduler) schedule(ctx *armadacontext.Context, inMemo
 		}
 	}
 
-	// Reset the scheduling keys cache after evicting jobs.
-	sch.schedulingContext.ClearUnfeasibleSchedulingKeys()
-
 	sched, err := NewQueueScheduler(
 		sch.schedulingContext,
 		sch.constraints,
 		sch.floatingResourceTypes,
 		sch.nodeDb,
 		jobIteratorByQueue,
-		skipUnsuccessfulSchedulingKeyCheck,
 		considerPriorityCLassPriority,
 	)
 	if err != nil {

--- a/internal/scheduler/scheduling/queue_scheduler.go
+++ b/internal/scheduler/scheduling/queue_scheduler.go
@@ -32,7 +32,6 @@ func NewQueueScheduler(
 	floatingResourceTypes *floatingresources.FloatingResourceTypes,
 	nodeDb *nodedb.NodeDb,
 	jobIteratorByQueue map[string]JobContextIterator,
-	skipUnsuccessfulSchedulingKeyCheck bool,
 	considerPriorityClassPriority bool,
 ) (*QueueScheduler, error) {
 	for queue := range jobIteratorByQueue {
@@ -40,7 +39,7 @@ func NewQueueScheduler(
 			return nil, errors.Errorf("no scheduling context for queue %s", queue)
 		}
 	}
-	gangScheduler, err := NewGangScheduler(sctx, constraints, floatingResourceTypes, nodeDb, skipUnsuccessfulSchedulingKeyCheck)
+	gangScheduler, err := NewGangScheduler(sctx, constraints, floatingResourceTypes, nodeDb)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/scheduler/scheduling/queue_scheduler.go
+++ b/internal/scheduler/scheduling/queue_scheduler.go
@@ -215,13 +215,11 @@ func (sch *QueueScheduler) Schedule(ctx *armadacontext.Context) (*SchedulerResul
 // Each gang is yielded once its final member is received from the underlying iterator.
 // Jobs without gangIdAnnotation are considered gangs of cardinality 1.
 type QueuedGangIterator struct {
-	//schedulingContext  *schedulercontext.SchedulingContext
+	// schedulingContext  *schedulercontext.SchedulingContext
 	queuedJobsIterator JobContextIterator
 	// Groups jctxs by the gang they belong to.
 	jctxsByGangId map[string][]*schedulercontext.JobSchedulingContext
-	// If true, do not yield jobs known to be unschedulable.
-	skipKnownUnschedulableJobs bool
-	next                       *schedulercontext.GangSchedulingContext
+	next          *schedulercontext.GangSchedulingContext
 }
 
 func NewQueuedGangIterator(it JobContextIterator) *QueuedGangIterator {

--- a/internal/scheduler/scheduling/queue_scheduler_test.go
+++ b/internal/scheduler/scheduling/queue_scheduler_test.go
@@ -526,7 +526,7 @@ func TestQueueScheduler(t *testing.T) {
 				it := jobRepo.GetJobIterator(q.Name)
 				jobIteratorByQueue[q.Name] = it
 			}
-			sch, err := NewQueueScheduler(sctx, constraints, testfixtures.TestEmptyFloatingResources, nodeDb, jobIteratorByQueue, false, false)
+			sch, err := NewQueueScheduler(sctx, constraints, testfixtures.TestEmptyFloatingResources, nodeDb, jobIteratorByQueue, false)
 			require.NoError(t, err)
 
 			result, err := sch.Schedule(armadacontext.Background())

--- a/internal/scheduler/scheduling/queue_scheduler_test.go
+++ b/internal/scheduler/scheduling/queue_scheduler_test.go
@@ -358,18 +358,6 @@ func TestQueueScheduler(t *testing.T) {
 			Queues:                   testfixtures.SingleQueuePriorityOne("A"),
 			ExpectedScheduledIndices: []int{0},
 		},
-		"MaxQueueLookback": {
-			SchedulingConfig: testfixtures.WithMaxQueueLookbackConfig(3, testfixtures.TestSchedulingConfig()),
-			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
-			Jobs: armadaslices.Concatenate(
-				testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 1),
-				testfixtures.N32Cpu256GiJobs("A", testfixtures.PriorityClass0, 3),
-				testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 1),
-			),
-			Queues:                        testfixtures.SingleQueuePriorityOne("A"),
-			ExpectedScheduledIndices:      []int{0},
-			ExpectedNeverAttemptedIndices: []int{3, 4},
-		},
 		"gang success": {
 			SchedulingConfig:         testfixtures.TestSchedulingConfig(),
 			Nodes:                    testfixtures.N32CpuNodes(2, testfixtures.TestPriorities),


### PR DESCRIPTION
The scheduling key check used to be in the`QueuedGangIterator`. I've moved it to to the `QueuedJobsIterator` because:
- It simplifies `QueuedGangIterator`
- It means we exit asap if we know a job is unscheduable.
- The QueuedJobsIterator is only used for Queued (i.e. not evicted) jobs.  This means we don't have to mess around with invalidating and skipping scheduling keys.