### PR TITLE
add lookout-migration and lookout ingester to mage localdev minimal

### DIFF
--- a/magefiles/main.go
+++ b/magefiles/main.go
@@ -203,7 +203,7 @@ func LocalDev(arg string) error {
 
 	switch arg {
 	case "minimal":
-		mg.Deps(mg.F(goreleaserMinimalRelease, "bundle"), Kind, downloadDependencyImages)
+		mg.Deps(mg.F(goreleaserMinimalRelease, "bundle", "lookout-bundle"), Kind, downloadDependencyImages)
 	case "full":
 		mg.Deps(BuildPython, BuildScala, mg.F(BuildDockers, "bundle, lookout-bundle"), Kind, downloadDependencyImages)
 	case "no-build", "debug":


### PR DESCRIPTION
Currently, running mage localDev can result in a situation where you are testing a combination of local changes and state on master, as localDev minimal pulls lookout for lookout-migration and lookout ingester as external dependencies.

Tested by running localDev minimal and testsuite.
