### PR TITLE
Convert scheduler pruner secret to configmap

### DIFF
--- a/deployment/scheduler/templates/scheduler-pruner-configmap.yaml
+++ b/deployment/scheduler/templates/scheduler-pruner-configmap.yaml
@@ -1,11 +1,10 @@
 apiVersion: v1
-kind: Secret
+kind: ConfigMap
 metadata:
   name: {{ include "armada-scheduler-pruner.config.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "armada-scheduler-pruner.labels.all" . | nindent 4 }}
-type: Opaque
 data:
   {{ include "armada-scheduler-pruner.config.filename" . }}: |
 {{- if .Values.pruner.applicationConfig }}


### PR DESCRIPTION
Patches the `v0.16.1` release to fix the issue whereby the scheduler db pruner now expects a configmap but we are still creating a secret.