### PR TITLE
Scheduler: submit checks: add queue fraction limits/floating resources

### DIFF
--- a/internal/scheduler/internaltypes/node_factory.go
+++ b/internal/scheduler/internaltypes/node_factory.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/armadaproject/armada/internal/common/util"
 	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
+	v1 "k8s.io/api/core/v1"
 )
 
 type NodeFactory struct {
@@ -42,6 +43,49 @@ func NewNodeFactory(
 		resourceListFactory: resourceListFactory,
 		nodeIndexCounter:    0,
 	}
+}
+
+func (f *NodeFactory) NewNode(node *schedulerobjects.Node,
+	id string,
+	executor string,
+	name string,
+	pool string,
+	taints []v1.Taint,
+	labels map[string]string,
+	totalResources ResourceList,
+	unallocatableResources map[int32]ResourceList,
+	allocatableByPriority map[int32]ResourceList,
+	allocatedByQueue map[string]ResourceList,
+	allocatedByJobId map[string]ResourceList,
+	evictedJobRunIds map[string]bool,
+) *Node {
+
+	nodeType := NewNodeType(
+		taints,
+		labels,
+		f.indexedTaints,
+		f.indexedNodeLabels,
+	)
+
+	f.nodeIndexCounter++
+
+	return CreateNode(
+		node.Id,
+		nodeType,
+		f.nodeIndexCounter,
+		node.Executor,
+		node.Name,
+		node.Pool,
+		taints,
+		labels,
+		totalResources,
+		unallocatableResources,
+		allocatableByPriority,
+		allocatedByQueue,
+		allocatedByJobId,
+		evictedJobRunIds,
+		nil,
+	)
 }
 
 func (f *NodeFactory) FromSchedulerObjectsNode(node *schedulerobjects.Node) (*Node, error) {

--- a/internal/scheduler/internaltypes/resource_list_factory.go
+++ b/internal/scheduler/internaltypes/resource_list_factory.go
@@ -75,6 +75,14 @@ func (factory *ResourceListFactory) MakeAllZero() ResourceList {
 	return ResourceList{resources: result, factory: factory}
 }
 
+func (factory *ResourceListFactory) MakeAllMax() ResourceList {
+	result := make([]int64, len(factory.indexToName))
+	for i := range result {
+		result[i] = math.MaxInt64
+	}
+	return ResourceList{resources: result, factory: factory}
+}
+
 // Ignore unknown resources, round down.
 func (factory *ResourceListFactory) FromNodeProto(resources map[string]k8sResource.Quantity) ResourceList {
 	result := make([]int64, len(factory.indexToName))

--- a/internal/scheduler/internaltypes/resource_list_factory_test.go
+++ b/internal/scheduler/internaltypes/resource_list_factory_test.go
@@ -125,6 +125,22 @@ func TestGetScaleFailsOnUnknown(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+func TestMakeAllZero(t *testing.T) {
+	factory := testFactory()
+	allZero := factory.MakeAllZero()
+	assert.False(t, allZero.IsEmpty())
+	assert.True(t, allZero.AllZero())
+}
+
+func TestMakeAllMax(t *testing.T) {
+	factory := testFactory()
+	allMax := factory.MakeAllMax()
+	assert.False(t, allMax.IsEmpty())
+	for _, res := range allMax.GetResources() {
+		assert.Equal(t, int64(math.MaxInt64), res.RawValue)
+	}
+}
+
 func testFactory() *ResourceListFactory {
 	factory, _ := NewResourceListFactory(
 		[]configuration.ResourceType{

--- a/internal/scheduler/internaltypes/testfixtures/testfixtures.go
+++ b/internal/scheduler/internaltypes/testfixtures/testfixtures.go
@@ -2,6 +2,9 @@ package testfixtures
 
 import (
 	"github.com/armadaproject/armada/internal/scheduler/internaltypes"
+	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
+	"github.com/google/uuid"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func TestSimpleNode(id string) *internaltypes.Node {
@@ -21,4 +24,47 @@ func TestSimpleNode(id string) *internaltypes.Node {
 		nil,
 		nil,
 		nil)
+}
+
+func N32CpuNodes(n int, priorities []int32) []*schedulerobjects.Node {
+	rv := make([]*schedulerobjects.Node, n)
+	for i := 0; i < n; i++ {
+		rv[i] = Test32CpuNode(priorities)
+	}
+	return rv
+}
+
+func Test32CpuNode(priorities []int32) *schedulerobjects.Node {
+	return TestNode(
+		priorities,
+		map[string]resource.Quantity{
+			"cpu":    resource.MustParse("32"),
+			"memory": resource.MustParse("256Gi"),
+		},
+	)
+}
+
+func TestNode(priorities []int32, resources map[string]resource.Quantity, nodeFactory *internaltypes.NodeFactory) *internaltypes.Node {
+	id := uuid.NewString()
+
+	return internaltypes.CreateNode(
+		id,
+	)
+
+	return &schedulerobjects.Node{
+		Id:             id,
+		Name:           id,
+		Pool:           TestPool,
+		TotalResources: schedulerobjects.ResourceList{Resources: resources},
+		AllocatableByPriorityAndResource: schedulerobjects.NewAllocatableByPriorityAndResourceType(
+			priorities,
+			schedulerobjects.ResourceList{Resources: resources},
+		),
+		StateByJobRunId: make(map[string]schedulerobjects.JobRunState),
+		Labels: map[string]string{
+			TestHostnameLabel: id,
+			// TODO(albin): Nodes should be created from the NodeDb to ensure this label is set automatically.
+			schedulerconfiguration.NodeIdLabel: id,
+		},
+	}
 }

--- a/internal/scheduler/schedulerapp.go
+++ b/internal/scheduler/schedulerapp.go
@@ -237,6 +237,8 @@ func Run(config schedulerconfig.Configuration) error {
 	submitChecker := NewSubmitChecker(
 		config.Scheduling,
 		executorRepository,
+		queueCache,
+		floatingResourceTypes,
 		resourceListFactory,
 	)
 	services = append(services, func() error {


### PR DESCRIPTION
Reject the job/gang if, for all pools it's eligible to run on, either of these apply
- It's requesting more than the maximum resource fraction for the queue
- It's requesting more floating resource than the amount available

Previously these jobs would just queue forever.