### PR TITLE
Scheduler: per-pool protectedFractionOfFairShare

### DIFF
--- a/internal/scheduler/configuration/configuration.go
+++ b/internal/scheduler/configuration/configuration.go
@@ -271,6 +271,16 @@ type WellKnownNodeType struct {
 }
 
 type PoolConfig struct {
-	Name      string `validate:"required"`
-	AwayPools []string
+	Name                         string `validate:"required"`
+	AwayPools                    []string
+	ProtectedFractionOfFairShare *float64
+}
+
+func (sc *SchedulingConfig) GetProtectedFractionOfFairShare(poolName string) float64 {
+	for _, poolConfig := range sc.Pools {
+		if poolConfig.Name == poolName && poolConfig.ProtectedFractionOfFairShare != nil {
+			return *poolConfig.ProtectedFractionOfFairShare
+		}
+	}
+	return sc.ProtectedFractionOfFairShare
 }

--- a/internal/scheduler/configuration/configuration_test.go
+++ b/internal/scheduler/configuration/configuration_test.go
@@ -1,0 +1,33 @@
+package configuration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetProtectedFractionOfFairShare(t *testing.T) {
+	zero := 0.0
+	half := 0.5
+	sc := SchedulingConfig{
+		ProtectedFractionOfFairShare: 0.1,
+		Pools: []PoolConfig{
+			{
+				Name:                         "overrides-pool",
+				ProtectedFractionOfFairShare: &half,
+			},
+			{
+				Name:                         "overrides-zero-pool",
+				ProtectedFractionOfFairShare: &zero,
+			},
+			{
+				Name: "not-set-pool",
+			},
+		},
+	}
+
+	assert.Equal(t, 0.5, sc.GetProtectedFractionOfFairShare("overrides-pool"))
+	assert.Equal(t, 0.0, sc.GetProtectedFractionOfFairShare("overrides-zero-pool"))
+	assert.Equal(t, 0.1, sc.GetProtectedFractionOfFairShare("not-set-pool"))
+	assert.Equal(t, 0.1, sc.GetProtectedFractionOfFairShare("missing-pool"))
+}

--- a/internal/scheduler/internaltypes/resource_list.go
+++ b/internal/scheduler/internaltypes/resource_list.go
@@ -3,6 +3,7 @@ package internaltypes
 import (
 	"fmt"
 	"math"
+	"strings"
 
 	"golang.org/x/exp/slices"
 	k8sResource "k8s.io/apimachinery/pkg/api/resource"
@@ -44,16 +45,17 @@ func (rl ResourceList) Equal(other ResourceList) bool {
 
 func (rl ResourceList) String() string {
 	if rl.IsEmpty() {
-		return "empty"
+		return "(empty)"
 	}
-	result := ""
+
+	parts := []string{}
 	for i, name := range rl.factory.indexToName {
-		if i > 0 {
-			result += " "
+		if rl.resources[i] == 0 {
+			continue
 		}
-		result += fmt.Sprintf("%s=%s", name, rl.asQuantity(i).String())
+		parts = append(parts, fmt.Sprintf("%s=%s", name, rl.asQuantity(i).String()))
 	}
-	return result
+	return "(" + strings.Join(parts, ",") + ")"
 }
 
 func (rl ResourceList) GetByName(name string) (int64, error) {

--- a/internal/scheduler/internaltypes/resource_list_test.go
+++ b/internal/scheduler/internaltypes/resource_list_test.go
@@ -395,6 +395,18 @@ func TestNegate_HandlesEmptyCorrectly(t *testing.T) {
 	assert.Equal(t, ResourceList{}, ResourceList{}.Negate())
 }
 
+func TestString(t *testing.T) {
+	factory := testFactory()
+
+	assert.Equal(t, "(memory=102400,cpu=100)", testResourceList(factory, "100", "100Ki").String())
+	assert.Equal(t, "(memory=102400)", testResourceList(factory, "0", "100Ki").String())
+	assert.Equal(t, "()", testResourceList(factory, "0", "0").String())
+}
+
+func TestString_HandlesEmptyCorrectly(t *testing.T) {
+	assert.Equal(t, "(empty)", ResourceList{}.String())
+}
+
 func testResourceList(factory *ResourceListFactory, cpu string, memory string) ResourceList {
 	return factory.FromJobResourceListIgnoreUnknown(map[string]k8sResource.Quantity{
 		"cpu":    k8sResource.MustParse(cpu),

--- a/internal/scheduler/simulator/simulator.go
+++ b/internal/scheduler/simulator/simulator.go
@@ -596,7 +596,7 @@ func (s *Simulator) handleScheduleEvent(ctx *armadacontext.Context) error {
 			sctx,
 			constraints,
 			s.floatingResourceTypes,
-			s.schedulingConfig.ProtectedFractionOfFairShare,
+			s.schedulingConfig.GetProtectedFractionOfFairShare(pool),
 			s.schedulingConfig.MaxQueueLookback,
 			txn,
 			nodeDb,


### PR DESCRIPTION
Allow setting protectedFractionOfFairShare by pool.
If not set by pool will fall back to the old, global, setting.
Also make the resource list `String()` method give more readable output, and add tests for it.