### PR TITLE
Add download button for logs in Lookout

### DIFF
--- a/internal/lookoutui/src/common/downloadTextFile.ts
+++ b/internal/lookoutui/src/common/downloadTextFile.ts
@@ -1,0 +1,10 @@
+export const downloadTextFile = (content: string, fileName: string, blobType: string) => {
+  const element = document.createElement("a")
+  const file = new Blob([content], {
+    type: blobType,
+  })
+  element.href = URL.createObjectURL(file)
+  element.download = fileName
+  document.body.appendChild(element)
+  element.click()
+}

--- a/internal/lookoutui/src/components/CodeBlock.tsx
+++ b/internal/lookoutui/src/components/CodeBlock.tsx
@@ -8,6 +8,7 @@ import "prismjs/components/prism-bash"
 import "prismjs/components/prism-yaml"
 
 import { CopyIconButton } from "./CopyIconButton"
+import { downloadTextFile } from "../common/downloadTextFile"
 import { useCodeSnippetsWrapLines } from "../userSettings"
 
 // All langauges in this set must be imported from Prism in the form:
@@ -138,14 +139,7 @@ export const CodeBlock = ({
       return
     }
 
-    const element = document.createElement("a")
-    const file = new Blob([code], {
-      type: downloadBlobType,
-    })
-    element.href = URL.createObjectURL(file)
-    element.download = downloadFileName
-    document.body.appendChild(element)
-    element.click()
+    downloadTextFile(code, downloadFileName, downloadBlobType)
   }, [code, downloadable, downloadBlobType, downloadFileName])
 
   if (loading) {


### PR DESCRIPTION
Similar to how users can download the YAML spec of a job, this commit adds a button to the logs viewer for users to download the logs displayed, for a particular container for a particular job run.

![image](https://github.com/user-attachments/assets/f69f3530-62b2-4b9f-b7d2-241c5f1aa570)

The text file's name takes the pattern `[job ID]-[run index]-[container name].txt`, for example, '01jpn0zj58rr1898ym3z93t01e-0-alpha.txt`.

![image](https://github.com/user-attachments/assets/2d357547-d089-4749-8fca-1ac004499a6c)

Each log line will be preceded by the ISO timestamp if and only if the user has enabled this with the toggle switch.

| ![image](https://github.com/user-attachments/assets/cfc3fa84-7920-49b9-b85e-c1e28c5e1308) | ![image](https://github.com/user-attachments/assets/b65513cd-a706-41b5-aeef-6fade1a5e97c) |
| -- | -- |