### PR TITLE
Fix Scala client release environment name

### DIFF
--- a/.github/workflows/scala-client-release-to-maven.yml
+++ b/.github/workflows/scala-client-release-to-maven.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-22.04
     # secrets are provided by environment
     environment:
-      name: scala-release
+      name: maven-release
       # a different URL for each point in the matrix, but the same URLs accross commits
       url: 'https://github.com/armadaproject/armada/tree/master/client/scala/armada-scala-client?scala=${{ matrix.scala-version }}'
     permissions: {}


### PR DESCRIPTION
#### What type of PR is this?
Renaming the environment used by the Scala client release workflow.

#### What this PR does / why we need it:
The environment has been changed from `scala-release` to `maven-release`, as it can be reused by the Java client release process.