### PR TITLE
Deterministically order the list of queues

### DIFF
--- a/internal/server/queue/queue_repository.go
+++ b/internal/server/queue/queue_repository.go
@@ -54,7 +54,7 @@ func NewPostgresQueueRepository(db *pgxpool.Pool) *PostgresQueueRepository {
 }
 
 func (r *PostgresQueueRepository) GetAllQueues(ctx *armadacontext.Context) ([]queue.Queue, error) {
-	rows, err := r.db.Query(ctx, "SELECT definition FROM queue ORDER BY definition")
+	rows, err := r.db.Query(ctx, "SELECT definition FROM queue ORDER BY name")
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/internal/server/queue/queue_repository.go
+++ b/internal/server/queue/queue_repository.go
@@ -54,7 +54,7 @@ func NewPostgresQueueRepository(db *pgxpool.Pool) *PostgresQueueRepository {
 }
 
 func (r *PostgresQueueRepository) GetAllQueues(ctx *armadacontext.Context) ([]queue.Queue, error) {
-	rows, err := r.db.Query(ctx, "SELECT definition FROM queue")
+	rows, err := r.db.Query(ctx, "SELECT definition FROM queue ORDER BY definition")
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}


### PR DESCRIPTION
Order the list of queues returned by the `/v1/batched/queues` endpoint. In the Lookout UI, this means that the autocomplete filter for the queues column lists the queues alphabetically.