### PR TITLE
Bump scalapb version o 0.11.13

### DIFF
--- a/client/scala/armada-scala-client/pom.xml
+++ b/client/scala/armada-scala-client/pom.xml
@@ -80,7 +80,7 @@
     <dependency>
       <groupId>com.thesamet.scalapb</groupId>
       <artifactId>scalapb-runtime-grpc_${scala.compat.version}</artifactId>
-      <version>0.9.8</version>
+      <version>0.11.13</version>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
@@ -207,7 +207,7 @@
               <type>scalapb</type>
               <outputOptions>grpc</outputOptions> <!-- more scalapb options can be added here -->
               <outputDirectorySuffix>scala-${scala.compat.version}</outputDirectorySuffix>
-              <pluginArtifact>com.thesamet.scalapb:protoc-gen-scala:0.9.8:sh:unix</pluginArtifact>
+              <pluginArtifact>com.thesamet.scalapb:protoc-gen-scala:0.11.13:sh:unix</pluginArtifact>
             </outputTarget>
           </outputTargets>
         </configuration>


### PR DESCRIPTION
#### What type of PR is this?
Scala client dependency upgrade.

#### What this PR does / why we need it:
This upgrades scalapb from 0.9.8 to 0.11.13, the version that was used by the Scala client before migrating to mvn.