### PR TITLE
Website: fix running Jekyll locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,8 @@ bin/
 *.out
 
 # Dependency directories (remove the comment below to include it)
-# vendor/
+vendor/
+.bundle/
 
 # .net core
 *.suo

--- a/Gemfile
+++ b/Gemfile
@@ -16,4 +16,4 @@ end
 gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
 
 # Requiring this version of webrick permits this to work under ruby 3.x.
-gem "webrick", "~> 1.7"
+gem "webrick", "~> 1.9"

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 # Use GitHub Pages locally to match the GitHub Pages server environment.
-gem "github-pages", "~> 226", group: :jekyll_plugins
+gem "github-pages", "~> 232", group: :jekyll_plugins
 # See: https://pages.github.com/versions/ for available Jekyll plugins.
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,8 @@
 source "https://rubygems.org"
 
-# If you want to use GitHub Pages, remove the "gem "jekyll"" above and
-# uncomment the line below. To upgrade, run `bundle update github-pages`.
+# Use GitHub Pages locally to match the GitHub Pages server environment.
 gem "github-pages", "~> 226", group: :jekyll_plugins
-# If you have any plugins, put them here!
-group :jekyll_plugins do
-  gem 'jekyll-paginate', "~> 1.1.0"
-  gem 'jekyll-sitemap', "~> 1.4.0"
-end
+# See: https://pages.github.com/versions/ for available Jekyll plugins.
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
 # and associated library.

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 # Use GitHub Pages locally to match the GitHub Pages server environment.
+# To upgrade, run `bundle update github-pages`.
 gem "github-pages", "~> 232", group: :jekyll_plugins
 # See: https://pages.github.com/versions/ for available Jekyll plugins.
 


### PR DESCRIPTION
#### What type of PR is this?
Fix

#### What this PR does / why we need it:
Allows developers to work on the website locally

#### Which issue(s) this PR fixes:
Fixes #4276 

#### Special notes for your reviewer:
Includes also adding dependency directories to `.gitignore` to allow installing gems in the folder-scope only