### PR TITLE
Scheduler Pruner Helm Chart Now Creates ConfigMap

### DIFF
--- a/deployment/scheduler/templates/scheduler-pruner-configmap.yaml
+++ b/deployment/scheduler/templates/scheduler-pruner-configmap.yaml
@@ -1,13 +1,12 @@
 apiVersion: v1
-kind: Secret
+kind: ConfigMap
 metadata:
   name: {{ include "armada-scheduler-pruner.config.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "armada-scheduler-pruner.labels.all" . | nindent 4 }}
-type: Opaque
 data:
   {{ include "armada-scheduler-pruner.config.filename" . }}: |
 {{- if .Values.pruner.applicationConfig }}
-{{ toYaml .Values.pruner.applicationConfig | b64enc | indent 4 }}
+{{ toYaml .Values.pruner.applicationConfig | indent 4 }}
 {{- end }}


### PR DESCRIPTION
Scheduler Pruner Helm Chart was still creating a secret even though we've moved to configmaps.

