### PR TITLE
[Website] fix: support deployment on forks GitHub Pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,6 @@
 site: Armada
-
-url: "https://armadaproject.io"
-baseurl: ""
+# title, description, url and baseurl will be set by jekyll-github-metadata
+# See: https://github.com/jekyll/github-metadata
 
 collections:
   pages:
@@ -35,6 +34,7 @@ sass:
 plugins:
   - jekyll-paginate
   - jekyll-sitemap
+  - jekyll-github-metadata
 
 paginate: 6
 paginate_path: "/blog/page:num/"

--- a/_includes/home-sample.html
+++ b/_includes/home-sample.html
@@ -79,7 +79,7 @@
       </div>
         <div class="col-lg-12 text-center">
           <div class="buttons">
-        <a href="/design" class="btn btn-primary">
+        <a href="{{ '/design' | relative_url }}" class="btn btn-primary">
           Learn More
         </a>
           </div>
@@ -102,7 +102,7 @@
             <div class="description pl-4">
               <h5 class="title">Queue</h5>
               <p>Represents a user or project, used to maintain fair share over time, with a priority factor</p>
-              <a href="/user#queue" class="text-info">Learn more</a>
+              <a href="{{ '/user#queue' | relative_url }}" class="text-info">Learn more</a>
             </div>
           </div>
           <div class="info info-horizontal info-hover-primary">
@@ -112,7 +112,7 @@
             <div class="description pl-4">
               <h5 class="title">Job</h5>
               <p>Unit of work to be run (described as a Kubernetes PodSpec)</p>
-              <a href="/user#job" class="text-info">Learn more</a>
+              <a href="{{ '/user#job' | relative_url }}" class="text-info">Learn more</a>
             </div>
           </div>
           <div class="info info-horizontal info-hover-primary">
@@ -122,7 +122,7 @@
             <div class="description pl-4">
               <h5 class="title">Job Set</h5>
               <p>Group of related jobs. The API allows observing progress of a job set together</p>
-              <a href="/user#job-set" class="text-info">Learn more</a>
+              <a href="{{ '/user#job-set' | relative_url }}" class="text-info">Learn more</a>
             </div>
           </div>
         </div>
@@ -144,7 +144,7 @@
         <p class="lead mt-0">Follow the quickstart guide to get Armada up and running locally.</p>
         <br>
         <div class="buttons">
-          <a href="/quickstart" class="btn btn-primary">
+          <a href="{{ '/quickstart' | relative_url }}" class="btn btn-primary">
             Get Started
           </a>
         </div>
@@ -163,7 +163,7 @@
       <p class="lead mt-0">Want to contribute to Armada? Here's all the information you need.</p>
       <br>
       <div class="buttons">
-        <a href="/contribute" class="btn btn-primary">
+        <a href="{{ '/contribute' | relative_url }}" class="btn btn-primary">
           Join Us
         </a>
       </div>

--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -1,13 +1,21 @@
 <!DOCTYPE html>
 <html>
+{% capture redirect_url %}
+    {% if page.redirect_to contains '://' %}
+        {% comment %}External URL{% endcomment %}
+        {{ page.redirect_to }}
+    {% else %}
+        {{ page.redirect_to | relative_url }}
+    {% endif %}
+{% endcapture %}
 <head>
-    <link rel="canonical" href="{{ page.redirect_to }}"/>
+    <link rel="canonical" href="{{ redirect_url | strip }}"/>
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-    <meta http-equiv="refresh" content="0;url={{ page.redirect_to }}" />
+    <meta http-equiv="refresh" content="0;url={{ redirect_url | strip }}"/>
 </head>
 <body>
 <h1>Redirecting...</h1>
-<a href="{{ page.redirect_to }}">Click here if you are not redirected.<a>
-    <script>location='{{ page.redirect_to }}'</script>
+<a href="{{ redirect_url | strip }}">Click here if you are not redirected.<a>
+        <script>location = '{{ redirect_url | strip }}'</script>
 </body>
 </html>


### PR DESCRIPTION
#### What type of PR is this?
Fix

#### What this PR does / why we need it:
Currently, when working on the website from a fork, assets fail to load because the baseurl is hardcoded.
(For example: https://jayofdoom.github.io/armada/).
This PR resolves this issue by dynamically setting the `baseurl` (fork vs main repository), allowing developers to deploy the website on their own forks. This makes it easier to preview changes when reviewing contributions.

#### Which issue(s) this PR fixes:
Fixes #1105

#### Special notes for your reviewer:
This PR ensures the website functions correctly when deployed from a fork (`{username}.github.io/armada`) by:
- Delegating control of `url` and `baseurl` to `jekyll-github-metadata`, which automatically configures the appropriate values during GitHub Pages deployment.
- Fixing usage of non-relative links in `index.html`.
- Correcting redirections to non-relative links in `_layouts/redirect.html`.

#### Preview:
- Without this fix: https://jayofdoom.github.io/armada/
- With it: https://naskio.github.io/armada/

