### PR TITLE
Upgrade goreleaser in release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v5
         with:
           distribution: goreleaser
-          version: v1.24.0
+          version: v2.8.1
           args: "-f ./.goreleaser.yml release --clean"
         env:
           FULL_RELEASE: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

#### What type of PR is this?

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
We're currently blocked from releasing Armada as the release action uses the wrong version of GoReleaser. GoReleaser was recently upgraded under #4293.

