### PR TITLE
Remove Old ResourceListCode

### DIFF
--- a/internal/common/maps/maps.go
+++ b/internal/common/maps/maps.go
@@ -40,15 +40,6 @@ func Map[M ~map[KA]VA, KA comparable, VA any, KB comparable, VB any](m M, keyFun
 	return rv
 }
 
-// DeepCopy returns a deep copy of M.
-func DeepCopy[M ~map[K]V, K comparable, V interfaces.DeepCopier[V]](m M) M {
-	rv := make(M, len(m))
-	for k, v := range m {
-		rv[k] = v.DeepCopy()
-	}
-	return rv
-}
-
 // DeepEqual compares two maps for equality using the Equals() method defined on the values.
 func DeepEqual[M ~map[K]V, K comparable, V interfaces.Equaler[V]](a, b M) bool {
 	if len(a) != len(b) {

--- a/internal/common/maps/maps_test.go
+++ b/internal/common/maps/maps_test.go
@@ -92,21 +92,6 @@ func (a mySlice) Equal(b mySlice) bool {
 	return slices.Equal(a, b)
 }
 
-func TestDeepCopy(t *testing.T) {
-	m := map[string]mySlice{
-		"foo": {1, 2, 3},
-		"bar": {10, 20, 30},
-	}
-	actual := DeepCopy(m)
-	m["foo"][0] = 100
-	m["bar"] = append(m["bar"], 40)
-	expected := map[string]mySlice{
-		"foo": {1, 2, 3},
-		"bar": {10, 20, 30},
-	}
-	assert.Equal(t, expected, actual)
-}
-
 func TestEqual(t *testing.T) {
 	tests := map[string]struct {
 		a        map[string]mySlice

--- a/internal/scheduler/schedulerobjects/node.go
+++ b/internal/scheduler/schedulerobjects/node.go
@@ -1,42 +1,5 @@
 package schedulerobjects
 
-import (
-	"fmt"
-
-	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
-
-	armadamaps "github.com/armadaproject/armada/internal/common/maps"
-)
-
-func (node *Node) DeepCopy() *Node {
-	if node == nil {
-		return nil
-	}
-	return &Node{
-		Id:             node.Id,
-		Name:           node.Name,
-		Executor:       node.Executor,
-		LastSeen:       node.LastSeen,
-		Taints:         slices.Clone(node.Taints),
-		Labels:         maps.Clone(node.Labels),
-		TotalResources: node.TotalResources.DeepCopy(),
-		AllocatableByPriorityAndResource: AllocatableByPriorityAndResourceType(
-			node.AllocatableByPriorityAndResource,
-		).DeepCopy(),
-		StateByJobRunId:        maps.Clone(node.StateByJobRunId),
-		UnallocatableResources: armadamaps.DeepCopy(node.UnallocatableResources),
-		Unschedulable:          node.Unschedulable,
-	}
-}
-
-func (node *Node) CompactString() string {
-	if node == nil {
-		return "<nil>"
-	}
-	return fmt.Sprintf("Node{Id; %s}", node.Id)
-}
-
 func (node *Node) AvailableArmadaResource() ResourceList {
 	tr := node.TotalResources.DeepCopy()
 	for _, rl := range node.UnallocatableResources {

--- a/internal/scheduler/schedulerobjects/resourcelist.go
+++ b/internal/scheduler/schedulerobjects/resourcelist.go
@@ -1,10 +1,6 @@
 package schedulerobjects
 
 import (
-	"fmt"
-	math "math"
-	"strings"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
@@ -42,99 +38,10 @@ func V1ResourceListFromResourceList(rl ResourceList) v1.ResourceList {
 
 type QuantityByTAndResourceType[T comparable] map[T]ResourceList
 
-// type QuantityByPriorityAndResourceType QuantityByTAndResourceType[int32]
-
-func (a QuantityByTAndResourceType[T]) Add(b QuantityByTAndResourceType[T]) {
-	for p, rlb := range b {
-		a.AddResourceList(p, rlb)
-	}
-}
-
 func (a QuantityByTAndResourceType[T]) AddResourceList(t T, rlb ResourceList) {
 	rla := a[t]
 	rla.Add(rlb)
 	a[t] = rla
-}
-
-func (a QuantityByTAndResourceType[T]) DeepCopy() QuantityByTAndResourceType[T] {
-	rv := make(QuantityByTAndResourceType[T])
-	for t, rl := range a {
-		rv[t] = rl.DeepCopy()
-	}
-	return rv
-}
-
-func (a QuantityByTAndResourceType[T]) String() string {
-	var sb strings.Builder
-	i := 0
-	sb.WriteString("{")
-	for t, rl := range a {
-		if i < len(a)-1 {
-			sb.WriteString(fmt.Sprintf("%v: %s, ", t, rl.CompactString()))
-		} else {
-			sb.WriteString(fmt.Sprintf("%v: %s", t, rl.CompactString()))
-		}
-	}
-	sb.WriteString("}")
-	return sb.String()
-}
-
-func (a QuantityByTAndResourceType[T]) Sub(b QuantityByTAndResourceType[T]) {
-	for t, rlb := range b {
-		a.SubResourceList(t, rlb)
-	}
-}
-
-func (a QuantityByTAndResourceType[T]) AddV1ResourceList(t T, rlb v1.ResourceList) {
-	rla := a[t]
-	rla.AddV1ResourceList(rlb)
-	a[t] = rla
-}
-
-func (a QuantityByTAndResourceType[T]) SubResourceList(t T, rlb ResourceList) {
-	rla := a[t]
-	rla.Sub(rlb)
-	a[t] = rla
-}
-
-func (a QuantityByTAndResourceType[T]) SubV1ResourceList(t T, rlb v1.ResourceList) {
-	rla := a[t]
-	rla.SubV1ResourceList(rlb)
-	a[t] = rla
-}
-
-func (a QuantityByTAndResourceType[T]) Equal(b QuantityByTAndResourceType[T]) bool {
-	for t, rla := range a {
-		if !rla.Equal(b[t]) {
-			return false
-		}
-	}
-	for t, rlb := range b {
-		if !rlb.Equal(a[t]) {
-			return false
-		}
-	}
-	return true
-}
-
-// IsZero returns true if all quantities in a are zero.
-func (a QuantityByTAndResourceType[T]) IsZero() bool {
-	for _, rl := range a {
-		if !rl.IsZero() {
-			return false
-		}
-	}
-	return true
-}
-
-// IsStrictlyNonNegative returns true if there are no quantities in a with value less than zero.
-func (a QuantityByTAndResourceType[T]) IsStrictlyNonNegative() bool {
-	for _, rl := range a {
-		if !rl.IsStrictlyNonNegative() {
-			return false
-		}
-	}
-	return true
 }
 
 func (a QuantityByTAndResourceType[T]) AggregateByResource() ResourceList {
@@ -217,23 +124,6 @@ func (a *ResourceList) Sub(b ResourceList) {
 	}
 }
 
-func (a *ResourceList) LimitToZero() {
-	a.initialise()
-	for t, qb := range a.Resources {
-		if qb.Sign() < 0 {
-			qb.Set(0)
-			a.Resources[t] = qb
-		}
-	}
-}
-
-func (rl *ResourceList) SubQuantity(resourceType string, quantity resource.Quantity) {
-	rl.initialise()
-	q := rl.Resources[resourceType]
-	q.Sub(quantity)
-	rl.Resources[resourceType] = q
-}
-
 func (rl ResourceList) DeepCopy() ResourceList {
 	if len(rl.Resources) == 0 {
 		return ResourceList{}
@@ -255,15 +145,6 @@ func (rl ResourceList) Zero() {
 	}
 }
 
-func (a ResourceList) IsZero() bool {
-	for _, q := range a.Resources {
-		if !q.IsZero() {
-			return false
-		}
-	}
-	return true
-}
-
 func (a ResourceList) Equal(b ResourceList) bool {
 	for t, qa := range a.Resources {
 		if qa.Cmp(b.Get(t)) != 0 {
@@ -276,43 +157,6 @@ func (a ResourceList) Equal(b ResourceList) bool {
 		}
 	}
 	return true
-}
-
-// IsStrictlyNonNegative returns true if there is no quantity less than zero.
-func (a ResourceList) IsStrictlyNonNegative() bool {
-	for _, q := range a.Resources {
-		if q.Cmp(resource.Quantity{}) == -1 {
-			return false
-		}
-	}
-	return true
-}
-
-func (rl ResourceList) CompactString() string {
-	var sb strings.Builder
-	sb.WriteString("{")
-	i := 0
-	for t, q := range rl.Resources {
-		if i < len(rl.Resources)-1 {
-			sb.WriteString(fmt.Sprintf("%s: %s, ", t, q.String()))
-		} else {
-			sb.WriteString(fmt.Sprintf("%s: %s", t, q.String()))
-		}
-		i++
-	}
-	sb.WriteString("}")
-	return sb.String()
-}
-
-// AsWeightedMillis returns the linear combination of the milli values in rl with given weights.
-// This function overflows for values greater than MaxInt64. E.g., 1Pi is fine but not 10Pi.
-func (rl *ResourceList) AsWeightedMillis(weights map[string]float64) int64 {
-	var rv int64
-	for t, w := range weights {
-		q := rl.Get(t)
-		rv += int64(math.Round(float64(q.MilliValue()) * w))
-	}
-	return rv
 }
 
 func (rl *ResourceList) initialise() {
@@ -334,14 +178,6 @@ func NewAllocatableByPriorityAndResourceType(priorities []int32, rl ResourceList
 	return rv
 }
 
-func (m AllocatableByPriorityAndResourceType) DeepCopy() AllocatableByPriorityAndResourceType {
-	rv := make(AllocatableByPriorityAndResourceType, len(m))
-	for priority, resourcesAtPriority := range m {
-		rv[priority] = resourcesAtPriority.DeepCopy()
-	}
-	return rv
-}
-
 // MarkAllocated indicates resources have been allocated to pods of priority p,
 // hence reducing the resources allocatable to pods of priority p or lower.
 func (m AllocatableByPriorityAndResourceType) MarkAllocated(p int32, rs ResourceList) {
@@ -350,68 +186,4 @@ func (m AllocatableByPriorityAndResourceType) MarkAllocated(p int32, rs Resource
 			allocatableResourcesAtPriority.Sub(rs)
 		}
 	}
-}
-
-// MarkAllocatable indicates resources have been released by pods of priority p,
-// thus increasing the resources allocatable to pods of priority p or lower.
-func (m AllocatableByPriorityAndResourceType) MarkAllocatable(p int32, rs ResourceList) {
-	for priority, allocatableResourcesAtPriority := range m {
-		if priority <= p {
-			allocatableResourcesAtPriority.Add(rs)
-		}
-	}
-}
-
-func (m AllocatableByPriorityAndResourceType) MarkAllocatableV1ResourceList(p int32, rs v1.ResourceList) {
-	for priority, allocatableResourcesAtPriority := range m {
-		if priority <= p {
-			allocatableResourcesAtPriority.AddV1ResourceList(rs)
-		}
-	}
-}
-
-// AllocatedByPriorityAndResourceType accounts for resources allocated to pods of a given priority or lower.
-// E.g., AllocatedByPriorityAndResourceType[5]["cpu"] is the amount of CPU allocated to pods with priority 5 or lower.
-type AllocatedByPriorityAndResourceType QuantityByTAndResourceType[int32]
-
-func NewAllocatedByPriorityAndResourceType(priorities []int32) AllocatedByPriorityAndResourceType {
-	rv := make(AllocatedByPriorityAndResourceType)
-	for _, priority := range priorities {
-		rv[priority] = NewResourceListWithDefaultSize()
-	}
-	return rv
-}
-
-// MarkAllocated increases the resources allocated to pods of priority p or lower.
-func (m AllocatedByPriorityAndResourceType) MarkAllocated(p int32, rs ResourceList) {
-	for priority, allocatedResourcesAtPriority := range m {
-		if priority <= p {
-			allocatedResourcesAtPriority.Add(rs)
-		}
-	}
-}
-
-// MarkAllocatable reduces the resources allocated to pods of priority p or lower.
-func (m AllocatedByPriorityAndResourceType) MarkAllocatable(p int32, rs ResourceList) {
-	for priority, allocatedResourcesAtPriority := range m {
-		if priority <= p {
-			allocatedResourcesAtPriority.Sub(rs)
-		}
-	}
-}
-
-func (allocatableByPriorityAndResourceType AllocatableByPriorityAndResourceType) Get(priority int32, resourceType string) resource.Quantity {
-	if allocatableByPriorityAndResourceType == nil {
-		return resource.Quantity{}
-	}
-	quantityByResourceType := allocatableByPriorityAndResourceType[priority]
-	return quantityByResourceType.Get(resourceType)
-}
-
-func (assignedByPriorityAndResourceType AllocatedByPriorityAndResourceType) Get(priority int32, resourceType string) resource.Quantity {
-	if assignedByPriorityAndResourceType == nil {
-		return resource.Quantity{}
-	}
-	quantityByResourceType := assignedByPriorityAndResourceType[priority]
-	return quantityByResourceType.Get(resourceType)
 }

--- a/internal/scheduler/schedulerobjects/resourcelist_test.go
+++ b/internal/scheduler/schedulerobjects/resourcelist_test.go
@@ -1,979 +1,158 @@
 package schedulerobjects
 
-//
-//import (
-//	"math"
-//	"testing"
-//
-//	"github.com/stretchr/testify/assert"
-//	"golang.org/x/exp/maps"
-//	"k8s.io/apimachinery/pkg/api/resource"
-//)
-//
-//func TestQuantityByTAndResourceTypeAdd(t *testing.T) {
-//	tests := map[string]struct {
-//		a        QuantityByTAndResourceType[int32]
-//		b        QuantityByTAndResourceType[int32]
-//		expected QuantityByTAndResourceType[int32]
-//	}{
-//		"nil and nil": {
-//			a:        nil,
-//			b:        nil,
-//			expected: nil,
-//		},
-//		"empty and nil": {
-//			a:        QuantityByTAndResourceType[int32]{},
-//			b:        nil,
-//			expected: QuantityByTAndResourceType[int32]{},
-//		},
-//		"nil and empty": {
-//			a:        nil,
-//			b:        QuantityByTAndResourceType[int32]{},
-//			expected: nil,
-//		},
-//		"matching": {
-//			a: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("3")}},
-//			},
-//			b: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("1")}},
-//			},
-//			expected: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("4")}},
-//			},
-//		},
-//		"mismatched resources": {
-//			a: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("3")}},
-//			},
-//			b: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{Resources: map[string]resource.Quantity{"bar": resource.MustParse("1")}},
-//			},
-//			expected: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{
-//					Resources: map[string]resource.Quantity{
-//						"foo": resource.MustParse("3"),
-//						"bar": resource.MustParse("1"),
-//					},
-//				},
-//			},
-//		},
-//		"mismatched priorities": {
-//			a: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("3")}},
-//			},
-//			b: QuantityByTAndResourceType[int32]{
-//				1: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("1")}},
-//			},
-//			expected: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("3")}},
-//				1: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("1")}},
-//			},
-//		},
-//	}
-//	for name, tc := range tests {
-//		t.Run(name, func(t *testing.T) {
-//			tc.a.Add(tc.b)
-//			assert.True(t, tc.a.Equal(tc.expected))
-//		})
-//	}
-//}
-//
-//func TestQuantityByTAndResourceTypeSub(t *testing.T) {
-//	tests := map[string]struct {
-//		a        QuantityByTAndResourceType[int32]
-//		b        QuantityByTAndResourceType[int32]
-//		expected QuantityByTAndResourceType[int32]
-//	}{
-//		"nil and nil": {
-//			a:        nil,
-//			b:        nil,
-//			expected: nil,
-//		},
-//		"empty and nil": {
-//			a:        QuantityByTAndResourceType[int32]{},
-//			b:        nil,
-//			expected: QuantityByTAndResourceType[int32]{},
-//		},
-//		"nil and empty": {
-//			a:        nil,
-//			b:        QuantityByTAndResourceType[int32]{},
-//			expected: nil,
-//		},
-//		"matching": {
-//			a: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("3")}},
-//			},
-//			b: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("1")}},
-//			},
-//			expected: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("2")}},
-//			},
-//		},
-//		"mismatched resources": {
-//			a: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("3")}},
-//			},
-//			b: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{Resources: map[string]resource.Quantity{"bar": resource.MustParse("1")}},
-//			},
-//			expected: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{
-//					Resources: map[string]resource.Quantity{
-//						"foo": resource.MustParse("3"),
-//						"bar": resource.MustParse("-1"),
-//					},
-//				},
-//			},
-//		},
-//		"mismatched priorities": {
-//			a: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("3")}},
-//			},
-//			b: QuantityByTAndResourceType[int32]{
-//				1: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("1")}},
-//			},
-//			expected: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("3")}},
-//				1: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("-1")}},
-//			},
-//		},
-//	}
-//	for name, tc := range tests {
-//		t.Run(name, func(t *testing.T) {
-//			tc.a.Sub(tc.b)
-//			assert.True(t, tc.a.Equal(tc.expected))
-//		})
-//	}
-//}
-//
-//func TestQuantityByTAndResourceTypeEqual(t *testing.T) {
-//	tests := map[string]struct {
-//		a        QuantityByTAndResourceType[int32]
-//		b        QuantityByTAndResourceType[int32]
-//		expected bool
-//	}{
-//		"both empty": {
-//			a:        QuantityByTAndResourceType[int32]{},
-//			b:        QuantityByTAndResourceType[int32]{},
-//			expected: true,
-//		},
-//		"both with an empty map": {
-//			a: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{},
-//			},
-//			b: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{},
-//			},
-//			expected: true,
-//		},
-//		"one empty map": {
-//			a: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{},
-//			},
-//			b:        QuantityByTAndResourceType[int32]{},
-//			expected: true,
-//		},
-//		"zero equals empty": {
-//			a: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{
-//					Resources: map[string]resource.Quantity{
-//						"foo": resource.MustParse("0"),
-//					},
-//				},
-//			},
-//			b: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{},
-//			},
-//			expected: true,
-//		},
-//		"zero equals missing": {
-//			a: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{},
-//			},
-//			b:        QuantityByTAndResourceType[int32]{},
-//			expected: true,
-//		},
-//		"zero equals missing with empty ResourceList": {
-//			a: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{
-//					Resources: map[string]resource.Quantity{
-//						"foo": resource.MustParse("0"),
-//					},
-//				},
-//			},
-//			b:        QuantityByTAndResourceType[int32]{},
-//			expected: true,
-//		},
-//		"simple equal": {
-//			a: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{
-//					Resources: map[string]resource.Quantity{
-//						"cpu":    resource.MustParse("1"),
-//						"memory": resource.MustParse("2"),
-//						"foo":    resource.MustParse("3"),
-//					},
-//				},
-//			},
-//			b: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{
-//					Resources: map[string]resource.Quantity{
-//						"cpu":    resource.MustParse("1"),
-//						"memory": resource.MustParse("2"),
-//						"foo":    resource.MustParse("3"),
-//					},
-//				},
-//			},
-//			expected: true,
-//		},
-//		"equal with two priorities": {
-//			a: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{
-//					Resources: map[string]resource.Quantity{
-//						"cpu":    resource.MustParse("1"),
-//						"memory": resource.MustParse("2"),
-//						"foo":    resource.MustParse("3"),
-//					},
-//				},
-//				1: ResourceList{
-//					Resources: map[string]resource.Quantity{
-//						"cpu":    resource.MustParse("4"),
-//						"memory": resource.MustParse("5"),
-//						"foo":    resource.MustParse("6"),
-//					},
-//				},
-//			},
-//			b: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{
-//					Resources: map[string]resource.Quantity{
-//						"cpu":    resource.MustParse("1"),
-//						"memory": resource.MustParse("2"),
-//						"foo":    resource.MustParse("3"),
-//					},
-//				},
-//				1: ResourceList{
-//					Resources: map[string]resource.Quantity{
-//						"cpu":    resource.MustParse("4"),
-//						"memory": resource.MustParse("5"),
-//						"foo":    resource.MustParse("6"),
-//					},
-//				},
-//			},
-//			expected: true,
-//		},
-//		"simple unequal": {
-//			a: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{
-//					Resources: map[string]resource.Quantity{
-//						"cpu":    resource.MustParse("1"),
-//						"memory": resource.MustParse("2"),
-//						"foo":    resource.MustParse("3"),
-//					},
-//				},
-//			},
-//			b: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{
-//					Resources: map[string]resource.Quantity{
-//						"cpu":    resource.MustParse("1"),
-//						"memory": resource.MustParse("2"),
-//						"foo":    resource.MustParse("4"),
-//					},
-//				},
-//			},
-//			expected: false,
-//		},
-//		"unequal differing priority": {
-//			a: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{
-//					Resources: map[string]resource.Quantity{
-//						"cpu":    resource.MustParse("1"),
-//						"memory": resource.MustParse("2"),
-//						"foo":    resource.MustParse("3"),
-//					},
-//				},
-//			},
-//			b: QuantityByTAndResourceType[int32]{
-//				1: ResourceList{
-//					Resources: map[string]resource.Quantity{
-//						"cpu":    resource.MustParse("1"),
-//						"memory": resource.MustParse("2"),
-//						"foo":    resource.MustParse("3"),
-//					},
-//				},
-//			},
-//			expected: false,
-//		},
-//	}
-//	for name, tc := range tests {
-//		t.Run(name, func(t *testing.T) {
-//			assert.Equal(t, tc.expected, tc.a.Equal(tc.b))
-//			assert.Equal(t, tc.expected, tc.b.Equal(tc.a))
-//		})
-//	}
-//}
-//
-//func TestQuantityByTAndResourceTypeIsStrictlyNonNegative(t *testing.T) {
-//	tests := map[string]struct {
-//		m        QuantityByTAndResourceType[int32]
-//		expected bool
-//	}{
-//		"nil": {
-//			m:        nil,
-//			expected: true,
-//		},
-//		"empty": {
-//			m:        QuantityByTAndResourceType[int32]{},
-//			expected: true,
-//		},
-//		"simple zero": {
-//			m: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("0")}},
-//			},
-//			expected: true,
-//		},
-//		"simple positive": {
-//			m: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("1")}},
-//			},
-//			expected: true,
-//		},
-//		"simple positive and negative": {
-//			m: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("1")}},
-//				1: ResourceList{Resources: map[string]resource.Quantity{"bar": resource.MustParse("-1")}},
-//			},
-//			expected: false,
-//		},
-//	}
-//	for name, tc := range tests {
-//		t.Run(name, func(t *testing.T) {
-//			assert.Equal(t, tc.expected, tc.m.IsStrictlyNonNegative())
-//		})
-//	}
-//}
-//
-//func TestQuantityByTAndResourceTypeMaxAggregatedByResource(t *testing.T) {
-//	tests := map[string]struct {
-//		q        QuantityByTAndResourceType[int32]
-//		p        int32
-//		rl       ResourceList
-//		expected QuantityByTAndResourceType[int32]
-//	}{
-//		"no change": {
-//			q: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("1")}},
-//			},
-//			p:  1,
-//			rl: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("1")}},
-//			expected: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("1")}},
-//			},
-//		},
-//		"empty": {
-//			q:  QuantityByTAndResourceType[int32]{},
-//			p:  0,
-//			rl: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("1")}},
-//			expected: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("1")}},
-//			},
-//		},
-//		"add same resource at same priority": {
-//			q: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("1")}},
-//			},
-//			p:  0,
-//			rl: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("2")}},
-//			expected: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("2")}},
-//			},
-//		},
-//		"add different resource at same priority": {
-//			q: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("1")}},
-//			},
-//			p:  0,
-//			rl: ResourceList{Resources: map[string]resource.Quantity{"memory": resource.MustParse("1Gi")}},
-//			expected: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("1"), "memory": resource.MustParse("1Gi")}},
-//			},
-//		},
-//		"add same resource at different priority": {
-//			q: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("1")}},
-//			},
-//			p:  1,
-//			rl: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("2")}},
-//			expected: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("1")}},
-//				1: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("1")}},
-//			},
-//		},
-//		"add different resource at different priority": {
-//			q: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("1")}},
-//			},
-//			p:  1,
-//			rl: ResourceList{Resources: map[string]resource.Quantity{"memory": resource.MustParse("1Gi")}},
-//			expected: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("1")}},
-//				1: ResourceList{Resources: map[string]resource.Quantity{"memory": resource.MustParse("1Gi")}},
-//			},
-//		},
-//		"multiple resources": {
-//			q: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("100m"), "memory": resource.MustParse("50Mi")}},
-//			},
-//			p:  1,
-//			rl: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("10"), "memory": resource.MustParse("4000Mi")}},
-//			expected: QuantityByTAndResourceType[int32]{
-//				0: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("100m"), "memory": resource.MustParse("50Mi")}},
-//				1: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("9900m"), "memory": resource.MustParse("3950Mi")}},
-//			},
-//		},
-//	}
-//	for name, tc := range tests {
-//		t.Run(name, func(t *testing.T) {
-//			tc.q.MaxAggregatedByResource(tc.p, tc.rl)
-//			assert.True(t, tc.expected.Equal(tc.q), "expected %s, but got %s", tc.expected.String(), tc.q.String())
-//		})
-//	}
-//}
-//
-//func TestAllocatableByPriorityAndResourceType(t *testing.T) {
-//	tests := map[string]struct {
-//		Priorities     []int32
-//		UsedAtPriority int32
-//		Resources      ResourceList
-//	}{
-//		"lowest priority": {
-//			Priorities:     []int32{1, 5, 10},
-//			UsedAtPriority: 1,
-//			Resources: ResourceList{
-//				Resources: map[string]resource.Quantity{
-//					"cpu":            resource.MustParse("1"),
-//					"nvidia.com/gpu": resource.MustParse("2"),
-//				},
-//			},
-//		},
-//		"mid priority": {
-//			Priorities:     []int32{1, 5, 10},
-//			UsedAtPriority: 5,
-//			Resources: ResourceList{
-//				Resources: map[string]resource.Quantity{
-//					"cpu":            resource.MustParse("1"),
-//					"nvidia.com/gpu": resource.MustParse("2"),
-//				},
-//			},
-//		},
-//		"highest priority": {
-//			Priorities:     []int32{1, 5, 10},
-//			UsedAtPriority: 10,
-//			Resources: ResourceList{
-//				Resources: map[string]resource.Quantity{
-//					"cpu":            resource.MustParse("1"),
-//					"nvidia.com/gpu": resource.MustParse("2"),
-//				},
-//			},
-//		},
-//	}
-//	for name, tc := range tests {
-//		t.Run(name, func(t *testing.T) {
-//			m := NewAllocatableByPriorityAndResourceType(tc.Priorities, tc.Resources)
-//			assert.Equal(t, len(tc.Priorities), len(m))
-//
-//			m.MarkAllocated(tc.UsedAtPriority, tc.Resources)
-//			for resourceType, quantity := range tc.Resources.Resources {
-//				for _, p := range tc.Priorities {
-//					actual := m.Get(p, resourceType)
-//					if p > tc.UsedAtPriority {
-//						assert.Equal(t, 0, quantity.Cmp(actual))
-//					} else {
-//						expected := resource.MustParse("0")
-//						assert.Equal(t, 0, expected.Cmp(actual))
-//					}
-//				}
-//			}
-//
-//			m.MarkAllocatable(tc.UsedAtPriority, tc.Resources)
-//			for resourceType, quantity := range tc.Resources.Resources {
-//				for _, p := range tc.Priorities {
-//					actual := m.Get(p, resourceType)
-//					assert.Equal(t, 0, quantity.Cmp(actual))
-//				}
-//			}
-//		})
-//	}
-//}
-//
-//func TestAllocatedByPriorityAndResourceType(t *testing.T) {
-//	tests := map[string]struct {
-//		Priorities     []int32
-//		UsedAtPriority int32
-//		Resources      map[string]resource.Quantity
-//	}{
-//		"lowest priority": {
-//			Priorities:     []int32{1, 5, 10},
-//			UsedAtPriority: 1,
-//			Resources: map[string]resource.Quantity{
-//				"cpu":            resource.MustParse("1"),
-//				"nvidia.com/gpu": resource.MustParse("2"),
-//			},
-//		},
-//		"mid priority": {
-//			Priorities:     []int32{1, 5, 10},
-//			UsedAtPriority: 5,
-//			Resources: map[string]resource.Quantity{
-//				"cpu":            resource.MustParse("1"),
-//				"nvidia.com/gpu": resource.MustParse("2"),
-//			},
-//		},
-//		"highest priority": {
-//			Priorities:     []int32{1, 5, 10},
-//			UsedAtPriority: 10,
-//			Resources: map[string]resource.Quantity{
-//				"cpu":            resource.MustParse("1"),
-//				"nvidia.com/gpu": resource.MustParse("2"),
-//			},
-//		},
-//	}
-//	for name, tc := range tests {
-//		t.Run(name, func(t *testing.T) {
-//			m := NewAllocatedByPriorityAndResourceType(tc.Priorities)
-//			assert.Equal(t, len(tc.Priorities), len(m))
-//
-//			m.MarkAllocated(tc.UsedAtPriority, ResourceList{Resources: tc.Resources})
-//			for resourceType, quantity := range tc.Resources {
-//				for _, p := range tc.Priorities {
-//					actual := m.Get(p, resourceType)
-//					if p <= tc.UsedAtPriority {
-//						assert.Equal(t, 0, quantity.Cmp(actual))
-//					} else {
-//						expected := resource.MustParse("0")
-//						assert.Equal(t, 0, expected.Cmp(actual))
-//					}
-//				}
-//			}
-//
-//			m.MarkAllocatable(tc.UsedAtPriority, ResourceList{Resources: tc.Resources})
-//			for resourceType := range tc.Resources {
-//				for _, p := range tc.Priorities {
-//					actual := m.Get(p, resourceType)
-//					expected := resource.MustParse("0")
-//					assert.Equal(t, 0, expected.Cmp(actual))
-//				}
-//			}
-//		})
-//	}
-//}
-//
-//func TestResourceListDeepCopy(t *testing.T) {
-//	rl := ResourceList{
-//		Resources: map[string]resource.Quantity{
-//			"foo": resource.MustParse("1"),
-//		},
-//	}
-//	rlCopy := rl.DeepCopy()
-//	rlCopy.Resources["bar"] = resource.MustParse("2")
-//	q := rlCopy.Resources["foo"]
-//	q.Add(resource.MustParse("10"))
-//	assert.True(
-//		t,
-//		rl.Equal(ResourceList{
-//			Resources: map[string]resource.Quantity{
-//				"foo": resource.MustParse("1"),
-//			},
-//		}),
-//	)
-//}
-//
-//func TestResourceListEqual(t *testing.T) {
-//	tests := map[string]struct {
-//		a        ResourceList
-//		b        ResourceList
-//		expected bool
-//	}{
-//		"both empty": {
-//			a:        ResourceList{},
-//			b:        ResourceList{},
-//			expected: true,
-//		},
-//		"both empty maps": {
-//			a: ResourceList{
-//				Resources: make(map[string]resource.Quantity),
-//			},
-//			b: ResourceList{
-//				Resources: make(map[string]resource.Quantity),
-//			},
-//			expected: true,
-//		},
-//		"one empty map": {
-//			a: ResourceList{
-//				Resources: make(map[string]resource.Quantity),
-//			},
-//			b:        ResourceList{},
-//			expected: true,
-//		},
-//		"zero equals empty": {
-//			a: ResourceList{
-//				Resources: map[string]resource.Quantity{
-//					"foo": resource.MustParse("0"),
-//				},
-//			},
-//			b:        ResourceList{},
-//			expected: true,
-//		},
-//		"simple equal": {
-//			a: ResourceList{
-//				Resources: map[string]resource.Quantity{
-//					"cpu":    resource.MustParse("1"),
-//					"memory": resource.MustParse("2"),
-//					"foo":    resource.MustParse("3"),
-//				},
-//			},
-//			b: ResourceList{
-//				Resources: map[string]resource.Quantity{
-//					"cpu":    resource.MustParse("1"),
-//					"memory": resource.MustParse("2"),
-//					"foo":    resource.MustParse("3"),
-//				},
-//			},
-//			expected: true,
-//		},
-//		"simple unequal": {
-//			a: ResourceList{
-//				Resources: map[string]resource.Quantity{
-//					"foo": resource.MustParse("1"),
-//					"bar": resource.MustParse("2"),
-//				},
-//			},
-//			b: ResourceList{
-//				Resources: map[string]resource.Quantity{
-//					"foo": resource.MustParse("1"),
-//					"bar": resource.MustParse("3"),
-//				},
-//			},
-//			expected: false,
-//		},
-//		"zero and missing is equal": {
-//			a: ResourceList{
-//				Resources: map[string]resource.Quantity{
-//					"foo": resource.MustParse("1"),
-//					"bar": resource.MustParse("0"),
-//				},
-//			},
-//			b: ResourceList{
-//				Resources: map[string]resource.Quantity{
-//					"foo": resource.MustParse("1"),
-//				},
-//			},
-//			expected: true,
-//		},
-//	}
-//	for name, tc := range tests {
-//		t.Run(name, func(t *testing.T) {
-//			assert.Equal(t, tc.expected, tc.a.Equal(tc.b))
-//			assert.Equal(t, tc.expected, tc.b.Equal(tc.a))
-//		})
-//	}
-//}
-//
-//func TestResourceListIsStrictlyNonNegative(t *testing.T) {
-//	tests := map[string]struct {
-//		rl       ResourceList
-//		expected bool
-//	}{
-//		"empty": {
-//			rl:       ResourceList{},
-//			expected: true,
-//		},
-//		"empty maps": {
-//			rl: ResourceList{
-//				Resources: make(map[string]resource.Quantity),
-//			},
-//			expected: true,
-//		},
-//		"zero-values resource": {
-//			rl: ResourceList{
-//				Resources: map[string]resource.Quantity{
-//					"foo": resource.MustParse("0"),
-//				},
-//			},
-//			expected: true,
-//		},
-//		"simple non-negative": {
-//			rl: ResourceList{
-//				Resources: map[string]resource.Quantity{
-//					"cpu":    resource.MustParse("1"),
-//					"memory": resource.MustParse("2"),
-//					"foo":    resource.MustParse("3"),
-//				},
-//			},
-//			expected: true,
-//		},
-//		"zero and positive": {
-//			rl: ResourceList{
-//				Resources: map[string]resource.Quantity{
-//					"foo": resource.MustParse("1"),
-//					"bar": resource.MustParse("0"),
-//				},
-//			},
-//			expected: true,
-//		},
-//		"simple negative": {
-//			rl: ResourceList{
-//				Resources: map[string]resource.Quantity{
-//					"foo": resource.MustParse("-1"),
-//					"bar": resource.MustParse("0"),
-//				},
-//			},
-//			expected: false,
-//		},
-//		"negative zero": {
-//			rl: ResourceList{
-//				Resources: map[string]resource.Quantity{
-//					"foo": resource.MustParse("1"),
-//					"bar": resource.MustParse("-0"),
-//				},
-//			},
-//			expected: true,
-//		},
-//	}
-//	for name, tc := range tests {
-//		t.Run(name, func(t *testing.T) {
-//			assert.Equal(t, tc.expected, tc.rl.IsStrictlyNonNegative())
-//		})
-//	}
-//}
-//
-//func TestResourceListLimitToZero(t *testing.T) {
-//	tests := map[string]struct {
-//		input    ResourceList
-//		expected ResourceList
-//	}{
-//		"empty": {
-//			input:    ResourceList{},
-//			expected: ResourceList{},
-//		},
-//		"empty maps": {
-//			input: ResourceList{
-//				Resources: make(map[string]resource.Quantity),
-//			},
-//			expected: ResourceList{
-//				Resources: make(map[string]resource.Quantity),
-//			},
-//		},
-//		"non-negative values": {
-//			input: ResourceList{
-//				Resources: map[string]resource.Quantity{
-//					"foo": resource.MustParse("5"),
-//					"bar": resource.MustParse("0"),
-//				},
-//			},
-//			expected: ResourceList{
-//				Resources: map[string]resource.Quantity{
-//					"foo": resource.MustParse("5"),
-//					"bar": resource.MustParse("0"),
-//				},
-//			},
-//		},
-//		"negative values": {
-//			input: ResourceList{
-//				Resources: map[string]resource.Quantity{
-//					"foo": resource.MustParse("-1"),
-//					"bar": resource.MustParse("0"),
-//					"baz": resource.MustParse("1"),
-//				},
-//			},
-//			expected: ResourceList{
-//				Resources: map[string]resource.Quantity{
-//					"foo": resource.MustParse("0"),
-//					"bar": resource.MustParse("0"),
-//					"baz": resource.MustParse("1"),
-//				},
-//			},
-//		},
-//	}
-//	for name, tc := range tests {
-//		t.Run(name, func(t *testing.T) {
-//			tc.input.LimitToZero()
-//			assert.True(t, tc.expected.Equal(tc.input))
-//		})
-//	}
-//}
-//
-//func TestResourceListZero(t *testing.T) {
-//	rl := ResourceList{
-//		Resources: map[string]resource.Quantity{
-//			"foo": resource.MustParse("1"),
-//			"bar": resource.MustParse("10Gi"),
-//			"baz": resource.MustParse("0"),
-//		},
-//	}
-//	rl.Zero()
-//	assert.True(t, rl.Equal(ResourceList{}))
-//}
-//
-//func BenchmarkResourceListZero(b *testing.B) {
-//	rl := ResourceList{
-//		Resources: map[string]resource.Quantity{
-//			"foo": resource.MustParse("1"),
-//			"bar": resource.MustParse("10Gi"),
-//			"baz": resource.MustParse("0"),
-//		},
-//	}
-//	b.ResetTimer()
-//	for n := 0; n < b.N; n++ {
-//		rl.Zero()
-//	}
-//}
-//
-//func TestV1ResourceListConversion(t *testing.T) {
-//	rl := ResourceList{
-//		Resources: map[string]resource.Quantity{
-//			"foo": resource.MustParse("1"),
-//		},
-//	}
-//	rlCopy := rl.DeepCopy()
-//	v1rl := V1ResourceListFromResourceList(rlCopy)
-//	rlCopy.Resources["bar"] = resource.MustParse("2")
-//	q := rlCopy.Resources["foo"]
-//	q.Add(resource.MustParse("10"))
-//
-//	rl = ResourceListFromV1ResourceList(v1rl)
-//	assert.True(
-//		t,
-//		rl.Equal(ResourceList{
-//			Resources: map[string]resource.Quantity{
-//				"foo": resource.MustParse("1"),
-//			},
-//		}),
-//	)
-//
-//	v1rlCopy := V1ResourceListFromResourceList(rl)
-//	assert.True(t, maps.Equal(v1rlCopy, v1rl))
-//}
-//
-//func TestResourceListAsWeightedMillis(t *testing.T) {
-//	tests := map[string]struct {
-//		rl       ResourceList
-//		weights  map[string]float64
-//		expected int64
-//	}{
-//		"default": {
-//			rl: ResourceList{
-//				Resources: map[string]resource.Quantity{
-//					"foo": resource.MustParse("2"),
-//					"bar": resource.MustParse("10Gi"),
-//					"baz": resource.MustParse("1"),
-//				},
-//			},
-//			weights: map[string]float64{
-//				"foo": 1,
-//				"bar": 0.1,
-//				"baz": 10,
-//			},
-//			expected: (1 * 2 * 1000) + (1 * 1000 * 1024 * 1024 * 1024) + (10 * 1 * 1000),
-//		},
-//		"zeroes": {
-//			rl: ResourceList{
-//				Resources: map[string]resource.Quantity{
-//					"foo": resource.MustParse("0"),
-//					"bar": resource.MustParse("1"),
-//					"baz": resource.MustParse("2"),
-//				},
-//			},
-//			weights: map[string]float64{
-//				"foo": 1,
-//				"bar": 0,
-//			},
-//			expected: 0,
-//		},
-//		"1Pi": {
-//			rl: ResourceList{
-//				Resources: map[string]resource.Quantity{
-//					"foo": resource.MustParse("1Pi"),
-//				},
-//			},
-//			weights: map[string]float64{
-//				"foo": 1,
-//			},
-//			expected: int64(math.Pow(1024, 5)) * 1000,
-//		},
-//		"rounding": {
-//			rl: ResourceList{
-//				Resources: map[string]resource.Quantity{
-//					"foo": resource.MustParse("1"),
-//				},
-//			},
-//			weights: map[string]float64{
-//				"foo": 0.3006,
-//			},
-//			expected: 301,
-//		},
-//	}
-//	for name, tc := range tests {
-//		t.Run(name, func(t *testing.T) {
-//			assert.Equal(t, tc.expected, tc.rl.AsWeightedMillis(tc.weights))
-//		})
-//	}
-//}
-//
-//func BenchmarkResourceListAsWeightedMillis(b *testing.B) {
-//	rl := NewResourceList(3)
-//	rl.Set("cpu", resource.MustParse("2"))
-//	rl.Set("memory", resource.MustParse("10Gi"))
-//	rl.Set("nvidia.com/gpu", resource.MustParse("1"))
-//	weights := map[string]float64{
-//		"cpu":            1,
-//		"memory":         0.1,
-//		"nvidia.com/gpu": 10,
-//	}
-//	b.ResetTimer()
-//	for n := 0; n < b.N; n++ {
-//		rl.AsWeightedMillis(weights)
-//	}
-//}
-//
-//func BenchmarkResourceListZeroAdd(b *testing.B) {
-//	rla := NewResourceList(3)
-//	rlb := NewResourceList(3)
-//	rlb.AddQuantity("cpu", resource.MustParse("2"))
-//	rlb.AddQuantity("memory", resource.MustParse("10Gi"))
-//	rlb.AddQuantity("nvidia.com/gpu", resource.MustParse("1"))
-//	for n := 0; n < b.N; n++ {
-//		rla.Zero()
-//		rla.Add(rlb)
-//	}
-//}
-//
-//func BenchmarkQuantityByTAndResourceTypeAdd(b *testing.B) {
-//	dst := make(QuantityByTAndResourceType[string], 3)
-//	src := QuantityByTAndResourceType[string]{
-//		"1": ResourceList{
-//			Resources: map[string]resource.Quantity{
-//				"foo": resource.MustParse("1"),
-//				"bar": resource.MustParse("2"),
-//				"baz": resource.MustParse("3"),
-//			},
-//		},
-//		"2": ResourceList{
-//			Resources: map[string]resource.Quantity{
-//				"foo": resource.MustParse("1"),
-//				"bar": resource.MustParse("2"),
-//				"baz": resource.MustParse("3"),
-//			},
-//		},
-//		"3": ResourceList{
-//			Resources: map[string]resource.Quantity{
-//				"foo": resource.MustParse("1"),
-//				"bar": resource.MustParse("2"),
-//				"baz": resource.MustParse("3"),
-//			},
-//		},
-//	}
-//	b.ResetTimer()
-//	for n := 0; n < b.N; n++ {
-//		dst.Add(src)
-//	}
-//}
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/exp/maps"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestResourceListDeepCopy(t *testing.T) {
+	rl := ResourceList{
+		Resources: map[string]resource.Quantity{
+			"foo": resource.MustParse("1"),
+		},
+	}
+	rlCopy := rl.DeepCopy()
+	rlCopy.Resources["bar"] = resource.MustParse("2")
+	q := rlCopy.Resources["foo"]
+	q.Add(resource.MustParse("10"))
+	assert.True(
+		t,
+		rl.Equal(ResourceList{
+			Resources: map[string]resource.Quantity{
+				"foo": resource.MustParse("1"),
+			},
+		}),
+	)
+}
+
+func TestResourceListEqual(t *testing.T) {
+	tests := map[string]struct {
+		a        ResourceList
+		b        ResourceList
+		expected bool
+	}{
+		"both empty": {
+			a:        ResourceList{},
+			b:        ResourceList{},
+			expected: true,
+		},
+		"both empty maps": {
+			a: ResourceList{
+				Resources: make(map[string]resource.Quantity),
+			},
+			b: ResourceList{
+				Resources: make(map[string]resource.Quantity),
+			},
+			expected: true,
+		},
+		"one empty map": {
+			a: ResourceList{
+				Resources: make(map[string]resource.Quantity),
+			},
+			b:        ResourceList{},
+			expected: true,
+		},
+		"zero equals empty": {
+			a: ResourceList{
+				Resources: map[string]resource.Quantity{
+					"foo": resource.MustParse("0"),
+				},
+			},
+			b:        ResourceList{},
+			expected: true,
+		},
+		"simple equal": {
+			a: ResourceList{
+				Resources: map[string]resource.Quantity{
+					"cpu":    resource.MustParse("1"),
+					"memory": resource.MustParse("2"),
+					"foo":    resource.MustParse("3"),
+				},
+			},
+			b: ResourceList{
+				Resources: map[string]resource.Quantity{
+					"cpu":    resource.MustParse("1"),
+					"memory": resource.MustParse("2"),
+					"foo":    resource.MustParse("3"),
+				},
+			},
+			expected: true,
+		},
+		"simple unequal": {
+			a: ResourceList{
+				Resources: map[string]resource.Quantity{
+					"foo": resource.MustParse("1"),
+					"bar": resource.MustParse("2"),
+				},
+			},
+			b: ResourceList{
+				Resources: map[string]resource.Quantity{
+					"foo": resource.MustParse("1"),
+					"bar": resource.MustParse("3"),
+				},
+			},
+			expected: false,
+		},
+		"zero and missing is equal": {
+			a: ResourceList{
+				Resources: map[string]resource.Quantity{
+					"foo": resource.MustParse("1"),
+					"bar": resource.MustParse("0"),
+				},
+			},
+			b: ResourceList{
+				Resources: map[string]resource.Quantity{
+					"foo": resource.MustParse("1"),
+				},
+			},
+			expected: true,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.a.Equal(tc.b))
+			assert.Equal(t, tc.expected, tc.b.Equal(tc.a))
+		})
+	}
+}
+
+func TestResourceListZero(t *testing.T) {
+	rl := ResourceList{
+		Resources: map[string]resource.Quantity{
+			"foo": resource.MustParse("1"),
+			"bar": resource.MustParse("10Gi"),
+			"baz": resource.MustParse("0"),
+		},
+	}
+	rl.Zero()
+	assert.True(t, rl.Equal(ResourceList{}))
+}
+
+func TestV1ResourceListConversion(t *testing.T) {
+	rl := ResourceList{
+		Resources: map[string]resource.Quantity{
+			"foo": resource.MustParse("1"),
+		},
+	}
+	rlCopy := rl.DeepCopy()
+	v1rl := V1ResourceListFromResourceList(rlCopy)
+	rlCopy.Resources["bar"] = resource.MustParse("2")
+	q := rlCopy.Resources["foo"]
+	q.Add(resource.MustParse("10"))
+
+	rl = ResourceListFromV1ResourceList(v1rl)
+	assert.True(
+		t,
+		rl.Equal(ResourceList{
+			Resources: map[string]resource.Quantity{
+				"foo": resource.MustParse("1"),
+			},
+		}),
+	)
+
+	v1rlCopy := V1ResourceListFromResourceList(rl)
+	assert.True(t, maps.Equal(v1rlCopy, v1rl))
+}

--- a/internal/scheduler/schedulerobjects/resourcelist_test.go
+++ b/internal/scheduler/schedulerobjects/resourcelist_test.go
@@ -1,978 +1,979 @@
 package schedulerobjects
 
-import (
-	"math"
-	"testing"
-
-	"github.com/stretchr/testify/assert"
-	"golang.org/x/exp/maps"
-	"k8s.io/apimachinery/pkg/api/resource"
-)
-
-func TestQuantityByTAndResourceTypeAdd(t *testing.T) {
-	tests := map[string]struct {
-		a        QuantityByTAndResourceType[int32]
-		b        QuantityByTAndResourceType[int32]
-		expected QuantityByTAndResourceType[int32]
-	}{
-		"nil and nil": {
-			a:        nil,
-			b:        nil,
-			expected: nil,
-		},
-		"empty and nil": {
-			a:        QuantityByTAndResourceType[int32]{},
-			b:        nil,
-			expected: QuantityByTAndResourceType[int32]{},
-		},
-		"nil and empty": {
-			a:        nil,
-			b:        QuantityByTAndResourceType[int32]{},
-			expected: nil,
-		},
-		"matching": {
-			a: QuantityByTAndResourceType[int32]{
-				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("3")}},
-			},
-			b: QuantityByTAndResourceType[int32]{
-				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("1")}},
-			},
-			expected: QuantityByTAndResourceType[int32]{
-				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("4")}},
-			},
-		},
-		"mismatched resources": {
-			a: QuantityByTAndResourceType[int32]{
-				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("3")}},
-			},
-			b: QuantityByTAndResourceType[int32]{
-				0: ResourceList{Resources: map[string]resource.Quantity{"bar": resource.MustParse("1")}},
-			},
-			expected: QuantityByTAndResourceType[int32]{
-				0: ResourceList{
-					Resources: map[string]resource.Quantity{
-						"foo": resource.MustParse("3"),
-						"bar": resource.MustParse("1"),
-					},
-				},
-			},
-		},
-		"mismatched priorities": {
-			a: QuantityByTAndResourceType[int32]{
-				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("3")}},
-			},
-			b: QuantityByTAndResourceType[int32]{
-				1: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("1")}},
-			},
-			expected: QuantityByTAndResourceType[int32]{
-				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("3")}},
-				1: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("1")}},
-			},
-		},
-	}
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			tc.a.Add(tc.b)
-			assert.True(t, tc.a.Equal(tc.expected))
-		})
-	}
-}
-
-func TestQuantityByTAndResourceTypeSub(t *testing.T) {
-	tests := map[string]struct {
-		a        QuantityByTAndResourceType[int32]
-		b        QuantityByTAndResourceType[int32]
-		expected QuantityByTAndResourceType[int32]
-	}{
-		"nil and nil": {
-			a:        nil,
-			b:        nil,
-			expected: nil,
-		},
-		"empty and nil": {
-			a:        QuantityByTAndResourceType[int32]{},
-			b:        nil,
-			expected: QuantityByTAndResourceType[int32]{},
-		},
-		"nil and empty": {
-			a:        nil,
-			b:        QuantityByTAndResourceType[int32]{},
-			expected: nil,
-		},
-		"matching": {
-			a: QuantityByTAndResourceType[int32]{
-				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("3")}},
-			},
-			b: QuantityByTAndResourceType[int32]{
-				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("1")}},
-			},
-			expected: QuantityByTAndResourceType[int32]{
-				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("2")}},
-			},
-		},
-		"mismatched resources": {
-			a: QuantityByTAndResourceType[int32]{
-				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("3")}},
-			},
-			b: QuantityByTAndResourceType[int32]{
-				0: ResourceList{Resources: map[string]resource.Quantity{"bar": resource.MustParse("1")}},
-			},
-			expected: QuantityByTAndResourceType[int32]{
-				0: ResourceList{
-					Resources: map[string]resource.Quantity{
-						"foo": resource.MustParse("3"),
-						"bar": resource.MustParse("-1"),
-					},
-				},
-			},
-		},
-		"mismatched priorities": {
-			a: QuantityByTAndResourceType[int32]{
-				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("3")}},
-			},
-			b: QuantityByTAndResourceType[int32]{
-				1: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("1")}},
-			},
-			expected: QuantityByTAndResourceType[int32]{
-				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("3")}},
-				1: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("-1")}},
-			},
-		},
-	}
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			tc.a.Sub(tc.b)
-			assert.True(t, tc.a.Equal(tc.expected))
-		})
-	}
-}
-
-func TestQuantityByTAndResourceTypeEqual(t *testing.T) {
-	tests := map[string]struct {
-		a        QuantityByTAndResourceType[int32]
-		b        QuantityByTAndResourceType[int32]
-		expected bool
-	}{
-		"both empty": {
-			a:        QuantityByTAndResourceType[int32]{},
-			b:        QuantityByTAndResourceType[int32]{},
-			expected: true,
-		},
-		"both with an empty map": {
-			a: QuantityByTAndResourceType[int32]{
-				0: ResourceList{},
-			},
-			b: QuantityByTAndResourceType[int32]{
-				0: ResourceList{},
-			},
-			expected: true,
-		},
-		"one empty map": {
-			a: QuantityByTAndResourceType[int32]{
-				0: ResourceList{},
-			},
-			b:        QuantityByTAndResourceType[int32]{},
-			expected: true,
-		},
-		"zero equals empty": {
-			a: QuantityByTAndResourceType[int32]{
-				0: ResourceList{
-					Resources: map[string]resource.Quantity{
-						"foo": resource.MustParse("0"),
-					},
-				},
-			},
-			b: QuantityByTAndResourceType[int32]{
-				0: ResourceList{},
-			},
-			expected: true,
-		},
-		"zero equals missing": {
-			a: QuantityByTAndResourceType[int32]{
-				0: ResourceList{},
-			},
-			b:        QuantityByTAndResourceType[int32]{},
-			expected: true,
-		},
-		"zero equals missing with empty ResourceList": {
-			a: QuantityByTAndResourceType[int32]{
-				0: ResourceList{
-					Resources: map[string]resource.Quantity{
-						"foo": resource.MustParse("0"),
-					},
-				},
-			},
-			b:        QuantityByTAndResourceType[int32]{},
-			expected: true,
-		},
-		"simple equal": {
-			a: QuantityByTAndResourceType[int32]{
-				0: ResourceList{
-					Resources: map[string]resource.Quantity{
-						"cpu":    resource.MustParse("1"),
-						"memory": resource.MustParse("2"),
-						"foo":    resource.MustParse("3"),
-					},
-				},
-			},
-			b: QuantityByTAndResourceType[int32]{
-				0: ResourceList{
-					Resources: map[string]resource.Quantity{
-						"cpu":    resource.MustParse("1"),
-						"memory": resource.MustParse("2"),
-						"foo":    resource.MustParse("3"),
-					},
-				},
-			},
-			expected: true,
-		},
-		"equal with two priorities": {
-			a: QuantityByTAndResourceType[int32]{
-				0: ResourceList{
-					Resources: map[string]resource.Quantity{
-						"cpu":    resource.MustParse("1"),
-						"memory": resource.MustParse("2"),
-						"foo":    resource.MustParse("3"),
-					},
-				},
-				1: ResourceList{
-					Resources: map[string]resource.Quantity{
-						"cpu":    resource.MustParse("4"),
-						"memory": resource.MustParse("5"),
-						"foo":    resource.MustParse("6"),
-					},
-				},
-			},
-			b: QuantityByTAndResourceType[int32]{
-				0: ResourceList{
-					Resources: map[string]resource.Quantity{
-						"cpu":    resource.MustParse("1"),
-						"memory": resource.MustParse("2"),
-						"foo":    resource.MustParse("3"),
-					},
-				},
-				1: ResourceList{
-					Resources: map[string]resource.Quantity{
-						"cpu":    resource.MustParse("4"),
-						"memory": resource.MustParse("5"),
-						"foo":    resource.MustParse("6"),
-					},
-				},
-			},
-			expected: true,
-		},
-		"simple unequal": {
-			a: QuantityByTAndResourceType[int32]{
-				0: ResourceList{
-					Resources: map[string]resource.Quantity{
-						"cpu":    resource.MustParse("1"),
-						"memory": resource.MustParse("2"),
-						"foo":    resource.MustParse("3"),
-					},
-				},
-			},
-			b: QuantityByTAndResourceType[int32]{
-				0: ResourceList{
-					Resources: map[string]resource.Quantity{
-						"cpu":    resource.MustParse("1"),
-						"memory": resource.MustParse("2"),
-						"foo":    resource.MustParse("4"),
-					},
-				},
-			},
-			expected: false,
-		},
-		"unequal differing priority": {
-			a: QuantityByTAndResourceType[int32]{
-				0: ResourceList{
-					Resources: map[string]resource.Quantity{
-						"cpu":    resource.MustParse("1"),
-						"memory": resource.MustParse("2"),
-						"foo":    resource.MustParse("3"),
-					},
-				},
-			},
-			b: QuantityByTAndResourceType[int32]{
-				1: ResourceList{
-					Resources: map[string]resource.Quantity{
-						"cpu":    resource.MustParse("1"),
-						"memory": resource.MustParse("2"),
-						"foo":    resource.MustParse("3"),
-					},
-				},
-			},
-			expected: false,
-		},
-	}
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, tc.expected, tc.a.Equal(tc.b))
-			assert.Equal(t, tc.expected, tc.b.Equal(tc.a))
-		})
-	}
-}
-
-func TestQuantityByTAndResourceTypeIsStrictlyNonNegative(t *testing.T) {
-	tests := map[string]struct {
-		m        QuantityByTAndResourceType[int32]
-		expected bool
-	}{
-		"nil": {
-			m:        nil,
-			expected: true,
-		},
-		"empty": {
-			m:        QuantityByTAndResourceType[int32]{},
-			expected: true,
-		},
-		"simple zero": {
-			m: QuantityByTAndResourceType[int32]{
-				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("0")}},
-			},
-			expected: true,
-		},
-		"simple positive": {
-			m: QuantityByTAndResourceType[int32]{
-				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("1")}},
-			},
-			expected: true,
-		},
-		"simple positive and negative": {
-			m: QuantityByTAndResourceType[int32]{
-				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("1")}},
-				1: ResourceList{Resources: map[string]resource.Quantity{"bar": resource.MustParse("-1")}},
-			},
-			expected: false,
-		},
-	}
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, tc.expected, tc.m.IsStrictlyNonNegative())
-		})
-	}
-}
-
-func TestQuantityByTAndResourceTypeMaxAggregatedByResource(t *testing.T) {
-	tests := map[string]struct {
-		q        QuantityByTAndResourceType[int32]
-		p        int32
-		rl       ResourceList
-		expected QuantityByTAndResourceType[int32]
-	}{
-		"no change": {
-			q: QuantityByTAndResourceType[int32]{
-				0: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("1")}},
-			},
-			p:  1,
-			rl: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("1")}},
-			expected: QuantityByTAndResourceType[int32]{
-				0: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("1")}},
-			},
-		},
-		"empty": {
-			q:  QuantityByTAndResourceType[int32]{},
-			p:  0,
-			rl: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("1")}},
-			expected: QuantityByTAndResourceType[int32]{
-				0: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("1")}},
-			},
-		},
-		"add same resource at same priority": {
-			q: QuantityByTAndResourceType[int32]{
-				0: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("1")}},
-			},
-			p:  0,
-			rl: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("2")}},
-			expected: QuantityByTAndResourceType[int32]{
-				0: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("2")}},
-			},
-		},
-		"add different resource at same priority": {
-			q: QuantityByTAndResourceType[int32]{
-				0: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("1")}},
-			},
-			p:  0,
-			rl: ResourceList{Resources: map[string]resource.Quantity{"memory": resource.MustParse("1Gi")}},
-			expected: QuantityByTAndResourceType[int32]{
-				0: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("1"), "memory": resource.MustParse("1Gi")}},
-			},
-		},
-		"add same resource at different priority": {
-			q: QuantityByTAndResourceType[int32]{
-				0: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("1")}},
-			},
-			p:  1,
-			rl: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("2")}},
-			expected: QuantityByTAndResourceType[int32]{
-				0: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("1")}},
-				1: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("1")}},
-			},
-		},
-		"add different resource at different priority": {
-			q: QuantityByTAndResourceType[int32]{
-				0: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("1")}},
-			},
-			p:  1,
-			rl: ResourceList{Resources: map[string]resource.Quantity{"memory": resource.MustParse("1Gi")}},
-			expected: QuantityByTAndResourceType[int32]{
-				0: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("1")}},
-				1: ResourceList{Resources: map[string]resource.Quantity{"memory": resource.MustParse("1Gi")}},
-			},
-		},
-		"multiple resources": {
-			q: QuantityByTAndResourceType[int32]{
-				0: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("100m"), "memory": resource.MustParse("50Mi")}},
-			},
-			p:  1,
-			rl: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("10"), "memory": resource.MustParse("4000Mi")}},
-			expected: QuantityByTAndResourceType[int32]{
-				0: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("100m"), "memory": resource.MustParse("50Mi")}},
-				1: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("9900m"), "memory": resource.MustParse("3950Mi")}},
-			},
-		},
-	}
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			tc.q.MaxAggregatedByResource(tc.p, tc.rl)
-			assert.True(t, tc.expected.Equal(tc.q), "expected %s, but got %s", tc.expected.String(), tc.q.String())
-		})
-	}
-}
-
-func TestAllocatableByPriorityAndResourceType(t *testing.T) {
-	tests := map[string]struct {
-		Priorities     []int32
-		UsedAtPriority int32
-		Resources      ResourceList
-	}{
-		"lowest priority": {
-			Priorities:     []int32{1, 5, 10},
-			UsedAtPriority: 1,
-			Resources: ResourceList{
-				Resources: map[string]resource.Quantity{
-					"cpu":            resource.MustParse("1"),
-					"nvidia.com/gpu": resource.MustParse("2"),
-				},
-			},
-		},
-		"mid priority": {
-			Priorities:     []int32{1, 5, 10},
-			UsedAtPriority: 5,
-			Resources: ResourceList{
-				Resources: map[string]resource.Quantity{
-					"cpu":            resource.MustParse("1"),
-					"nvidia.com/gpu": resource.MustParse("2"),
-				},
-			},
-		},
-		"highest priority": {
-			Priorities:     []int32{1, 5, 10},
-			UsedAtPriority: 10,
-			Resources: ResourceList{
-				Resources: map[string]resource.Quantity{
-					"cpu":            resource.MustParse("1"),
-					"nvidia.com/gpu": resource.MustParse("2"),
-				},
-			},
-		},
-	}
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			m := NewAllocatableByPriorityAndResourceType(tc.Priorities, tc.Resources)
-			assert.Equal(t, len(tc.Priorities), len(m))
-
-			m.MarkAllocated(tc.UsedAtPriority, tc.Resources)
-			for resourceType, quantity := range tc.Resources.Resources {
-				for _, p := range tc.Priorities {
-					actual := m.Get(p, resourceType)
-					if p > tc.UsedAtPriority {
-						assert.Equal(t, 0, quantity.Cmp(actual))
-					} else {
-						expected := resource.MustParse("0")
-						assert.Equal(t, 0, expected.Cmp(actual))
-					}
-				}
-			}
-
-			m.MarkAllocatable(tc.UsedAtPriority, tc.Resources)
-			for resourceType, quantity := range tc.Resources.Resources {
-				for _, p := range tc.Priorities {
-					actual := m.Get(p, resourceType)
-					assert.Equal(t, 0, quantity.Cmp(actual))
-				}
-			}
-		})
-	}
-}
-
-func TestAllocatedByPriorityAndResourceType(t *testing.T) {
-	tests := map[string]struct {
-		Priorities     []int32
-		UsedAtPriority int32
-		Resources      map[string]resource.Quantity
-	}{
-		"lowest priority": {
-			Priorities:     []int32{1, 5, 10},
-			UsedAtPriority: 1,
-			Resources: map[string]resource.Quantity{
-				"cpu":            resource.MustParse("1"),
-				"nvidia.com/gpu": resource.MustParse("2"),
-			},
-		},
-		"mid priority": {
-			Priorities:     []int32{1, 5, 10},
-			UsedAtPriority: 5,
-			Resources: map[string]resource.Quantity{
-				"cpu":            resource.MustParse("1"),
-				"nvidia.com/gpu": resource.MustParse("2"),
-			},
-		},
-		"highest priority": {
-			Priorities:     []int32{1, 5, 10},
-			UsedAtPriority: 10,
-			Resources: map[string]resource.Quantity{
-				"cpu":            resource.MustParse("1"),
-				"nvidia.com/gpu": resource.MustParse("2"),
-			},
-		},
-	}
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			m := NewAllocatedByPriorityAndResourceType(tc.Priorities)
-			assert.Equal(t, len(tc.Priorities), len(m))
-
-			m.MarkAllocated(tc.UsedAtPriority, ResourceList{Resources: tc.Resources})
-			for resourceType, quantity := range tc.Resources {
-				for _, p := range tc.Priorities {
-					actual := m.Get(p, resourceType)
-					if p <= tc.UsedAtPriority {
-						assert.Equal(t, 0, quantity.Cmp(actual))
-					} else {
-						expected := resource.MustParse("0")
-						assert.Equal(t, 0, expected.Cmp(actual))
-					}
-				}
-			}
-
-			m.MarkAllocatable(tc.UsedAtPriority, ResourceList{Resources: tc.Resources})
-			for resourceType := range tc.Resources {
-				for _, p := range tc.Priorities {
-					actual := m.Get(p, resourceType)
-					expected := resource.MustParse("0")
-					assert.Equal(t, 0, expected.Cmp(actual))
-				}
-			}
-		})
-	}
-}
-
-func TestResourceListDeepCopy(t *testing.T) {
-	rl := ResourceList{
-		Resources: map[string]resource.Quantity{
-			"foo": resource.MustParse("1"),
-		},
-	}
-	rlCopy := rl.DeepCopy()
-	rlCopy.Resources["bar"] = resource.MustParse("2")
-	q := rlCopy.Resources["foo"]
-	q.Add(resource.MustParse("10"))
-	assert.True(
-		t,
-		rl.Equal(ResourceList{
-			Resources: map[string]resource.Quantity{
-				"foo": resource.MustParse("1"),
-			},
-		}),
-	)
-}
-
-func TestResourceListEqual(t *testing.T) {
-	tests := map[string]struct {
-		a        ResourceList
-		b        ResourceList
-		expected bool
-	}{
-		"both empty": {
-			a:        ResourceList{},
-			b:        ResourceList{},
-			expected: true,
-		},
-		"both empty maps": {
-			a: ResourceList{
-				Resources: make(map[string]resource.Quantity),
-			},
-			b: ResourceList{
-				Resources: make(map[string]resource.Quantity),
-			},
-			expected: true,
-		},
-		"one empty map": {
-			a: ResourceList{
-				Resources: make(map[string]resource.Quantity),
-			},
-			b:        ResourceList{},
-			expected: true,
-		},
-		"zero equals empty": {
-			a: ResourceList{
-				Resources: map[string]resource.Quantity{
-					"foo": resource.MustParse("0"),
-				},
-			},
-			b:        ResourceList{},
-			expected: true,
-		},
-		"simple equal": {
-			a: ResourceList{
-				Resources: map[string]resource.Quantity{
-					"cpu":    resource.MustParse("1"),
-					"memory": resource.MustParse("2"),
-					"foo":    resource.MustParse("3"),
-				},
-			},
-			b: ResourceList{
-				Resources: map[string]resource.Quantity{
-					"cpu":    resource.MustParse("1"),
-					"memory": resource.MustParse("2"),
-					"foo":    resource.MustParse("3"),
-				},
-			},
-			expected: true,
-		},
-		"simple unequal": {
-			a: ResourceList{
-				Resources: map[string]resource.Quantity{
-					"foo": resource.MustParse("1"),
-					"bar": resource.MustParse("2"),
-				},
-			},
-			b: ResourceList{
-				Resources: map[string]resource.Quantity{
-					"foo": resource.MustParse("1"),
-					"bar": resource.MustParse("3"),
-				},
-			},
-			expected: false,
-		},
-		"zero and missing is equal": {
-			a: ResourceList{
-				Resources: map[string]resource.Quantity{
-					"foo": resource.MustParse("1"),
-					"bar": resource.MustParse("0"),
-				},
-			},
-			b: ResourceList{
-				Resources: map[string]resource.Quantity{
-					"foo": resource.MustParse("1"),
-				},
-			},
-			expected: true,
-		},
-	}
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, tc.expected, tc.a.Equal(tc.b))
-			assert.Equal(t, tc.expected, tc.b.Equal(tc.a))
-		})
-	}
-}
-
-func TestResourceListIsStrictlyNonNegative(t *testing.T) {
-	tests := map[string]struct {
-		rl       ResourceList
-		expected bool
-	}{
-		"empty": {
-			rl:       ResourceList{},
-			expected: true,
-		},
-		"empty maps": {
-			rl: ResourceList{
-				Resources: make(map[string]resource.Quantity),
-			},
-			expected: true,
-		},
-		"zero-values resource": {
-			rl: ResourceList{
-				Resources: map[string]resource.Quantity{
-					"foo": resource.MustParse("0"),
-				},
-			},
-			expected: true,
-		},
-		"simple non-negative": {
-			rl: ResourceList{
-				Resources: map[string]resource.Quantity{
-					"cpu":    resource.MustParse("1"),
-					"memory": resource.MustParse("2"),
-					"foo":    resource.MustParse("3"),
-				},
-			},
-			expected: true,
-		},
-		"zero and positive": {
-			rl: ResourceList{
-				Resources: map[string]resource.Quantity{
-					"foo": resource.MustParse("1"),
-					"bar": resource.MustParse("0"),
-				},
-			},
-			expected: true,
-		},
-		"simple negative": {
-			rl: ResourceList{
-				Resources: map[string]resource.Quantity{
-					"foo": resource.MustParse("-1"),
-					"bar": resource.MustParse("0"),
-				},
-			},
-			expected: false,
-		},
-		"negative zero": {
-			rl: ResourceList{
-				Resources: map[string]resource.Quantity{
-					"foo": resource.MustParse("1"),
-					"bar": resource.MustParse("-0"),
-				},
-			},
-			expected: true,
-		},
-	}
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, tc.expected, tc.rl.IsStrictlyNonNegative())
-		})
-	}
-}
-
-func TestResourceListLimitToZero(t *testing.T) {
-	tests := map[string]struct {
-		input    ResourceList
-		expected ResourceList
-	}{
-		"empty": {
-			input:    ResourceList{},
-			expected: ResourceList{},
-		},
-		"empty maps": {
-			input: ResourceList{
-				Resources: make(map[string]resource.Quantity),
-			},
-			expected: ResourceList{
-				Resources: make(map[string]resource.Quantity),
-			},
-		},
-		"non-negative values": {
-			input: ResourceList{
-				Resources: map[string]resource.Quantity{
-					"foo": resource.MustParse("5"),
-					"bar": resource.MustParse("0"),
-				},
-			},
-			expected: ResourceList{
-				Resources: map[string]resource.Quantity{
-					"foo": resource.MustParse("5"),
-					"bar": resource.MustParse("0"),
-				},
-			},
-		},
-		"negative values": {
-			input: ResourceList{
-				Resources: map[string]resource.Quantity{
-					"foo": resource.MustParse("-1"),
-					"bar": resource.MustParse("0"),
-					"baz": resource.MustParse("1"),
-				},
-			},
-			expected: ResourceList{
-				Resources: map[string]resource.Quantity{
-					"foo": resource.MustParse("0"),
-					"bar": resource.MustParse("0"),
-					"baz": resource.MustParse("1"),
-				},
-			},
-		},
-	}
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			tc.input.LimitToZero()
-			assert.True(t, tc.expected.Equal(tc.input))
-		})
-	}
-}
-
-func TestResourceListZero(t *testing.T) {
-	rl := ResourceList{
-		Resources: map[string]resource.Quantity{
-			"foo": resource.MustParse("1"),
-			"bar": resource.MustParse("10Gi"),
-			"baz": resource.MustParse("0"),
-		},
-	}
-	rl.Zero()
-	assert.True(t, rl.Equal(ResourceList{}))
-}
-
-func BenchmarkResourceListZero(b *testing.B) {
-	rl := ResourceList{
-		Resources: map[string]resource.Quantity{
-			"foo": resource.MustParse("1"),
-			"bar": resource.MustParse("10Gi"),
-			"baz": resource.MustParse("0"),
-		},
-	}
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		rl.Zero()
-	}
-}
-
-func TestV1ResourceListConversion(t *testing.T) {
-	rl := ResourceList{
-		Resources: map[string]resource.Quantity{
-			"foo": resource.MustParse("1"),
-		},
-	}
-	rlCopy := rl.DeepCopy()
-	v1rl := V1ResourceListFromResourceList(rlCopy)
-	rlCopy.Resources["bar"] = resource.MustParse("2")
-	q := rlCopy.Resources["foo"]
-	q.Add(resource.MustParse("10"))
-
-	rl = ResourceListFromV1ResourceList(v1rl)
-	assert.True(
-		t,
-		rl.Equal(ResourceList{
-			Resources: map[string]resource.Quantity{
-				"foo": resource.MustParse("1"),
-			},
-		}),
-	)
-
-	v1rlCopy := V1ResourceListFromResourceList(rl)
-	assert.True(t, maps.Equal(v1rlCopy, v1rl))
-}
-
-func TestResourceListAsWeightedMillis(t *testing.T) {
-	tests := map[string]struct {
-		rl       ResourceList
-		weights  map[string]float64
-		expected int64
-	}{
-		"default": {
-			rl: ResourceList{
-				Resources: map[string]resource.Quantity{
-					"foo": resource.MustParse("2"),
-					"bar": resource.MustParse("10Gi"),
-					"baz": resource.MustParse("1"),
-				},
-			},
-			weights: map[string]float64{
-				"foo": 1,
-				"bar": 0.1,
-				"baz": 10,
-			},
-			expected: (1 * 2 * 1000) + (1 * 1000 * 1024 * 1024 * 1024) + (10 * 1 * 1000),
-		},
-		"zeroes": {
-			rl: ResourceList{
-				Resources: map[string]resource.Quantity{
-					"foo": resource.MustParse("0"),
-					"bar": resource.MustParse("1"),
-					"baz": resource.MustParse("2"),
-				},
-			},
-			weights: map[string]float64{
-				"foo": 1,
-				"bar": 0,
-			},
-			expected: 0,
-		},
-		"1Pi": {
-			rl: ResourceList{
-				Resources: map[string]resource.Quantity{
-					"foo": resource.MustParse("1Pi"),
-				},
-			},
-			weights: map[string]float64{
-				"foo": 1,
-			},
-			expected: int64(math.Pow(1024, 5)) * 1000,
-		},
-		"rounding": {
-			rl: ResourceList{
-				Resources: map[string]resource.Quantity{
-					"foo": resource.MustParse("1"),
-				},
-			},
-			weights: map[string]float64{
-				"foo": 0.3006,
-			},
-			expected: 301,
-		},
-	}
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, tc.expected, tc.rl.AsWeightedMillis(tc.weights))
-		})
-	}
-}
-
-func BenchmarkResourceListAsWeightedMillis(b *testing.B) {
-	rl := NewResourceList(3)
-	rl.Set("cpu", resource.MustParse("2"))
-	rl.Set("memory", resource.MustParse("10Gi"))
-	rl.Set("nvidia.com/gpu", resource.MustParse("1"))
-	weights := map[string]float64{
-		"cpu":            1,
-		"memory":         0.1,
-		"nvidia.com/gpu": 10,
-	}
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		rl.AsWeightedMillis(weights)
-	}
-}
-
-func BenchmarkResourceListZeroAdd(b *testing.B) {
-	rla := NewResourceList(3)
-	rlb := NewResourceList(3)
-	rlb.AddQuantity("cpu", resource.MustParse("2"))
-	rlb.AddQuantity("memory", resource.MustParse("10Gi"))
-	rlb.AddQuantity("nvidia.com/gpu", resource.MustParse("1"))
-	for n := 0; n < b.N; n++ {
-		rla.Zero()
-		rla.Add(rlb)
-	}
-}
-
-func BenchmarkQuantityByTAndResourceTypeAdd(b *testing.B) {
-	dst := make(QuantityByTAndResourceType[string], 3)
-	src := QuantityByTAndResourceType[string]{
-		"1": ResourceList{
-			Resources: map[string]resource.Quantity{
-				"foo": resource.MustParse("1"),
-				"bar": resource.MustParse("2"),
-				"baz": resource.MustParse("3"),
-			},
-		},
-		"2": ResourceList{
-			Resources: map[string]resource.Quantity{
-				"foo": resource.MustParse("1"),
-				"bar": resource.MustParse("2"),
-				"baz": resource.MustParse("3"),
-			},
-		},
-		"3": ResourceList{
-			Resources: map[string]resource.Quantity{
-				"foo": resource.MustParse("1"),
-				"bar": resource.MustParse("2"),
-				"baz": resource.MustParse("3"),
-			},
-		},
-	}
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		dst.Add(src)
-	}
-}
+//
+//import (
+//	"math"
+//	"testing"
+//
+//	"github.com/stretchr/testify/assert"
+//	"golang.org/x/exp/maps"
+//	"k8s.io/apimachinery/pkg/api/resource"
+//)
+//
+//func TestQuantityByTAndResourceTypeAdd(t *testing.T) {
+//	tests := map[string]struct {
+//		a        QuantityByTAndResourceType[int32]
+//		b        QuantityByTAndResourceType[int32]
+//		expected QuantityByTAndResourceType[int32]
+//	}{
+//		"nil and nil": {
+//			a:        nil,
+//			b:        nil,
+//			expected: nil,
+//		},
+//		"empty and nil": {
+//			a:        QuantityByTAndResourceType[int32]{},
+//			b:        nil,
+//			expected: QuantityByTAndResourceType[int32]{},
+//		},
+//		"nil and empty": {
+//			a:        nil,
+//			b:        QuantityByTAndResourceType[int32]{},
+//			expected: nil,
+//		},
+//		"matching": {
+//			a: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("3")}},
+//			},
+//			b: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("1")}},
+//			},
+//			expected: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("4")}},
+//			},
+//		},
+//		"mismatched resources": {
+//			a: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("3")}},
+//			},
+//			b: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{Resources: map[string]resource.Quantity{"bar": resource.MustParse("1")}},
+//			},
+//			expected: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{
+//					Resources: map[string]resource.Quantity{
+//						"foo": resource.MustParse("3"),
+//						"bar": resource.MustParse("1"),
+//					},
+//				},
+//			},
+//		},
+//		"mismatched priorities": {
+//			a: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("3")}},
+//			},
+//			b: QuantityByTAndResourceType[int32]{
+//				1: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("1")}},
+//			},
+//			expected: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("3")}},
+//				1: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("1")}},
+//			},
+//		},
+//	}
+//	for name, tc := range tests {
+//		t.Run(name, func(t *testing.T) {
+//			tc.a.Add(tc.b)
+//			assert.True(t, tc.a.Equal(tc.expected))
+//		})
+//	}
+//}
+//
+//func TestQuantityByTAndResourceTypeSub(t *testing.T) {
+//	tests := map[string]struct {
+//		a        QuantityByTAndResourceType[int32]
+//		b        QuantityByTAndResourceType[int32]
+//		expected QuantityByTAndResourceType[int32]
+//	}{
+//		"nil and nil": {
+//			a:        nil,
+//			b:        nil,
+//			expected: nil,
+//		},
+//		"empty and nil": {
+//			a:        QuantityByTAndResourceType[int32]{},
+//			b:        nil,
+//			expected: QuantityByTAndResourceType[int32]{},
+//		},
+//		"nil and empty": {
+//			a:        nil,
+//			b:        QuantityByTAndResourceType[int32]{},
+//			expected: nil,
+//		},
+//		"matching": {
+//			a: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("3")}},
+//			},
+//			b: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("1")}},
+//			},
+//			expected: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("2")}},
+//			},
+//		},
+//		"mismatched resources": {
+//			a: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("3")}},
+//			},
+//			b: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{Resources: map[string]resource.Quantity{"bar": resource.MustParse("1")}},
+//			},
+//			expected: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{
+//					Resources: map[string]resource.Quantity{
+//						"foo": resource.MustParse("3"),
+//						"bar": resource.MustParse("-1"),
+//					},
+//				},
+//			},
+//		},
+//		"mismatched priorities": {
+//			a: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("3")}},
+//			},
+//			b: QuantityByTAndResourceType[int32]{
+//				1: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("1")}},
+//			},
+//			expected: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("3")}},
+//				1: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("-1")}},
+//			},
+//		},
+//	}
+//	for name, tc := range tests {
+//		t.Run(name, func(t *testing.T) {
+//			tc.a.Sub(tc.b)
+//			assert.True(t, tc.a.Equal(tc.expected))
+//		})
+//	}
+//}
+//
+//func TestQuantityByTAndResourceTypeEqual(t *testing.T) {
+//	tests := map[string]struct {
+//		a        QuantityByTAndResourceType[int32]
+//		b        QuantityByTAndResourceType[int32]
+//		expected bool
+//	}{
+//		"both empty": {
+//			a:        QuantityByTAndResourceType[int32]{},
+//			b:        QuantityByTAndResourceType[int32]{},
+//			expected: true,
+//		},
+//		"both with an empty map": {
+//			a: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{},
+//			},
+//			b: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{},
+//			},
+//			expected: true,
+//		},
+//		"one empty map": {
+//			a: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{},
+//			},
+//			b:        QuantityByTAndResourceType[int32]{},
+//			expected: true,
+//		},
+//		"zero equals empty": {
+//			a: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{
+//					Resources: map[string]resource.Quantity{
+//						"foo": resource.MustParse("0"),
+//					},
+//				},
+//			},
+//			b: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{},
+//			},
+//			expected: true,
+//		},
+//		"zero equals missing": {
+//			a: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{},
+//			},
+//			b:        QuantityByTAndResourceType[int32]{},
+//			expected: true,
+//		},
+//		"zero equals missing with empty ResourceList": {
+//			a: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{
+//					Resources: map[string]resource.Quantity{
+//						"foo": resource.MustParse("0"),
+//					},
+//				},
+//			},
+//			b:        QuantityByTAndResourceType[int32]{},
+//			expected: true,
+//		},
+//		"simple equal": {
+//			a: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{
+//					Resources: map[string]resource.Quantity{
+//						"cpu":    resource.MustParse("1"),
+//						"memory": resource.MustParse("2"),
+//						"foo":    resource.MustParse("3"),
+//					},
+//				},
+//			},
+//			b: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{
+//					Resources: map[string]resource.Quantity{
+//						"cpu":    resource.MustParse("1"),
+//						"memory": resource.MustParse("2"),
+//						"foo":    resource.MustParse("3"),
+//					},
+//				},
+//			},
+//			expected: true,
+//		},
+//		"equal with two priorities": {
+//			a: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{
+//					Resources: map[string]resource.Quantity{
+//						"cpu":    resource.MustParse("1"),
+//						"memory": resource.MustParse("2"),
+//						"foo":    resource.MustParse("3"),
+//					},
+//				},
+//				1: ResourceList{
+//					Resources: map[string]resource.Quantity{
+//						"cpu":    resource.MustParse("4"),
+//						"memory": resource.MustParse("5"),
+//						"foo":    resource.MustParse("6"),
+//					},
+//				},
+//			},
+//			b: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{
+//					Resources: map[string]resource.Quantity{
+//						"cpu":    resource.MustParse("1"),
+//						"memory": resource.MustParse("2"),
+//						"foo":    resource.MustParse("3"),
+//					},
+//				},
+//				1: ResourceList{
+//					Resources: map[string]resource.Quantity{
+//						"cpu":    resource.MustParse("4"),
+//						"memory": resource.MustParse("5"),
+//						"foo":    resource.MustParse("6"),
+//					},
+//				},
+//			},
+//			expected: true,
+//		},
+//		"simple unequal": {
+//			a: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{
+//					Resources: map[string]resource.Quantity{
+//						"cpu":    resource.MustParse("1"),
+//						"memory": resource.MustParse("2"),
+//						"foo":    resource.MustParse("3"),
+//					},
+//				},
+//			},
+//			b: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{
+//					Resources: map[string]resource.Quantity{
+//						"cpu":    resource.MustParse("1"),
+//						"memory": resource.MustParse("2"),
+//						"foo":    resource.MustParse("4"),
+//					},
+//				},
+//			},
+//			expected: false,
+//		},
+//		"unequal differing priority": {
+//			a: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{
+//					Resources: map[string]resource.Quantity{
+//						"cpu":    resource.MustParse("1"),
+//						"memory": resource.MustParse("2"),
+//						"foo":    resource.MustParse("3"),
+//					},
+//				},
+//			},
+//			b: QuantityByTAndResourceType[int32]{
+//				1: ResourceList{
+//					Resources: map[string]resource.Quantity{
+//						"cpu":    resource.MustParse("1"),
+//						"memory": resource.MustParse("2"),
+//						"foo":    resource.MustParse("3"),
+//					},
+//				},
+//			},
+//			expected: false,
+//		},
+//	}
+//	for name, tc := range tests {
+//		t.Run(name, func(t *testing.T) {
+//			assert.Equal(t, tc.expected, tc.a.Equal(tc.b))
+//			assert.Equal(t, tc.expected, tc.b.Equal(tc.a))
+//		})
+//	}
+//}
+//
+//func TestQuantityByTAndResourceTypeIsStrictlyNonNegative(t *testing.T) {
+//	tests := map[string]struct {
+//		m        QuantityByTAndResourceType[int32]
+//		expected bool
+//	}{
+//		"nil": {
+//			m:        nil,
+//			expected: true,
+//		},
+//		"empty": {
+//			m:        QuantityByTAndResourceType[int32]{},
+//			expected: true,
+//		},
+//		"simple zero": {
+//			m: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("0")}},
+//			},
+//			expected: true,
+//		},
+//		"simple positive": {
+//			m: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("1")}},
+//			},
+//			expected: true,
+//		},
+//		"simple positive and negative": {
+//			m: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{Resources: map[string]resource.Quantity{"foo": resource.MustParse("1")}},
+//				1: ResourceList{Resources: map[string]resource.Quantity{"bar": resource.MustParse("-1")}},
+//			},
+//			expected: false,
+//		},
+//	}
+//	for name, tc := range tests {
+//		t.Run(name, func(t *testing.T) {
+//			assert.Equal(t, tc.expected, tc.m.IsStrictlyNonNegative())
+//		})
+//	}
+//}
+//
+//func TestQuantityByTAndResourceTypeMaxAggregatedByResource(t *testing.T) {
+//	tests := map[string]struct {
+//		q        QuantityByTAndResourceType[int32]
+//		p        int32
+//		rl       ResourceList
+//		expected QuantityByTAndResourceType[int32]
+//	}{
+//		"no change": {
+//			q: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("1")}},
+//			},
+//			p:  1,
+//			rl: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("1")}},
+//			expected: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("1")}},
+//			},
+//		},
+//		"empty": {
+//			q:  QuantityByTAndResourceType[int32]{},
+//			p:  0,
+//			rl: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("1")}},
+//			expected: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("1")}},
+//			},
+//		},
+//		"add same resource at same priority": {
+//			q: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("1")}},
+//			},
+//			p:  0,
+//			rl: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("2")}},
+//			expected: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("2")}},
+//			},
+//		},
+//		"add different resource at same priority": {
+//			q: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("1")}},
+//			},
+//			p:  0,
+//			rl: ResourceList{Resources: map[string]resource.Quantity{"memory": resource.MustParse("1Gi")}},
+//			expected: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("1"), "memory": resource.MustParse("1Gi")}},
+//			},
+//		},
+//		"add same resource at different priority": {
+//			q: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("1")}},
+//			},
+//			p:  1,
+//			rl: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("2")}},
+//			expected: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("1")}},
+//				1: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("1")}},
+//			},
+//		},
+//		"add different resource at different priority": {
+//			q: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("1")}},
+//			},
+//			p:  1,
+//			rl: ResourceList{Resources: map[string]resource.Quantity{"memory": resource.MustParse("1Gi")}},
+//			expected: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("1")}},
+//				1: ResourceList{Resources: map[string]resource.Quantity{"memory": resource.MustParse("1Gi")}},
+//			},
+//		},
+//		"multiple resources": {
+//			q: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("100m"), "memory": resource.MustParse("50Mi")}},
+//			},
+//			p:  1,
+//			rl: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("10"), "memory": resource.MustParse("4000Mi")}},
+//			expected: QuantityByTAndResourceType[int32]{
+//				0: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("100m"), "memory": resource.MustParse("50Mi")}},
+//				1: ResourceList{Resources: map[string]resource.Quantity{"cpu": resource.MustParse("9900m"), "memory": resource.MustParse("3950Mi")}},
+//			},
+//		},
+//	}
+//	for name, tc := range tests {
+//		t.Run(name, func(t *testing.T) {
+//			tc.q.MaxAggregatedByResource(tc.p, tc.rl)
+//			assert.True(t, tc.expected.Equal(tc.q), "expected %s, but got %s", tc.expected.String(), tc.q.String())
+//		})
+//	}
+//}
+//
+//func TestAllocatableByPriorityAndResourceType(t *testing.T) {
+//	tests := map[string]struct {
+//		Priorities     []int32
+//		UsedAtPriority int32
+//		Resources      ResourceList
+//	}{
+//		"lowest priority": {
+//			Priorities:     []int32{1, 5, 10},
+//			UsedAtPriority: 1,
+//			Resources: ResourceList{
+//				Resources: map[string]resource.Quantity{
+//					"cpu":            resource.MustParse("1"),
+//					"nvidia.com/gpu": resource.MustParse("2"),
+//				},
+//			},
+//		},
+//		"mid priority": {
+//			Priorities:     []int32{1, 5, 10},
+//			UsedAtPriority: 5,
+//			Resources: ResourceList{
+//				Resources: map[string]resource.Quantity{
+//					"cpu":            resource.MustParse("1"),
+//					"nvidia.com/gpu": resource.MustParse("2"),
+//				},
+//			},
+//		},
+//		"highest priority": {
+//			Priorities:     []int32{1, 5, 10},
+//			UsedAtPriority: 10,
+//			Resources: ResourceList{
+//				Resources: map[string]resource.Quantity{
+//					"cpu":            resource.MustParse("1"),
+//					"nvidia.com/gpu": resource.MustParse("2"),
+//				},
+//			},
+//		},
+//	}
+//	for name, tc := range tests {
+//		t.Run(name, func(t *testing.T) {
+//			m := NewAllocatableByPriorityAndResourceType(tc.Priorities, tc.Resources)
+//			assert.Equal(t, len(tc.Priorities), len(m))
+//
+//			m.MarkAllocated(tc.UsedAtPriority, tc.Resources)
+//			for resourceType, quantity := range tc.Resources.Resources {
+//				for _, p := range tc.Priorities {
+//					actual := m.Get(p, resourceType)
+//					if p > tc.UsedAtPriority {
+//						assert.Equal(t, 0, quantity.Cmp(actual))
+//					} else {
+//						expected := resource.MustParse("0")
+//						assert.Equal(t, 0, expected.Cmp(actual))
+//					}
+//				}
+//			}
+//
+//			m.MarkAllocatable(tc.UsedAtPriority, tc.Resources)
+//			for resourceType, quantity := range tc.Resources.Resources {
+//				for _, p := range tc.Priorities {
+//					actual := m.Get(p, resourceType)
+//					assert.Equal(t, 0, quantity.Cmp(actual))
+//				}
+//			}
+//		})
+//	}
+//}
+//
+//func TestAllocatedByPriorityAndResourceType(t *testing.T) {
+//	tests := map[string]struct {
+//		Priorities     []int32
+//		UsedAtPriority int32
+//		Resources      map[string]resource.Quantity
+//	}{
+//		"lowest priority": {
+//			Priorities:     []int32{1, 5, 10},
+//			UsedAtPriority: 1,
+//			Resources: map[string]resource.Quantity{
+//				"cpu":            resource.MustParse("1"),
+//				"nvidia.com/gpu": resource.MustParse("2"),
+//			},
+//		},
+//		"mid priority": {
+//			Priorities:     []int32{1, 5, 10},
+//			UsedAtPriority: 5,
+//			Resources: map[string]resource.Quantity{
+//				"cpu":            resource.MustParse("1"),
+//				"nvidia.com/gpu": resource.MustParse("2"),
+//			},
+//		},
+//		"highest priority": {
+//			Priorities:     []int32{1, 5, 10},
+//			UsedAtPriority: 10,
+//			Resources: map[string]resource.Quantity{
+//				"cpu":            resource.MustParse("1"),
+//				"nvidia.com/gpu": resource.MustParse("2"),
+//			},
+//		},
+//	}
+//	for name, tc := range tests {
+//		t.Run(name, func(t *testing.T) {
+//			m := NewAllocatedByPriorityAndResourceType(tc.Priorities)
+//			assert.Equal(t, len(tc.Priorities), len(m))
+//
+//			m.MarkAllocated(tc.UsedAtPriority, ResourceList{Resources: tc.Resources})
+//			for resourceType, quantity := range tc.Resources {
+//				for _, p := range tc.Priorities {
+//					actual := m.Get(p, resourceType)
+//					if p <= tc.UsedAtPriority {
+//						assert.Equal(t, 0, quantity.Cmp(actual))
+//					} else {
+//						expected := resource.MustParse("0")
+//						assert.Equal(t, 0, expected.Cmp(actual))
+//					}
+//				}
+//			}
+//
+//			m.MarkAllocatable(tc.UsedAtPriority, ResourceList{Resources: tc.Resources})
+//			for resourceType := range tc.Resources {
+//				for _, p := range tc.Priorities {
+//					actual := m.Get(p, resourceType)
+//					expected := resource.MustParse("0")
+//					assert.Equal(t, 0, expected.Cmp(actual))
+//				}
+//			}
+//		})
+//	}
+//}
+//
+//func TestResourceListDeepCopy(t *testing.T) {
+//	rl := ResourceList{
+//		Resources: map[string]resource.Quantity{
+//			"foo": resource.MustParse("1"),
+//		},
+//	}
+//	rlCopy := rl.DeepCopy()
+//	rlCopy.Resources["bar"] = resource.MustParse("2")
+//	q := rlCopy.Resources["foo"]
+//	q.Add(resource.MustParse("10"))
+//	assert.True(
+//		t,
+//		rl.Equal(ResourceList{
+//			Resources: map[string]resource.Quantity{
+//				"foo": resource.MustParse("1"),
+//			},
+//		}),
+//	)
+//}
+//
+//func TestResourceListEqual(t *testing.T) {
+//	tests := map[string]struct {
+//		a        ResourceList
+//		b        ResourceList
+//		expected bool
+//	}{
+//		"both empty": {
+//			a:        ResourceList{},
+//			b:        ResourceList{},
+//			expected: true,
+//		},
+//		"both empty maps": {
+//			a: ResourceList{
+//				Resources: make(map[string]resource.Quantity),
+//			},
+//			b: ResourceList{
+//				Resources: make(map[string]resource.Quantity),
+//			},
+//			expected: true,
+//		},
+//		"one empty map": {
+//			a: ResourceList{
+//				Resources: make(map[string]resource.Quantity),
+//			},
+//			b:        ResourceList{},
+//			expected: true,
+//		},
+//		"zero equals empty": {
+//			a: ResourceList{
+//				Resources: map[string]resource.Quantity{
+//					"foo": resource.MustParse("0"),
+//				},
+//			},
+//			b:        ResourceList{},
+//			expected: true,
+//		},
+//		"simple equal": {
+//			a: ResourceList{
+//				Resources: map[string]resource.Quantity{
+//					"cpu":    resource.MustParse("1"),
+//					"memory": resource.MustParse("2"),
+//					"foo":    resource.MustParse("3"),
+//				},
+//			},
+//			b: ResourceList{
+//				Resources: map[string]resource.Quantity{
+//					"cpu":    resource.MustParse("1"),
+//					"memory": resource.MustParse("2"),
+//					"foo":    resource.MustParse("3"),
+//				},
+//			},
+//			expected: true,
+//		},
+//		"simple unequal": {
+//			a: ResourceList{
+//				Resources: map[string]resource.Quantity{
+//					"foo": resource.MustParse("1"),
+//					"bar": resource.MustParse("2"),
+//				},
+//			},
+//			b: ResourceList{
+//				Resources: map[string]resource.Quantity{
+//					"foo": resource.MustParse("1"),
+//					"bar": resource.MustParse("3"),
+//				},
+//			},
+//			expected: false,
+//		},
+//		"zero and missing is equal": {
+//			a: ResourceList{
+//				Resources: map[string]resource.Quantity{
+//					"foo": resource.MustParse("1"),
+//					"bar": resource.MustParse("0"),
+//				},
+//			},
+//			b: ResourceList{
+//				Resources: map[string]resource.Quantity{
+//					"foo": resource.MustParse("1"),
+//				},
+//			},
+//			expected: true,
+//		},
+//	}
+//	for name, tc := range tests {
+//		t.Run(name, func(t *testing.T) {
+//			assert.Equal(t, tc.expected, tc.a.Equal(tc.b))
+//			assert.Equal(t, tc.expected, tc.b.Equal(tc.a))
+//		})
+//	}
+//}
+//
+//func TestResourceListIsStrictlyNonNegative(t *testing.T) {
+//	tests := map[string]struct {
+//		rl       ResourceList
+//		expected bool
+//	}{
+//		"empty": {
+//			rl:       ResourceList{},
+//			expected: true,
+//		},
+//		"empty maps": {
+//			rl: ResourceList{
+//				Resources: make(map[string]resource.Quantity),
+//			},
+//			expected: true,
+//		},
+//		"zero-values resource": {
+//			rl: ResourceList{
+//				Resources: map[string]resource.Quantity{
+//					"foo": resource.MustParse("0"),
+//				},
+//			},
+//			expected: true,
+//		},
+//		"simple non-negative": {
+//			rl: ResourceList{
+//				Resources: map[string]resource.Quantity{
+//					"cpu":    resource.MustParse("1"),
+//					"memory": resource.MustParse("2"),
+//					"foo":    resource.MustParse("3"),
+//				},
+//			},
+//			expected: true,
+//		},
+//		"zero and positive": {
+//			rl: ResourceList{
+//				Resources: map[string]resource.Quantity{
+//					"foo": resource.MustParse("1"),
+//					"bar": resource.MustParse("0"),
+//				},
+//			},
+//			expected: true,
+//		},
+//		"simple negative": {
+//			rl: ResourceList{
+//				Resources: map[string]resource.Quantity{
+//					"foo": resource.MustParse("-1"),
+//					"bar": resource.MustParse("0"),
+//				},
+//			},
+//			expected: false,
+//		},
+//		"negative zero": {
+//			rl: ResourceList{
+//				Resources: map[string]resource.Quantity{
+//					"foo": resource.MustParse("1"),
+//					"bar": resource.MustParse("-0"),
+//				},
+//			},
+//			expected: true,
+//		},
+//	}
+//	for name, tc := range tests {
+//		t.Run(name, func(t *testing.T) {
+//			assert.Equal(t, tc.expected, tc.rl.IsStrictlyNonNegative())
+//		})
+//	}
+//}
+//
+//func TestResourceListLimitToZero(t *testing.T) {
+//	tests := map[string]struct {
+//		input    ResourceList
+//		expected ResourceList
+//	}{
+//		"empty": {
+//			input:    ResourceList{},
+//			expected: ResourceList{},
+//		},
+//		"empty maps": {
+//			input: ResourceList{
+//				Resources: make(map[string]resource.Quantity),
+//			},
+//			expected: ResourceList{
+//				Resources: make(map[string]resource.Quantity),
+//			},
+//		},
+//		"non-negative values": {
+//			input: ResourceList{
+//				Resources: map[string]resource.Quantity{
+//					"foo": resource.MustParse("5"),
+//					"bar": resource.MustParse("0"),
+//				},
+//			},
+//			expected: ResourceList{
+//				Resources: map[string]resource.Quantity{
+//					"foo": resource.MustParse("5"),
+//					"bar": resource.MustParse("0"),
+//				},
+//			},
+//		},
+//		"negative values": {
+//			input: ResourceList{
+//				Resources: map[string]resource.Quantity{
+//					"foo": resource.MustParse("-1"),
+//					"bar": resource.MustParse("0"),
+//					"baz": resource.MustParse("1"),
+//				},
+//			},
+//			expected: ResourceList{
+//				Resources: map[string]resource.Quantity{
+//					"foo": resource.MustParse("0"),
+//					"bar": resource.MustParse("0"),
+//					"baz": resource.MustParse("1"),
+//				},
+//			},
+//		},
+//	}
+//	for name, tc := range tests {
+//		t.Run(name, func(t *testing.T) {
+//			tc.input.LimitToZero()
+//			assert.True(t, tc.expected.Equal(tc.input))
+//		})
+//	}
+//}
+//
+//func TestResourceListZero(t *testing.T) {
+//	rl := ResourceList{
+//		Resources: map[string]resource.Quantity{
+//			"foo": resource.MustParse("1"),
+//			"bar": resource.MustParse("10Gi"),
+//			"baz": resource.MustParse("0"),
+//		},
+//	}
+//	rl.Zero()
+//	assert.True(t, rl.Equal(ResourceList{}))
+//}
+//
+//func BenchmarkResourceListZero(b *testing.B) {
+//	rl := ResourceList{
+//		Resources: map[string]resource.Quantity{
+//			"foo": resource.MustParse("1"),
+//			"bar": resource.MustParse("10Gi"),
+//			"baz": resource.MustParse("0"),
+//		},
+//	}
+//	b.ResetTimer()
+//	for n := 0; n < b.N; n++ {
+//		rl.Zero()
+//	}
+//}
+//
+//func TestV1ResourceListConversion(t *testing.T) {
+//	rl := ResourceList{
+//		Resources: map[string]resource.Quantity{
+//			"foo": resource.MustParse("1"),
+//		},
+//	}
+//	rlCopy := rl.DeepCopy()
+//	v1rl := V1ResourceListFromResourceList(rlCopy)
+//	rlCopy.Resources["bar"] = resource.MustParse("2")
+//	q := rlCopy.Resources["foo"]
+//	q.Add(resource.MustParse("10"))
+//
+//	rl = ResourceListFromV1ResourceList(v1rl)
+//	assert.True(
+//		t,
+//		rl.Equal(ResourceList{
+//			Resources: map[string]resource.Quantity{
+//				"foo": resource.MustParse("1"),
+//			},
+//		}),
+//	)
+//
+//	v1rlCopy := V1ResourceListFromResourceList(rl)
+//	assert.True(t, maps.Equal(v1rlCopy, v1rl))
+//}
+//
+//func TestResourceListAsWeightedMillis(t *testing.T) {
+//	tests := map[string]struct {
+//		rl       ResourceList
+//		weights  map[string]float64
+//		expected int64
+//	}{
+//		"default": {
+//			rl: ResourceList{
+//				Resources: map[string]resource.Quantity{
+//					"foo": resource.MustParse("2"),
+//					"bar": resource.MustParse("10Gi"),
+//					"baz": resource.MustParse("1"),
+//				},
+//			},
+//			weights: map[string]float64{
+//				"foo": 1,
+//				"bar": 0.1,
+//				"baz": 10,
+//			},
+//			expected: (1 * 2 * 1000) + (1 * 1000 * 1024 * 1024 * 1024) + (10 * 1 * 1000),
+//		},
+//		"zeroes": {
+//			rl: ResourceList{
+//				Resources: map[string]resource.Quantity{
+//					"foo": resource.MustParse("0"),
+//					"bar": resource.MustParse("1"),
+//					"baz": resource.MustParse("2"),
+//				},
+//			},
+//			weights: map[string]float64{
+//				"foo": 1,
+//				"bar": 0,
+//			},
+//			expected: 0,
+//		},
+//		"1Pi": {
+//			rl: ResourceList{
+//				Resources: map[string]resource.Quantity{
+//					"foo": resource.MustParse("1Pi"),
+//				},
+//			},
+//			weights: map[string]float64{
+//				"foo": 1,
+//			},
+//			expected: int64(math.Pow(1024, 5)) * 1000,
+//		},
+//		"rounding": {
+//			rl: ResourceList{
+//				Resources: map[string]resource.Quantity{
+//					"foo": resource.MustParse("1"),
+//				},
+//			},
+//			weights: map[string]float64{
+//				"foo": 0.3006,
+//			},
+//			expected: 301,
+//		},
+//	}
+//	for name, tc := range tests {
+//		t.Run(name, func(t *testing.T) {
+//			assert.Equal(t, tc.expected, tc.rl.AsWeightedMillis(tc.weights))
+//		})
+//	}
+//}
+//
+//func BenchmarkResourceListAsWeightedMillis(b *testing.B) {
+//	rl := NewResourceList(3)
+//	rl.Set("cpu", resource.MustParse("2"))
+//	rl.Set("memory", resource.MustParse("10Gi"))
+//	rl.Set("nvidia.com/gpu", resource.MustParse("1"))
+//	weights := map[string]float64{
+//		"cpu":            1,
+//		"memory":         0.1,
+//		"nvidia.com/gpu": 10,
+//	}
+//	b.ResetTimer()
+//	for n := 0; n < b.N; n++ {
+//		rl.AsWeightedMillis(weights)
+//	}
+//}
+//
+//func BenchmarkResourceListZeroAdd(b *testing.B) {
+//	rla := NewResourceList(3)
+//	rlb := NewResourceList(3)
+//	rlb.AddQuantity("cpu", resource.MustParse("2"))
+//	rlb.AddQuantity("memory", resource.MustParse("10Gi"))
+//	rlb.AddQuantity("nvidia.com/gpu", resource.MustParse("1"))
+//	for n := 0; n < b.N; n++ {
+//		rla.Zero()
+//		rla.Add(rlb)
+//	}
+//}
+//
+//func BenchmarkQuantityByTAndResourceTypeAdd(b *testing.B) {
+//	dst := make(QuantityByTAndResourceType[string], 3)
+//	src := QuantityByTAndResourceType[string]{
+//		"1": ResourceList{
+//			Resources: map[string]resource.Quantity{
+//				"foo": resource.MustParse("1"),
+//				"bar": resource.MustParse("2"),
+//				"baz": resource.MustParse("3"),
+//			},
+//		},
+//		"2": ResourceList{
+//			Resources: map[string]resource.Quantity{
+//				"foo": resource.MustParse("1"),
+//				"bar": resource.MustParse("2"),
+//				"baz": resource.MustParse("3"),
+//			},
+//		},
+//		"3": ResourceList{
+//			Resources: map[string]resource.Quantity{
+//				"foo": resource.MustParse("1"),
+//				"bar": resource.MustParse("2"),
+//				"baz": resource.MustParse("3"),
+//			},
+//		},
+//	}
+//	b.ResetTimer()
+//	for n := 0; n < b.N; n++ {
+//		dst.Add(src)
+//	}
+//}


### PR DESCRIPTION
Now that we've (mainly) moved to `internaltypes.ResouceList` there are a bunch of functions on `schedulerobjects.resourcelist` that we no longer use.  This PR removes these.