### PR TITLE
Scheduler: testfixture method renaming

### DIFF
--- a/internal/scheduler/nodedb/nodedb_test.go
+++ b/internal/scheduler/nodedb/nodedb_test.go
@@ -35,7 +35,7 @@ func TestTotalResources(t *testing.T) {
 
 	expected := testfixtures.TestNodeFactory.ResourceListFactory().MakeAllZero()
 	// Upserting nodes for the first time should increase the resource count.
-	nodes := testfixtures.ItN32CpuNodes(2, testfixtures.TestPriorities)
+	nodes := testfixtures.N32CpuNodes(2, testfixtures.TestPriorities)
 	for _, node := range nodes {
 		expected = expected.Add(node.GetTotalResources())
 	}
@@ -49,7 +49,7 @@ func TestTotalResources(t *testing.T) {
 	assert.True(t, expected.Equal(nodeDb.TotalKubernetesResources()))
 
 	// Upserting new nodes should increase the resource count.
-	nodes = testfixtures.ItN8GpuNodes(3, testfixtures.TestPriorities)
+	nodes = testfixtures.N8GpuNodes(3, testfixtures.TestPriorities)
 	for _, node := range nodes {
 		expected = expected.Add(node.GetTotalResources())
 	}
@@ -64,7 +64,7 @@ func TestTotalResources(t *testing.T) {
 }
 
 func TestSelectNodeForPod_NodeIdLabel_Success(t *testing.T) {
-	nodes := testfixtures.ItN32CpuNodes(2, testfixtures.TestPriorities)
+	nodes := testfixtures.N32CpuNodes(2, testfixtures.TestPriorities)
 	nodeId := nodes[1].GetId()
 	require.NotEmpty(t, nodeId)
 	db, err := newNodeDbWithNodes(nodes)
@@ -89,7 +89,7 @@ func TestSelectNodeForPod_NodeIdLabel_Success(t *testing.T) {
 }
 
 func TestSelectNodeForPod_NodeIdLabel_Failure(t *testing.T) {
-	nodes := testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities)
+	nodes := testfixtures.N32CpuNodes(1, testfixtures.TestPriorities)
 	nodeId := nodes[0].GetId()
 	require.NotEmpty(t, nodeId)
 	db, err := newNodeDbWithNodes(nodes)
@@ -114,7 +114,7 @@ func TestSelectNodeForPod_NodeIdLabel_Failure(t *testing.T) {
 }
 
 func TestNodeBindingEvictionUnbinding(t *testing.T) {
-	node := testfixtures.ItTest8GpuNode(testfixtures.TestPriorities)
+	node := testfixtures.Test8GpuNode(testfixtures.TestPriorities)
 	nodeDb, err := newNodeDbWithNodes([]*internaltypes.Node{node})
 	require.NoError(t, err)
 	entry, err := nodeDb.GetNode(node.GetId())
@@ -278,7 +278,7 @@ func TestEviction(t *testing.T) {
 				testfixtures.Test1Cpu4GiJob("queue-alice", testfixtures.PriorityClass0),
 				testfixtures.Test1Cpu4GiJob("queue-alice", testfixtures.PriorityClass3),
 			}
-			node := testfixtures.ItTest32CpuNode(testfixtures.TestPriorities)
+			node := testfixtures.Test32CpuNode(testfixtures.TestPriorities)
 			require.NoError(t, err)
 			err = nodeDb.CreateAndInsertWithJobDbJobsWithTxn(txn, jobs, node)
 			txn.Commit()
@@ -308,22 +308,22 @@ func TestScheduleIndividually(t *testing.T) {
 		ExpectSuccess []bool
 	}{
 		"all jobs fit": {
-			Nodes:         testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:         testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Jobs:          testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 32),
 			ExpectSuccess: testfixtures.Repeat(true, 32),
 		},
 		"not all jobs fit": {
-			Nodes:         testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:         testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Jobs:          testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 33),
 			ExpectSuccess: append(testfixtures.Repeat(true, 32), testfixtures.Repeat(false, 1)...),
 		},
 		"unavailable resource": {
-			Nodes:         testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:         testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Jobs:          testfixtures.N1GpuJobs("A", testfixtures.PriorityClass0, 1),
 			ExpectSuccess: testfixtures.Repeat(false, 1),
 		},
 		"unsupported resource": {
-			Nodes: testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes: testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Jobs: testfixtures.WithRequestsJobs(
 				schedulerobjects.ResourceList{
 					Resources: map[string]resource.Quantity{
@@ -335,7 +335,7 @@ func TestScheduleIndividually(t *testing.T) {
 			ExpectSuccess: testfixtures.Repeat(true, 1), // we ignore unknown resource types on jobs, should never happen in practice anyway as these should fail earlier.
 		},
 		"preemption": {
-			Nodes: testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes: testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Jobs: append(
 				append(
 					testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 32),
@@ -346,7 +346,7 @@ func TestScheduleIndividually(t *testing.T) {
 			ExpectSuccess: append(testfixtures.Repeat(true, 64), testfixtures.Repeat(false, 32)...),
 		},
 		"taints/tolerations": {
-			Nodes: testfixtures.ItNTainted32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes: testfixtures.NTainted32CpuNodes(1, testfixtures.TestPriorities),
 			Jobs: append(
 				append(
 					testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 1),
@@ -357,9 +357,9 @@ func TestScheduleIndividually(t *testing.T) {
 			ExpectSuccess: []bool{false, false, true},
 		},
 		"node selector": {
-			Nodes: append(testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes: append(testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 				testfixtures.TestNodeFactory.AddLabels(
-					testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+					testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					map[string]string{
 						"key": "value",
 					},
@@ -374,7 +374,7 @@ func TestScheduleIndividually(t *testing.T) {
 		},
 		"node selector with mismatched value": {
 			Nodes: testfixtures.TestNodeFactory.AddLabels(
-				testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+				testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 				map[string]string{
 					"key": "value",
 				},
@@ -388,7 +388,7 @@ func TestScheduleIndividually(t *testing.T) {
 			ExpectSuccess: testfixtures.Repeat(false, 1),
 		},
 		"node selector with missing label": {
-			Nodes: testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes: testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Jobs: testfixtures.WithNodeSelectorJobs(
 				map[string]string{
 					"this label does not exist": "value",
@@ -399,9 +399,9 @@ func TestScheduleIndividually(t *testing.T) {
 		},
 		"node affinity": {
 			Nodes: append(
-				testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+				testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 				testfixtures.TestNodeFactory.AddLabels(
-					testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+					testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					map[string]string{
 						"key": "value",
 					},
@@ -482,18 +482,18 @@ func TestScheduleMany(t *testing.T) {
 	}{
 		// Attempts to schedule 32. All jobs get scheduled.
 		"simple success": {
-			Nodes:         testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:         testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Jobs:          [][]*jobdb.Job{gangSuccess},
 			ExpectSuccess: []bool{true},
 		},
 		// Attempts to schedule 33 jobs. The overall result fails.
 		"simple failure with min cardinality": {
-			Nodes:         testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:         testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Jobs:          [][]*jobdb.Job{gangFailure},
 			ExpectSuccess: []bool{false},
 		},
 		"correct rollback": {
-			Nodes: testfixtures.ItN32CpuNodes(2, testfixtures.TestPriorities),
+			Nodes: testfixtures.N32CpuNodes(2, testfixtures.TestPriorities),
 			Jobs: [][]*jobdb.Job{
 				gangSuccess,
 				gangFailure,
@@ -502,7 +502,7 @@ func TestScheduleMany(t *testing.T) {
 			ExpectSuccess: []bool{true, false, true},
 		},
 		"varying job size": {
-			Nodes: testfixtures.ItN32CpuNodes(2, testfixtures.TestPriorities),
+			Nodes: testfixtures.N32CpuNodes(2, testfixtures.TestPriorities),
 			Jobs: [][]*jobdb.Job{
 				append(
 					testfixtures.N32Cpu256GiJobs("A", testfixtures.PriorityClass0, 1),
@@ -556,7 +556,7 @@ func TestAwayNodeTypes(t *testing.T) {
 	require.NoError(t, err)
 
 	nodeDbTxn := nodeDb.Txn(true)
-	node := testfixtures.ItTest32CpuNode([]int32{29000, 30000})
+	node := testfixtures.Test32CpuNode([]int32{29000, 30000})
 	node = testfixtures.TestNodeFactory.AddTaints(
 		[]*internaltypes.Node{node},
 		[]v1.Taint{
@@ -740,15 +740,15 @@ func benchmarkUpsert(nodes []*internaltypes.Node, b *testing.B) {
 }
 
 func BenchmarkUpsert1(b *testing.B) {
-	benchmarkUpsert(testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities), b)
+	benchmarkUpsert(testfixtures.N32CpuNodes(1, testfixtures.TestPriorities), b)
 }
 
 func BenchmarkUpsert1000(b *testing.B) {
-	benchmarkUpsert(testfixtures.ItN32CpuNodes(1000, testfixtures.TestPriorities), b)
+	benchmarkUpsert(testfixtures.N32CpuNodes(1000, testfixtures.TestPriorities), b)
 }
 
 func BenchmarkUpsert100000(b *testing.B) {
-	benchmarkUpsert(testfixtures.ItN32CpuNodes(100000, testfixtures.TestPriorities), b)
+	benchmarkUpsert(testfixtures.N32CpuNodes(100000, testfixtures.TestPriorities), b)
 }
 
 func benchmarkScheduleMany(b *testing.B, nodes []*internaltypes.Node, jobs []*jobdb.Job) {
@@ -782,7 +782,7 @@ func benchmarkScheduleMany(b *testing.B, nodes []*internaltypes.Node, jobs []*jo
 func BenchmarkScheduleMany10CpuNodes320SmallJobs(b *testing.B) {
 	benchmarkScheduleMany(
 		b,
-		testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+		testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 		testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 320),
 	)
 }
@@ -790,7 +790,7 @@ func BenchmarkScheduleMany10CpuNodes320SmallJobs(b *testing.B) {
 func BenchmarkScheduleMany10CpuNodes640SmallJobs(b *testing.B) {
 	benchmarkScheduleMany(
 		b,
-		testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+		testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 		testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 640),
 	)
 }
@@ -798,7 +798,7 @@ func BenchmarkScheduleMany10CpuNodes640SmallJobs(b *testing.B) {
 func BenchmarkScheduleMany100CpuNodes3200SmallJobs(b *testing.B) {
 	benchmarkScheduleMany(
 		b,
-		testfixtures.ItN32CpuNodes(100, testfixtures.TestPriorities),
+		testfixtures.N32CpuNodes(100, testfixtures.TestPriorities),
 		testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 3200),
 	)
 }
@@ -806,7 +806,7 @@ func BenchmarkScheduleMany100CpuNodes3200SmallJobs(b *testing.B) {
 func BenchmarkScheduleMany100CpuNodes6400SmallJobs(b *testing.B) {
 	benchmarkScheduleMany(
 		b,
-		testfixtures.ItN32CpuNodes(100, testfixtures.TestPriorities),
+		testfixtures.N32CpuNodes(100, testfixtures.TestPriorities),
 		testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 6400),
 	)
 }
@@ -814,7 +814,7 @@ func BenchmarkScheduleMany100CpuNodes6400SmallJobs(b *testing.B) {
 func BenchmarkScheduleMany1000CpuNodes32000SmallJobs(b *testing.B) {
 	benchmarkScheduleMany(
 		b,
-		testfixtures.ItN32CpuNodes(1000, testfixtures.TestPriorities),
+		testfixtures.N32CpuNodes(1000, testfixtures.TestPriorities),
 		testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 32000),
 	)
 }
@@ -822,7 +822,7 @@ func BenchmarkScheduleMany1000CpuNodes32000SmallJobs(b *testing.B) {
 func BenchmarkScheduleMany1000CpuNodes64000SmallJobs(b *testing.B) {
 	benchmarkScheduleMany(
 		b,
-		testfixtures.ItN32CpuNodes(1000, testfixtures.TestPriorities),
+		testfixtures.N32CpuNodes(1000, testfixtures.TestPriorities),
 		testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 64000),
 	)
 }
@@ -830,10 +830,10 @@ func BenchmarkScheduleMany1000CpuNodes64000SmallJobs(b *testing.B) {
 func BenchmarkScheduleMany100CpuNodes1CpuUnused(b *testing.B) {
 	benchmarkScheduleMany(
 		b,
-		testfixtures.ItWithUsedResourcesNodes(
+		testfixtures.WithUsedResourcesNodes(
 			0,
 			testfixtures.Cpu("31"),
-			testfixtures.ItN32CpuNodes(100, testfixtures.TestPriorities),
+			testfixtures.N32CpuNodes(100, testfixtures.TestPriorities),
 		),
 		testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 100),
 	)
@@ -842,10 +842,10 @@ func BenchmarkScheduleMany100CpuNodes1CpuUnused(b *testing.B) {
 func BenchmarkScheduleMany1000CpuNodes1CpuUnused(b *testing.B) {
 	benchmarkScheduleMany(
 		b,
-		testfixtures.ItWithUsedResourcesNodes(
+		testfixtures.WithUsedResourcesNodes(
 			0,
 			testfixtures.Cpu("31"),
-			testfixtures.ItN32CpuNodes(1000, testfixtures.TestPriorities),
+			testfixtures.N32CpuNodes(1000, testfixtures.TestPriorities),
 		),
 		testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 1000),
 	)
@@ -854,10 +854,10 @@ func BenchmarkScheduleMany1000CpuNodes1CpuUnused(b *testing.B) {
 func BenchmarkScheduleMany10000CpuNodes1CpuUnused(b *testing.B) {
 	benchmarkScheduleMany(
 		b,
-		testfixtures.ItWithUsedResourcesNodes(
+		testfixtures.WithUsedResourcesNodes(
 			0,
 			testfixtures.Cpu("31"),
-			testfixtures.ItN32CpuNodes(10000, testfixtures.TestPriorities),
+			testfixtures.N32CpuNodes(10000, testfixtures.TestPriorities),
 		),
 		testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 10000),
 	)
@@ -865,9 +865,9 @@ func BenchmarkScheduleMany10000CpuNodes1CpuUnused(b *testing.B) {
 
 func BenchmarkScheduleManyResourceConstrained(b *testing.B) {
 	nodes := append(append(
-		testfixtures.ItN32CpuNodes(500, testfixtures.TestPriorities),
-		testfixtures.ItN8GpuNodes(1, testfixtures.TestPriorities)...),
-		testfixtures.ItN32CpuNodes(499, testfixtures.TestPriorities)...,
+		testfixtures.N32CpuNodes(500, testfixtures.TestPriorities),
+		testfixtures.N8GpuNodes(1, testfixtures.TestPriorities)...),
+		testfixtures.N32CpuNodes(499, testfixtures.TestPriorities)...,
 	)
 	benchmarkScheduleMany(
 		b,

--- a/internal/scheduler/nodedb/nodeiteration_test.go
+++ b/internal/scheduler/nodedb/nodeiteration_test.go
@@ -23,13 +23,13 @@ func TestNodesIterator(t *testing.T) {
 		Nodes []*internaltypes.Node
 	}{
 		"1 node": {
-			Nodes: testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes: testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 		},
 		"0 nodes": {
-			Nodes: testfixtures.ItN32CpuNodes(0, testfixtures.TestPriorities),
+			Nodes: testfixtures.N32CpuNodes(0, testfixtures.TestPriorities),
 		},
 		"3 nodes": {
-			Nodes: testfixtures.ItN32CpuNodes(3, testfixtures.TestPriorities),
+			Nodes: testfixtures.N32CpuNodes(3, testfixtures.TestPriorities),
 		},
 	}
 	for name, tc := range tests {
@@ -85,17 +85,17 @@ func TestNodeTypeIterator(t *testing.T) {
 	}{
 		"only yield nodes of the right nodeType": {
 			nodes: armadaslices.Concatenate(
-				testfixtures.ItWithNodeTypeNodes(
+				testfixtures.WithNodeTypeNodes(
 					nodeTypeA,
-					testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+					testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 				),
-				testfixtures.ItWithNodeTypeNodes(
+				testfixtures.WithNodeTypeNodes(
 					nodeTypeB,
-					testfixtures.ItN32CpuNodes(2, testfixtures.TestPriorities),
+					testfixtures.N32CpuNodes(2, testfixtures.TestPriorities),
 				),
-				testfixtures.ItWithNodeTypeNodes(
+				testfixtures.WithNodeTypeNodes(
 					nodeTypeA,
-					testfixtures.ItN32CpuNodes(3, testfixtures.TestPriorities),
+					testfixtures.N32CpuNodes(3, testfixtures.TestPriorities),
 				),
 			),
 			nodeTypeId:       nodeTypeA.GetId(),
@@ -107,23 +107,23 @@ func TestNodeTypeIterator(t *testing.T) {
 			),
 		},
 		"filter nodes with insufficient resources and return in increasing order": {
-			nodes: testfixtures.ItWithNodeTypeNodes(
+			nodes: testfixtures.WithNodeTypeNodes(
 				nodeTypeA,
 				armadaslices.Concatenate(
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						0,
 						testfixtures.Cpu("15"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						0,
 						testfixtures.Cpu("16"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						0,
 						testfixtures.Cpu("17"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
 				),
 			),
@@ -133,53 +133,53 @@ func TestNodeTypeIterator(t *testing.T) {
 			expected:         []int{1, 0},
 		},
 		"filter nodes with insufficient resources at priority and return in increasing order": {
-			nodes: testfixtures.ItWithNodeTypeNodes(
+			nodes: testfixtures.WithNodeTypeNodes(
 				nodeTypeA,
 				armadaslices.Concatenate(
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						0,
 						testfixtures.Cpu("15"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						0,
 						testfixtures.Cpu("16"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						0,
 						testfixtures.Cpu("17"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						1,
 						testfixtures.Cpu("15"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						1,
 						testfixtures.Cpu("16"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						1,
 						testfixtures.Cpu("17"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						2,
 						testfixtures.Cpu("15"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						2,
 						testfixtures.Cpu("16"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						2,
 						testfixtures.Cpu("17"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
 				),
 			),
@@ -189,53 +189,53 @@ func TestNodeTypeIterator(t *testing.T) {
 			expected:         []int{4, 7, 3, 6, 0, 1, 2},
 		},
 		"nested ordering": {
-			nodes: testfixtures.ItWithNodeTypeNodes(
+			nodes: testfixtures.WithNodeTypeNodes(
 				nodeTypeA,
 				armadaslices.Concatenate(
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						0,
 						testfixtures.CpuMem("15", "1Gi"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						0,
 						testfixtures.CpuMem("15", "2Gi"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						0,
 						testfixtures.CpuMem("15", "129Gi"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						0,
 						testfixtures.CpuMem("15", "130Gi"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						0,
 						testfixtures.CpuMem("15", "131Gi"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						0,
 						testfixtures.CpuMem("16", "130Gi"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						0,
 						testfixtures.CpuMem("16", "128Gi"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						0,
 						testfixtures.CpuMem("16", "129Gi"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						0,
 						testfixtures.Cpu("17"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
 				),
 			),
@@ -245,58 +245,58 @@ func TestNodeTypeIterator(t *testing.T) {
 			expected:         []int{6, 1, 0},
 		},
 		"double-nested ordering": {
-			nodes: testfixtures.ItWithNodeTypeNodes(
+			nodes: testfixtures.WithNodeTypeNodes(
 				nodeTypeA,
 				armadaslices.Concatenate(
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						0,
 						testfixtures.CpuMem("31", "1Gi"),
-						testfixtures.ItN8GpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N8GpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						0,
 						testfixtures.CpuMemGpu("31", "1Gi", "1"),
-						testfixtures.ItN8GpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N8GpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						0,
 						testfixtures.CpuMemGpu("31", "1Gi", "2"),
-						testfixtures.ItN8GpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N8GpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						0,
 						testfixtures.CpuMemGpu("31", "1Gi", "5"),
-						testfixtures.ItN8GpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N8GpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						0,
 						testfixtures.CpuMem("31", "2Gi"),
-						testfixtures.ItN8GpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N8GpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						0,
 						testfixtures.CpuMemGpu("31", "2Gi", "1"),
-						testfixtures.ItN8GpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N8GpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						0,
 						testfixtures.CpuMem("32", "514Gi"),
-						testfixtures.ItN8GpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N8GpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						0,
 						testfixtures.CpuMem("32", "512Gi"),
-						testfixtures.ItN8GpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N8GpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						0,
 						testfixtures.CpuMem("32", "513Gi"),
-						testfixtures.ItN8GpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N8GpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						0,
 						testfixtures.Cpu("33"),
-						testfixtures.ItN8GpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N8GpuNodes(1, testfixtures.TestPriorities),
 					),
 				),
 			),
@@ -315,7 +315,7 @@ func TestNodeTypeIterator(t *testing.T) {
 			for i, node := range tc.nodes {
 				// Set monotonically increasing node IDs to ensure nodes appear in predictable order.
 				newNodeId := fmt.Sprintf("%d", i)
-				entry := testfixtures.ItWithIdNodes(newNodeId, []*internaltypes.Node{node})[0]
+				entry := testfixtures.WithIdNodes(newNodeId, []*internaltypes.Node{node})[0]
 
 				nodeDb.AddNodeToDb(entry)
 				entries[i] = entry
@@ -388,17 +388,17 @@ func TestNodeTypesIterator(t *testing.T) {
 	}{
 		"only yield nodes of the right nodeType": {
 			nodes: armadaslices.Concatenate(
-				testfixtures.ItWithNodeTypeNodes(
+				testfixtures.WithNodeTypeNodes(
 					nodeTypeA,
-					testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+					testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 				),
-				testfixtures.ItWithNodeTypeNodes(
+				testfixtures.WithNodeTypeNodes(
 					nodeTypeB,
-					testfixtures.ItN32CpuNodes(2, testfixtures.TestPriorities),
+					testfixtures.N32CpuNodes(2, testfixtures.TestPriorities),
 				),
-				testfixtures.ItWithNodeTypeNodes(
+				testfixtures.WithNodeTypeNodes(
 					nodeTypeC,
-					testfixtures.ItN32CpuNodes(3, testfixtures.TestPriorities),
+					testfixtures.N32CpuNodes(3, testfixtures.TestPriorities),
 				),
 			),
 			nodeTypeIds:      []uint64{nodeTypeA.GetId(), nodeTypeC.GetId()},
@@ -411,35 +411,35 @@ func TestNodeTypesIterator(t *testing.T) {
 		},
 		"filter nodes with insufficient resources and return in increasing order": {
 			nodes: armadaslices.Concatenate(
-				testfixtures.ItWithNodeTypeNodes(
+				testfixtures.WithNodeTypeNodes(
 					nodeTypeA,
-					testfixtures.ItWithUsedResourcesNodes(0,
+					testfixtures.WithUsedResourcesNodes(0,
 						testfixtures.Cpu("15"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
 				),
-				testfixtures.ItWithNodeTypeNodes(
+				testfixtures.WithNodeTypeNodes(
 					nodeTypeB,
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						0,
 						testfixtures.Cpu("16"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
 				),
-				testfixtures.ItWithNodeTypeNodes(
+				testfixtures.WithNodeTypeNodes(
 					nodeTypeC,
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						0,
 						testfixtures.Cpu("17"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
 				),
-				testfixtures.ItWithNodeTypeNodes(
+				testfixtures.WithNodeTypeNodes(
 					nodeTypeD,
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						0,
 						testfixtures.Cpu("14"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
 				),
 			),
@@ -449,53 +449,53 @@ func TestNodeTypesIterator(t *testing.T) {
 			expected:         []int{1, 0},
 		},
 		"filter nodes with insufficient resources at priority and return in increasing order": {
-			nodes: testfixtures.ItWithNodeTypeNodes(
+			nodes: testfixtures.WithNodeTypeNodes(
 				nodeTypeA,
 				armadaslices.Concatenate(
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						0,
 						testfixtures.Cpu("15"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						0,
 						testfixtures.Cpu("16"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						0,
 						testfixtures.Cpu("17"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						1,
 						testfixtures.Cpu("15"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						1,
 						testfixtures.Cpu("16"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						1,
 						testfixtures.Cpu("17"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						2,
 						testfixtures.Cpu("15"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						2,
 						testfixtures.Cpu("16"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						2,
 						testfixtures.Cpu("17"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
 				),
 			),
@@ -505,53 +505,53 @@ func TestNodeTypesIterator(t *testing.T) {
 			expected:         []int{4, 7, 3, 6, 0, 1, 2},
 		},
 		"nested ordering": {
-			nodes: testfixtures.ItWithNodeTypeNodes(
+			nodes: testfixtures.WithNodeTypeNodes(
 				nodeTypeA,
 				armadaslices.Concatenate(
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						0,
 						testfixtures.CpuMem("15", "1Gi"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						0,
 						testfixtures.CpuMem("15", "2Gi"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						0,
 						testfixtures.CpuMem("15", "129Gi"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						0,
 						testfixtures.CpuMem("15", "130Gi"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						0,
 						testfixtures.CpuMem("15", "131Gi"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						0,
 						testfixtures.CpuMem("16", "130Gi"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						0,
 						testfixtures.CpuMem("16", "128Gi"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						0,
 						testfixtures.CpuMem("16", "129Gi"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						0,
 						testfixtures.Cpu("17"),
-						testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					),
 				),
 			),
@@ -562,68 +562,68 @@ func TestNodeTypesIterator(t *testing.T) {
 		},
 		"double-nested ordering": {
 			nodes: armadaslices.Concatenate(
-				testfixtures.ItWithNodeTypeNodes(
+				testfixtures.WithNodeTypeNodes(
 					nodeTypeA,
 					armadaslices.Concatenate(
-						testfixtures.ItWithUsedResourcesNodes(
+						testfixtures.WithUsedResourcesNodes(
 							0,
 							testfixtures.CpuMem("31", "1Gi"),
-							testfixtures.ItN8GpuNodes(1, testfixtures.TestPriorities),
+							testfixtures.N8GpuNodes(1, testfixtures.TestPriorities),
 						),
-						testfixtures.ItWithUsedResourcesNodes(
+						testfixtures.WithUsedResourcesNodes(
 							0,
 							testfixtures.CpuMemGpu("31", "1Gi", "1"),
-							testfixtures.ItN8GpuNodes(1, testfixtures.TestPriorities),
+							testfixtures.N8GpuNodes(1, testfixtures.TestPriorities),
 						),
-						testfixtures.ItWithUsedResourcesNodes(
+						testfixtures.WithUsedResourcesNodes(
 							0,
 							testfixtures.CpuMemGpu("31", "1Gi", "2"),
-							testfixtures.ItN8GpuNodes(1, testfixtures.TestPriorities),
+							testfixtures.N8GpuNodes(1, testfixtures.TestPriorities),
 						),
-						testfixtures.ItWithUsedResourcesNodes(
+						testfixtures.WithUsedResourcesNodes(
 							0,
 							testfixtures.CpuMemGpu("31", "1Gi", "5"),
-							testfixtures.ItN8GpuNodes(1, testfixtures.TestPriorities),
+							testfixtures.N8GpuNodes(1, testfixtures.TestPriorities),
 						),
 					),
 				),
-				testfixtures.ItWithNodeTypeNodes(
+				testfixtures.WithNodeTypeNodes(
 					nodeTypeB,
 					armadaslices.Concatenate(
-						testfixtures.ItWithUsedResourcesNodes(
+						testfixtures.WithUsedResourcesNodes(
 							0,
 							testfixtures.CpuMem("31", "2Gi"),
-							testfixtures.ItN8GpuNodes(1, testfixtures.TestPriorities),
+							testfixtures.N8GpuNodes(1, testfixtures.TestPriorities),
 						),
-						testfixtures.ItWithUsedResourcesNodes(
+						testfixtures.WithUsedResourcesNodes(
 							0,
 							testfixtures.CpuMemGpu("31", "2Gi", "1"),
-							testfixtures.ItN8GpuNodes(1, testfixtures.TestPriorities),
+							testfixtures.N8GpuNodes(1, testfixtures.TestPriorities),
 						),
-						testfixtures.ItWithUsedResourcesNodes(
+						testfixtures.WithUsedResourcesNodes(
 							0,
 							testfixtures.CpuMem("32", "514Gi"),
-							testfixtures.ItN8GpuNodes(1, testfixtures.TestPriorities),
+							testfixtures.N8GpuNodes(1, testfixtures.TestPriorities),
 						),
-						testfixtures.ItWithUsedResourcesNodes(
+						testfixtures.WithUsedResourcesNodes(
 							0,
 							testfixtures.CpuMem("32", "512Gi"),
-							testfixtures.ItN8GpuNodes(1, testfixtures.TestPriorities),
+							testfixtures.N8GpuNodes(1, testfixtures.TestPriorities),
 						),
 					),
 				),
-				testfixtures.ItWithNodeTypeNodes(
+				testfixtures.WithNodeTypeNodes(
 					nodeTypeC,
 					armadaslices.Concatenate(
-						testfixtures.ItWithUsedResourcesNodes(
+						testfixtures.WithUsedResourcesNodes(
 							0,
 							testfixtures.CpuMem("32", "513Gi"),
-							testfixtures.ItN8GpuNodes(1, testfixtures.TestPriorities),
+							testfixtures.N8GpuNodes(1, testfixtures.TestPriorities),
 						),
-						testfixtures.ItWithUsedResourcesNodes(
+						testfixtures.WithUsedResourcesNodes(
 							0,
 							testfixtures.Cpu("33"),
-							testfixtures.ItN8GpuNodes(1, testfixtures.TestPriorities),
+							testfixtures.N8GpuNodes(1, testfixtures.TestPriorities),
 						),
 					),
 				),
@@ -643,8 +643,8 @@ func TestNodeTypesIterator(t *testing.T) {
 			for i, node := range tc.nodes {
 				// Set monotonically increasing node IDs to ensure nodes appear in predictable order.
 				nodeId := fmt.Sprintf("%d", i)
-				entry := testfixtures.ItWithIdNodes(nodeId, []*internaltypes.Node{node})[0]
-				entry = testfixtures.ItWithIndexNode(uint64(i), entry)
+				entry := testfixtures.WithIdNodes(nodeId, []*internaltypes.Node{node})[0]
+				entry = testfixtures.WithIndexNode(uint64(i), entry)
 
 				require.NoError(t, err)
 
@@ -704,11 +704,11 @@ func BenchmarkNodeTypeIterator(b *testing.B) {
 		2, 2100, 2200, 2300, 2400, 2500, 2600, 2700, 2800, 2900,
 		3, 4, 5, 6, 7, 8, 9,
 	}
-	nodes := testfixtures.ItN32CpuNodes(numNodes, testfixtures.TestPriorities)
+	nodes := testfixtures.N32CpuNodes(numNodes, testfixtures.TestPriorities)
 	for i, node := range nodes {
 		var q resource.Quantity
 		q.SetMilli(allocatedMilliCpus[i%len(allocatedMilliCpus)])
-		testfixtures.ItWithUsedResourcesNodes(
+		testfixtures.WithUsedResourcesNodes(
 			testfixtures.TestPriorities[len(testfixtures.TestPriorities)-1],
 			testfixtures.TestResourceListFactory.FromJobResourceListIgnoreUnknown(map[string]resource.Quantity{"cpu": q}),
 			[]*internaltypes.Node{node},

--- a/internal/scheduler/scheduling/gang_scheduler_test.go
+++ b/internal/scheduler/scheduling/gang_scheduler_test.go
@@ -54,7 +54,7 @@ func TestGangScheduler(t *testing.T) {
 	}{
 		"simple success": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Gangs: [][]*jobdb.Job{
 				testfixtures.WithGangAnnotationsJobs(testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 32)),
 			},
@@ -65,7 +65,7 @@ func TestGangScheduler(t *testing.T) {
 		},
 		"simple failure": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Gangs: [][]*jobdb.Job{
 				testfixtures.WithGangAnnotationsJobs(testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 33)),
 			},
@@ -76,7 +76,7 @@ func TestGangScheduler(t *testing.T) {
 		},
 		"one success and one failure": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Gangs: [][]*jobdb.Job{
 				testfixtures.WithGangAnnotationsJobs(testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 32)),
 				testfixtures.WithGangAnnotationsJobs(testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 1)),
@@ -88,7 +88,7 @@ func TestGangScheduler(t *testing.T) {
 		},
 		"multiple nodes": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(2, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(2, testfixtures.TestPriorities),
 			Gangs: [][]*jobdb.Job{
 				testfixtures.WithGangAnnotationsJobs(testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 64)),
 			},
@@ -103,7 +103,7 @@ func TestGangScheduler(t *testing.T) {
 				cfg.ExperimentalFloatingResources = testfixtures.TestFloatingResourceConfig
 				return cfg
 			}(),
-			Nodes: testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes: testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Gangs: [][]*jobdb.Job{
 				// we have 10 of test-floating-resource so only the first of these two jobs should fit
 				addFloatingResourceRequest("6", testfixtures.WithGangAnnotationsJobs(testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 1))),
@@ -119,7 +119,7 @@ func TestGangScheduler(t *testing.T) {
 				map[string]float64{"cpu": 0.5},
 				testfixtures.TestSchedulingConfig(),
 			),
-			Nodes: testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes: testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Gangs: [][]*jobdb.Job{
 				testfixtures.WithGangAnnotationsJobs(testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 8)),
 				testfixtures.WithGangAnnotationsJobs(testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 16)),
@@ -138,7 +138,7 @@ func TestGangScheduler(t *testing.T) {
 					testfixtures.TestSchedulingConfig(),
 				),
 			),
-			Nodes: testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes: testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Gangs: [][]*jobdb.Job{
 				testfixtures.WithGangAnnotationsJobs(testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 1)),
 				testfixtures.WithGangAnnotationsJobs(testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 1)),
@@ -159,7 +159,7 @@ func TestGangScheduler(t *testing.T) {
 					testfixtures.TestSchedulingConfig(),
 				),
 			),
-			Nodes: testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes: testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Gangs: [][]*jobdb.Job{
 				testfixtures.WithGangAnnotationsJobs(testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 1)),
 				testfixtures.WithGangAnnotationsJobs(testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 1)),
@@ -182,7 +182,7 @@ func TestGangScheduler(t *testing.T) {
 				},
 				testfixtures.TestSchedulingConfig(),
 			),
-			Nodes: testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes: testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Gangs: [][]*jobdb.Job{
 				testfixtures.WithGangAnnotationsJobs(testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 1)),
 				testfixtures.WithGangAnnotationsJobs(testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 2)),
@@ -206,7 +206,7 @@ func TestGangScheduler(t *testing.T) {
 				},
 				testfixtures.TestSchedulingConfig(),
 			),
-			Nodes: testfixtures.ItN32CpuNodes(3, testfixtures.TestPriorities),
+			Nodes: testfixtures.N32CpuNodes(3, testfixtures.TestPriorities),
 			Gangs: [][]*jobdb.Job{
 				testfixtures.WithGangAnnotationsJobs(testfixtures.N16Cpu128GiJobs("A", testfixtures.PriorityClass0, 1)),
 				testfixtures.WithGangAnnotationsJobs(testfixtures.N16Cpu128GiJobs("A", testfixtures.PriorityClass0, 1)),
@@ -228,7 +228,7 @@ func TestGangScheduler(t *testing.T) {
 				},
 				testfixtures.TestSchedulingConfig(),
 			),
-			Nodes: testfixtures.ItN32CpuNodes(3, testfixtures.TestPriorities),
+			Nodes: testfixtures.N32CpuNodes(3, testfixtures.TestPriorities),
 			Gangs: [][]*jobdb.Job{
 				testfixtures.WithGangAnnotationsJobs(testfixtures.N16Cpu128GiJobs("A", testfixtures.PriorityClass0, 1)),
 				testfixtures.WithGangAnnotationsJobs(testfixtures.N16Cpu128GiJobs("A", testfixtures.PriorityClass0, 1)),
@@ -250,15 +250,15 @@ func TestGangScheduler(t *testing.T) {
 				testfixtures.TestSchedulingConfig(),
 			),
 			Nodes: armadaslices.Concatenate(
-				testfixtures.ItWithUsedResourcesNodes(
+				testfixtures.WithUsedResourcesNodes(
 					0,
 					testfixtures.CpuMemGpu("31.5", "512Gi", "8"),
-					testfixtures.ItN8GpuNodes(1, testfixtures.TestPriorities),
+					testfixtures.N8GpuNodes(1, testfixtures.TestPriorities),
 				),
-				testfixtures.ItWithUsedResourcesNodes(
+				testfixtures.WithUsedResourcesNodes(
 					0,
 					testfixtures.Cpu("32"),
-					testfixtures.ItN8GpuNodes(1, testfixtures.TestPriorities),
+					testfixtures.N8GpuNodes(1, testfixtures.TestPriorities),
 				),
 			),
 			Gangs: [][]*jobdb.Job{
@@ -272,7 +272,7 @@ func TestGangScheduler(t *testing.T) {
 		"NodeUniformityLabel set but not indexed": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
 			Nodes: testfixtures.TestNodeFactory.AddLabels(
-				testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+				testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 				map[string]string{"foo": "foov"},
 			),
 			Gangs: [][]*jobdb.Job{
@@ -292,7 +292,7 @@ func TestGangScheduler(t *testing.T) {
 				[]string{"foo", "bar"},
 				testfixtures.TestSchedulingConfig(),
 			),
-			Nodes: testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes: testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Gangs: [][]*jobdb.Job{
 				testfixtures.WithGangAnnotationsJobs(
 					testfixtures.WithNodeUniformityLabelAnnotationJobs(
@@ -312,11 +312,11 @@ func TestGangScheduler(t *testing.T) {
 			),
 			Nodes: armadaslices.Concatenate(
 				testfixtures.TestNodeFactory.AddLabels(
-					testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+					testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					map[string]string{"foo": "foov1"},
 				),
 				testfixtures.TestNodeFactory.AddLabels(
-					testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+					testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					map[string]string{"foo": "foov2"},
 				),
 			),
@@ -337,22 +337,22 @@ func TestGangScheduler(t *testing.T) {
 			),
 			Nodes: armadaslices.Concatenate(
 				testfixtures.TestNodeFactory.AddLabels(
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						0,
 						testfixtures.Cpu("1"),
-						testfixtures.ItN32CpuNodes(2, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(2, testfixtures.TestPriorities),
 					),
 					map[string]string{"foo": "foov1"},
 				),
 				testfixtures.TestNodeFactory.AddLabels(
-					testfixtures.ItN32CpuNodes(2, testfixtures.TestPriorities),
+					testfixtures.N32CpuNodes(2, testfixtures.TestPriorities),
 					map[string]string{"foo": "foov2"},
 				),
 				testfixtures.TestNodeFactory.AddLabels(
-					testfixtures.ItWithUsedResourcesNodes(
+					testfixtures.WithUsedResourcesNodes(
 						0,
 						testfixtures.Cpu("1"),
-						testfixtures.ItN32CpuNodes(2, testfixtures.TestPriorities),
+						testfixtures.N32CpuNodes(2, testfixtures.TestPriorities),
 					),
 					map[string]string{"foo": "foov3"},
 				),
@@ -376,11 +376,11 @@ func TestGangScheduler(t *testing.T) {
 			),
 			Nodes: append(
 				testfixtures.TestNodeFactory.AddLabels(
-					testfixtures.ItN32CpuNodes(2, testfixtures.TestPriorities),
+					testfixtures.N32CpuNodes(2, testfixtures.TestPriorities),
 					map[string]string{"my-cool-node-uniformity": "a"},
 				),
 				testfixtures.TestNodeFactory.AddLabels(
-					testfixtures.ItN32CpuNodes(3, testfixtures.TestPriorities),
+					testfixtures.N32CpuNodes(3, testfixtures.TestPriorities),
 					map[string]string{"my-cool-node-uniformity": "b"},
 				)...,
 			),
@@ -445,7 +445,7 @@ func TestGangScheduler(t *testing.T) {
 				return config
 			}(),
 			Nodes: testfixtures.TestNodeFactory.AddTaints(
-				testfixtures.ItN8GpuNodes(1, []int32{29000, 30000}),
+				testfixtures.N8GpuNodes(1, []int32{29000, 30000}),
 				[]v1.Taint{
 					{Key: "taint-a", Value: "true", Effect: v1.TaintEffectNoSchedule},
 					{Key: "taint-b", Value: "true", Effect: v1.TaintEffectNoSchedule},
@@ -494,7 +494,7 @@ func TestGangScheduler(t *testing.T) {
 				return config
 			}(),
 			Nodes: testfixtures.TestNodeFactory.AddTaints(
-				testfixtures.ItN32CpuNodes(1, []int32{29000, 30000}),
+				testfixtures.N32CpuNodes(1, []int32{29000, 30000}),
 				[]v1.Taint{
 					{Key: "taint-a", Value: "true", Effect: v1.TaintEffectNoSchedule},
 				},
@@ -518,7 +518,7 @@ func TestGangScheduler(t *testing.T) {
 				cfg.MaximumPerQueueSchedulingRate = 2
 				return cfg
 			}(),
-			Nodes: testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes: testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Gangs: [][]*jobdb.Job{
 				testfixtures.WithGangAnnotationsJobs(testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 2)),
 				testfixtures.WithGangAnnotationsJobs(testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 1)),
@@ -531,7 +531,7 @@ func TestGangScheduler(t *testing.T) {
 		},
 		"Hitting globally applicable constraint makes job scheduling key unfeasible": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Gangs: [][]*jobdb.Job{
 				testfixtures.WithGangAnnotationsJobs(testfixtures.N1GpuJobs("A", testfixtures.PriorityClass0, 1)),
 				testfixtures.WithGangAnnotationsJobs(testfixtures.N1GpuJobs("B", testfixtures.PriorityClass0, 1)),

--- a/internal/scheduler/scheduling/market_driven_preempting_queue_scheduler_test.go
+++ b/internal/scheduler/scheduling/market_driven_preempting_queue_scheduler_test.go
@@ -54,7 +54,7 @@ func TestMarketDrivenPreemptingQueueScheduler(t *testing.T) {
 	}{
 		"three users, highest price jobs from single queue get on": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -78,7 +78,7 @@ func TestMarketDrivenPreemptingQueueScheduler(t *testing.T) {
 		},
 		"three users, highest price jobs between queues get on": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -114,7 +114,7 @@ func TestMarketDrivenPreemptingQueueScheduler(t *testing.T) {
 		},
 		"Two users, no preemption if price lower": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -134,7 +134,7 @@ func TestMarketDrivenPreemptingQueueScheduler(t *testing.T) {
 		},
 		"Two users, preemption if price higher": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -162,7 +162,7 @@ func TestMarketDrivenPreemptingQueueScheduler(t *testing.T) {
 		},
 		"Two users, partial preemption if price higher": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -193,7 +193,7 @@ func TestMarketDrivenPreemptingQueueScheduler(t *testing.T) {
 		},
 		"Self Preemption If Price Is Higher": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -224,7 +224,7 @@ func TestMarketDrivenPreemptingQueueScheduler(t *testing.T) {
 		},
 		"Two Users. Self preemption plus cross user preemption": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -254,7 +254,7 @@ func TestMarketDrivenPreemptingQueueScheduler(t *testing.T) {
 		},
 		"gang preemption": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{

--- a/internal/scheduler/scheduling/preempting_queue_scheduler_test.go
+++ b/internal/scheduler/scheduling/preempting_queue_scheduler_test.go
@@ -57,7 +57,7 @@ func TestEvictOversubscribed(t *testing.T) {
 	err = nodeDb.CreateAndInsertWithJobDbJobsWithTxn(
 		nodeDbTxn,
 		jobs,
-		testfixtures.ItTest32CpuNode(priorities),
+		testfixtures.Test32CpuNode(priorities),
 	)
 	require.NoError(t, err)
 
@@ -110,7 +110,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 	}{
 		"balancing three queues": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -166,7 +166,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 		},
 		"balancing two queues weighted": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -204,7 +204,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 		},
 		"balancing two queues weighted with inactive queues": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -244,7 +244,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 		},
 		"don't prempt jobs where we don't know the queue": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -264,7 +264,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 		},
 		"avoid preemption when not improving fairness": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -287,7 +287,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 		},
 		"avoid preemption when not improving fairness reverse queue naming": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -310,7 +310,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 		},
 		"preemption when improving fairness": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(2, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(2, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -341,7 +341,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 		},
 		"reschedule onto same node": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(2, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(2, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -368,7 +368,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 		},
 		"reschedule onto same node reverse order": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(2, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(2, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -395,7 +395,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 		},
 		"urgency-based preemption stability": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -432,7 +432,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 		},
 		"avoid urgency-based preemption when possible": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(2, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(2, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -458,7 +458,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 		},
 		"preempt in order of priority": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(2, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(2, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -497,7 +497,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 		},
 		"avoid urgency-based preemption when possible cross-queue": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(3, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(3, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -549,7 +549,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 		},
 		"gang preemption": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(2, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(2, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					// Fill half of node 1 and half of node 2.
@@ -596,7 +596,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 
 		"gang preemption avoid cascading preemption": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(3, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(3, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					// Schedule a gang spanning nodes 1 and 2.
@@ -642,7 +642,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 		},
 		"rescheduled jobs don't count towards global scheduling rate limit": {
 			SchedulingConfig: testfixtures.WithGlobalSchedulingRateLimiterConfig(2, 5, testfixtures.TestSchedulingConfig()),
-			Nodes:            testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -667,7 +667,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 		},
 		"MaximumSchedulingRate": {
 			SchedulingConfig: testfixtures.WithGlobalSchedulingRateLimiterConfig(2, 4, testfixtures.TestSchedulingConfig()),
-			Nodes:            testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -703,7 +703,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 		},
 		"rescheduled jobs don't count towards maxQueueLookback": {
 			SchedulingConfig: testfixtures.WithMaxLookbackPerQueueConfig(5, testfixtures.TestSchedulingConfig()),
-			Nodes:            testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -733,7 +733,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 				},
 				testfixtures.TestSchedulingConfig(),
 			),
-			Nodes: testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes: testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -758,7 +758,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 		},
 		"priority class preemption two classes": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -788,7 +788,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 		},
 		"priority class preemption cross-queue": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -819,7 +819,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 		},
 		"priority class preemption not scheduled": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -840,7 +840,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 		// - 17 jobs should be preempted to make space;  all the priority zero jobs and a single priority 1 job
 		"priority class preemption through multiple levels": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -906,7 +906,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 		//},
 		"priority class preemption four classes": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -948,7 +948,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 				},
 				testfixtures.TestSchedulingConfig(),
 			),
-			Nodes: testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes: testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -984,7 +984,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 				},
 				testfixtures.TestSchedulingConfig(),
 			),
-			Nodes: testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes: testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -1052,7 +1052,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 				map[string]float64{"cpu": 15.0 / 64.0},
 				testfixtures.TestSchedulingConfig(),
 			),
-			Nodes: testfixtures.ItN32CpuNodes(2, testfixtures.TestPriorities),
+			Nodes: testfixtures.N32CpuNodes(2, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -1099,7 +1099,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 		},
 		"Queued jobs are not preempted cross queue": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -1119,7 +1119,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 		},
 		"Queued jobs are not preempted cross queue with some scheduled": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -1140,7 +1140,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 		},
 		"Queued jobs are not preempted cross queue with non-preemptible jobs": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -1160,7 +1160,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 		},
 		"Queued jobs are not preempted cross queue multiple rounds": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -1188,7 +1188,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 		},
 		"Oversubscribed eviction does not evict non-preemptible": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(2, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(2, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -1226,7 +1226,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 		},
 		"Cordoning prevents scheduling new jobs but not re-scheduling running jobs": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -1259,7 +1259,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 				1.0,
 				testfixtures.TestSchedulingConfig(),
 			),
-			Nodes: testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes: testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -1295,7 +1295,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 				0.5,
 				testfixtures.TestSchedulingConfig(),
 			),
-			Nodes: testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes: testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -1331,7 +1331,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 				0.5,
 				testfixtures.TestSchedulingConfig(),
 			),
-			Nodes: testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes: testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -1375,7 +1375,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 				1.0,
 				testfixtures.TestSchedulingConfig(),
 			),
-			Nodes: testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes: testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -1411,7 +1411,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 				1.0,
 				testfixtures.TestSchedulingConfig(),
 			),
-			Nodes: testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes: testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -1439,7 +1439,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 		},
 		"DominantResourceFairness": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -1462,18 +1462,18 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
 			Nodes: armadaslices.Concatenate(
 				testfixtures.TestNodeFactory.AddLabels(
-					testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+					testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					map[string]string{"key": "val1"},
 				),
 				testfixtures.TestNodeFactory.AddLabels(
-					testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+					testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					map[string]string{"key": "val2"},
 				),
 				testfixtures.TestNodeFactory.AddLabels(
-					testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+					testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					map[string]string{"key": "val3"},
 				),
-				testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+				testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			),
 			Rounds: []SchedulingRound{
 				{
@@ -1507,7 +1507,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 			// Schedule job from queue C.
 			// This does not prevent re-scheduling.
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(2, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(2, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -1544,7 +1544,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 			// Try to schedule a job from queue B. This fails as the node is cordoned.
 			// This should not prevent re-scheduling jobs in queue A.
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
@@ -1576,7 +1576,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 				return config
 			}(),
 			Nodes: testfixtures.TestNodeFactory.AddTaints(
-				testfixtures.ItN8GpuNodes(2, []int32{29000, 30000}),
+				testfixtures.N8GpuNodes(2, []int32{29000, 30000}),
 				[]v1.Taint{{Key: "gpu", Value: "true", Effect: v1.TaintEffectNoSchedule}},
 			),
 			Rounds: []SchedulingRound{
@@ -1633,7 +1633,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 				return config
 			}(),
 			Nodes: testfixtures.TestNodeFactory.AddTaints(
-				testfixtures.ItN8GpuNodes(2, []int32{29000, 30000}),
+				testfixtures.N8GpuNodes(2, []int32{29000, 30000}),
 				[]v1.Taint{{Key: "gpu", Value: "true", Effect: v1.TaintEffectNoSchedule}},
 			),
 			Rounds: []SchedulingRound{
@@ -1698,10 +1698,10 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 			Nodes: func() []*internaltypes.Node {
 				priorities := []int32{29000, 30000}
 				gpuNodes := testfixtures.TestNodeFactory.AddTaints(
-					testfixtures.ItN8GpuNodes(1, priorities),
+					testfixtures.N8GpuNodes(1, priorities),
 					[]v1.Taint{{Key: "gpu", Value: "true", Effect: v1.TaintEffectNoSchedule}},
 				)
-				return append(testfixtures.ItN32CpuNodes(1, priorities), gpuNodes...)
+				return append(testfixtures.N32CpuNodes(1, priorities), gpuNodes...)
 			}(),
 			Rounds: []SchedulingRound{
 				{
@@ -1759,10 +1759,10 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 			Nodes: func() []*internaltypes.Node {
 				priorities := []int32{29000, 30000}
 				gpuNodes := testfixtures.TestNodeFactory.AddTaints(
-					testfixtures.ItN8GpuNodes(1, priorities),
+					testfixtures.N8GpuNodes(1, priorities),
 					[]v1.Taint{{Key: "gpu", Value: "true", Effect: v1.TaintEffectNoSchedule}},
 				)
-				return append(testfixtures.ItN32CpuNodes(1, priorities), gpuNodes...)
+				return append(testfixtures.N32CpuNodes(1, priorities), gpuNodes...)
 			}(),
 			Rounds: []SchedulingRound{
 				{
@@ -1831,7 +1831,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 				return config
 			}(),
 			Nodes: testfixtures.TestNodeFactory.AddTaints(
-				testfixtures.ItN32CpuNodes(1, []int32{29000, 28000, 30000}),
+				testfixtures.N32CpuNodes(1, []int32{29000, 28000, 30000}),
 				[]v1.Taint{{Key: "gpu", Value: "true", Effect: v1.TaintEffectNoSchedule}},
 			),
 			Rounds: []SchedulingRound{
@@ -2259,7 +2259,7 @@ func BenchmarkPreemptingQueueScheduler(b *testing.B) {
 	}{
 		"1 node 1 queue 320 jobs": {
 			SchedulingConfig:  testfixtures.TestSchedulingConfig(),
-			Nodes:             testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:             testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			JobFunc:           testfixtures.N1Cpu4GiJobs,
 			NumQueues:         1,
 			NumJobsPerQueue:   320,
@@ -2268,7 +2268,7 @@ func BenchmarkPreemptingQueueScheduler(b *testing.B) {
 		},
 		"1 node 10 queues 320 jobs": {
 			SchedulingConfig:  testfixtures.TestSchedulingConfig(),
-			Nodes:             testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:             testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			JobFunc:           testfixtures.N1Cpu4GiJobs,
 			NumQueues:         10,
 			NumJobsPerQueue:   320,
@@ -2277,7 +2277,7 @@ func BenchmarkPreemptingQueueScheduler(b *testing.B) {
 		},
 		"10 nodes 1 queue 3200 jobs": {
 			SchedulingConfig:  testfixtures.TestSchedulingConfig(),
-			Nodes:             testfixtures.ItN32CpuNodes(10, testfixtures.TestPriorities),
+			Nodes:             testfixtures.N32CpuNodes(10, testfixtures.TestPriorities),
 			JobFunc:           testfixtures.N1Cpu4GiJobs,
 			NumQueues:         1,
 			NumJobsPerQueue:   3200,
@@ -2286,7 +2286,7 @@ func BenchmarkPreemptingQueueScheduler(b *testing.B) {
 		},
 		"10 nodes 10 queues 3200 jobs": {
 			SchedulingConfig:  testfixtures.TestSchedulingConfig(),
-			Nodes:             testfixtures.ItN32CpuNodes(10, testfixtures.TestPriorities),
+			Nodes:             testfixtures.N32CpuNodes(10, testfixtures.TestPriorities),
 			JobFunc:           testfixtures.N1Cpu4GiJobs,
 			NumQueues:         10,
 			NumJobsPerQueue:   3200,
@@ -2295,7 +2295,7 @@ func BenchmarkPreemptingQueueScheduler(b *testing.B) {
 		},
 		"100 nodes 1 queue 32000 jobs": {
 			SchedulingConfig:  testfixtures.TestSchedulingConfig(),
-			Nodes:             testfixtures.ItN32CpuNodes(100, testfixtures.TestPriorities),
+			Nodes:             testfixtures.N32CpuNodes(100, testfixtures.TestPriorities),
 			JobFunc:           testfixtures.N1Cpu4GiJobs,
 			NumQueues:         1,
 			NumJobsPerQueue:   32000,
@@ -2304,7 +2304,7 @@ func BenchmarkPreemptingQueueScheduler(b *testing.B) {
 		},
 		"100 nodes 10 queues 32000 jobs": {
 			SchedulingConfig:  testfixtures.TestSchedulingConfig(),
-			Nodes:             testfixtures.ItN32CpuNodes(100, testfixtures.TestPriorities),
+			Nodes:             testfixtures.N32CpuNodes(100, testfixtures.TestPriorities),
 			JobFunc:           testfixtures.N1Cpu4GiJobs,
 			NumQueues:         10,
 			NumJobsPerQueue:   32000,
@@ -2313,7 +2313,7 @@ func BenchmarkPreemptingQueueScheduler(b *testing.B) {
 		},
 		"1000 nodes 1 queue 320000 jobs": {
 			SchedulingConfig:  testfixtures.TestSchedulingConfig(),
-			Nodes:             testfixtures.ItN32CpuNodes(1000, testfixtures.TestPriorities),
+			Nodes:             testfixtures.N32CpuNodes(1000, testfixtures.TestPriorities),
 			JobFunc:           testfixtures.N1Cpu4GiJobs,
 			NumQueues:         1,
 			NumJobsPerQueue:   320000,
@@ -2322,7 +2322,7 @@ func BenchmarkPreemptingQueueScheduler(b *testing.B) {
 		},
 		"1000 nodes 10 queues 320000 jobs": {
 			SchedulingConfig:  testfixtures.TestSchedulingConfig(),
-			Nodes:             testfixtures.ItN32CpuNodes(1000, testfixtures.TestPriorities),
+			Nodes:             testfixtures.N32CpuNodes(1000, testfixtures.TestPriorities),
 			JobFunc:           testfixtures.N1Cpu4GiJobs,
 			NumQueues:         1,
 			NumJobsPerQueue:   32000,

--- a/internal/scheduler/scheduling/queue_scheduler_test.go
+++ b/internal/scheduler/scheduling/queue_scheduler_test.go
@@ -46,48 +46,48 @@ func TestQueueScheduler(t *testing.T) {
 		"simple success": {
 			SchedulingConfig:         testfixtures.TestSchedulingConfig(),
 			Queues:                   testfixtures.SingleQueuePriorityOne("A"),
-			Nodes:                    testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:                    testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Jobs:                     testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 32),
 			ExpectedScheduledIndices: testfixtures.IntRange(0, 31),
 		},
 		"simple failure": {
 			SchedulingConfig:         testfixtures.TestSchedulingConfig(),
 			Queues:                   testfixtures.SingleQueuePriorityOne("A"),
-			Nodes:                    testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:                    testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Jobs:                     testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 33),
 			ExpectedScheduledIndices: testfixtures.IntRange(0, 31),
 		},
 		"multiple nodes": {
 			SchedulingConfig:         testfixtures.TestSchedulingConfig(),
 			Queues:                   testfixtures.SingleQueuePriorityOne("A"),
-			Nodes:                    testfixtures.ItN32CpuNodes(2, testfixtures.TestPriorities),
+			Nodes:                    testfixtures.N32CpuNodes(2, testfixtures.TestPriorities),
 			Jobs:                     testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 64),
 			ExpectedScheduledIndices: testfixtures.IntRange(0, 63),
 		},
 		"preempt lower-priority jobs": {
 			SchedulingConfig:         testfixtures.TestSchedulingConfig(),
-			Nodes:                    testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:                    testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Jobs:                     armadaslices.Concatenate(testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 1), testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass1, 1)),
 			Queues:                   testfixtures.SingleQueuePriorityOne("A"),
 			ExpectedScheduledIndices: testfixtures.IntRange(0, 1),
 		},
 		"no preemption of higher-priority jobs": {
 			SchedulingConfig:         testfixtures.TestSchedulingConfig(),
-			Nodes:                    testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:                    testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Jobs:                     armadaslices.Concatenate(testfixtures.N32Cpu256GiJobs("A", testfixtures.PriorityClass1, 1), testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 1)),
 			Queues:                   testfixtures.SingleQueuePriorityOne("A"),
 			ExpectedScheduledIndices: testfixtures.IntRange(0, 0),
 		},
 		"unschedulable jobs do not block schedulable jobs": {
 			SchedulingConfig:         testfixtures.TestSchedulingConfig(),
-			Nodes:                    testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:                    testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Jobs:                     armadaslices.Concatenate(testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 1), testfixtures.N32Cpu256GiJobs("A", testfixtures.PriorityClass0, 10), testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 1)),
 			Queues:                   testfixtures.SingleQueuePriorityOne("A"),
 			ExpectedScheduledIndices: []int{0, 11},
 		},
 		"MaximumSchedulingBurst": {
 			SchedulingConfig: testfixtures.WithGlobalSchedulingRateLimiterConfig(10, 2, testfixtures.TestSchedulingConfig()),
-			Nodes:            testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Jobs: armadaslices.Concatenate(
 				testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 1),
 				testfixtures.N32Cpu256GiJobs("A", testfixtures.PriorityClass0, 10),
@@ -99,7 +99,7 @@ func TestQueueScheduler(t *testing.T) {
 		},
 		"MaximumPerQueueSchedulingBurst": {
 			SchedulingConfig: testfixtures.WithPerQueueSchedulingLimiterConfig(10, 2, testfixtures.TestSchedulingConfig()),
-			Nodes:            testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Jobs: armadaslices.Concatenate(
 				testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 1),
 				testfixtures.N32Cpu256GiJobs("A", testfixtures.PriorityClass0, 10),
@@ -112,7 +112,7 @@ func TestQueueScheduler(t *testing.T) {
 		},
 		"MaximumSchedulingBurst is not exceeded by gangs": {
 			SchedulingConfig: testfixtures.WithGlobalSchedulingRateLimiterConfig(10, 2, testfixtures.TestSchedulingConfig()),
-			Nodes:            testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Jobs: armadaslices.Concatenate(
 				testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 1),
 				testfixtures.N32Cpu256GiJobs("A", testfixtures.PriorityClass0, 1),
@@ -126,7 +126,7 @@ func TestQueueScheduler(t *testing.T) {
 		},
 		"MaximumPerQueueSchedulingBurst is not exceeded by gangs": {
 			SchedulingConfig: testfixtures.WithPerQueueSchedulingLimiterConfig(10, 2, testfixtures.TestSchedulingConfig()),
-			Nodes:            testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Jobs: armadaslices.Concatenate(
 				testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 1),
 				testfixtures.N32Cpu256GiJobs("A", testfixtures.PriorityClass0, 1),
@@ -144,7 +144,7 @@ func TestQueueScheduler(t *testing.T) {
 				testfixtures.TestSchedulingConfig(),
 			),
 			Queues:                        testfixtures.SingleQueuePriorityOne("A"),
-			Nodes:                         testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:                         testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Jobs:                          testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 32),
 			ExpectedScheduledIndices:      testfixtures.IntRange(0, 16),
 			ExpectedNeverAttemptedIndices: testfixtures.IntRange(17, 31),
@@ -160,7 +160,7 @@ func TestQueueScheduler(t *testing.T) {
 				testfixtures.TestSchedulingConfig(),
 			),
 			Queues: testfixtures.SingleQueuePriorityOne("A"),
-			Nodes:  testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:  testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Jobs: armadaslices.Concatenate(
 				testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 1),
 				testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 2),
@@ -196,20 +196,20 @@ func TestQueueScheduler(t *testing.T) {
 					},
 				},
 			},
-			Nodes:                    testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:                    testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Jobs:                     testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 32),
 			ExpectedScheduledIndices: testfixtures.IntRange(0, 15),
 		},
 		"fairness two queues": {
 			SchedulingConfig:         testfixtures.TestSchedulingConfig(),
-			Nodes:                    testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:                    testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Jobs:                     armadaslices.Concatenate(testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 32), testfixtures.N1Cpu4GiJobs("B", testfixtures.PriorityClass0, 32)),
 			Queues:                   []*api.Queue{{Name: "A", PriorityFactor: 1.0}, {Name: "B", PriorityFactor: 1.0}},
 			ExpectedScheduledIndices: armadaslices.Concatenate(testfixtures.IntRange(0, 15), testfixtures.IntRange(32, 47)),
 		},
 		"fairness three queues": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Jobs: armadaslices.Concatenate(
 				testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 32),
 				testfixtures.N1Cpu4GiJobs("B", testfixtures.PriorityClass0, 32),
@@ -224,7 +224,7 @@ func TestQueueScheduler(t *testing.T) {
 		},
 		"weighted fairness two queues": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(3, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(3, testfixtures.TestPriorities),
 			Jobs: armadaslices.Concatenate(
 				testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 96),
 				testfixtures.N1Cpu4GiJobs("B", testfixtures.PriorityClass0, 96),
@@ -237,7 +237,7 @@ func TestQueueScheduler(t *testing.T) {
 		},
 		"weighted fairness three queues": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(3, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(3, testfixtures.TestPriorities),
 			Jobs: armadaslices.Concatenate(
 				testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 96),
 				testfixtures.N1Cpu4GiJobs("B", testfixtures.PriorityClass0, 96),
@@ -252,7 +252,7 @@ func TestQueueScheduler(t *testing.T) {
 		},
 		"fairness two queues with initial allocation": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Jobs: armadaslices.Concatenate(
 				testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 32),
 				testfixtures.N1Cpu4GiJobs("B", testfixtures.PriorityClass0, 32),
@@ -267,10 +267,10 @@ func TestQueueScheduler(t *testing.T) {
 		},
 		"node with no available capacity": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes: testfixtures.ItWithUsedResourcesNodes(
+			Nodes: testfixtures.WithUsedResourcesNodes(
 				0,
 				testfixtures.Cpu("32"),
-				testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+				testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			),
 			Jobs:                     testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 1),
 			Queues:                   testfixtures.SingleQueuePriorityOne("A"),
@@ -278,10 +278,10 @@ func TestQueueScheduler(t *testing.T) {
 		},
 		"node with some available capacity": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes: testfixtures.ItWithUsedResourcesNodes(
+			Nodes: testfixtures.WithUsedResourcesNodes(
 				0,
 				testfixtures.Cpu("31"),
-				testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+				testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			),
 			Jobs:                     testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 2),
 			Queues:                   testfixtures.SingleQueuePriorityOne("A"),
@@ -289,10 +289,10 @@ func TestQueueScheduler(t *testing.T) {
 		},
 		"preempt used resources of lower-priority jobs": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes: testfixtures.ItWithUsedResourcesNodes(
+			Nodes: testfixtures.WithUsedResourcesNodes(
 				0,
 				testfixtures.Cpu("32"),
-				testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+				testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			),
 			Jobs:                     testfixtures.N32Cpu256GiJobs("A", testfixtures.PriorityClass1, 1),
 			Queues:                   testfixtures.SingleQueuePriorityOne("A"),
@@ -300,14 +300,14 @@ func TestQueueScheduler(t *testing.T) {
 		},
 		"respect taints": {
 			SchedulingConfig:         testfixtures.TestSchedulingConfig(),
-			Nodes:                    testfixtures.ItNTainted32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:                    testfixtures.NTainted32CpuNodes(1, testfixtures.TestPriorities),
 			Jobs:                     armadaslices.Concatenate(testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 1), testfixtures.N32Cpu256GiJobs("A", testfixtures.PriorityClass0, 1)),
 			Queues:                   testfixtures.SingleQueuePriorityOne("A"),
 			ExpectedScheduledIndices: []int{1},
 		},
 		"taints and tolerations": {
 			SchedulingConfig:         testfixtures.TestSchedulingConfig(),
-			Nodes:                    testfixtures.ItNTainted32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:                    testfixtures.NTainted32CpuNodes(1, testfixtures.TestPriorities),
 			Jobs:                     armadaslices.Concatenate(testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 1), testfixtures.N32Cpu256GiJobs("A", testfixtures.PriorityClass0, 1)),
 			Queues:                   testfixtures.SingleQueuePriorityOne("A"),
 			ExpectedScheduledIndices: []int{1},
@@ -315,9 +315,9 @@ func TestQueueScheduler(t *testing.T) {
 		"Node selector": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
 			Nodes: armadaslices.Concatenate(
-				testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+				testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 				testfixtures.TestNodeFactory.AddLabels(
-					testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+					testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					map[string]string{"foo": "foo"},
 				),
 			),
@@ -327,7 +327,7 @@ func TestQueueScheduler(t *testing.T) {
 		},
 		"taints and tolerations (indexed)": {
 			SchedulingConfig:         testfixtures.WithIndexedTaintsConfig([]string{"largeJobsOnly"}, testfixtures.TestSchedulingConfig()),
-			Nodes:                    testfixtures.ItNTainted32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:                    testfixtures.NTainted32CpuNodes(1, testfixtures.TestPriorities),
 			Jobs:                     armadaslices.Concatenate(testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 1), testfixtures.N32Cpu256GiJobs("A", testfixtures.PriorityClass0, 1)),
 			Queues:                   testfixtures.SingleQueuePriorityOne("A"),
 			ExpectedScheduledIndices: []int{1},
@@ -335,9 +335,9 @@ func TestQueueScheduler(t *testing.T) {
 		"Node selector (indexed)": {
 			SchedulingConfig: testfixtures.WithIndexedNodeLabelsConfig([]string{"foo"}, testfixtures.TestSchedulingConfig()),
 			Nodes: append(
-				testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+				testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 				testfixtures.TestNodeFactory.AddLabels(
-					testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+					testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					map[string]string{"foo": "foo"},
 				)...,
 			),
@@ -347,7 +347,7 @@ func TestQueueScheduler(t *testing.T) {
 		},
 		"MaxQueueLookback": {
 			SchedulingConfig: testfixtures.WithMaxQueueLookbackConfig(3, testfixtures.TestSchedulingConfig()),
-			Nodes:            testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Jobs: armadaslices.Concatenate(
 				testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 1),
 				testfixtures.N32Cpu256GiJobs("A", testfixtures.PriorityClass0, 3),
@@ -359,14 +359,14 @@ func TestQueueScheduler(t *testing.T) {
 		},
 		"gang success": {
 			SchedulingConfig:         testfixtures.TestSchedulingConfig(),
-			Nodes:                    testfixtures.ItN32CpuNodes(2, testfixtures.TestPriorities),
+			Nodes:                    testfixtures.N32CpuNodes(2, testfixtures.TestPriorities),
 			Jobs:                     testfixtures.WithGangAnnotationsJobs(testfixtures.N32Cpu256GiJobs("A", testfixtures.PriorityClass0, 2)),
 			Queues:                   testfixtures.SingleQueuePriorityOne("A"),
 			ExpectedScheduledIndices: []int{0, 1},
 		},
 		"non-consecutive gang success": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(3, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(3, testfixtures.TestPriorities),
 			Jobs: armadaslices.Concatenate(
 				testfixtures.WithAnnotationsJobs(map[string]string{
 					armadaconfiguration.GangIdAnnotation:          "my-gang",
@@ -385,14 +385,14 @@ func TestQueueScheduler(t *testing.T) {
 		},
 		"gang failure": {
 			SchedulingConfig:         testfixtures.TestSchedulingConfig(),
-			Nodes:                    testfixtures.ItN32CpuNodes(2, testfixtures.TestPriorities),
+			Nodes:                    testfixtures.N32CpuNodes(2, testfixtures.TestPriorities),
 			Jobs:                     testfixtures.WithGangAnnotationsJobs(testfixtures.N32Cpu256GiJobs("A", testfixtures.PriorityClass0, 3)),
 			Queues:                   testfixtures.SingleQueuePriorityOne("A"),
 			ExpectedScheduledIndices: nil,
 		},
 		"non-consecutive gang failure": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(2, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(2, testfixtures.TestPriorities),
 			Jobs: armadaslices.Concatenate(
 				testfixtures.WithAnnotationsJobs(map[string]string{
 					armadaconfiguration.GangIdAnnotation:          "my-gang",
@@ -411,7 +411,7 @@ func TestQueueScheduler(t *testing.T) {
 		},
 		"job priority": {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
-			Nodes:            testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+			Nodes:            testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			Jobs: armadaslices.Concatenate(
 				testfixtures.WithPriorityJobs(10, testfixtures.N32Cpu256GiJobs("A", testfixtures.PriorityClass0, 1)),
 				testfixtures.WithPriorityJobs(1, testfixtures.N32Cpu256GiJobs("A", testfixtures.PriorityClass0, 1)),
@@ -424,18 +424,18 @@ func TestQueueScheduler(t *testing.T) {
 			SchedulingConfig: testfixtures.TestSchedulingConfig(),
 			Nodes: armadaslices.Concatenate(
 				testfixtures.TestNodeFactory.AddLabels(
-					testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+					testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					map[string]string{"key": "val1"},
 				),
 				testfixtures.TestNodeFactory.AddLabels(
-					testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+					testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					map[string]string{"key": "val2"},
 				),
 				testfixtures.TestNodeFactory.AddLabels(
-					testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+					testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 					map[string]string{"key": "val3"},
 				),
-				testfixtures.ItN32CpuNodes(1, testfixtures.TestPriorities),
+				testfixtures.N32CpuNodes(1, testfixtures.TestPriorities),
 			),
 			Jobs: armadaslices.Concatenate(
 				testfixtures.WithNodeAffinityJobs(

--- a/internal/scheduler/scheduling/scheduling_algo_test.go
+++ b/internal/scheduler/scheduling/scheduling_algo_test.go
@@ -639,7 +639,7 @@ func BenchmarkNodeDbConstruction(b *testing.B) {
 		numNodes := int(math.Pow10(e))
 		b.Run(fmt.Sprintf("%d nodes", numNodes), func(b *testing.B) {
 			jobs := testfixtures.N1Cpu4GiJobs("queue-alice", testfixtures.PriorityClass0, 32*numNodes)
-			nodes := testfixtures.ItN32CpuNodes(numNodes, testfixtures.TestPriorities)
+			nodes := testfixtures.N32CpuNodes(numNodes, testfixtures.TestPriorities)
 			for i, node := range nodes {
 				for j := 32 * i; j < 32*(i+1); j++ {
 					jobs[j] = jobs[j].WithNewRun("executor-01", node.GetId(), node.GetName(), node.GetPool(), jobs[j].PriorityClass().Priority)

--- a/internal/scheduler/testfixtures/testfixtures.go
+++ b/internal/scheduler/testfixtures/testfixtures.go
@@ -290,14 +290,14 @@ func WithMaxQueueLookbackConfig(maxQueueLookback uint, config schedulerconfigura
 	return config
 }
 
-func ItWithUsedResourcesNodes(p int32, rl internaltypes.ResourceList, nodes []*internaltypes.Node) []*internaltypes.Node {
+func WithUsedResourcesNodes(p int32, rl internaltypes.ResourceList, nodes []*internaltypes.Node) []*internaltypes.Node {
 	for _, node := range nodes {
 		internaltypes.MarkAllocated(node.AllocatableByPriority, p, rl)
 	}
 	return nodes
 }
 
-func ItWithNodeTypeNodes(nodeType *internaltypes.NodeType, nodes []*internaltypes.Node) []*internaltypes.Node {
+func WithNodeTypeNodes(nodeType *internaltypes.NodeType, nodes []*internaltypes.Node) []*internaltypes.Node {
 	result := make([]*internaltypes.Node, len(nodes))
 	for i, node := range nodes {
 		result[i] = internaltypes.CreateNode(node.GetId(),
@@ -319,7 +319,7 @@ func ItWithNodeTypeNodes(nodeType *internaltypes.NodeType, nodes []*internaltype
 	return result
 }
 
-func ItWithIdNodes(nodeId string, nodes []*internaltypes.Node) []*internaltypes.Node {
+func WithIdNodes(nodeId string, nodes []*internaltypes.Node) []*internaltypes.Node {
 	result := make([]*internaltypes.Node, len(nodes))
 	for i, node := range nodes {
 		result[i] = internaltypes.CreateNode(nodeId,
@@ -342,7 +342,7 @@ func ItWithIdNodes(nodeId string, nodes []*internaltypes.Node) []*internaltypes.
 	return result
 }
 
-func ItWithIndexNode(idx uint64, node *internaltypes.Node) *internaltypes.Node {
+func WithIndexNode(idx uint64, node *internaltypes.Node) *internaltypes.Node {
 	return internaltypes.CreateNode(node.GetId(),
 		node.GetNodeType(),
 		idx,
@@ -700,26 +700,26 @@ func TestUnitReqs() *schedulerobjects.PodRequirements {
 	}
 }
 
-func ItN32CpuNodes(n int, priorities []int32) []*internaltypes.Node {
+func N32CpuNodes(n int, priorities []int32) []*internaltypes.Node {
 	rv := make([]*internaltypes.Node, n)
 	for i := 0; i < n; i++ {
-		rv[i] = ItTest32CpuNode(priorities)
+		rv[i] = Test32CpuNode(priorities)
 	}
 	return rv
 }
 
-func ItNTainted32CpuNodes(n int, priorities []int32) []*internaltypes.Node {
+func NTainted32CpuNodes(n int, priorities []int32) []*internaltypes.Node {
 	rv := make([]*internaltypes.Node, n)
 	for i := 0; i < n; i++ {
-		rv[i] = ItTestTainted32CpuNode(priorities)
+		rv[i] = TestTainted32CpuNode(priorities)
 	}
 	return rv
 }
 
-func ItN8GpuNodes(n int, priorities []int32) []*internaltypes.Node {
+func N8GpuNodes(n int, priorities []int32) []*internaltypes.Node {
 	rv := make([]*internaltypes.Node, n)
 	for i := 0; i < n; i++ {
-		rv[i] = ItTest8GpuNode(priorities)
+		rv[i] = Test8GpuNode(priorities)
 	}
 	return rv
 }
@@ -767,7 +767,7 @@ func TestSimpleNode(id string) *internaltypes.Node {
 		nil)
 }
 
-func ItTestNode(priorities []int32, resources map[string]resource.Quantity) *internaltypes.Node {
+func TestNode(priorities []int32, resources map[string]resource.Quantity) *internaltypes.Node {
 	rl := TestNodeFactory.ResourceListFactory().FromNodeProto(resources)
 	id := uuid.NewString()
 	return TestNodeFactory.CreateNodeAndType(id,
@@ -785,8 +785,8 @@ func ItTestNode(priorities []int32, resources map[string]resource.Quantity) *int
 		internaltypes.NewAllocatableByPriorityAndResourceType(priorities, rl))
 }
 
-func ItTest32CpuNode(priorities []int32) *internaltypes.Node {
-	return ItTestNode(
+func Test32CpuNode(priorities []int32) *internaltypes.Node {
+	return TestNode(
 		priorities,
 		map[string]resource.Quantity{
 			"cpu":    resource.MustParse("32"),
@@ -795,8 +795,8 @@ func ItTest32CpuNode(priorities []int32) *internaltypes.Node {
 	)
 }
 
-func ItTestTainted32CpuNode(priorities []int32) *internaltypes.Node {
-	node := ItTest32CpuNode(priorities)
+func TestTainted32CpuNode(priorities []int32) *internaltypes.Node {
+	node := Test32CpuNode(priorities)
 
 	node = TestNodeFactory.AddTaints([]*internaltypes.Node{node},
 		[]v1.Taint{
@@ -815,8 +815,8 @@ func ItTestTainted32CpuNode(priorities []int32) *internaltypes.Node {
 	return node
 }
 
-func ItTest8GpuNode(priorities []int32) *internaltypes.Node {
-	node := ItTestNode(
+func Test8GpuNode(priorities []int32) *internaltypes.Node {
+	node := TestNode(
 		priorities,
 		map[string]resource.Quantity{
 			"cpu":            resource.MustParse("64"),


### PR DESCRIPTION
All these methods use `internaltypes` not `schedulerobjects` now. So there is no need to distinguish the `internaltypes` versions with an `It` prefix.