### PR TITLE
Add spot price for fair-share scheduled pools (#301)

### DIFF
--- a/config/scheduler/config.yaml
+++ b/config/scheduler/config.yaml
@@ -115,4 +115,7 @@ scheduling:
   executorTimeout: "10m"
   maxUnacknowledgedJobsPerExecutor: 2500
   executorUpdateFrequency: "60s"
+  experimentalIndicativePricing:
+    basePrice: 100.0
+    basePriority: 500.0
 

--- a/internal/scheduler/configuration/configuration.go
+++ b/internal/scheduler/configuration/configuration.go
@@ -239,7 +239,8 @@ type SchedulingConfig struct {
 	DefaultPoolSchedulePriority int
 	Pools                       []PoolConfig
 	// TODO: Remove this feature gate
-	EnableExecutorCordoning bool
+	EnableExecutorCordoning       bool
+	ExperimentalIndicativePricing ExperimentalIndicativePricing
 }
 
 const (
@@ -288,4 +289,9 @@ func (sc *SchedulingConfig) GetProtectedFractionOfFairShare(poolName string) flo
 		}
 	}
 	return sc.ProtectedFractionOfFairShare
+}
+
+type ExperimentalIndicativePricing struct {
+	BasePrice    float64
+	BasePriority float64
 }


### PR DESCRIPTION
Adds a sport price for fair-share (i.e. non-market-driven) pools.

Spot price is calculate from a base price, modified by the amount of contention on the pool. The contention is derived from the adjusted fair share that a new user with a standard priority would achieve.