### PR TITLE
New Airflow Operator release 1.0.13

### DIFF
--- a/third_party/airflow/pyproject.toml
+++ b/third_party/airflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "armada_airflow"
-version = "1.0.12"
+version = "1.0.13"
 description = "Armada Airflow Operator"
 readme='README.md'
 authors = [{name = "Armada-GROSS", email = "armada@armadaproject.io"}]
@@ -41,7 +41,7 @@ include = ["armada_airflow*"]
 
 [tool.black]
 line-length = 88
-target-version = ['py38', 'py39', 'py310']
+target-version = ['py310', 'py311', 'py312']
 include = '''
 /(
     armada


### PR DESCRIPTION
* Operator now supports python >= 3.10.
* Operator now support extra_links argument, which is a dict of link name -> (templateable URL or regex) in case of regex, Link URL will be first match fetched from container logs.
