### PR TITLE
Handle job db initialization edge case

### DIFF
--- a/internal/scheduler/database/job_repository.go
+++ b/internal/scheduler/database/job_repository.go
@@ -36,8 +36,9 @@ type JobRunLease struct {
 
 // JobRepository is an interface to be implemented by structs which provide job and run information
 type JobRepository interface {
-	// FetchInitialJobs returns all non-terminal jobs and their associated job runs.
-	FetchInitialJobs(ctx *armadacontext.Context) ([]Job, []Run, error)
+	// FetchInitialJobs returns all non-terminal jobs and their associated job runs as well as the maximum job and run
+	// serials in the event that there are no non-terminal jobs/runs.
+	FetchInitialJobs(ctx *armadacontext.Context) ([]Job, []Run, *int64, *int64, error)
 
 	// FetchJobUpdates returns all jobs and job dbRuns that have been updated after jobSerial and jobRunSerial respectively
 	// These updates are guaranteed to be consistent with each other
@@ -76,15 +77,17 @@ func NewPostgresJobRepository(db *pgxpool.Pool, batchSize int32) *PostgresJobRep
 	}
 }
 
-func (r *PostgresJobRepository) FetchInitialJobs(ctx *armadacontext.Context) ([]Job, []Run, error) {
-	var updatedJobs []Job
+func (r *PostgresJobRepository) FetchInitialJobs(ctx *armadacontext.Context) ([]Job, []Run, *int64, *int64, error) {
+	var initialJobs []Job
 	var initialRuns []Run
+	var maxJobSerial *int64
+	var maxRunSerial *int64
 
 	start := time.Now()
 	defer func() {
 		ctx.Infof(
 			"received %d initial jobs and %d initial job runs from postgres in %s",
-			len(updatedJobs), len(initialRuns), time.Since(start),
+			len(initialJobs), len(initialRuns), time.Since(start),
 		)
 	}()
 
@@ -102,14 +105,14 @@ func (r *PostgresJobRepository) FetchInitialJobs(ctx *armadacontext.Context) ([]
 			return queries.SelectInitialJobs(ctx, SelectInitialJobsParams{Serial: from, Limit: r.batchSize})
 		})
 		if err != nil {
-			return err
+			return fmt.Errorf("selecting initial jobs: %w", err)
 		}
 
-		updatedJobs = make([]Job, len(initialJobRows))
+		initialJobs = make([]Job, len(initialJobRows))
 		updatedJobIds := make([]string, len(initialJobRows))
 		for i, row := range initialJobRows {
 			updatedJobIds[i] = row.JobID
-			updatedJobs[i] = Job{
+			initialJobs[i] = Job{
 				JobID:                   row.JobID,
 				JobSet:                  row.JobSet,
 				Queue:                   row.Queue,
@@ -135,11 +138,38 @@ func (r *PostgresJobRepository) FetchInitialJobs(ctx *armadacontext.Context) ([]
 		initialRuns, err = fetch(0, r.batchSize, func(from int64) ([]Run, error) {
 			return queries.SelectInitialRuns(ctx, SelectInitialRunsParams{Serial: from, Limit: r.batchSize, JobIds: updatedJobIds})
 		})
+		if err != nil {
+			return fmt.Errorf("selecting initial runs: %w", err)
+		}
 
-		return err
+		// Hit a case where the database is empty or all rows are in a terminal state. In the event that all rows are
+		// in a terminal state return the max job/run serial.
+		if len(initialJobs) == 0 {
+			maybeMaxJobSerial, err := queries.SelectMaxJobSerial(ctx)
+			if err != nil {
+				if !errors.Is(err, pgx.ErrNoRows) { // Ignore errors when the DB is empty
+					return fmt.Errorf("selecting max job serial: %w", err)
+				}
+			} else {
+				maxJobSerial = &maybeMaxJobSerial
+			}
+		}
+
+		if len(initialRuns) == 0 {
+			maybeMaxRunSerial, err := queries.SelectMaxRunSerial(ctx)
+			if err != nil {
+				if !errors.Is(err, pgx.ErrNoRows) { // Ignore errors when the DB is empty
+					return fmt.Errorf("selecting max run serial: %w", err)
+				}
+			} else {
+				maxRunSerial = &maybeMaxRunSerial
+			}
+		}
+
+		return nil
 	})
 
-	return updatedJobs, initialRuns, err
+	return initialJobs, initialRuns, maxJobSerial, maxRunSerial, err
 }
 
 // FetchJobRunErrors returns all armadaevents.JobRunErrors for the provided job run ids.  The returned map is

--- a/internal/scheduler/database/query.sql.go
+++ b/internal/scheduler/database/query.sql.go
@@ -714,6 +714,28 @@ func (q *Queries) SelectLeasedJobsByQueue(ctx context.Context, queue []string) (
 	return items, nil
 }
 
+const selectMaxJobSerial = `-- name: SelectMaxJobSerial :one
+SELECT serial FROM jobs ORDER BY serial DESC LIMIT 1
+`
+
+func (q *Queries) SelectMaxJobSerial(ctx context.Context) (int64, error) {
+	row := q.db.QueryRow(ctx, selectMaxJobSerial)
+	var serial int64
+	err := row.Scan(&serial)
+	return serial, err
+}
+
+const selectMaxRunSerial = `-- name: SelectMaxRunSerial :one
+SELECT serial FROM runs ORDER BY serial DESC LIMIT 1
+`
+
+func (q *Queries) SelectMaxRunSerial(ctx context.Context) (int64, error) {
+	row := q.db.QueryRow(ctx, selectMaxRunSerial)
+	var serial int64
+	err := row.Scan(&serial)
+	return serial, err
+}
+
 const selectNewJobs = `-- name: SelectNewJobs :many
 SELECT job_id, job_set, queue, user_id, submitted, groups, priority, queued, queued_version, cancel_requested, cancelled, cancel_by_jobset_requested, succeeded, failed, submit_message, scheduling_info, scheduling_info_version, serial, last_modified, validated, pools, bid_price, cancel_user FROM jobs WHERE serial > $1 ORDER BY serial LIMIT $2
 `

--- a/internal/scheduler/database/query/query.sql
+++ b/internal/scheduler/database/query/query.sql
@@ -4,6 +4,12 @@ SELECT * FROM jobs WHERE serial > $1 ORDER BY serial LIMIT $2;
 -- name: SelectAllJobIds :many
 SELECT job_id FROM jobs;
 
+-- name: SelectMaxJobSerial :one
+SELECT serial FROM jobs ORDER BY serial DESC LIMIT 1;
+
+-- name: SelectMaxRunSerial :one
+SELECT serial FROM runs ORDER BY serial DESC LIMIT 1;
+
 -- name: SelectInitialJobs :many
 SELECT job_id, job_set, queue, priority, submitted, queued, queued_version, validated, cancel_requested, cancel_user, cancel_by_jobset_requested, cancelled, succeeded, failed, scheduling_info, scheduling_info_version, pools, serial FROM jobs WHERE serial > $1 AND cancelled = 'false' AND succeeded = 'false' and failed = 'false' ORDER BY serial LIMIT $2;
 

--- a/internal/scheduler/mocks/job_repository.go
+++ b/internal/scheduler/mocks/job_repository.go
@@ -59,13 +59,15 @@ func (mr *MockJobRepositoryMockRecorder) CountReceivedPartitions(ctx, groupId an
 }
 
 // FetchInitialJobs mocks base method.
-func (m *MockJobRepository) FetchInitialJobs(ctx *armadacontext.Context) ([]database.Job, []database.Run, error) {
+func (m *MockJobRepository) FetchInitialJobs(ctx *armadacontext.Context) ([]database.Job, []database.Run, *int64, *int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FetchInitialJobs", ctx)
 	ret0, _ := ret[0].([]database.Job)
 	ret1, _ := ret[1].([]database.Run)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret2, _ := ret[2].(*int64)
+	ret3, _ := ret[3].(*int64)
+	ret4, _ := ret[4].(error)
+	return ret0, ret1, ret2, ret3, ret4
 }
 
 // FetchInitialJobs indicates an expected call of FetchInitialJobs.


### PR DESCRIPTION
This pull request fixes an edge case with job db initialization. Previously if initialization did not find any non-terminal jobs the next synchronization would do a full table scan since the job db would fetch job updates with starting serial 0. This change makes it such if initialization does not find any non-terminal jobs it sets the job db's max serials to the maximum serial possible in the database. As a result, the next synchronization will start with the maximum serials that were discovered during synchronization instead of 0. 

