### PR TITLE
Scheduler: rename capped demand to constrained demand (incl metric), some adjustedFairShare refactoring

### DIFF
--- a/internal/scheduler/metrics/cycle_metrics_test.go
+++ b/internal/scheduler/metrics/cycle_metrics_test.go
@@ -35,7 +35,7 @@ func TestReportStateTransitions(t *testing.T) {
 					"queue1": {
 						Allocated:         cpu(10),
 						Demand:            cpu(20),
-						CappedDemand:      cpu(15),
+						ConstrainedDemand: cpu(15),
 						AdjustedFairShare: 0.15,
 						SuccessfulJobSchedulingContexts: map[string]*context.JobSchedulingContext{
 							"job1": {
@@ -70,8 +70,8 @@ func TestReportStateTransitions(t *testing.T) {
 	demand := testutil.ToFloat64(m.latestCycleMetrics.Load().demand.WithLabelValues(poolQueue...))
 	assert.InDelta(t, 0.2, demand, epsilon, "demand")
 
-	cappedDemand := testutil.ToFloat64(m.latestCycleMetrics.Load().cappedDemand.WithLabelValues(poolQueue...))
-	assert.InDelta(t, 0.15, cappedDemand, epsilon, "cappedDemand")
+	constrainedDemand := testutil.ToFloat64(m.latestCycleMetrics.Load().constrainedDemand.WithLabelValues(poolQueue...))
+	assert.InDelta(t, 0.15, constrainedDemand, epsilon, "constrainedDemand")
 
 	adjustedFairShare := testutil.ToFloat64(m.latestCycleMetrics.Load().adjustedFairShare.WithLabelValues(poolQueue...))
 	assert.InDelta(t, 0.15, adjustedFairShare, epsilon, "adjustedFairShare")
@@ -121,7 +121,7 @@ func TestResetLeaderMetrics_ResetsLatestCycleMetrics(t *testing.T) {
 	testResetGauge(func(metrics *cycleMetrics) *prometheus.GaugeVec { return m.latestCycleMetrics.Load().actualShare }, poolQueueLabelValues)
 	testResetGauge(func(metrics *cycleMetrics) *prometheus.GaugeVec { return m.latestCycleMetrics.Load().fairnessError }, []string{"pool1"})
 	testResetGauge(func(metrics *cycleMetrics) *prometheus.GaugeVec { return m.latestCycleMetrics.Load().demand }, poolQueueLabelValues)
-	testResetGauge(func(metrics *cycleMetrics) *prometheus.GaugeVec { return m.latestCycleMetrics.Load().cappedDemand }, poolQueueLabelValues)
+	testResetGauge(func(metrics *cycleMetrics) *prometheus.GaugeVec { return m.latestCycleMetrics.Load().constrainedDemand }, poolQueueLabelValues)
 	testResetGauge(func(metrics *cycleMetrics) *prometheus.GaugeVec { return m.latestCycleMetrics.Load().gangsConsidered }, poolQueueLabelValues)
 	testResetGauge(func(metrics *cycleMetrics) *prometheus.GaugeVec { return m.latestCycleMetrics.Load().gangsScheduled }, poolQueueLabelValues)
 	testResetGauge(func(metrics *cycleMetrics) *prometheus.GaugeVec {
@@ -157,7 +157,7 @@ func TestDisableLeaderMetrics(t *testing.T) {
 		m.latestCycleMetrics.Load().actualShare.WithLabelValues(poolQueueLabelValues...).Inc()
 		m.latestCycleMetrics.Load().fairnessError.WithLabelValues("pool1").Inc()
 		m.latestCycleMetrics.Load().demand.WithLabelValues(poolQueueLabelValues...).Inc()
-		m.latestCycleMetrics.Load().cappedDemand.WithLabelValues(poolQueueLabelValues...).Inc()
+		m.latestCycleMetrics.Load().constrainedDemand.WithLabelValues(poolQueueLabelValues...).Inc()
 		m.scheduleCycleTime.Observe(float64(1000))
 		m.reconciliationCycleTime.Observe(float64(1000))
 		m.latestCycleMetrics.Load().gangsConsidered.WithLabelValues("pool1", "queue1").Inc()

--- a/internal/scheduler/scheduling/context/queue.go
+++ b/internal/scheduler/scheduling/context/queue.go
@@ -39,9 +39,9 @@ type QueueSchedulingContext struct {
 	// Total demand from this queue.  This is essentially the cumulative resources of all non-terminal jobs at the
 	// start of the scheduling cycle
 	Demand internaltypes.ResourceList
-	// Capped Demand for this queue. This differs from Demand in that it takes into account any limits that we have
+	// Constrained demand for this queue. This differs from Demand in that it takes into account any constraints that we have
 	// placed on the queue
-	CappedDemand internaltypes.ResourceList
+	ConstrainedDemand internaltypes.ResourceList
 	// Fair share is the weight of this queue over the sum of the weights of all queues
 	FairShare float64
 	// AdjustedFairShare modifies fair share such that queues that have a demand cost less than their fair share, have their fair share reallocated.

--- a/internal/scheduler/scheduling/scheduling_algo.go
+++ b/internal/scheduler/scheduling/scheduling_algo.go
@@ -488,7 +488,7 @@ func (l *FairSchedulingAlgo) constructSchedulingContext(
 			// To ensure fair share is computed only from active queues, i.e., queues with jobs queued or running.
 			continue
 		}
-		cappedDemand := constraints.CapResources(queue.Name, demand)
+		constrainedDemand := constraints.CapResources(queue.Name, demand)
 
 		var allocatedByPriorityClass map[string]internaltypes.ResourceList
 		if allocationByQueueAndPriorityClass != nil {
@@ -523,7 +523,7 @@ func (l *FairSchedulingAlgo) constructSchedulingContext(
 			l.limiterByQueue[queue.Name] = queueLimiter
 		}
 
-		if err := sctx.AddQueueSchedulingContext(queue.Name, weight, rawWeight, allocatedByPriorityClass, internaltypes.RlMapSumValues(demand), internaltypes.RlMapSumValues(cappedDemand), queueLimiter); err != nil {
+		if err := sctx.AddQueueSchedulingContext(queue.Name, weight, rawWeight, allocatedByPriorityClass, internaltypes.RlMapSumValues(demand), internaltypes.RlMapSumValues(constrainedDemand), queueLimiter); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Preparation for making adjustedFairShare uncapped
- Rename capped demand to constrained demand - this avoids confusion between capped demand and capped adjusted fair share.
- Introduce a new uncappedAdjustedFairShare field but don't wire it in yet.