### PR TITLE
Scheduler: submit checks: add queue fraction limits/floating resources

### DIFF
--- a/internal/scheduler/internaltypes/resource_list_factory.go
+++ b/internal/scheduler/internaltypes/resource_list_factory.go
@@ -75,6 +75,14 @@ func (factory *ResourceListFactory) MakeAllZero() ResourceList {
 	return ResourceList{resources: result, factory: factory}
 }
 
+func (factory *ResourceListFactory) MakeAllMax() ResourceList {
+	result := make([]int64, len(factory.indexToName))
+	for i := range result {
+		result[i] = math.MaxInt64
+	}
+	return ResourceList{resources: result, factory: factory}
+}
+
 // Ignore unknown resources, round down.
 func (factory *ResourceListFactory) FromNodeProto(resources map[string]k8sResource.Quantity) ResourceList {
 	result := make([]int64, len(factory.indexToName))

--- a/internal/scheduler/internaltypes/resource_list_factory_test.go
+++ b/internal/scheduler/internaltypes/resource_list_factory_test.go
@@ -125,6 +125,22 @@ func TestGetScaleFailsOnUnknown(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+func TestMakeAllZero(t *testing.T) {
+	factory := testFactory()
+	allZero := factory.MakeAllZero()
+	assert.False(t, allZero.IsEmpty())
+	assert.True(t, allZero.AllZero())
+}
+
+func TestMakeAllMax(t *testing.T) {
+	factory := testFactory()
+	allMax := factory.MakeAllMax()
+	assert.False(t, allMax.IsEmpty())
+	for _, res := range allMax.GetResources() {
+		assert.Equal(t, int64(math.MaxInt64), res.RawValue)
+	}
+}
+
 func testFactory() *ResourceListFactory {
 	factory, _ := NewResourceListFactory(
 		[]configuration.ResourceType{

--- a/internal/scheduler/schedulerapp.go
+++ b/internal/scheduler/schedulerapp.go
@@ -237,6 +237,8 @@ func Run(config schedulerconfig.Configuration) error {
 	submitChecker := NewSubmitChecker(
 		config.Scheduling,
 		executorRepository,
+		queueCache,
+		floatingResourceTypes,
 		resourceListFactory,
 	)
 	services = append(services, func() error {


### PR DESCRIPTION
Reject the job/gang if, for all pools it's eligible to run on, either of these apply

- It's requesting more than the maximum resource fraction for the queue
- It's requesting more floating resource than the amount available

Previously these jobs would just queue forever.
