### PR TITLE
Run push only on tags and master, run any pull_request

### DIFF
--- a/.github/workflows/airflow-operator.yml
+++ b/.github/workflows/airflow-operator.yml
@@ -2,7 +2,9 @@ name: Python Airflow Operator
 
 on:
   push:
-    branches-ignore:
+    tags:
+      - v*
+    branches:
       - master
     paths:
       - '.github/workflows/airflow-operator.yml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,8 @@ on:
   push:
     tags:
       - v*
-    branches-ignore:
-      - gh-pages
+    branches:
+      - master
   pull_request:
     branches-ignore:
       - gh-pages
@@ -27,13 +27,10 @@ permissions:
 
 jobs:
   lint:
-    if: github.event_name == 'schedule' || github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     uses: ./.github/workflows/lint.yml
   test:
-    if: github.event_name == 'schedule' || github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     uses: ./.github/workflows/test.yml
   build:
-    if: github.event_name == 'schedule' || github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     uses: ./.github/workflows/build.yml
 
   # Virtual job that can be configured as a required check before a PR can be merged.

--- a/.github/workflows/java-client.yml
+++ b/.github/workflows/java-client.yml
@@ -2,7 +2,9 @@ name: Java Client
 
 on:
   push:
-    branches-ignore:
+    tags:
+      - v*
+    branches:
       - master
     paths:
       - 'client/java/**'

--- a/.github/workflows/python-client.yml
+++ b/.github/workflows/python-client.yml
@@ -2,7 +2,9 @@ name: Python Client
 
 on:
   push:
-    branches-ignore:
+    tags:
+      - v*
+    branches:
       - master
     paths:
       - 'client/python/**'

--- a/.github/workflows/scala-client.yml
+++ b/.github/workflows/scala-client.yml
@@ -2,7 +2,9 @@ name: Scala Client
 
 on:
   push:
-    branches-ignore:
+    tags:
+      - v*
+    branches:
       - master
     paths:
       - 'client/scala/**'


### PR DESCRIPTION
#### What type of PR is this?
Purely CI related.

#### What this PR does / why we need it:
This configures the `lint`, `test`, and `build` jobs to also run on `pull_request` events inside the `armada` repo. Currently it only runs for fork pull requests.

Generally, you want to prefer running on `pull_request` events over `push` events, because the former runs on a merge commit (branch HEAD merged into target branch), while the latter runs on the actual commit of the branch (branch HEAD). So the former reflects what `master` will look like after the merge. Currently, the `pull_request` evens for pull requests within the `armada` repo (non-fork pull requests) only run the `commit` event.

Further, workflows should run on `push` events only for `master` branch and `v*` tags to avoid two runs for pull request commits. To avoid that, #2988 added the if clauses causing the above mentioned issue.

Branches will eventually be merged into `master`, so they will run CI via the `pull_request` event. No need to run CI on each commit that is not part of a pull request (unless  `master` or a `v*` tag).