### PR TITLE
Add EnricoMi to approver author list, end expression with `$`

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -9,6 +9,6 @@ pull_request_rules:
           - "#approved-reviews-by>=2"
           - and: 
             - "#approved-reviews-by>=1"
-            - "author~=^(d80tb7|dave[-]gantenbein|dejanzele|eleanorpratt|geaere|JamesMurkin|mauriceyap|masipauskas|MustafaI|zuqq|richscott|robertdavidsmith|samclark|suprjinx)"
+            - "author~=^(d80tb7|dave[-]gantenbein|dejanzele|eleanorpratt|geaere|JamesMurkin|mauriceyap|masipauskas|MustafaI|zuqq|richscott|robertdavidsmith|samclark|suprjinx|EnricoMi)"
         title:
-          Two are checks required.
+          Two approvals required, or one if author is a maintainer.

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -9,6 +9,6 @@ pull_request_rules:
           - "#approved-reviews-by>=2"
           - and: 
             - "#approved-reviews-by>=1"
-            - "author~=^(d80tb7|dave[-]gantenbein|dejanzele|eleanorpratt|geaere|JamesMurkin|mauriceyap|masipauskas|MustafaI|zuqq|richscott|robertdavidsmith|samclark|suprjinx|EnricoMi)"
+            - "author~=^(d80tb7|dave[-]gantenbein|dejanzele|eleanorpratt|geaere|JamesMurkin|mauriceyap|masipauskas|MustafaI|zuqq|richscott|robertdavidsmith|samclark|suprjinx|EnricoMi)$"
         title:
           Two approvals required, or one if author is a maintainer.


### PR DESCRIPTION
#### What type of PR is this?
CI only.

#### What this PR does / why we need it:
- Adds @EnricoMi to the list of authors that require only one approval.
- Adds `$` to the end of the `author` expression so that longer names cannot match the author names.
- Improves the title of the check result

#### Which issue(s) this PR fixes:
Minor

#### Special notes for your reviewer: