### PR TITLE
Allow user to set font size and text wrapping for logs display

### DIFF
--- a/internal/lookoutui/src/components/CodeBlock.tsx
+++ b/internal/lookoutui/src/components/CodeBlock.tsx
@@ -8,6 +8,7 @@ import "prismjs/components/prism-bash"
 import "prismjs/components/prism-yaml"
 
 import { CopyIconButton } from "./CopyIconButton"
+import { useCodeSnippetsWrapLines } from "../userSettings"
 
 // All langauges in this set must be imported from Prism in the form:
 // import "prismjs/components/prism-{language}"
@@ -36,7 +37,7 @@ const CodeBlockContainer = styled("div")({
   },
 })
 
-const StyledPre = styled("pre")(({ theme }) => ({
+const StyledPre = styled("pre")<{ wrap: boolean }>(({ theme, wrap }) => ({
   lineHeight: 1.2,
   fontSize: theme.typography.body2.fontSize,
   overflow: "auto",
@@ -46,6 +47,7 @@ const StyledPre = styled("pre")(({ theme }) => ({
   display: "flex",
   alignItems: "center",
   margin: 0,
+  textWrap: wrap ? "wrap" : undefined,
 }))
 
 const Code = styled("code")({
@@ -127,6 +129,7 @@ export const CodeBlock = ({
   additionalActions = [],
 }: CodeBlockProps) => {
   const { colorScheme } = useColorScheme()
+  const [wrapLines] = useCodeSnippetsWrapLines()
 
   const downloadFile = useCallback(() => {
     if (!downloadable || loading) {
@@ -153,7 +156,7 @@ export const CodeBlock = ({
           code={Array(loadingLines).fill("").join("\n")}
         >
           {({ style, tokens, getLineProps }) => (
-            <StyledPre style={style}>
+            <StyledPre style={style} wrap={wrapLines}>
               <Code>
                 {tokens.map((line, i) =>
                   showLineNumbers ? (
@@ -199,7 +202,7 @@ export const CodeBlock = ({
         code={code}
       >
         {({ style, tokens, getLineProps, getTokenProps }) => (
-          <StyledPre style={style}>
+          <StyledPre style={style} wrap={wrapLines}>
             <Code>
               {tokens.map((line, i) => {
                 const lineTokens = line.map((token, key) => <span key={key} {...getTokenProps({ token })} />)

--- a/internal/lookoutui/src/components/JobRunLogsTextSizeToggle.tsx
+++ b/internal/lookoutui/src/components/JobRunLogsTextSizeToggle.tsx
@@ -1,0 +1,82 @@
+import { FC } from "react"
+
+import { FormatSize } from "@mui/icons-material"
+import { styled, SvgIconProps, ToggleButton, ToggleButtonGroup, ToggleButtonProps } from "@mui/material"
+
+import { SPACING } from "../styling/spacing"
+import { JOB_RUN_LOGS_TEXT_SIZES, JobRunLogsTextSize, useJobRunLogsTextSize } from "../userSettings"
+
+const ToggleButtonSmall = styled(ToggleButton)(({ theme }) => ({
+  display: "flex",
+  gap: theme.spacing(SPACING.xs),
+
+  [".MuiSvgIcon-root"]: {
+    fontSize: 12,
+  },
+}))
+
+const ToggleButtonMedium = styled(ToggleButton)(({ theme }) => ({
+  display: "flex",
+  gap: theme.spacing(SPACING.xs),
+
+  [".MuiSvgIcon-root"]: {
+    fontSize: 17,
+  },
+}))
+
+const ToggleButtonLarge = styled(ToggleButton)(({ theme }) => ({
+  display: "flex",
+  gap: theme.spacing(SPACING.xs),
+
+  [".MuiSvgIcon-root"]: {
+    fontSize: 24,
+  },
+}))
+
+const textSizeToggleButtonComponentMap: Record<JobRunLogsTextSize, FC<ToggleButtonProps>> = {
+  small: ToggleButtonSmall,
+  medium: ToggleButtonMedium,
+  large: ToggleButtonLarge,
+}
+
+const textSizeIconFontSizeMap: Record<JobRunLogsTextSize, SvgIconProps["fontSize"]> = {
+  small: "inherit",
+  medium: "medium",
+  large: "large",
+}
+
+const textSizeDisplayNameMap: Record<JobRunLogsTextSize, string> = {
+  small: "Small",
+  medium: "Medium",
+  large: "Large",
+}
+
+export interface JobRunLogsTextSizeToggleProps {
+  compact?: boolean
+}
+
+export const JobRunLogsTextSizeToggle = ({ compact }: JobRunLogsTextSizeToggleProps) => {
+  const [jobRunLogsTextSize, setJobRunLogsTextSize] = useJobRunLogsTextSize()
+
+  return (
+    <ToggleButtonGroup
+      color="primary"
+      value={jobRunLogsTextSize}
+      exclusive
+      aria-label="colour mode"
+      onChange={(_, newTextSize) => setJobRunLogsTextSize(newTextSize as JobRunLogsTextSize)}
+      size={compact ? "small" : "medium"}
+      fullWidth={!compact}
+    >
+      {JOB_RUN_LOGS_TEXT_SIZES.map((textSize) => {
+        const ToggleButtonComponent = textSizeToggleButtonComponentMap[textSize]
+        return (
+          <ToggleButtonComponent key={textSize} value={textSize}>
+            <FormatSize fontSize={textSizeIconFontSizeMap[textSize]} />
+            {!compact && <div>{textSizeDisplayNameMap[textSize]}</div>}
+          </ToggleButtonComponent>
+        )
+      })}
+    </ToggleButtonGroup>
+  )
+}

--- a/internal/lookoutui/src/components/SettingsDialog.tsx
+++ b/internal/lookoutui/src/components/SettingsDialog.tsx
@@ -5,11 +5,31 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
+  Divider,
+  FormControlLabel,
+  FormGroup,
+  styled,
+  Switch,
   ToggleButton,
   ToggleButtonGroup,
   Typography,
   useColorScheme,
 } from "@mui/material"
+
+import { SPACING } from "../styling/spacing"
+import { useCodeSnippetsWrapLines, useJobRunLogsShowTimestamps, useJobRunLogsWrapLines } from "../userSettings"
+import { JobRunLogsTextSizeToggle } from "./JobRunLogsTextSizeToggle"
+
+const DialogContentContainer = styled("div")(({ theme }) => ({
+  display: "flex",
+  flexDirection: "column",
+  gap: theme.spacing(SPACING.md),
+}))
+
+const SettingsGroupHeading = styled(Typography)({
+  fontSize: "1.1rem",
+  fontWeight: 500,
+})
 
 export interface SettingsDialogProps {
   open: boolean
@@ -19,28 +39,97 @@ export interface SettingsDialogProps {
 export const SettingsDialog = ({ open, onClose }: SettingsDialogProps) => {
   const { mode, setMode } = useColorScheme()
 
+  const [jobRunLogsShowTimestamps, setJobRunLogsShowTimestamps] = useJobRunLogsShowTimestamps()
+  const [jobRunLogsWrapLines, setJobRunLogsWrapLines] = useJobRunLogsWrapLines()
+  const [codeSnippetsWrapLines, setCodeSnippetsWrapLines] = useCodeSnippetsWrapLines()
+
   return (
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="xs">
       <DialogTitle>Settings</DialogTitle>
       <DialogContent>
-        <div>
-          <Typography variant="overline">Colour mode</Typography>
-        </div>
-        <div>
-          <ToggleButtonGroup
-            color="primary"
-            disabled={mode === undefined}
-            value={mode ?? "system"}
-            exclusive
-            aria-label="colour mode"
-            onChange={(_, colorMode) => setMode(colorMode)}
-            fullWidth
-          >
-            <ToggleButton value="light">Light</ToggleButton>
-            <ToggleButton value="system">System</ToggleButton>
-            <ToggleButton value="dark">Dark</ToggleButton>
-          </ToggleButtonGroup>
-        </div>
+        <DialogContentContainer>
+          <div>
+            <div>
+              <Typography variant="overline">Colour mode</Typography>
+            </div>
+            <div>
+              <ToggleButtonGroup
+                color="primary"
+                disabled={mode === undefined}
+                value={mode ?? "system"}
+                exclusive
+                aria-label="colour mode"
+                onChange={(_, colorMode) => setMode(colorMode)}
+                fullWidth
+              >
+                <ToggleButton value="light">Light</ToggleButton>
+                <ToggleButton value="system">System</ToggleButton>
+                <ToggleButton value="dark">Dark</ToggleButton>
+              </ToggleButtonGroup>
+            </div>
+          </div>
+          <div>
+            <Divider />
+          </div>
+          <div>
+            <SettingsGroupHeading variant="h2">Job run logs</SettingsGroupHeading>
+          </div>
+          <div>
+            <FormGroup>
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={jobRunLogsShowTimestamps}
+                    onChange={({ target: { checked } }) => setJobRunLogsShowTimestamps(checked)}
+                  />
+                }
+                label="Show timestamps"
+              />
+            </FormGroup>
+          </div>
+          <div>
+            <FormGroup>
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={jobRunLogsWrapLines}
+                    onChange={({ target: { checked } }) => setJobRunLogsWrapLines(checked)}
+                  />
+                }
+                label="Wrap lines"
+              />
+            </FormGroup>
+          </div>
+          <div>
+            <div>
+              <Typography variant="overline">Text size</Typography>
+            </div>
+            <div>
+              <JobRunLogsTextSizeToggle />
+            </div>
+          </div>
+          <div></div>
+          <Divider />
+          <div>
+            <SettingsGroupHeading>Code snippets</SettingsGroupHeading>
+          </div>
+          <div>
+            <Typography component="p">These settings do not apply to job run logs.</Typography>
+          </div>
+          <div>
+            <FormGroup>
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={codeSnippetsWrapLines}
+                    onChange={({ target: { checked } }) => setCodeSnippetsWrapLines(checked)}
+                  />
+                }
+                label="Wrap lines"
+              />
+            </FormGroup>
+          </div>
+        </DialogContentContainer>
       </DialogContent>
       <DialogActions>
         <Button autoFocus onClick={onClose} variant="outlined" endIcon={<Close />}>

--- a/internal/lookoutui/src/userSettings/index.ts
+++ b/internal/lookoutui/src/userSettings/index.ts
@@ -1,0 +1,1 @@
+export * from "./settings"

--- a/internal/lookoutui/src/userSettings/localStorageKeys.ts
+++ b/internal/lookoutui/src/userSettings/localStorageKeys.ts
@@ -1,0 +1,7 @@
+const LOCAL_STORAGE_KEY_PREFIX = "lookout-user-settings-"
+
+export const JOB_RUN_LOGS_SHOW_TIMESTAMPS_KEY = `${LOCAL_STORAGE_KEY_PREFIX}job-run-logs-show-timestamps`
+export const JOB_RUN_LOGS_TEXT_SIZE_KEY = `${LOCAL_STORAGE_KEY_PREFIX}job-run-logs-text-size`
+export const JOB_RUN_LOGS_WRAP_LINES_KEY = `${LOCAL_STORAGE_KEY_PREFIX}job-run-logs-wrap-lines`
+
+export const CODE_SNIPPETS_WRAP_LINES_KEY = `${LOCAL_STORAGE_KEY_PREFIX}code-snippets-wrap-lines`

--- a/internal/lookoutui/src/userSettings/settings.ts
+++ b/internal/lookoutui/src/userSettings/settings.ts
@@ -1,0 +1,43 @@
+import {
+  CODE_SNIPPETS_WRAP_LINES_KEY,
+  JOB_RUN_LOGS_SHOW_TIMESTAMPS_KEY,
+  JOB_RUN_LOGS_TEXT_SIZE_KEY,
+  JOB_RUN_LOGS_WRAP_LINES_KEY,
+} from "./localStorageKeys"
+import {
+  booleanFromStorageValue,
+  booleanToStorageValue,
+  textEnumFromStorageValue,
+  textEnumToStorageValue,
+  useLocalStorageValue,
+} from "./storage"
+
+export const JOB_RUN_LOGS_TEXT_SIZES = ["small", "medium", "large"] as const
+
+export type JobRunLogsTextSize = (typeof JOB_RUN_LOGS_TEXT_SIZES)[number]
+
+const jobRunLogsTextSizeEnumMap: Record<JobRunLogsTextSize, true> = {
+  small: true,
+  medium: true,
+  large: true,
+}
+
+export const useJobRunLogsShowTimestamps = () =>
+  useLocalStorageValue(JOB_RUN_LOGS_SHOW_TIMESTAMPS_KEY, false, booleanFromStorageValue, booleanToStorageValue)
+
+export const useJobRunLogsWrapLines = () =>
+  useLocalStorageValue(JOB_RUN_LOGS_WRAP_LINES_KEY, false, booleanFromStorageValue, booleanToStorageValue)
+
+const jobRunLogsTextSizeFromStorageValue = (storageValue: string | null) =>
+  textEnumFromStorageValue(storageValue, jobRunLogsTextSizeEnumMap)
+
+export const useJobRunLogsTextSize = () =>
+  useLocalStorageValue<JobRunLogsTextSize>(
+    JOB_RUN_LOGS_TEXT_SIZE_KEY,
+    "medium",
+    jobRunLogsTextSizeFromStorageValue,
+    textEnumToStorageValue,
+  )
+
+export const useCodeSnippetsWrapLines = () =>
+  useLocalStorageValue(CODE_SNIPPETS_WRAP_LINES_KEY, true, booleanFromStorageValue, booleanToStorageValue)

--- a/internal/lookoutui/src/userSettings/storage.ts
+++ b/internal/lookoutui/src/userSettings/storage.ts
@@ -1,0 +1,75 @@
+import { Dispatch, SetStateAction, useCallback, useEffect, useState } from "react"
+
+export const booleanFromStorageValue = (storageValue: string | null): boolean | null => {
+  if (storageValue === null) {
+    return null
+  }
+
+  try {
+    const parsedValue = JSON.parse(storageValue)
+    if (typeof parsedValue !== "boolean") {
+      return null
+    }
+
+    return parsedValue
+  } catch {
+    return null
+  }
+}
+
+export const booleanToStorageValue = (value: boolean): string => JSON.stringify(value)
+
+export const textEnumFromStorageValue = <TEnum extends string>(
+  storageValue: string | null,
+  enumMap: Record<TEnum, true>,
+): TEnum | null => {
+  if (storageValue === null) {
+    return null
+  }
+
+  if (enumMap[storageValue as TEnum]) {
+    return storageValue as TEnum
+  }
+
+  return null
+}
+
+export const textEnumToStorageValue = <TEnum extends string>(value: TEnum): string => value
+
+const EVENT_TYPE = "localstorage"
+
+export const useLocalStorageValue = <TValue>(
+  key: string,
+  defaultValue: TValue,
+  fromStorageValue: (storageValue: string | null) => TValue | null,
+  toStorageValue: (value: TValue) => string,
+): [TValue, Dispatch<SetStateAction<TValue>>] => {
+  const updateState = useCallback(() => {
+    const storageValue = localStorage.getItem(key)
+    const value = fromStorageValue(storageValue)
+    if (value !== null) {
+      return value
+    }
+
+    localStorage.setItem(key, toStorageValue(defaultValue))
+    window.dispatchEvent(new Event(EVENT_TYPE))
+    return defaultValue
+  }, [key, defaultValue, fromStorageValue, toStorageValue])
+
+  const [state, setState] = useState(updateState)
+
+  useEffect(() => {
+    localStorage.setItem(key, toStorageValue(state))
+    window.dispatchEvent(new Event(EVENT_TYPE))
+  }, [key, state])
+
+  useEffect(() => {
+    const listenStorageChange = () => {
+      setState(updateState)
+    }
+    window.addEventListener(EVENT_TYPE, listenStorageChange)
+    return () => window.removeEventListener(EVENT_TYPE, listenStorageChange)
+  }, [updateState])
+
+  return [state, setState]
+}


### PR DESCRIPTION
In the Lookout UI, this allows users to set the following preferences, which are each stored and persisted in local storage:
- text wrapping of job run logs
- text size of job run logs (small/medium/large)
- whether to show timestamps for job run log lines (this was not previously persisted)
- text wrapping for code snippets, such as commands

For all these settings, the user can set them in the existing settings dialog:
![image](https://github.com/user-attachments/assets/ae0c0d6f-b3cd-44d1-94c1-56fa7e834a12)

For settings related to job run logs, they can also set these when viewing the logs:
![image](https://github.com/user-attachments/assets/99e012d9-e626-4448-8a25-e49e52b49ed0)
![image](https://github.com/user-attachments/assets/8a5754e4-1bb5-440c-8606-1844c7e913f3)
![image](https://github.com/user-attachments/assets/3d91e687-3e39-4d83-8e75-80faa190c48d)
