### PR TITLE
Use central portal host to publish to maven

### DIFF
--- a/client/scala/armada-scala-client/build.sbt
+++ b/client/scala/armada-scala-client/build.sbt
@@ -1,3 +1,5 @@
+import xerial.sbt.Sonatype.sonatypeCentralHost
+
 val scala2Version = "2.13.15"
 
 lazy val root = project
@@ -75,3 +77,5 @@ libraryDependencies ++= Seq(
     "com.thesamet.scalapb" %% "scalapb-runtime-grpc" % scalapb.compiler.Version.scalapbVersion,
     "com.github.jkugiya" %% "ulid-scala" % "1.0.5"
 )
+
+ThisBuild / sonatypeCredentialHost := sonatypeCentralHost


### PR DESCRIPTION
#### What type of PR is this?
CI

#### What this PR does / why we need it:
Makes the Scala client to be published via the Sonatype Central Portal host. Our user is registered with that host, and not the [legacy OSSRH](https://central.sonatype.org/faq/what-is-different-between-central-portal-and-legacy-ossrh/).

#### Which issue(s) this PR fixes:
Publishing the Scala client to Maven fails.

#### Special notes for your reviewer:
Publishing snapshots is blocked by https://github.com/sbt/sbt-ci-release/issues/344, which is blocked by https://github.com/xerial/sbt-sonatype/issues/564.