### PR TITLE
Bug fixes (#259)

### DIFF
--- a/internal/common/ingest/ingestion_pipeline_test.go
+++ b/internal/common/ingest/ingestion_pipeline_test.go
@@ -1,6 +1,7 @@
 package ingest
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -263,6 +264,7 @@ func TestRun_ControlPlaneEvents_HappyPath_SingleMessage(t *testing.T) {
 
 	mockConsumer.assertDidAck(messages)
 	sink.assertDidProcess(messages)
+	sink.assertProcessedMessageCount(len(messages))
 }
 
 func TestRun_ControlPlaneEvents_HappyPath_MultipleMessages(t *testing.T) {
@@ -286,6 +288,7 @@ func TestRun_ControlPlaneEvents_HappyPath_MultipleMessages(t *testing.T) {
 
 	mockConsumer.assertDidAck(messages)
 	sink.assertDidProcess(messages)
+	sink.assertProcessedMessageCount(len(messages))
 }
 
 func TestRun_ControlPlaneEvents_LimitsProcessingBatchSize(t *testing.T) {
@@ -337,6 +340,7 @@ func TestRun_ControlPlaneEvents_LimitsProcessingBatchSize(t *testing.T) {
 				assert.True(t, eventCount < tc.batchSize+1)
 			}
 			sink.assertDidProcess(messages)
+			sink.assertProcessedMessageCount(len(messages))
 		})
 	}
 }
@@ -356,7 +360,6 @@ func testControlPlaneEventsPipeline(consumer pulsar.Consumer, converter Instruct
 		metricPublisher:        controlplaneevents_ingest_utils.BatchMetricPublisher,
 		converter:              converter,
 		sink:                   sink,
-		metricsPort:            8080,
 		metrics:                testMetrics,
 		consumer:               consumer,
 	}
@@ -365,30 +368,40 @@ func testControlPlaneEventsPipeline(consumer pulsar.Consumer, converter Instruct
 type simpleSink struct {
 	simpleMessages map[pulsar.MessageID]*simpleMessage
 	t              *testing.T
+	mutex          sync.Mutex
 }
 
 func newSimpleSink(t *testing.T) *simpleSink {
 	return &simpleSink{
 		simpleMessages: make(map[pulsar.MessageID]*simpleMessage),
 		t:              t,
+		mutex:          sync.Mutex{},
 	}
 }
 
 func (s *simpleSink) Store(_ *armadacontext.Context, msg *simpleMessages) error {
 	for _, simpleMessage := range msg.msgs {
-		s.simpleMessages[simpleMessage.id] = simpleMessage
+		s.mutex.Lock()
+		if simpleMessage != nil {
+			s.simpleMessages[simpleMessage.id] = simpleMessage
+		}
+		s.mutex.Unlock()
 	}
 	return nil
 }
 
 func (s *simpleSink) assertDidProcess(messages []pulsar.Message) {
 	s.t.Helper()
-	assert.Len(s.t, s.simpleMessages, len(messages))
 	for _, msg := range messages {
 		simpleMessage, ok := s.simpleMessages[msg.ID()]
 		assert.True(s.t, ok)
 		assert.Greater(s.t, simpleMessage.size, 0)
 	}
+}
+
+func (s *simpleSink) assertProcessedMessageCount(count int) {
+	s.t.Helper()
+	assert.Len(s.t, s.simpleMessages, count)
 }
 
 func TestRun_JobSetEvents_HappyPath_SingleMessage(t *testing.T) {
@@ -410,6 +423,7 @@ func TestRun_JobSetEvents_HappyPath_SingleMessage(t *testing.T) {
 
 	mockConsumer.assertDidAck(messages)
 	sink.assertDidProcess(messages)
+	sink.assertProcessedMessageCount(len(messages))
 }
 
 func TestRun_JobSetEvents_HappyPath_MultipleMessages(t *testing.T) {
@@ -433,6 +447,7 @@ func TestRun_JobSetEvents_HappyPath_MultipleMessages(t *testing.T) {
 
 	mockConsumer.assertDidAck(messages)
 	sink.assertDidProcess(messages)
+	sink.assertProcessedMessageCount(len(messages))
 }
 
 func TestRun_JobSetEvents_LimitsProcessingBatchSize(t *testing.T) {
@@ -490,8 +505,65 @@ func TestRun_JobSetEvents_LimitsProcessingBatchSize(t *testing.T) {
 				assert.True(t, eventCount < tc.batchSize+tc.numberOfEventsPerMessage)
 			}
 			sink.assertDidProcess(messages)
+			sink.assertProcessedMessageCount(len(messages))
 		})
 	}
+}
+
+// This will become a more common use case - multiple ingesters ingesting into the same sink
+func TestRun_MultipleSimultaneousIngesters(t *testing.T) {
+	jsCtx, jsCancel := armadacontext.WithDeadline(armadacontext.Background(), time.Now().Add(10*time.Second))
+	cpCtx, cpCancel := armadacontext.WithDeadline(armadacontext.Background(), time.Now().Add(10*time.Second))
+	jobSetMessages := []pulsar.Message{
+		pulsarutils.NewPulsarMessage(1, baseTime, marshal(t, succeeded)),
+		pulsarutils.NewPulsarMessage(2, baseTime.Add(1*time.Second), marshal(t, pendingAndRunning)),
+		pulsarutils.NewPulsarMessage(3, baseTime.Add(2*time.Second), marshal(t, failed)),
+	}
+	controlPlaneMessages := []pulsar.Message{
+		pulsarutils.NewPulsarMessage(4, baseTime, marshal(t, f.UpsertExecutorSettingsCordon)),
+		pulsarutils.NewPulsarMessage(5, baseTime.Add(1*time.Second), marshal(t, f.UpsertExecutorSettingsUncordon)),
+		pulsarutils.NewPulsarMessage(6, baseTime.Add(2*time.Second), marshal(t, f.DeleteExecutorSettings)),
+	}
+	mockJobSetEventsConsumer := newMockPulsarConsumer(t, jobSetMessages, jsCancel)
+	mockControlPlaneEventsConsumer := newMockPulsarConsumer(t, controlPlaneMessages, cpCancel)
+
+	jobSetEventsConverter := newSimpleEventSequenceConverter(t)
+	controlPlaneEventsConverter := newSimpleControlPlaneEventConverter(t)
+
+	sink := newSimpleSink(t)
+
+	jobSetEventsPipeline := testJobSetEventsPipeline(mockJobSetEventsConsumer, jobSetEventsConverter, sink)
+	controlPlaneEventsPipeline := testControlPlaneEventsPipeline(mockControlPlaneEventsConsumer, controlPlaneEventsConverter, sink)
+
+	var jsErr error
+	var cpErr error
+	wg := sync.WaitGroup{}
+	start := time.Now()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		jsErr = jobSetEventsPipeline.Run(jsCtx)
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		cpErr = controlPlaneEventsPipeline.Run(cpCtx)
+	}()
+
+	wg.Wait()
+	elapsed := time.Since(start)
+
+	assert.NoError(t, jsErr)
+	assert.NoError(t, cpErr)
+	assert.LessOrEqual(t, elapsed, batchDuration*2)
+
+	mockJobSetEventsConsumer.assertDidAck(jobSetMessages)
+	mockControlPlaneEventsConsumer.assertDidAck(controlPlaneMessages)
+	sink.assertDidProcess(jobSetMessages)
+	sink.assertDidProcess(controlPlaneMessages)
+	sink.assertProcessedMessageCount(len(controlPlaneMessages) + len(jobSetMessages))
 }
 
 func testJobSetEventsPipeline(consumer pulsar.Consumer, converter InstructionConverter[*simpleMessages, *armadaevents.EventSequence], sink Sink[*simpleMessages]) *IngestionPipeline[*simpleMessages, *armadaevents.EventSequence] {
@@ -509,7 +581,6 @@ func testJobSetEventsPipeline(consumer pulsar.Consumer, converter InstructionCon
 		metricPublisher:        jobsetevents.BatchMetricPublisher,
 		converter:              converter,
 		sink:                   sink,
-		metricsPort:            8080,
 		metrics:                testMetrics,
 		consumer:               consumer,
 	}

--- a/internal/common/metrics/scheduler_metrics.go
+++ b/internal/common/metrics/scheduler_metrics.go
@@ -1,6 +1,8 @@
 package metrics
 
 import (
+	"regexp"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
@@ -394,8 +396,10 @@ func NewQueueLabelsMetric(queue string, labels map[string]string) prometheus.Met
 	values = append(values, queue)
 
 	for key, value := range labels {
-		metricLabels = append(metricLabels, key)
-		values = append(values, value)
+		if isValidMetricLabelName(key) {
+			metricLabels = append(metricLabels, key)
+			values = append(values, value)
+		}
 	}
 
 	queueLabelsDesc := prometheus.NewDesc(
@@ -406,4 +410,11 @@ func NewQueueLabelsMetric(queue string, labels map[string]string) prometheus.Met
 	)
 
 	return prometheus.MustNewConstMetric(queueLabelsDesc, prometheus.GaugeValue, 1, values...)
+}
+
+func isValidMetricLabelName(labelName string) bool {
+	// Prometheus metric label names must match the following regex: [a-zA-Z_][a-zA-Z0-9_]*
+	// See: https://prometheus.io/docs/concepts/data_model/
+	match, _ := regexp.MatchString("^[a-zA-Z_][a-zA-Z0-9_]*$", labelName)
+	return match
 }

--- a/internal/common/metrics/scheduler_metrics_test.go
+++ b/internal/common/metrics/scheduler_metrics_test.go
@@ -1,0 +1,54 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQueueLabelValidation(t *testing.T) {
+	tests := map[string]struct {
+		labelName string
+		isValid   bool
+	}{
+		"Empty label name": {
+			labelName: "",
+			isValid:   false,
+		},
+		"Priority label": {
+			labelName: "priority",
+			isValid:   true,
+		},
+		"Label name with underscores": {
+			labelName: "priority__cpu_pool",
+			isValid:   true,
+		},
+		"Label name with spaces": {
+			labelName: "priority cpu pool",
+			isValid:   false,
+		},
+		"Alphanumeric label name": {
+			labelName: "cluster_12_user",
+			isValid:   true,
+		},
+		"Invalid Kubernetes-style label name 1": {
+			labelName: "armadaproject.io/category",
+			isValid:   false,
+		},
+		"Invalid Kubernetes-style label name 2": {
+			labelName: "armadaproject.io/ttl",
+			isValid:   false,
+		},
+		"Invalid Kubernetes-style label name 3": {
+			labelName: "kubernetes.io/metadata.name",
+			isValid:   false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			isValid := isValidMetricLabelName(tc.labelName)
+			assert.Equal(t, tc.isValid, isValid)
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

#### What type of PR is this?

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Summary of changes:
- Fixes a bug where mutliple ingestion pipelines attempt to start the same metrics server, resulting in a panic
- Validating queue label metric names to avoid scheduler panics if labels aren't formatted correctly
