### PR TITLE
Update scheduler initialization behavior to avoid OOM

### DIFF
--- a/internal/scheduler/database/job_repository.go
+++ b/internal/scheduler/database/job_repository.go
@@ -36,6 +36,13 @@ type JobRunLease struct {
 
 // JobRepository is an interface to be implemented by structs which provide job and run information
 type JobRepository interface {
+
+	// FetchInitialJobs returns all non-terminal jobs and their associated job runs.
+	FetchInitialJobs(ctx *armadacontext.Context) ([]Job, []Run, error)
+
+	// FetchLatestSerials returns the latest job and job runs serials in the DB for use during initialization.
+	FetchLatestSerials(ctx *armadacontext.Context) (int64, int64, error)
+
 	// FetchJobUpdates returns all jobs and job dbRuns that have been updated after jobSerial and jobRunSerial respectively
 	// These updates are guaranteed to be consistent with each other
 	FetchJobUpdates(ctx *armadacontext.Context, jobSerial int64, jobRunSerial int64) ([]Job, []Run, error)
@@ -71,6 +78,71 @@ func NewPostgresJobRepository(db *pgxpool.Pool, batchSize int32) *PostgresJobRep
 		db:        db,
 		batchSize: batchSize,
 	}
+}
+
+func (r *PostgresJobRepository) FetchInitialJobs(ctx *armadacontext.Context) ([]Job, []Run, error) {
+	var updatedJobs []Job = nil
+	var initialRuns []Run = nil
+
+	start := time.Now()
+	defer func() {
+		ctx.Infof(
+			"received %d initial jobs and %d initial job runs from postgres in %s",
+			len(updatedJobs), len(initialRuns), time.Since(start),
+		)
+	}()
+
+	// Use a RepeatableRead transaction here so that we get consistency between jobs and dbRuns
+	err := pgx.BeginTxFunc(ctx, r.db, pgx.TxOptions{
+		IsoLevel:       pgx.RepeatableRead,
+		AccessMode:     pgx.ReadOnly,
+		DeferrableMode: pgx.Deferrable,
+	}, func(tx pgx.Tx) error {
+		var err error
+		queries := New(tx)
+
+		// Fetch jobs
+		initialJobRows, err := fetch(0, r.batchSize, func(from int64) ([]SelectInitialJobsRow, error) {
+			return queries.SelectInitialJobs(ctx, SelectInitialJobsParams{Serial: from, Limit: r.batchSize})
+		})
+		updatedJobs = make([]Job, len(initialJobRows))
+		updatedJobIds := make([]string, len(initialJobRows))
+		for i, row := range initialJobRows {
+			updatedJobIds[i] = row.JobID
+			updatedJobs[i] = Job{
+				JobID:                   row.JobID,
+				JobSet:                  row.JobSet,
+				Queue:                   row.Queue,
+				Priority:                row.Priority,
+				Submitted:               row.Submitted,
+				Validated:               row.Validated,
+				Queued:                  row.Queued,
+				QueuedVersion:           row.QueuedVersion,
+				CancelRequested:         row.CancelRequested,
+				Cancelled:               row.Cancelled,
+				CancelByJobsetRequested: row.CancelByJobsetRequested,
+				Succeeded:               row.Succeeded,
+				Failed:                  row.Failed,
+				SchedulingInfo:          row.SchedulingInfo,
+				SchedulingInfoVersion:   row.SchedulingInfoVersion,
+				Serial:                  row.Serial,
+				Pools:                   row.Pools,
+			}
+		}
+
+		if err != nil {
+			return err
+		}
+
+		// Fetch dbRuns
+		initialRuns, err = fetch(0, r.batchSize, func(from int64) ([]Run, error) {
+			return queries.SelectInitialRuns(ctx, SelectInitialRunsParams{Serial: from, Limit: r.batchSize, JobIds: updatedJobIds})
+		})
+
+		return err
+	})
+
+	return updatedJobs, initialRuns, err
 }
 
 // FetchJobRunErrors returns all armadaevents.JobRunErrors for the provided job run ids.  The returned map is
@@ -292,6 +364,33 @@ func (r *PostgresJobRepository) CountReceivedPartitions(ctx *armadacontext.Conte
 		return 0, err
 	}
 	return uint32(count), nil
+}
+
+func (r *PostgresJobRepository) FetchLatestSerials(ctx *armadacontext.Context) (int64, int64, error) {
+	var jobSerial int64 = 0
+	var jobRunSerial int64 = 0
+
+	err := pgx.BeginTxFunc(ctx, r.db, pgx.TxOptions{
+		IsoLevel:       pgx.RepeatableRead,
+		AccessMode:     pgx.ReadOnly,
+		DeferrableMode: pgx.Deferrable,
+	}, func(tx pgx.Tx) error {
+		var err error
+		queries := New(tx)
+
+		jobSerial, err = queries.SelectLatestJobSerial(ctx)
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+			return err
+		}
+		jobRunSerial, err = queries.SelectLatestJobRunSerial(ctx)
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+			return err
+		}
+
+		return nil
+	})
+
+	return jobSerial, jobRunSerial, err
 }
 
 // fetch gets all rows from the database with a serial greater than from.

--- a/internal/scheduler/database/job_repository.go
+++ b/internal/scheduler/database/job_repository.go
@@ -36,7 +36,6 @@ type JobRunLease struct {
 
 // JobRepository is an interface to be implemented by structs which provide job and run information
 type JobRepository interface {
-
 	// FetchInitialJobs returns all non-terminal jobs and their associated job runs.
 	FetchInitialJobs(ctx *armadacontext.Context) ([]Job, []Run, error)
 

--- a/internal/scheduler/database/job_repository_test.go
+++ b/internal/scheduler/database/job_repository_test.go
@@ -24,6 +24,180 @@ import (
 
 const defaultBatchSize = 1
 
+func TestFetchInitialJobs(t *testing.T) {
+	leasedJob := Job{
+		JobID:          util.NewULID(),
+		JobSet:         "test-jobset",
+		Queue:          "test-queue",
+		QueuedVersion:  1,
+		SchedulingInfo: []byte{byte(0)},
+		SubmitMessage:  []byte{},
+	}
+
+	expectedLeasedJob := Job{
+		JobID:          leasedJob.JobID,
+		JobSet:         "test-jobset",
+		Queue:          "test-queue",
+		QueuedVersion:  1,
+		SchedulingInfo: []byte{byte(0)},
+		Serial:         1,
+	}
+
+	leasedJobRun := Run{
+		RunID:    util.NewULID(),
+		JobID:    leasedJob.JobID,
+		JobSet:   "test-jobset",
+		Executor: "test-executor",
+		Node:     fmt.Sprintf("test-node-%d", 0),
+		Running:  true,
+	}
+
+	expectedLeasedJobRun := Run{
+		RunID:    leasedJobRun.RunID,
+		JobID:    leasedJob.JobID,
+		JobSet:   "test-jobset",
+		Executor: "test-executor",
+		Node:     fmt.Sprintf("test-node-%d", 0),
+		Running:  true,
+		Serial:   1,
+	}
+
+	queuedJob := Job{
+		JobID:          util.NewULID(),
+		JobSet:         "test-jobset",
+		Queue:          "test-queue",
+		Queued:         true,
+		QueuedVersion:  1,
+		SchedulingInfo: []byte{byte(0)},
+		SubmitMessage:  []byte{},
+	}
+
+	expectedQueuedJob := Job{
+		JobID:          queuedJob.JobID,
+		JobSet:         "test-jobset",
+		Queue:          "test-queue",
+		Queued:         true,
+		QueuedVersion:  1,
+		SchedulingInfo: []byte{byte(0)},
+		Serial:         2,
+	}
+
+	cancelledJob := Job{
+		JobID:          util.NewULID(),
+		JobSet:         "test-jobset",
+		Queue:          "test-queue",
+		QueuedVersion:  1,
+		Cancelled:      true,
+		SchedulingInfo: []byte{byte(0)},
+		SubmitMessage:  []byte{},
+	}
+
+	cancelledJobRun := Run{
+		RunID:     util.NewULID(),
+		JobID:     cancelledJob.JobID,
+		JobSet:    "test-jobset",
+		Executor:  "test-executor",
+		Node:      fmt.Sprintf("test-node-%d", 0),
+		Cancelled: true,
+	}
+
+	failedJob := Job{
+		JobID:          util.NewULID(),
+		JobSet:         "test-jobset",
+		Queue:          "test-queue",
+		QueuedVersion:  1,
+		Failed:         true,
+		SchedulingInfo: []byte{byte(0)},
+		SubmitMessage:  []byte{},
+	}
+
+	failedJobRun := Run{
+		RunID:    util.NewULID(),
+		JobID:    failedJob.JobID,
+		JobSet:   "test-jobset",
+		Executor: "test-executor",
+		Node:     fmt.Sprintf("test-node-%d", 0),
+		Failed:   true,
+	}
+
+	succeededJob := Job{
+		JobID:          util.NewULID(),
+		JobSet:         "test-jobset",
+		Queue:          "test-queue",
+		Queued:         false,
+		QueuedVersion:  1,
+		Succeeded:      true,
+		SchedulingInfo: []byte{byte(0)},
+		SubmitMessage:  []byte{},
+	}
+
+	succeededJobRun := Run{
+		RunID:     util.NewULID(),
+		JobID:     succeededJob.JobID,
+		JobSet:    "test-jobset",
+		Executor:  "test-executor",
+		Node:      fmt.Sprintf("test-node-%d", 0),
+		Succeeded: true,
+	}
+
+	tests := map[string]struct {
+		dbJobs       []Job
+		dbRuns       []Run
+		expectedJobs []Job
+		expectedRuns []Run
+	}{
+		"all jobs and runs": {
+			dbJobs:       []Job{leasedJob, queuedJob, cancelledJob, failedJob, succeededJob},
+			expectedJobs: []Job{expectedLeasedJob, expectedQueuedJob},
+			dbRuns:       []Run{leasedJobRun, cancelledJobRun, failedJobRun, succeededJobRun},
+			expectedRuns: []Run{expectedLeasedJobRun},
+		},
+		"only jobs": {
+			dbJobs:       []Job{leasedJob, queuedJob, cancelledJob, failedJob, succeededJob},
+			expectedJobs: []Job{expectedLeasedJob, expectedQueuedJob},
+			expectedRuns: []Run{},
+		},
+		"only runs": {
+			dbRuns:       []Run{leasedJobRun, cancelledJobRun, failedJobRun, succeededJobRun},
+			expectedJobs: []Job{},
+			expectedRuns: []Run{},
+		},
+		"empty db": {
+			expectedJobs: []Job{},
+			expectedRuns: []Run{},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := withJobRepository(func(repo *PostgresJobRepository) error {
+				ctx, cancel := armadacontext.WithTimeout(armadacontext.Background(), 5*time.Second)
+
+				// Set up db
+				err := database.UpsertWithTransaction(ctx, repo.db, "jobs", tc.dbJobs)
+				require.NoError(t, err)
+				err = database.UpsertWithTransaction(ctx, repo.db, "runs", tc.dbRuns)
+				require.NoError(t, err)
+
+				// Fetch updates
+				jobs, runs, err := repo.FetchInitialJobs(ctx)
+				require.NoError(t, err)
+
+				// Runs will have LastModified filled in- we don't want to compare this
+				for i := range runs {
+					runs[i].LastModified = time.Time{}
+				}
+
+				// Assert results
+				assert.Equal(t, tc.expectedJobs, jobs)
+				assert.Equal(t, tc.expectedRuns, runs)
+				cancel()
+				return nil
+			})
+			require.NoError(t, err)
+		})
+	}
+}
+
 func TestFetchJobUpdates(t *testing.T) {
 	dbJobs, expectedJobs := createTestJobs(10)
 	dbRuns, expectedRuns := createTestRuns(10)
@@ -537,6 +711,66 @@ func TestFetchJobRunLeases(t *testing.T) {
 				slices.SortFunc(leases, leaseSort)
 				slices.SortFunc(tc.expectedLeases, leaseSort)
 				assert.Equal(t, tc.expectedLeases, leases)
+				cancel()
+				return nil
+			})
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestFetchLatestSerials(t *testing.T) {
+	dbJobs, _ := createTestJobs(10)
+	dbRuns, _ := createTestRuns(10)
+
+	tests := map[string]struct {
+		dbJobs             []Job
+		dbRuns             []Run
+		latestJobSerial    int64
+		latestJobRunSerial int64
+	}{
+		"all jobs": {
+			dbJobs:          dbJobs,
+			latestJobSerial: 10,
+		},
+		"some jobs": {
+			dbJobs:          dbJobs[:5],
+			latestJobSerial: 5,
+		},
+		"all runs": {
+			dbRuns:             dbRuns,
+			latestJobRunSerial: 10,
+		},
+		"some runs": {
+			dbRuns:             dbRuns[:5],
+			latestJobRunSerial: 5,
+		},
+		"both jobs and runs": {
+			dbJobs:             dbJobs,
+			dbRuns:             dbRuns,
+			latestJobSerial:    10,
+			latestJobRunSerial: 10,
+		},
+		"empty db": {},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := withJobRepository(func(repo *PostgresJobRepository) error {
+				ctx, cancel := armadacontext.WithTimeout(armadacontext.Background(), 5*time.Second)
+
+				// Set up db
+				err := database.UpsertWithTransaction(ctx, repo.db, "jobs", tc.dbJobs)
+				require.NoError(t, err)
+				err = database.UpsertWithTransaction(ctx, repo.db, "runs", tc.dbRuns)
+				require.NoError(t, err)
+
+				// Fetch updates
+				jobSerial, jobRunSerial, err := repo.FetchLatestSerials(ctx)
+				require.NoError(t, err)
+
+				// Assert results
+				assert.Equal(t, tc.latestJobSerial, jobSerial)
+				assert.Equal(t, tc.latestJobRunSerial, jobRunSerial)
 				cancel()
 				return nil
 			})

--- a/internal/scheduler/database/modelsext.go
+++ b/internal/scheduler/database/modelsext.go
@@ -19,3 +19,8 @@ func (run Run) GetSerial() int64 {
 func (row SelectUpdatedJobsRow) GetSerial() int64 {
 	return row.Serial
 }
+
+// GetSerial is needed for the HasSerial interface
+func (row SelectInitialJobsRow) GetSerial() int64 {
+	return row.Serial
+}

--- a/internal/scheduler/database/query.sql.go
+++ b/internal/scheduler/database/query.sql.go
@@ -398,6 +398,73 @@ func (q *Queries) SelectJobsForExecutor(ctx context.Context, arg SelectJobsForEx
 	return items, nil
 }
 
+const selectInitialJobs = `-- name: SelectInitialJobs :many
+SELECT job_id, job_set, queue, priority, submitted, queued, queued_version, validated, cancel_requested, cancel_by_jobset_requested, cancelled, succeeded, failed, scheduling_info, scheduling_info_version, pools, serial FROM jobs WHERE serial > $1 AND cancelled = 'false' AND succeeded = 'false' and failed = 'false' ORDER BY serial LIMIT $2
+`
+
+type SelectInitialJobsParams struct {
+	Serial int64 `db:"serial"`
+	Limit  int32 `db:"limit"`
+}
+
+type SelectInitialJobsRow struct {
+	JobID                   string   `db:"job_id"`
+	JobSet                  string   `db:"job_set"`
+	Queue                   string   `db:"queue"`
+	Priority                int64    `db:"priority"`
+	Submitted               int64    `db:"submitted"`
+	Queued                  bool     `db:"queued"`
+	QueuedVersion           int32    `db:"queued_version"`
+	Validated               bool     `db:"validated"`
+	CancelRequested         bool     `db:"cancel_requested"`
+	CancelByJobsetRequested bool     `db:"cancel_by_jobset_requested"`
+	Cancelled               bool     `db:"cancelled"`
+	Succeeded               bool     `db:"succeeded"`
+	Failed                  bool     `db:"failed"`
+	SchedulingInfo          []byte   `db:"scheduling_info"`
+	SchedulingInfoVersion   int32    `db:"scheduling_info_version"`
+	Pools                   []string `db:"pools"`
+	Serial                  int64    `db:"serial"`
+}
+
+func (q *Queries) SelectInitialJobs(ctx context.Context, arg SelectInitialJobsParams) ([]SelectInitialJobsRow, error) {
+	rows, err := q.db.Query(ctx, selectInitialJobs, arg.Serial, arg.Limit)
+	if err != nil {
+			return nil, err
+		}
+	defer rows.Close()
+	var items []SelectInitialJobsRow
+	for rows.Next() {
+			var i SelectInitialJobsRow
+			if err := rows.Scan(
+					&i.JobID,
+					&i.JobSet,
+					&i.Queue,
+					&i.Priority,
+					&i.Submitted,
+					&i.Queued,
+					&i.QueuedVersion,
+					&i.Validated,
+					&i.CancelRequested,
+					&i.CancelByJobsetRequested,
+					&i.Cancelled,
+					&i.Succeeded,
+					&i.Failed,
+					&i.SchedulingInfo,
+					&i.SchedulingInfoVersion,
+					&i.Pools,
+					&i.Serial,
+				); err != nil {
+					return nil, err
+				}
+			items = append(items, i)
+		}
+	if err := rows.Err(); err != nil {
+			return nil, err
+		}
+	return items, nil
+}
+
 const selectNewJobs = `-- name: SelectNewJobs :many
 SELECT job_id, job_set, queue, user_id, submitted, groups, priority, queued, queued_version, cancel_requested, cancelled, cancel_by_jobset_requested, succeeded, failed, submit_message, scheduling_info, scheduling_info_version, serial, last_modified, validated, pools FROM jobs WHERE serial > $1 ORDER BY serial LIMIT $2
 `
@@ -446,6 +513,63 @@ func (q *Queries) SelectNewJobs(ctx context.Context, arg SelectNewJobsParams) ([
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
+	return items, nil
+}
+
+const selectInitialRuns = `-- name: SelectInitialRuns :many
+SELECT run_id, job_id, created, job_set, executor, node, cancelled, running, succeeded, failed, returned, run_attempted, serial, last_modified, leased_timestamp, pending_timestamp, running_timestamp, terminated_timestamp, scheduled_at_priority, preempted, pending, preempted_timestamp, pod_requirements_overlay, preempt_requested, queue, pool FROM runs WHERE serial > $1 AND job_id = ANY($3::text[]) ORDER BY serial LIMIT $2
+`
+
+type SelectInitialRunsParams struct {
+	Serial int64    `db:"serial"`
+	Limit  int32    `db:"limit"`
+	JobIds []string `db:"job_ids"`
+}
+
+func (q *Queries) SelectInitialRuns(ctx context.Context, arg SelectInitialRunsParams) ([]Run, error) {
+	rows, err := q.db.Query(ctx, selectInitialRuns, arg.Serial, arg.Limit, arg.JobIds)
+	if err != nil {
+			return nil, err
+		}
+	defer rows.Close()
+	var items []Run
+	for rows.Next() {
+			var i Run
+			if err := rows.Scan(
+					&i.RunID,
+					&i.JobID,
+					&i.Created,
+					&i.JobSet,
+					&i.Executor,
+					&i.Node,
+					&i.Cancelled,
+					&i.Running,
+					&i.Succeeded,
+					&i.Failed,
+					&i.Returned,
+					&i.RunAttempted,
+					&i.Serial,
+					&i.LastModified,
+					&i.LeasedTimestamp,
+					&i.PendingTimestamp,
+					&i.RunningTimestamp,
+					&i.TerminatedTimestamp,
+					&i.ScheduledAtPriority,
+					&i.Preempted,
+					&i.Pending,
+					&i.PreemptedTimestamp,
+					&i.PodRequirementsOverlay,
+					&i.PreemptRequested,
+					&i.Queue,
+					&i.Pool,
+				); err != nil {
+					return nil, err
+				}
+			items = append(items, i)
+		}
+	if err := rows.Err(); err != nil {
+			return nil, err
+		}
 	return items, nil
 }
 
@@ -815,4 +939,26 @@ func (q *Queries) SelectAllExecutorSettings(ctx context.Context) ([]ExecutorSett
 		return nil, err
 	}
 	return items, nil
+}
+
+const selectLatestJobSerial = `-- name: SelectLatestJobSerial :one
+SELECT serial FROM jobs ORDER BY serial DESC LIMIT 1
+`
+
+func (q *Queries) SelectLatestJobSerial(ctx context.Context) (int64, error) {
+	row := q.db.QueryRow(ctx, selectLatestJobSerial)
+	var serial int64
+	err := row.Scan(&serial)
+	return serial, err
+}
+
+const selectLatestJobRunSerial = `-- name: SelectLatestJobRunSerial :one
+SELECT serial FROM runs ORDER BY serial DESC LIMIT 1
+`
+
+func (q *Queries) SelectLatestJobRunSerial(ctx context.Context) (int64, error) {
+	row := q.db.QueryRow(ctx, selectLatestJobRunSerial)
+	var serial int64
+	err := row.Scan(&serial)
+	return serial, err
 }

--- a/internal/scheduler/database/query/query.sql
+++ b/internal/scheduler/database/query/query.sql
@@ -119,9 +119,3 @@ UPDATE runs SET running_timestamp = $1 WHERE run_id = $2;
 -- name: SetTerminatedTime :exec
 UPDATE runs SET terminated_timestamp = $1 WHERE run_id = $2;
 
--- name: SelectLatestJobSerial :one
-SELECT serial FROM jobs ORDER BY serial DESC LIMIT 1;
-
--- name: SelectLatestJobRunSerial :one
-SELECT serial FROM runs ORDER BY serial DESC LIMIT 1;
-

--- a/internal/scheduler/database/query/query.sql
+++ b/internal/scheduler/database/query/query.sql
@@ -4,6 +4,9 @@ SELECT * FROM jobs WHERE serial > $1 ORDER BY serial LIMIT $2;
 -- name: SelectAllJobIds :many
 SELECT job_id FROM jobs;
 
+-- name: SelectInitialJobs :many
+SELECT job_id, job_set, queue, priority, submitted, queued, queued_version, validated, cancel_requested, cancel_by_jobset_requested, cancelled, succeeded, failed, scheduling_info, scheduling_info_version, pools, serial FROM jobs WHERE serial > $1 AND cancelled = 'false' AND succeeded = 'false' and failed = 'false' ORDER BY serial LIMIT $2;
+
 -- name: SelectUpdatedJobs :many
 SELECT job_id, job_set, queue, priority, submitted, queued, queued_version, validated, cancel_requested, cancel_by_jobset_requested, cancelled, succeeded, failed, scheduling_info, scheduling_info_version, pools, serial FROM jobs WHERE serial > $1 ORDER BY serial LIMIT $2;
 
@@ -27,6 +30,9 @@ UPDATE jobs SET failed = true WHERE job_id = ANY(sqlc.arg(job_ids)::text[]);
 
 -- name: UpdateJobPriorityById :exec
 UPDATE jobs SET priority = $1 WHERE queue = sqlc.arg(queue) and job_set = sqlc.arg(job_set) and job_id = ANY(sqlc.arg(job_ids)::text[]);
+
+-- name: SelectInitialRuns :many
+SELECT * FROM runs WHERE serial > $1 AND job_id = ANY(sqlc.arg(job_ids)::text[]) ORDER BY serial LIMIT $2;
 
 -- name: SelectNewRuns :many
 SELECT * FROM runs WHERE serial > $1 ORDER BY serial LIMIT $2;
@@ -112,4 +118,10 @@ UPDATE runs SET running_timestamp = $1 WHERE run_id = $2;
 
 -- name: SetTerminatedTime :exec
 UPDATE runs SET terminated_timestamp = $1 WHERE run_id = $2;
+
+-- name: SelectLatestJobSerial :one
+SELECT serial FROM jobs ORDER BY serial DESC LIMIT 1;
+
+-- name: SelectLatestJobRunSerial :one
+SELECT serial FROM runs ORDER BY serial DESC LIMIT 1;
 

--- a/internal/scheduler/mocks/job_repository.go
+++ b/internal/scheduler/mocks/job_repository.go
@@ -114,22 +114,6 @@ func (mr *MockJobRepositoryMockRecorder) FetchJobUpdates(arg0, arg1, arg2 interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchJobUpdates", reflect.TypeOf((*MockJobRepository)(nil).FetchJobUpdates), arg0, arg1, arg2)
 }
 
-// FetchLatestSerials mocks base method.
-func (m *MockJobRepository) FetchLatestSerials(arg0 *armadacontext.Context) (int64, int64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FetchLatestSerials", arg0)
-	ret0, _ := ret[0].(int64)
-	ret1, _ := ret[1].(int64)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// FetchLatestSerials indicates an expected call of FetchLatestSerials.
-func (mr *MockJobRepositoryMockRecorder) FetchLatestSerials(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchLatestSerials", reflect.TypeOf((*MockJobRepository)(nil).FetchLatestSerials), arg0)
-}
-
 // FindInactiveRuns mocks base method.
 func (m *MockJobRepository) FindInactiveRuns(arg0 *armadacontext.Context, arg1 []string) ([]string, error) {
 	m.ctrl.T.Helper()

--- a/internal/scheduler/mocks/job_repository.go
+++ b/internal/scheduler/mocks/job_repository.go
@@ -52,6 +52,22 @@ func (mr *MockJobRepositoryMockRecorder) CountReceivedPartitions(arg0, arg1 inte
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountReceivedPartitions", reflect.TypeOf((*MockJobRepository)(nil).CountReceivedPartitions), arg0, arg1)
 }
 
+// FetchInitialJobs mocks base method.
+func (m *MockJobRepository) FetchInitialJobs(arg0 *armadacontext.Context) ([]database.Job, []database.Run, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FetchInitialJobs", arg0)
+	ret0, _ := ret[0].([]database.Job)
+	ret1, _ := ret[1].([]database.Run)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// FetchInitialJobs indicates an expected call of FetchInitialJobs.
+func (mr *MockJobRepositoryMockRecorder) FetchInitialJobs(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchInitialJobs", reflect.TypeOf((*MockJobRepository)(nil).FetchInitialJobs), arg0)
+}
+
 // FetchJobRunErrors mocks base method.
 func (m *MockJobRepository) FetchJobRunErrors(arg0 *armadacontext.Context, arg1 []string) (map[string]*armadaevents.Error, error) {
 	m.ctrl.T.Helper()
@@ -96,6 +112,22 @@ func (m *MockJobRepository) FetchJobUpdates(arg0 *armadacontext.Context, arg1, a
 func (mr *MockJobRepositoryMockRecorder) FetchJobUpdates(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchJobUpdates", reflect.TypeOf((*MockJobRepository)(nil).FetchJobUpdates), arg0, arg1, arg2)
+}
+
+// FetchLatestSerials mocks base method.
+func (m *MockJobRepository) FetchLatestSerials(arg0 *armadacontext.Context) (int64, int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FetchLatestSerials", arg0)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(int64)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// FetchLatestSerials indicates an expected call of FetchLatestSerials.
+func (mr *MockJobRepositoryMockRecorder) FetchLatestSerials(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchLatestSerials", reflect.TypeOf((*MockJobRepository)(nil).FetchLatestSerials), arg0)
 }
 
 // FindInactiveRuns mocks base method.

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -356,6 +356,49 @@ func (s *Scheduler) cycle(ctx *armadacontext.Context, updateAll bool, leaderToke
 	return overallSchedulerResult, nil
 }
 
+// syncInitialState updates jobs in jobDb to match state in postgres and returns all in-progress jobs.
+func (s *Scheduler) syncInitialState(ctx *armadacontext.Context) ([]*jobdb.Job, []jobdb.JobStateTransitions, error) {
+	txn := s.jobDb.WriteTxn()
+	defer txn.Abort()
+
+	// Load initial jobs and jobs runs from the jobRepo.
+	updatedJobs, updatedRuns, err := s.jobRepository.FetchInitialJobs(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Reconcile any differences between the updated jobs and runs.
+	jsts, err := s.jobDb.ReconcileDifferences(txn, updatedJobs, updatedRuns)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Upsert updated jobs (including associated runs).
+	jobDbJobs := make([]*jobdb.Job, 0, len(jsts))
+	for _, jst := range jsts {
+		if jst.Job != nil {
+			// We receive nil jobs from jobDb.ReconcileDifferences if a run is updated after the associated job is deleted.
+			// These nil job must be sorted out.
+			jobDbJobs = append(jobDbJobs, jst.Job)
+		}
+	}
+	if err := txn.Upsert(jobDbJobs); err != nil {
+		return nil, nil, err
+	}
+
+	latestJobSerial, latestJobRunSerial, err := s.jobRepository.FetchLatestSerials(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	txn.Commit()
+
+	s.jobsSerial = latestJobSerial
+	s.runsSerial = latestJobRunSerial
+
+	return jobDbJobs, jsts, nil
+}
+
 // syncState updates jobs in jobDb to match state in postgres and returns all updated jobs.
 func (s *Scheduler) syncState(ctx *armadacontext.Context) ([]*jobdb.Job, []jobdb.JobStateTransitions, error) {
 	txn := s.jobDb.WriteTxn()
@@ -966,7 +1009,7 @@ func (s *Scheduler) initialise(ctx *armadacontext.Context) error {
 		case <-ctx.Done():
 			return nil
 		default:
-			if _, _, err := s.syncState(ctx); err != nil {
+			if _, _, err := s.syncInitialState(ctx); err != nil {
 				logging.WithStacktrace(ctx, err).Error("failed to initialise; trying again in 1 second")
 				time.Sleep(1 * time.Second)
 			} else {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -393,8 +393,13 @@ func (s *Scheduler) syncInitialState(ctx *armadacontext.Context) ([]*jobdb.Job, 
 
 	txn.Commit()
 
-	s.jobsSerial = latestJobSerial
-	s.runsSerial = latestJobRunSerial
+	if len(initialJobs) > 0 {
+		s.jobsSerial = latestJobSerial
+	}
+
+	if len(initialRuns) > 0 {
+		s.runsSerial = latestJobRunSerial
+	}
 
 	return jobDbJobs, jsts, nil
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -362,13 +362,13 @@ func (s *Scheduler) syncInitialState(ctx *armadacontext.Context) ([]*jobdb.Job, 
 	defer txn.Abort()
 
 	// Load initial jobs and jobs runs from the jobRepo.
-	updatedJobs, updatedRuns, err := s.jobRepository.FetchInitialJobs(ctx)
+	initialJobs, initialRuns, err := s.jobRepository.FetchInitialJobs(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	// Reconcile any differences between the updated jobs and runs.
-	jsts, err := s.jobDb.ReconcileDifferences(txn, updatedJobs, updatedRuns)
+	jsts, err := s.jobDb.ReconcileDifferences(txn, initialJobs, initialRuns)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1268,6 +1268,8 @@ func (t *testSubmitChecker) Check(_ *armadacontext.Context, jobs []*jobdb.Job) (
 
 // Test implementations of the interfaces needed by the Scheduler
 type testJobRepository struct {
+	initialJobs           []database.Job
+	initialRuns           []database.Run
 	updatedJobs           []database.Job
 	updatedRuns           []database.Run
 	errors                map[string]*armadaevents.Error
@@ -1304,6 +1306,28 @@ func (t *testJobRepository) CountReceivedPartitions(ctx *armadacontext.Context, 
 		return 0, errors.New("error counting received partitions")
 	}
 	return t.numReceivedPartitions, nil
+}
+
+func (t *testJobRepository) FetchInitialJobs(ctx *armadacontext.Context) ([]database.Job, []database.Run, error) {
+	if t.shouldError {
+		return nil, nil, errors.New("error fetching job updates")
+	}
+	return t.updatedJobs, t.updatedRuns, nil
+}
+
+func (t *testJobRepository) FetchLatestSerials(ctx *armadacontext.Context) (int64, int64, error) {
+	var jobSerial int64 = -1
+	var jobRunSerial int64 = -1
+
+	if len(t.initialJobs) > 0 {
+		jobSerial = t.initialJobs[len(t.initialJobs)-1].Serial
+	}
+
+	if len(t.initialRuns) > 0 {
+		jobRunSerial = t.initialRuns[len(t.initialRuns)-1].Serial
+	}
+
+	return jobSerial, jobRunSerial, nil
 }
 
 type testExecutorRepository struct {

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1045,12 +1045,16 @@ func TestScheduler_TestSyncInitialState(t *testing.T) {
 		initialJobRuns          []database.Run // jobs runs in the jobdb at the start of the cycle
 		expectedInitialJobs     []*jobdb.Job
 		expectedInitialJobDbIds []string
+		expectedJobsSerial      int64
+		expectedRunsSerial      int64
 	}{
 		"no initial jobs": {
 			initialJobs:             []database.Job{},
 			initialJobRuns:          []database.Run{},
 			expectedInitialJobs:     []*jobdb.Job{},
 			expectedInitialJobDbIds: []string{},
+			expectedJobsSerial:      -1,
+			expectedRunsSerial:      -1,
 		},
 		"initial jobs are present": {
 			initialJobs: []database.Job{
@@ -1079,6 +1083,7 @@ func TestScheduler_TestSyncInitialState(t *testing.T) {
 						scheduledAtPriority := int32(5)
 						return &scheduledAtPriority
 					}(),
+					Serial: 1,
 				},
 			},
 			expectedInitialJobs: []*jobdb.Job{
@@ -1110,6 +1115,8 @@ func TestScheduler_TestSyncInitialState(t *testing.T) {
 					)).WithQueued(false).WithQueuedVersion(1),
 			},
 			expectedInitialJobDbIds: []string{queuedJob.Id()},
+			expectedJobsSerial:      1,
+			expectedRunsSerial:      1,
 		},
 	}
 	for name, tc := range tests {
@@ -1162,6 +1169,9 @@ func TestScheduler_TestSyncInitialState(t *testing.T) {
 				_, ok := expectedIds[job.Id()]
 				assert.True(t, ok)
 			}
+
+			require.Equal(t, tc.expectedJobsSerial, sched.jobsSerial)
+			require.Equal(t, tc.expectedRunsSerial, sched.runsSerial)
 		})
 	}
 }

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1155,7 +1155,7 @@ func TestScheduler_TestSyncInitialState(t *testing.T) {
 			// which must be consistent within tests.
 			sched.jobDb = testfixtures.NewJobDb(testfixtures.TestResourceListFactory)
 
-			initialJobs, _, err := sched.syncInitialState(ctx)
+			initialJobs, _, err := sched.syncState(ctx, true)
 			require.NoError(t, err)
 
 			expectedJobDb := testfixtures.NewJobDbWithJobs(tc.expectedInitialJobs)
@@ -1369,7 +1369,7 @@ func TestScheduler_TestSyncState(t *testing.T) {
 			require.NoError(t, err)
 			txn.Commit()
 
-			updatedJobs, _, err := sched.syncState(ctx)
+			updatedJobs, _, err := sched.syncState(ctx, false)
 			require.NoError(t, err)
 
 			expectedJobDb := testfixtures.NewJobDbWithJobs(tc.expectedUpdatedJobs)
@@ -1450,21 +1450,6 @@ func (t *testJobRepository) FetchInitialJobs(ctx *armadacontext.Context) ([]data
 		return nil, nil, errors.New("error fetching job updates")
 	}
 	return t.initialJobs, t.initialRuns, nil
-}
-
-func (t *testJobRepository) FetchLatestSerials(ctx *armadacontext.Context) (int64, int64, error) {
-	var jobSerial int64 = -1
-	var jobRunSerial int64 = -1
-
-	if len(t.initialJobs) > 0 {
-		jobSerial = t.initialJobs[len(t.initialJobs)-1].Serial
-	}
-
-	if len(t.initialRuns) > 0 {
-		jobRunSerial = t.initialRuns[len(t.initialRuns)-1].Serial
-	}
-
-	return jobSerial, jobRunSerial, nil
 }
 
 type testExecutorRepository struct {

--- a/magefiles/tests.go
+++ b/magefiles/tests.go
@@ -52,12 +52,20 @@ func Tests() error {
 		return err
 	}
 
-	err = dockerRun("run", "-d", "--name=redis", docker_Net, "-p=6379:6379", "redis:6.2.6")
+	if len(docker_Net) > 0 {
+		err = dockerRun("run", "-d", "--name=redis", docker_Net, "-p=6379:6379", "redis:6.2.6")
+	} else {
+		err = dockerRun("run", "-d", "--name=redis", "-p=6379:6379", "redis:6.2.6")
+	}
 	if err != nil {
 		return err
 	}
 
-	err = dockerRun("run", "-d", "--name=postgres", docker_Net, "-p", "5432:5432", "-e", "POSTGRES_PASSWORD=psw", "postgres:14.2")
+	if len(docker_Net) > 0 {
+		err = dockerRun("run", "-d", "--name=postgres", docker_Net, "-p", "5432:5432", "-e", "POSTGRES_PASSWORD=psw", "postgres:14.2")
+	} else {
+		err = dockerRun("run", "-d", "--name=postgres", "-p", "5432:5432", "-e", "POSTGRES_PASSWORD=psw", "postgres:14.2")
+	}
 	if err != nil {
 		return err
 	}

--- a/magefiles/tests.go
+++ b/magefiles/tests.go
@@ -17,6 +17,11 @@ var Gotestsum string
 
 var LocalBin = filepath.Join(os.Getenv("PWD"), "/bin")
 
+var (
+	redisImage    = "redis:6.2.6"
+	postgresImage = "postgres:14.2"
+)
+
 func makeLocalBin() error {
 	if _, err := os.Stat(LocalBin); os.IsNotExist(err) {
 		err = os.MkdirAll(LocalBin, os.ModePerm)
@@ -52,20 +57,22 @@ func Tests() error {
 		return err
 	}
 
+	redisArgs := []string{"run", "-d", "--name=redis", "-p=6379:6379"}
 	if len(docker_Net) > 0 {
-		err = dockerRun("run", "-d", "--name=redis", docker_Net, "-p=6379:6379", "redis:6.2.6")
-	} else {
-		err = dockerRun("run", "-d", "--name=redis", "-p=6379:6379", "redis:6.2.6")
+		redisArgs = append(redisArgs, docker_Net)
 	}
+	redisArgs = append(redisArgs, redisImage)
+	err = dockerRun(redisArgs...)
 	if err != nil {
 		return err
 	}
 
+	postgresArgs := []string{"run", "-d", "--name=postgres", "-p", "5432:5432", "-e", "POSTGRES_PASSWORD=psw"}
 	if len(docker_Net) > 0 {
-		err = dockerRun("run", "-d", "--name=postgres", docker_Net, "-p", "5432:5432", "-e", "POSTGRES_PASSWORD=psw", "postgres:14.2")
-	} else {
-		err = dockerRun("run", "-d", "--name=postgres", "-p", "5432:5432", "-e", "POSTGRES_PASSWORD=psw", "postgres:14.2")
+		postgresArgs = append(postgresArgs, docker_Net)
 	}
+	postgresArgs = append(postgresArgs, postgresImage)
+	err = dockerRun(postgresArgs...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes https://github.com/armadaproject/armada/issues/4018

This pull request updates the scheduler logic such that it only pulls non-terminal jobs and their associated job runs to load into the in-memory job db. Additionally, it fetches that latest job and job run serials and sets its not he in-memory job db such that later syncs only fetch the true delta of jobs and job runs after initialization (since there may been jobs that completed after the most recent non-terminal job started running).

This has reduced our memory consumption considerably on startup however it will still grow related to the number of non-terminal jobs. Additionally, initialization still takes an awful long time for us (~2 mins) so I assume that there is a linear scan going without indexes on the various terminal-state columns. That is something I may try and optimize in another pull request.
