### PR TITLE
Scala client: wrap in submitHealth() return value in a Future

### DIFF
--- a/client/scala/armada-scala-client/src/main/scala/io/armadaproject/armada/ArmadaClient.scala
+++ b/client/scala/armada-scala-client/src/main/scala/io/armadaproject/armada/ArmadaClient.scala
@@ -51,9 +51,8 @@ class ArmadaClient(channel: ManagedChannel) {
     blockingStub.health(Empty()).status
   }
 
-  def submitHealth(): HealthCheckResponse.ServingStatus = {
-    val blockingStub = SubmitGrpc.blockingStub(channel)
-    blockingStub.health(Empty()).status
+  def submitHealth(): scala.concurrent.Future[HealthCheckResponse] = {
+    SubmitGrpc.stub(channel).health(Empty())
   }
 
   def createQueue(name: String): Unit = {


### PR DESCRIPTION
The `SubmitGrpc.scala` generated from the original `submit.proto` defines the `health()` method as returning a `Future[HealthCheckResponse]` - make the ArmadaClient convenience wrapper's `submitHealth()` also return the same. Without this change, an UnsupportedOperationException is raised in some tests.

Fixes https://github.com/armadaproject/armada/issues/4330
