### PR TITLE
Fix java client project path in the workflow.

### DIFF
--- a/.github/workflows/java-client-release-to-maven.yml
+++ b/.github/workflows/java-client-release-to-maven.yml
@@ -25,7 +25,6 @@ jobs:
     - name: Build
       run: |
         cp client/java/settings.xml /home/runner/.m2
-        cat /home/runner/.m2/settings.xml
         cd client/java
         mvn clean install
       env:
@@ -33,9 +32,6 @@ jobs:
 
     - name: Release artifacts
       run: |
-        pwd
-        ls -la /home/runner/.m2
-        cat /home/runner/.m2/settings.xml
         cd client/java
         mvn --batch-mode deploy -DskipTests -Pci
       env:

--- a/.github/workflows/java-client-release-to-maven.yml
+++ b/.github/workflows/java-client-release-to-maven.yml
@@ -26,6 +26,7 @@ jobs:
       run: |
         cp client/java/settings.xml /home/runner/.m2
         cat /home/runner/.m2/settings.xml
+        cd client/java
         mvn clean install
       env:
         MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
@@ -35,6 +36,7 @@ jobs:
         pwd
         ls -la /home/runner/.m2
         cat /home/runner/.m2/settings.xml
+        cd client/java
         mvn --batch-mode deploy -DskipTests -Pci
       env:
         MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}


### PR DESCRIPTION
This PR fixes the path to the correct java client directory for the Java Client release workflow.

Related to https://github.com/armadaproject/armada/issues/4264

