### PR TITLE
Scheduler: refactor floating resources to use internaltypes

### DIFF
--- a/internal/scheduler/internaltypes/resource_list.go
+++ b/internal/scheduler/internaltypes/resource_list.go
@@ -24,10 +24,11 @@ type ResourceList struct {
 }
 
 type Resource struct {
-	Name  string
-	Value int64
-	Scale k8sResource.Scale
-	Type  ResourceType
+	Name     string
+	RawValue int64
+	Value    k8sResource.Quantity
+	Scale    k8sResource.Scale
+	Type     ResourceType
 }
 
 func (rl ResourceList) Equal(other ResourceList) bool {
@@ -87,7 +88,7 @@ func (rl ResourceList) GetResourceByNameZeroIfMissing(name string) k8sResource.Q
 		return k8sResource.Quantity{}
 	}
 
-	return *k8sResource.NewScaledQuantity(rl.resources[index], rl.factory.scales[index])
+	return *rl.asQuantity(index)
 }
 
 func (rl ResourceList) GetResources() []Resource {
@@ -98,10 +99,11 @@ func (rl ResourceList) GetResources() []Resource {
 	result := make([]Resource, len(rl.resources))
 	for i, q := range rl.resources {
 		result[i] = Resource{
-			Name:  rl.factory.indexToName[i],
-			Value: q,
-			Scale: rl.factory.scales[i],
-			Type:  rl.factory.types[i],
+			Name:     rl.factory.indexToName[i],
+			RawValue: q,
+			Value:    *rl.asQuantity(i),
+			Scale:    rl.factory.scales[i],
+			Type:     rl.factory.types[i],
 		}
 	}
 	return result

--- a/internal/scheduler/internaltypes/resource_list_test.go
+++ b/internal/scheduler/internaltypes/resource_list_test.go
@@ -83,13 +83,18 @@ func TestGetResources(t *testing.T) {
 	a := testResourceList(factory, "1", "1Gi")
 
 	expected := []Resource{
-		{Name: "memory", Value: 1024 * 1024 * 1024, Scale: k8sResource.Scale(0), Type: Kubernetes},
-		{Name: "ephemeral-storage", Value: 0, Scale: k8sResource.Scale(0), Type: Kubernetes},
-		{Name: "cpu", Value: 1000, Scale: k8sResource.Milli, Type: Kubernetes},
-		{Name: "nvidia.com/gpu", Value: 0, Scale: k8sResource.Milli, Type: Kubernetes},
-		{Name: "external-storage-connections", Value: 0, Scale: 0, Type: Floating},
-		{Name: "external-storage-bytes", Value: 0, Scale: 0, Type: Floating},
+		{Name: "memory", RawValue: 1024 * 1024 * 1024, Scale: k8sResource.Scale(0), Type: Kubernetes},
+		{Name: "ephemeral-storage", RawValue: 0, Scale: k8sResource.Scale(0), Type: Kubernetes},
+		{Name: "cpu", RawValue: 1000, Scale: k8sResource.Milli, Type: Kubernetes},
+		{Name: "nvidia.com/gpu", RawValue: 0, Scale: k8sResource.Milli, Type: Kubernetes},
+		{Name: "external-storage-connections", RawValue: 0, Scale: 0, Type: Floating},
+		{Name: "external-storage-bytes", RawValue: 0, Scale: 0, Type: Floating},
 	}
+
+	for i, r := range expected {
+		expected[i].Value = *k8sResource.NewScaledQuantity(r.RawValue, r.Scale)
+	}
+
 	assert.Equal(t, expected, a.GetResources())
 }
 

--- a/internal/scheduler/metrics.go
+++ b/internal/scheduler/metrics.go
@@ -415,7 +415,7 @@ func (c *MetricsCollector) updateClusterMetrics(ctx *armadacontext.Context) ([]p
 	}
 
 	for _, pool := range c.floatingResourceTypes.AllPools() {
-		totalFloatingResources := c.floatingResourceTypes.GetTotalAvailableForPool(pool)
+		totalFloatingResources := schedulerobjects.ResourceList{Resources: c.floatingResourceTypes.GetTotalAvailableForPoolAsMap(pool)}
 		clusterKey := clusterMetricKey{
 			cluster:  "floating",
 			pool:     pool,

--- a/internal/scheduler/metrics/cycle_metrics.go
+++ b/internal/scheduler/metrics/cycle_metrics.go
@@ -302,7 +302,7 @@ func (m *cycleMetrics) ReportSchedulerResult(result scheduling.SchedulerResult) 
 			m.evictedJobs.WithLabelValues(pool, queue).Set(float64(s.EvictedJobCount))
 
 			for _, r := range s.EvictedResources.GetResources() {
-				m.evictedResources.WithLabelValues(pool, queue, r.Name).Set(float64(r.Value))
+				m.evictedResources.WithLabelValues(pool, queue, r.Name).Set(float64(r.RawValue))
 			}
 		}
 	}

--- a/internal/scheduler/scheduling/preempting_queue_scheduler_test.go
+++ b/internal/scheduler/scheduling/preempting_queue_scheduler_test.go
@@ -76,7 +76,7 @@ func TestEvictOversubscribed(t *testing.T) {
 	for nodeId, node := range result.AffectedNodesById {
 		for _, p := range priorities {
 			for _, r := range node.AllocatableByPriority[p].GetResources() {
-				assert.True(t, r.Value >= 0, "resource %s oversubscribed by %d on node %s", r.Name, r.Value, nodeId)
+				assert.True(t, r.RawValue >= 0, "resource %s oversubscribed by %d on node %s", r.Name, r.RawValue, nodeId)
 			}
 		}
 	}
@@ -2202,7 +2202,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 				for node := it.NextNode(); node != nil; node = it.NextNode() {
 					for _, p := range priorities {
 						for _, r := range node.AllocatableByPriority[p].GetResources() {
-							assert.True(t, r.Value >= 0, "resource %s oversubscribed by %d on node %s", r.Name, r.Value, node.GetId())
+							assert.True(t, r.RawValue >= 0, "resource %s oversubscribed by %d on node %s", r.Name, r.RawValue, node.GetId())
 						}
 					}
 				}

--- a/internal/scheduler/scheduling/scheduling_algo.go
+++ b/internal/scheduler/scheduling/scheduling_algo.go
@@ -129,7 +129,7 @@ func (l *FairSchedulingAlgo) Schedule(
 		ctx.Infof("Scheduling on pool %s with capacity %s %s",
 			pool,
 			fsctx.nodeDb.TotalKubernetesResources().String(),
-			l.floatingResourceTypes.GetTotalAvailableForPoolInternalTypes(pool.Name).String(),
+			l.floatingResourceTypes.GetTotalAvailableForPool(pool.Name).String(),
 		)
 
 		start := time.Now()
@@ -277,7 +277,7 @@ func (l *FairSchedulingAlgo) newFairSchedulingAlgoContext(ctx *armadacontext.Con
 	}
 
 	totalResources := nodeDb.TotalKubernetesResources()
-	totalResources = totalResources.Add(l.floatingResourceTypes.GetTotalAvailableForPoolInternalTypes(pool.Name))
+	totalResources = totalResources.Add(l.floatingResourceTypes.GetTotalAvailableForPool(pool.Name))
 
 	schedulingContext, err := l.constructSchedulingContext(
 		pool.Name,
@@ -528,7 +528,7 @@ func (l *FairSchedulingAlgo) SchedulePool(
 	pool string,
 ) (*SchedulerResult, *schedulercontext.SchedulingContext, error) {
 	totalResources := fsctx.nodeDb.TotalKubernetesResources()
-	totalResources = totalResources.Add(l.floatingResourceTypes.GetTotalAvailableForPoolInternalTypes(pool))
+	totalResources = totalResources.Add(l.floatingResourceTypes.GetTotalAvailableForPool(pool))
 
 	constraints := schedulerconstraints.NewSchedulingConstraints(pool, totalResources, l.schedulingConfig, maps.Values(fsctx.queues))
 


### PR DESCRIPTION
Make `floating_resource_types.go` use `internaltypes.ResourceList` internally.

Before this used `schedulerobjects.ResourceList` internally and had a special getter for `internaltypes.ResourceList`. Now it uses `internaltypes.ResourceList` internally but has a special getter `GetTotalAvailableForPoolAsMap` for if you need a  `schedulerobjects.ResourceList`.