### PR TITLE
Some more simulator improvements

### DIFF
--- a/internal/scheduler/simulator/runner.go
+++ b/internal/scheduler/simulator/runner.go
@@ -5,49 +5,12 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/mattn/go-zglob"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 
 	commonconfig "github.com/armadaproject/armada/internal/common/config"
 	"github.com/armadaproject/armada/internal/scheduler/configuration"
 )
-
-func SchedulingConfigsByFilePathFromPattern(pattern string) (map[string]configuration.SchedulingConfig, error) {
-	filePaths, err := zglob.Glob(pattern)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-	filePathConfigMap := make(map[string]configuration.SchedulingConfig)
-	for _, path := range filePaths {
-		config, err := SchedulingConfigsFromFilePaths(filePaths)
-		if err != nil {
-			return nil, err
-		}
-		filePathConfigMap[path] = config[0]
-	}
-	return filePathConfigMap, nil
-}
-
-func SchedulingConfigsFromPattern(pattern string) ([]configuration.SchedulingConfig, error) {
-	filePaths, err := zglob.Glob(pattern)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-	return SchedulingConfigsFromFilePaths(filePaths)
-}
-
-func SchedulingConfigsFromFilePaths(filePaths []string) ([]configuration.SchedulingConfig, error) {
-	rv := make([]configuration.SchedulingConfig, len(filePaths))
-	for i, filePath := range filePaths {
-		config, err := SchedulingConfigFromFilePath(filePath)
-		if err != nil {
-			return nil, err
-		}
-		rv[i] = config
-	}
-	return rv, nil
-}
 
 func SchedulingConfigFromFilePath(filePath string) (configuration.SchedulingConfig, error) {
 	config := configuration.SchedulingConfig{}

--- a/internal/scheduler/simulator/simulator.go
+++ b/internal/scheduler/simulator/simulator.go
@@ -636,6 +636,12 @@ func (s *Simulator) handleScheduleEvent(ctx *armadacontext.Context) error {
 				event.Created = protoutil.ToTimestamp(t)
 			}
 		}
+
+		// If nothing changed, we're in steady state and can safely skip scheduling until something external has changed.
+		// Do this only if a non-zero amount of time has passed.
+		if !s.time.Equal(time.Time{}) && len(result.ScheduledJobs) == 0 && len(result.PreemptedJobs) == 0 {
+			s.shouldSchedule = false
+		}
 	}
 	txn.Commit()
 

--- a/internal/scheduler/simulator/simulator_test.go
+++ b/internal/scheduler/simulator/simulator_test.go
@@ -484,39 +484,6 @@ func TestSimulator(t *testing.T) {
 	}
 }
 
-func TestSchedulingConfigsFromPattern(t *testing.T) {
-	actual, err := SchedulingConfigsFromPattern("./testdata/configs/basicSchedulingConfig.yaml")
-	require.NoError(t, err)
-	expected := []configuration.SchedulingConfig{GetBasicSchedulingConfig()}
-	assert.Equal(t, expected, actual)
-}
-
-//func TestClusterSpecsFromPattern(t *testing.T) {
-//	clusterSpecs, err := ClusterSpecsFromPattern("./testdata/clusters/tinyCluster.yaml")
-//	require.NoError(t, err)
-//	assert.Equal(t, []*ClusterSpec{GetTwoPoolTwoNodeCluster()}, clusterSpecs)
-//	require.NoError(t, err)
-//}
-//
-//func TestWorkloadsFromPattern(t *testing.T) {
-//	workloadSpecs, err := WorkloadsFromPattern("./testdata/workloads/basicWorkload.yaml")
-//	require.NoError(t, err)
-//	assert.Equal(t, []*WorkloadSpec{GetOneQueue10JobWorkload()}, workloadSpecs)
-//	require.NoError(t, err)
-//}
-//
-//func TestClusterSpecTotalResources(t *testing.T) {
-//	actual := GetTwoPoolTwoNodeCluster().TotalResources()
-//	expected := schedulerobjects.ResourceList{
-//		Resources: map[string]resource.Quantity{
-//			"cpu":            resource.MustParse("160"),
-//			"memory":         resource.MustParse("4352Gi"),
-//			"nvidia.com/gpu": resource.MustParse("8"),
-//		},
-//	}
-//	assert.True(t, expected.Equal(actual), "expected %s, but got %s", expected.CompactString(), actual.CompactString())
-//}
-
 func TestGenerateRandomShiftedExponentialDuration(t *testing.T) {
 	assert.Equal(
 		t,


### PR DESCRIPTION
- Remove some unused code
- Add back in fast forward 
- Hard code all scheduler rate limiting to be unlimited as any other value is objectively wrong until we make the rate limiter respect the simulator clock.
- Don't clone the config- this was only previously needed as the simulator accessed this config from multiple threads and this is no longer the case.
- Scheduler now logs every 15 seconds of elapsed time rather than every 60 seconds of simulated time. 