### PR TITLE
Authenticate requests for scheduling reports

### DIFF
--- a/internal/lookout/ui/src/services/lookoutV2/useGetJobSchedulingReport.ts
+++ b/internal/lookout/ui/src/services/lookoutV2/useGetJobSchedulingReport.ts
@@ -1,21 +1,33 @@
 import { useQuery } from "@tanstack/react-query"
 
 import { useGetUiConfig } from "./useGetUiConfig"
+import { getAccessToken, getAuthorizationHeaders, useUserManager } from "../../oidc"
 import { SchedulerReportingApi, Configuration, SchedulerobjectsJobReport } from "../../openapi/schedulerobjects"
 import { getErrorMessage } from "../../utils"
 
 export const useGetJobSchedulingReport = (jobId: string, enabled = true) => {
+  const userManager = useUserManager()
+
   const { data: uiConfig } = useGetUiConfig(enabled)
   const armadaApiBaseUrl = uiConfig?.armadaApiBaseUrl
 
-  const schedulerReportingApiConfiguration: Configuration = new Configuration({ basePath: armadaApiBaseUrl })
+  const schedulerReportingApiConfiguration: Configuration = new Configuration({
+    basePath: armadaApiBaseUrl,
+    credentials: "include",
+  })
   const schedulerReportingApi = new SchedulerReportingApi(schedulerReportingApiConfiguration)
 
   return useQuery<SchedulerobjectsJobReport, string>({
     queryKey: ["getJobSchedulingReport", jobId],
     queryFn: async ({ signal }) => {
       try {
-        return await schedulerReportingApi.getJobReport({ jobId }, { signal })
+        const headers: HeadersInit = {}
+
+        if (userManager !== undefined) {
+          Object.assign(headers, getAuthorizationHeaders(await getAccessToken(userManager)))
+        }
+
+        return await schedulerReportingApi.getJobReport({ jobId }, { headers, signal })
       } catch (e) {
         throw await getErrorMessage(e)
       }

--- a/internal/lookout/ui/src/services/lookoutV2/useGetQueueSchedulingReport.ts
+++ b/internal/lookout/ui/src/services/lookoutV2/useGetQueueSchedulingReport.ts
@@ -1,21 +1,33 @@
 import { useQuery } from "@tanstack/react-query"
 
 import { useGetUiConfig } from "./useGetUiConfig"
+import { getAccessToken, getAuthorizationHeaders, useUserManager } from "../../oidc"
 import { SchedulerReportingApi, Configuration, SchedulerobjectsQueueReport } from "../../openapi/schedulerobjects"
 import { getErrorMessage } from "../../utils"
 
 export const useGetQueueSchedulingReport = (queueName: string, verbosity: number, enabled = true) => {
+  const userManager = useUserManager()
+
   const { data: uiConfig } = useGetUiConfig(enabled)
   const armadaApiBaseUrl = uiConfig?.armadaApiBaseUrl
 
-  const schedulerReportingApiConfiguration: Configuration = new Configuration({ basePath: armadaApiBaseUrl })
+  const schedulerReportingApiConfiguration: Configuration = new Configuration({
+    basePath: armadaApiBaseUrl,
+    credentials: "include",
+  })
   const schedulerReportingApi = new SchedulerReportingApi(schedulerReportingApiConfiguration)
 
   return useQuery<SchedulerobjectsQueueReport, string>({
     queryKey: ["getQueueSchedulingReport", queueName, verbosity],
     queryFn: async ({ signal }) => {
       try {
-        return await schedulerReportingApi.getQueueReport({ queueName, verbosity }, { signal })
+        const headers: HeadersInit = {}
+
+        if (userManager !== undefined) {
+          Object.assign(headers, getAuthorizationHeaders(await getAccessToken(userManager)))
+        }
+
+        return await schedulerReportingApi.getQueueReport({ queueName, verbosity }, { headers, signal })
       } catch (e) {
         throw await getErrorMessage(e)
       }

--- a/internal/lookout/ui/src/services/lookoutV2/useGetSchedulingReport.ts
+++ b/internal/lookout/ui/src/services/lookoutV2/useGetSchedulingReport.ts
@@ -1,20 +1,32 @@
 import { useQuery } from "@tanstack/react-query"
 
 import { useGetUiConfig } from "./useGetUiConfig"
+import { getAccessToken, getAuthorizationHeaders, useUserManager } from "../../oidc"
 import { SchedulerReportingApi, Configuration, SchedulerobjectsSchedulingReport } from "../../openapi/schedulerobjects"
 import { getErrorMessage } from "../../utils"
 
 export const useGetSchedulingReport = (verbosity: number, enabled = true) => {
+  const userManager = useUserManager()
+
   const { data: uiConfig } = useGetUiConfig(enabled)
   const armadaApiBaseUrl = uiConfig?.armadaApiBaseUrl
 
-  const schedulerReportingApiConfiguration: Configuration = new Configuration({ basePath: armadaApiBaseUrl })
+  const schedulerReportingApiConfiguration: Configuration = new Configuration({
+    basePath: armadaApiBaseUrl,
+    credentials: "include",
+  })
   const schedulerReportingApi = new SchedulerReportingApi(schedulerReportingApiConfiguration)
 
   return useQuery<SchedulerobjectsSchedulingReport, string>({
     queryKey: ["getSchedulingReport", verbosity],
     queryFn: async ({ signal }) => {
       try {
+        const headers: HeadersInit = {}
+
+        if (userManager !== undefined) {
+          Object.assign(headers, getAuthorizationHeaders(await getAccessToken(userManager)))
+        }
+
         return await schedulerReportingApi.getSchedulingReport({ verbosity }, { signal })
       } catch (e) {
         throw await getErrorMessage(e)


### PR DESCRIPTION
On the Lookout UI, the fetch requests for scheduling reports require authentication via the user's access token.
