### PR TITLE
Preserve URL path and search params in login flow

### DIFF
--- a/internal/lookoutui/src/oidcAuth/OidcAuthProvider.tsx
+++ b/internal/lookoutui/src/oidcAuth/OidcAuthProvider.tsx
@@ -79,6 +79,7 @@ export const OidcAuthProvider = ({ children, oidcConfig }: OidcAuthProviderProps
 
     if (isOidcRedirectPath && typeof user.state === "string" && user.state) {
       const originalURL = new URL(user.state)
+      // Preserve the current location's host, in case this has been changed by the redirect
       window.location.replace(`${originalURL.pathname}${originalURL.search}`)
     } else {
       setAuthError(undefined)

--- a/internal/lookoutui/src/oidcAuth/OidcAuthProvider.tsx
+++ b/internal/lookoutui/src/oidcAuth/OidcAuthProvider.tsx
@@ -74,11 +74,16 @@ export const OidcAuthProvider = ({ children, oidcConfig }: OidcAuthProviderProps
     }
     const user = await (isOidcRedirectPath ? userManager.signinRedirectCallback() : userManager.getUser())
     if (!user || user.expired) {
-      return await userManager.signinRedirect()
+      return await userManager.signinRedirect({ state: window.location.href })
     }
 
-    setAuthError(undefined)
-    setIsLoading(false)
+    if (isOidcRedirectPath && typeof user.state === "string" && user.state) {
+      const originalURL = new URL(user.state)
+      window.location.replace(`${originalURL.pathname}${originalURL.search}`)
+    } else {
+      setAuthError(undefined)
+      setIsLoading(false)
+    }
   }, [userManager, isOidcRedirectPath])
 
   const handlerAuthenticationError = useCallback((e: any) => {


### PR DESCRIPTION
In Lookout, when the user is redirected to the OIDC provider to log in, store the URL path and search params from which they were redirected, then navigate to it when they return to the app.

This means that when the user follows a link to the jobs page with filters encoded in their URL, if they need to login, they will land back on their desired page after logging in, rather than the default page (which will use their previous set filters from their browser's local storage, if present).