### PR TITLE
Fix preemption reason - fairshare preemption

### DIFF
--- a/internal/scheduler/nodedb/nodedb.go
+++ b/internal/scheduler/nodedb/nodedb.go
@@ -340,7 +340,6 @@ func (nodeDb *NodeDb) ScheduleManyWithTxn(txn *memdb.Txn, gctx *context.GangSche
 		// order to find the best fit for this gang); clear out any remnants of
 		// previous attempts.
 		jctx.UnschedulableReason = ""
-		jctx.PreemptingJobId = ""
 
 		node, err := nodeDb.SelectNodeForJobWithTxn(txn, jctx)
 		if err != nil {


### PR DESCRIPTION
We were incorrectly resetting the PreemptingJobId, which shouldn't get reset

The UnschedulableReason is only reset as we try scheduling the jobs several times, during these rounds the jobs we're scheduling cannot be preempted - so it makes no sense to reset their PreemptingJobId

This makes it so we now correct populate the preemption reason for fairshare preemption



