### PR TITLE
Fix text filter pasting behaviour

### DIFF
--- a/internal/lookoutui/src/components/lookout/JobsTableFilter.tsx
+++ b/internal/lookoutui/src/components/lookout/JobsTableFilter.tsx
@@ -217,7 +217,6 @@ const TextFilter = ({
         e.preventDefault()
 
         const trimmedPastedText = e.clipboardData.getData("text/plain").trim()
-        console.log({ start: ref.current?.selectionStart, end: ref.current?.selectionEnd, l: trimmedPastedText.length })
         if (!ref.current || ref.current.selectionStart == null || ref.current.selectionEnd === null) {
           setTextFieldValue(trimmedPastedText)
           return

--- a/internal/lookoutui/src/components/lookout/JobsTableFilter.tsx
+++ b/internal/lookoutui/src/components/lookout/JobsTableFilter.tsx
@@ -215,7 +215,18 @@ const TextFilter = ({
       onChange={(e) => setTextFieldValue(e.currentTarget.value)}
       onPaste={(e) => {
         e.preventDefault()
-        setTextFieldValue(e.clipboardData.getData("text/plain").trim())
+
+        const trimmedPastedText = e.clipboardData.getData("text/plain").trim()
+        console.log({ start: ref.current?.selectionStart, end: ref.current?.selectionEnd, l: trimmedPastedText.length })
+        if (!ref.current || ref.current.selectionStart == null || ref.current.selectionEnd === null) {
+          setTextFieldValue(trimmedPastedText)
+          return
+        }
+
+        const textBefore = textFieldValue.substring(0, ref.current.selectionStart)
+        const textAfter = textFieldValue.substring(ref.current.selectionEnd)
+
+        setTextFieldValue(textBefore + trimmedPastedText + textAfter)
       }}
       value={textFieldValue}
       inputRef={ref}


### PR DESCRIPTION
When pasting into a text filter in the Lookout UI, we trim the pasted text to remove whitespace at the start or end. Currently, the pasted text replaces the entire contents of the text box. This fix prevents the existing contents of the text box from being overwritten - rather, it respects the cursor any selected text.