### PR TITLE
Fix auth scheduling reports

### DIFF
--- a/internal/lookout/ui/src/services/lookoutV2/useGetJobSchedulingReport.ts
+++ b/internal/lookout/ui/src/services/lookoutV2/useGetJobSchedulingReport.ts
@@ -21,13 +21,12 @@ export const useGetJobSchedulingReport = (jobId: string, enabled = true) => {
     queryKey: ["getJobSchedulingReport", jobId],
     queryFn: async ({ signal }) => {
       try {
-        const headers: HeadersInit = {}
+        const accessToken = userManager === undefined ? undefined : await getAccessToken(userManager)
 
-        if (userManager !== undefined) {
-          Object.assign(headers, getAuthorizationHeaders(await getAccessToken(userManager)))
-        }
-
-        return await schedulerReportingApi.getJobReport({ jobId }, { headers, signal })
+        return await schedulerReportingApi.getJobReport(
+          { jobId },
+          { headers: accessToken ? getAuthorizationHeaders(accessToken) : undefined, signal },
+        )
       } catch (e) {
         throw await getErrorMessage(e)
       }

--- a/internal/lookout/ui/src/services/lookoutV2/useGetQueueSchedulingReport.ts
+++ b/internal/lookout/ui/src/services/lookoutV2/useGetQueueSchedulingReport.ts
@@ -21,13 +21,12 @@ export const useGetQueueSchedulingReport = (queueName: string, verbosity: number
     queryKey: ["getQueueSchedulingReport", queueName, verbosity],
     queryFn: async ({ signal }) => {
       try {
-        const headers: HeadersInit = {}
+        const accessToken = userManager === undefined ? undefined : await getAccessToken(userManager)
 
-        if (userManager !== undefined) {
-          Object.assign(headers, getAuthorizationHeaders(await getAccessToken(userManager)))
-        }
-
-        return await schedulerReportingApi.getQueueReport({ queueName, verbosity }, { headers, signal })
+        return await schedulerReportingApi.getQueueReport(
+          { queueName, verbosity },
+          { headers: accessToken ? getAuthorizationHeaders(accessToken) : undefined, signal },
+        )
       } catch (e) {
         throw await getErrorMessage(e)
       }

--- a/internal/lookout/ui/src/services/lookoutV2/useGetSchedulingReport.ts
+++ b/internal/lookout/ui/src/services/lookoutV2/useGetSchedulingReport.ts
@@ -21,13 +21,12 @@ export const useGetSchedulingReport = (verbosity: number, enabled = true) => {
     queryKey: ["getSchedulingReport", verbosity],
     queryFn: async ({ signal }) => {
       try {
-        const headers: HeadersInit = {}
+        const accessToken = userManager === undefined ? undefined : await getAccessToken(userManager)
 
-        if (userManager !== undefined) {
-          Object.assign(headers, getAuthorizationHeaders(await getAccessToken(userManager)))
-        }
-
-        return await schedulerReportingApi.getSchedulingReport({ verbosity }, { signal })
+        return await schedulerReportingApi.getSchedulingReport(
+          { verbosity },
+          { headers: accessToken ? getAuthorizationHeaders(accessToken) : undefined, signal },
+        )
       } catch (e) {
         throw await getErrorMessage(e)
       }


### PR DESCRIPTION
In the Lookout UI, this fixes the authentication of requests to get scheduling reports.
