### PR TITLE
Upgrade gRPC and protobuf versions

### DIFF
--- a/client/scala/armada-scala-client/pom.xml
+++ b/client/scala/armada-scala-client/pom.xml
@@ -67,8 +67,8 @@
     <scala.patch.version>15</scala.patch.version>
     <scala.compat.version>${scala.major.version}.${scala.minor.version}</scala.compat.version>
     <scala.version>${scala.compat.version}.${scala.patch.version}</scala.version>
-    <protobuf.version>3.19.6</protobuf.version>
-    <grpc.version>1.47.1</grpc.version>
+    <protobuf.version>3.25.5</protobuf.version>
+    <grpc.version>1.53.0</grpc.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
#### What type of PR is this?
Upgrading dependencies to please dependabot security alerts.

#### What this PR does / why we need it:
This upgrades the gRPC and protobuf dependencies to a version that patches the following allerts:
- https://github.com/armadaproject/armada/security/dependabot/145
- https://github.com/armadaproject/armada/security/dependabot/146
- https://github.com/armadaproject/armada/security/dependabot/147
- https://github.com/armadaproject/armada/security/dependabot/148

#### Special notes for your reviewer:
This should be reviewed after #4288 is merged into master to have test coverage.