### PR TITLE
Fix filter button in queue table cells

### DIFF
--- a/internal/lookoutui/src/components/lookout/JobsTableCell.tsx
+++ b/internal/lookoutui/src/components/lookout/JobsTableCell.tsx
@@ -300,7 +300,9 @@ export const BodyCell = ({ cell, rowIsGroup, rowIsExpanded, onExpandedChange, on
             : {
                 onFilter: () => {
                   cell.column.setFilterValue(
-                    columnMetadata.filterType === FilterType.Enum ? [cell.getValue()] : cell.getValue(),
+                    cell.column.id === StandardColumnId.Queue || columnMetadata.filterType === FilterType.Enum
+                      ? [cell.getValue()]
+                      : cell.getValue(),
                   )
                 },
               }


### PR DESCRIPTION
Clicking the filter button next to a value for a queue name in the jobs table currently causes a runtime error. It sets the value of the filter to a string, whereas the queue filter expects an array of strings.