### PR TITLE
Add typecheck command for Lookout UI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,9 +23,9 @@ jobs:
           cache: yarn
           cache-dependency-path: ./internal/lookoutui/yarn.lock
 
-      - name: Install Dependencies And Run Unit Tests
+      - name: Install Dependencies, Check Types And Run Unit Tests
         run: |
-          yarn install --frozen-lockfile && yarn openapi && CI=true yarn test --reporter=junit
+          yarn install --frozen-lockfile && yarn openapi && yarn typecheck && CI=true yarn test --reporter=junit
         working-directory: ./internal/lookoutui
 
       - name: Publish JUnit Report

--- a/internal/lookoutui/README.md
+++ b/internal/lookoutui/README.md
@@ -73,6 +73,14 @@ yarn test --run
 If you are actively changing unit tests or code covered by unit tests, you may
 find it useful to omit `--run` to continuously run affected tests.
 
+### Run typechecker
+
+Ensure that the types in TypeScript source and test files are correct.
+
+```bash
+yarn typecheck
+```
+
 ### Lint
 
 Formatting and linting is done using [Prettier](https://prettier.io/) and

--- a/internal/lookoutui/package.json
+++ b/internal/lookoutui/package.json
@@ -12,6 +12,7 @@
     "build": "vite build",
     "serve": "vite preview",
     "test": "vitest",
+    "typecheck": "tsc --noEmit",
     "openapi": "docker run --rm -u $(id -u ${USER}):$(id -g ${USER}) -v \"${PWD}/../../:/project\" openapitools/openapi-generator-cli:v5.4.0 /project/internal/lookoutui/openapi.sh",
     "openapi:win": "powershell -Command \"$uid = (New-Object System.Security.Principal.WindowsPrincipal([System.Security.Principal.WindowsIdentity]::GetCurrent())).Identity.User.Value; $gid = (Get-WmiObject Win32_UserAccount | Where-Object { $_.SID -eq $uid }).SID.Value; docker run --rm -e USERID=$uid -e GROUPID=$gid -v \"%cd%/../../:/project\" openapitools/openapi-generator-cli:v5.4.0 /project/internal/lookoutui/openapi.sh\"",
     "lint": "eslint 'src/**/*.{js,ts,tsx}' --max-warnings 0",


### PR DESCRIPTION
Currently, only the source code for the Lookout UI is typechecked with TypeScript. This happens as part of the build process (run using `yarn build`). Test code written in TypeScript is not currently typechecked as part of any CI or developer workflow, so type errors in test code are able to be committed without causing visible build failures.

This change introduces a new `yarn typecheck` command which simply runs `tsc`. The README has been updated to encourage developers to use this command during development. The command is also run in the existing *Tests* GitHub workflow, which will therefore now fail if there are typechecker errors.