### PR TITLE
Fix check for determining if we should run the optimiser

### DIFF
--- a/internal/scheduler/scheduling/scheduling_algo.go
+++ b/internal/scheduler/scheduling/scheduling_algo.go
@@ -626,7 +626,7 @@ func (l *FairSchedulingAlgo) shouldRunOptimiser(pool configuration.PoolConfig) b
 	timeOfLastOptimiserRun, ok := l.lastOptimiserRoundTimeByPool[pool.Name]
 	if !ok {
 		return true
-	} else if l.clock.Since(timeOfLastOptimiserRun) <= pool.ExperimentalOptimiser.Interval {
+	} else if l.clock.Since(timeOfLastOptimiserRun) > pool.ExperimentalOptimiser.Interval {
 		return true
 	}
 	return false


### PR DESCRIPTION
This was a bug and where I was checking the inverse of what I wanted, meaning we ran the optimiser every round rather than only after the interval