### PR TITLE
Scala client: add implementation of getActiveQueues() in test suite

### DIFF
--- a/client/scala/armada-scala-client/src/test/scala/io/armadaproject/armada/ArmadaClientSuite.scala
+++ b/client/scala/armada-scala-client/src/test/scala/io/armadaproject/armada/ArmadaClientSuite.scala
@@ -24,6 +24,8 @@ import api.submit.{
   SubmitGrpc
 }
 import api.job.{
+  GetActiveQueuesRequest,
+  GetActiveQueuesResponse,
   JobDetailsRequest,
   JobDetailsResponse,
   JobErrorsRequest,
@@ -204,6 +206,12 @@ private class SubmitMockServer(
 private class JobsMockServer(
     statusMap: TrieMap[String, JobState]
 ) extends JobsGrpc.Jobs {
+
+  def getActiveQueues(
+      request: GetActiveQueuesRequest
+  ): scala.concurrent.Future[GetActiveQueuesResponse] = {
+    Future.successful(new GetActiveQueuesResponse)
+  }
 
   def getJobDetails(
       request: JobDetailsRequest


### PR DESCRIPTION
These changes simply add a mock implementation of the new `getActiveQueues()` method (generated by a recent GRPC proto change) to the `ArmadaClientSuite` test suite for the Scala client, so the Scala client library can be built successfully again.

Fixes https://github.com/armadaproject/armada/issues/4314
