### PR TITLE
add onPaste trim for jobs table text filter

### DIFF
--- a/internal/lookoutui/src/components/lookout/JobsTableFilter.tsx
+++ b/internal/lookoutui/src/components/lookout/JobsTableFilter.tsx
@@ -213,6 +213,10 @@ const TextFilter = ({
   return (
     <TextField
       onChange={(e) => setTextFieldValue(e.currentTarget.value)}
+      onPaste={(e) => {
+        e.preventDefault()
+        setTextFieldValue(e.clipboardData.getData("text/plain").trim())
+      }}
       value={textFieldValue}
       inputRef={ref}
       type={"text"}


### PR DESCRIPTION
Trims whitespace from pasted content into the text filter fields of the Lookout UI jobs table.