### PR TITLE
Update pruners to use configmaps

### DIFF
--- a/deployment/lookout-v2/templates/cronjob.yaml
+++ b/deployment/lookout-v2/templates/cronjob.yaml
@@ -51,9 +51,9 @@ spec:
               securityContext:
                 allowPrivilegeEscalation: false
           volumes:
-            - name: user-config
-              secret:
-                secretName: {{ include "lookout_v2.config.name" . }}
+          - name: user-config
+            configMap:
+              name: {{ include "lookout_v2.config.name" . }}
             {{- if .Values.additionalVolumes }}
             {{- toYaml .Values.additionalVolumes | nindent 12 }}
             {{- end }}

--- a/deployment/scheduler/templates/cronjob.yaml
+++ b/deployment/scheduler/templates/cronjob.yaml
@@ -65,8 +65,8 @@ spec:
                 allowPrivilegeEscalation: false
           volumes:
             - name: user-config
-              secret:
-                secretName: {{ include "armada-scheduler-pruner.config.name" . }}
+              configMap:
+                name: {{ include "armada-scheduler-pruner.config.name" . }}
             {{- if .Values.scheduler.additionalVolumes }}
             {{- toYaml .Values.scheduler.additionalVolumes | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
I'd moved the helm charts to use configmaps rather than secrets but had forgotten the lookout/scheduler pruners