### PR TITLE
Apply 'exactly' match-type when clicking filter button

### DIFF
--- a/internal/lookoutui/src/components/lookout/JobsTableCell.tsx
+++ b/internal/lookoutui/src/components/lookout/JobsTableCell.tsx
@@ -232,9 +232,17 @@ export interface BodyCellProps {
   rowIsExpanded: boolean
   onExpandedChange: () => void
   onClickRowCheckbox: (row: Row<JobTableRow>) => void
+  onColumnMatchChange: (columnId: string, newMatch: Match) => void
 }
 
-export const BodyCell = ({ cell, rowIsGroup, rowIsExpanded, onExpandedChange, onClickRowCheckbox }: BodyCellProps) => {
+export const BodyCell = ({
+  cell,
+  rowIsGroup,
+  rowIsExpanded,
+  onExpandedChange,
+  onClickRowCheckbox,
+  onColumnMatchChange,
+}: BodyCellProps) => {
   const columnMetadata = getColumnMetadata(cell.column.columnDef)
   const cellHasValue = cell.renderValue()
   const isRightAligned = columnMetadata.isRightAligned ?? false
@@ -299,11 +307,12 @@ export const BodyCell = ({ cell, rowIsGroup, rowIsExpanded, onExpandedChange, on
             ? undefined
             : {
                 onFilter: () => {
-                  cell.column.setFilterValue(
-                    cell.column.id === StandardColumnId.Queue || columnMetadata.filterType === FilterType.Enum
-                      ? [cell.getValue()]
-                      : cell.getValue(),
-                  )
+                  if (cell.column.id === StandardColumnId.Queue || columnMetadata.filterType === FilterType.Enum) {
+                    cell.column.setFilterValue([cell.getValue()])
+                  } else {
+                    onColumnMatchChange(cell.column.id, Match.Exact)
+                    cell.column.setFilterValue(cell.getValue())
+                  }
                 },
               }
         }

--- a/internal/lookoutui/src/components/lookout/JobsTableRow.tsx
+++ b/internal/lookoutui/src/components/lookout/JobsTableRow.tsx
@@ -6,14 +6,23 @@ import { Row } from "@tanstack/table-core"
 import { BodyCell } from "./JobsTableCell"
 import styles from "./JobsTableRow.module.css"
 import { JobTableRow, isJobGroupRow } from "../../models/jobsTableModels"
+import { Match } from "../../models/lookoutModels"
 
 export interface JobsTableRowProps {
   row: Row<JobTableRow>
   isOpenInSidebar: boolean
   onClick?: (e: MouseEvent<HTMLTableRowElement>) => void
   onClickRowCheckbox: (row: Row<JobTableRow>) => void
+  onColumnMatchChange: (columnId: string, newMatch: Match) => void
 }
-export const JobsTableRow = ({ row, isOpenInSidebar, onClick, onClickRowCheckbox }: JobsTableRowProps) => {
+
+export const JobsTableRow = ({
+  row,
+  isOpenInSidebar,
+  onClick,
+  onClickRowCheckbox,
+  onColumnMatchChange,
+}: JobsTableRowProps) => {
   // Helpers to avoid triggering onClick if the user is selecting text
   const [{ pageX, pageY }, setPagePosition] = useState({ pageX: -1, pageY: -1 })
   const isDragging = (e: MouseEvent) => {
@@ -59,6 +68,7 @@ export const JobsTableRow = ({ row, isOpenInSidebar, onClick, onClickRowCheckbox
           rowIsExpanded={row.getIsExpanded()}
           onExpandedChange={row.toggleExpanded}
           onClickRowCheckbox={onClickRowCheckbox}
+          onColumnMatchChange={onColumnMatchChange}
           key={cell.id}
         />
       ))}

--- a/internal/lookoutui/src/containers/lookout/JobsTableContainer.tsx
+++ b/internal/lookoutui/src/containers/lookout/JobsTableContainer.tsx
@@ -858,6 +858,7 @@ export const JobsTableContainer = ({
                 onClickRow={(row) => selectRow(row, true)}
                 onShiftClickRow={shiftSelectRow}
                 onControlClickRow={(row) => selectRow(row, false)}
+                onColumnMatchChange={onColumnMatchChange}
               />
             </Table>
           </TableContainer>
@@ -911,6 +912,7 @@ interface JobsTableBodyProps {
   onClickRow: (row: Row<JobTableRow>) => void
   onControlClickRow: (row: Row<JobTableRow>) => void
   onShiftClickRow: (row: Row<JobTableRow>) => void
+  onColumnMatchChange: (columnId: string, newMatch: Match) => void
 }
 
 const JobsTableBody = ({
@@ -924,6 +926,7 @@ const JobsTableBody = ({
   onClickRow,
   onControlClickRow,
   onShiftClickRow,
+  onColumnMatchChange,
 }: JobsTableBodyProps) => {
   const canDisplay = !dataIsLoading && topLevelRows.length > 0
   return (
@@ -950,6 +953,7 @@ const JobsTableBody = ({
           onClickRow,
           onControlClickRow,
           onShiftClickRow,
+          onColumnMatchChange,
           dataIsLoading,
         ),
       )}
@@ -966,6 +970,7 @@ const recursiveRowRender = (
   onClickRow: (row: Row<JobTableRow>) => void,
   onControlClickRow: (row: Row<JobTableRow>) => void,
   onShiftClickRow: (row: Row<JobTableRow>) => void,
+  onColumnMatchChange: (columnId: string, newMatch: Match) => void,
   dataIsLoading: boolean,
 ): JSX.Element => {
   const original = row.original
@@ -993,6 +998,7 @@ const recursiveRowRender = (
           }
         }}
         onClickRowCheckbox={onClickRowCheckbox}
+        onColumnMatchChange={onColumnMatchChange}
       />
 
       {/* Render any sub rows if expanded */}
@@ -1008,6 +1014,7 @@ const recursiveRowRender = (
             onClickRow,
             onControlClickRow,
             onShiftClickRow,
+            onColumnMatchChange,
             dataIsLoading,
           ),
         )}


### PR DESCRIPTION
In the Lookout UI's jobs table, users can filter by the value in a cell by clicking on a button next to the value which appears on hover, so long as the column supports filtering.

Currently, for non-enum values, the filter value is applied, but the match-type is left unchanged (this defaults to starts-with). This changes the match-type to 'exactly', which is both more appropriate and more efficient for the database to process.