### PR TITLE
Add error boundaries to Lookout UI

### DIFF
--- a/internal/lookoutui/package.json
+++ b/internal/lookoutui/package.json
@@ -48,6 +48,7 @@
     "query-string": "^9.1.1",
     "react": "^19",
     "react-dom": "^19",
+    "react-error-boundary": "^5.0.0",
     "react-router-dom": "7.2.0",
     "react-virtuoso": "^4.12.3",
     "timezone-support": "^3.1.0",

--- a/internal/lookoutui/src/App.tsx
+++ b/internal/lookoutui/src/App.tsx
@@ -4,8 +4,11 @@ import { CssBaseline, styled, ThemeProvider } from "@mui/material"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { SnackbarProvider } from "notistack"
 import { UserManager, WebStorageStateStore, UserManagerSettings } from "oidc-client-ts"
+import { ErrorBoundary } from "react-error-boundary"
 import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom"
 
+import { AlertInPageContainerErrorFallback } from "./components/AlertInPageContainerErrorFallback"
+import { FullPageErrorFallback } from "./components/FullPageErrorFallback"
 import NavBar from "./components/NavBar"
 import JobSetsContainer from "./containers/JobSetsContainer"
 import { JobsTableContainer } from "./containers/lookout/JobsTableContainer"
@@ -69,61 +72,82 @@ export function App(props: AppProps) {
   }, [props.customTitle])
 
   return (
-    <ThemeProvider theme={theme} defaultMode="light">
-      <CssBaseline />
-      <SnackbarProvider anchorOrigin={{ horizontal: "right", vertical: "bottom" }} autoHideDuration={8000} maxSnack={3}>
-        <QueryClientProvider client={queryClient}>
-          <OidcAuthProvider oidcConfig={props.oidcConfig}>
-            <BrowserRouter>
-              <ServicesProvider services={props.services}>
-                <AppContainer>
-                  <NavBar customTitle={props.customTitle} />
-                  <AppContent>
-                    <Routes>
-                      <Route
-                        path="/"
-                        element={
-                          <JobsTableContainer
-                            getJobsService={props.services.v2GetJobsService}
-                            groupJobsService={props.services.v2GroupJobsService}
-                            updateJobsService={props.services.v2UpdateJobsService}
-                            runInfoService={props.services.v2RunInfoService}
-                            jobSpecService={props.services.v2JobSpecService}
-                            cordonService={props.services.v2CordonService}
-                            debug={props.debugEnabled}
-                            autoRefreshMs={props.jobsAutoRefreshMs}
-                            commandSpecs={props.commandSpecs}
+    <ErrorBoundary FallbackComponent={FullPageErrorFallback}>
+      <ThemeProvider theme={theme} defaultMode="light">
+        <CssBaseline />
+        <SnackbarProvider
+          anchorOrigin={{ horizontal: "right", vertical: "bottom" }}
+          autoHideDuration={8000}
+          maxSnack={3}
+        >
+          <QueryClientProvider client={queryClient}>
+            <ErrorBoundary FallbackComponent={FullPageErrorFallback}>
+              <OidcAuthProvider oidcConfig={props.oidcConfig}>
+                <BrowserRouter>
+                  <ServicesProvider services={props.services}>
+                    <AppContainer>
+                      <NavBar customTitle={props.customTitle} />
+                      <AppContent>
+                        <Routes>
+                          <Route
+                            path="/"
+                            element={
+                              <ErrorBoundary FallbackComponent={AlertInPageContainerErrorFallback}>
+                                <JobsTableContainer
+                                  getJobsService={props.services.v2GetJobsService}
+                                  groupJobsService={props.services.v2GroupJobsService}
+                                  updateJobsService={props.services.v2UpdateJobsService}
+                                  runInfoService={props.services.v2RunInfoService}
+                                  jobSpecService={props.services.v2JobSpecService}
+                                  cordonService={props.services.v2CordonService}
+                                  debug={props.debugEnabled}
+                                  autoRefreshMs={props.jobsAutoRefreshMs}
+                                  commandSpecs={props.commandSpecs}
+                                />
+                              </ErrorBoundary>
+                            }
                           />
-                        }
-                      />
-                      <Route
-                        path="/job-sets"
-                        element={
-                          <JobSetsContainer
-                            v2GroupJobsService={props.services.v2GroupJobsService}
-                            v2UpdateJobSetsService={props.services.v2UpdateJobSetsService}
-                            jobSetsAutoRefreshMs={props.jobSetsAutoRefreshMs}
+                          <Route
+                            path="/job-sets"
+                            element={
+                              <ErrorBoundary FallbackComponent={AlertInPageContainerErrorFallback}>
+                                <JobSetsContainer
+                                  v2GroupJobsService={props.services.v2GroupJobsService}
+                                  v2UpdateJobSetsService={props.services.v2UpdateJobSetsService}
+                                  jobSetsAutoRefreshMs={props.jobSetsAutoRefreshMs}
+                                />
+                              </ErrorBoundary>
+                            }
                           />
-                        }
-                      />
-                      <Route path="/v2" element={<V2Redirect />} />
-                      <Route
-                        path="*"
-                        element={
-                          // This wildcard route ensures that users who follow old
-                          // links to /job-sets or /jobs see something other than
-                          // a blank page.
-                          <Navigate to="/" />
-                        }
-                      />
-                    </Routes>
-                  </AppContent>
-                </AppContainer>
-              </ServicesProvider>
-            </BrowserRouter>
-          </OidcAuthProvider>
-        </QueryClientProvider>
-      </SnackbarProvider>
-    </ThemeProvider>
+                          <Route
+                            path="/v2"
+                            element={
+                              <ErrorBoundary FallbackComponent={AlertInPageContainerErrorFallback}>
+                                <V2Redirect />
+                              </ErrorBoundary>
+                            }
+                          />
+                          <Route
+                            path="*"
+                            element={
+                              // This wildcard route ensures that users who follow old
+                              // links to /job-sets or /jobs see something other than
+                              // a blank page.
+                              <ErrorBoundary FallbackComponent={AlertInPageContainerErrorFallback}>
+                                <Navigate to="/" />
+                              </ErrorBoundary>
+                            }
+                          />
+                        </Routes>
+                      </AppContent>
+                    </AppContainer>
+                  </ServicesProvider>
+                </BrowserRouter>
+              </OidcAuthProvider>
+            </ErrorBoundary>
+          </QueryClientProvider>
+        </SnackbarProvider>
+      </ThemeProvider>
+    </ErrorBoundary>
   )
 }

--- a/internal/lookoutui/src/components/AlertErrorFallback.tsx
+++ b/internal/lookoutui/src/components/AlertErrorFallback.tsx
@@ -1,0 +1,52 @@
+import { useState } from "react"
+
+import { ExpandLess, ExpandMore } from "@mui/icons-material"
+import { Alert, AlertTitle, Button, Collapse, Stack, Typography } from "@mui/material"
+import { FallbackProps } from "react-error-boundary"
+
+import { CodeBlock } from "./CodeBlock"
+import { SPACING } from "../styling/spacing"
+
+export const AlertErrorFallback = ({ error }: FallbackProps) => {
+  const [detailsExpanded, setDetailsExpanded] = useState(false)
+
+  const { errorMessage, errorDetails } =
+    error instanceof Error
+      ? { errorMessage: `${error.name}: ${error.message}`, errorDetails: error.stack }
+      : { errorMessage: String(error), errorDetails: undefined }
+
+  return (
+    <Alert variant="filled" severity="error">
+      <AlertTitle>Something went wrong</AlertTitle>
+      <Typography component="p" gutterBottom>
+        {errorMessage}
+      </Typography>
+      <Typography component="p" variant="body2" gutterBottom>
+        This is an unexpected error. Please reach out to the maintainers of Armada for help with this problem.
+      </Typography>
+      {errorDetails && (
+        <Stack spacing={SPACING.sm}>
+          <Button
+            color="inherit"
+            fullWidth
+            size="small"
+            variant="outlined"
+            startIcon={detailsExpanded ? <ExpandLess /> : <ExpandMore />}
+            onClick={() => setDetailsExpanded((prev) => !prev)}
+          >
+            {detailsExpanded ? "Hide" : "Show"} error details
+          </Button>
+          <Collapse in={detailsExpanded}>
+            <CodeBlock
+              language="text"
+              loading={false}
+              downloadable={false}
+              showLineNumbers={false}
+              code={errorDetails}
+            />
+          </Collapse>
+        </Stack>
+      )}
+    </Alert>
+  )
+}

--- a/internal/lookoutui/src/components/AlertInPageContainerErrorFallback.tsx
+++ b/internal/lookoutui/src/components/AlertInPageContainerErrorFallback.tsx
@@ -1,0 +1,18 @@
+import { Container, styled } from "@mui/material"
+import { FallbackProps } from "react-error-boundary"
+
+import { AlertErrorFallback } from "./AlertErrorFallback"
+import { SPACING } from "../styling/spacing"
+
+const StyledContainer = styled(Container)(({ theme }) => ({
+  marginTop: theme.spacing(SPACING.lg),
+  marginBottom: theme.spacing(SPACING.lg),
+}))
+
+export const AlertInPageContainerErrorFallback = (props: FallbackProps) => (
+  <StyledContainer maxWidth="md">
+    <div>
+      <AlertErrorFallback {...props} />
+    </div>
+  </StyledContainer>
+)

--- a/internal/lookoutui/src/components/ErrorPage.tsx
+++ b/internal/lookoutui/src/components/ErrorPage.tsx
@@ -1,0 +1,105 @@
+import { Replay } from "@mui/icons-material"
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Alert,
+  AlertTitle,
+  Button,
+  Container,
+  Stack,
+  styled,
+  Typography,
+} from "@mui/material"
+
+import { CodeBlock } from "./CodeBlock"
+import { SPACING } from "../styling/spacing"
+
+const Wrapper = styled("main")(({ theme }) => ({
+  minHeight: "100vh",
+  backgroundColor: theme.palette.background.default,
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+}))
+
+const ContentContainer = styled(Container)(({ theme }) => ({
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  gap: theme.spacing(SPACING.xl),
+}))
+
+const StyledAlert = styled(Alert)({
+  width: "100%",
+})
+
+const StyledAccordion = styled(Accordion)({
+  width: "100%",
+})
+
+const IconImg = styled("img")({
+  maxHeight: 200,
+})
+
+export interface ErrorPageProps {
+  error: any
+  errorTitle: string
+  errorContextMessage?: string
+  retry?: () => void
+}
+
+export const ErrorPage = ({ error, errorTitle, errorContextMessage, retry }: ErrorPageProps) => {
+  const { errorMessage, errorDetails } =
+    error instanceof Error
+      ? { errorMessage: `${error.name}: ${error.message}`, errorDetails: error.stack }
+      : { errorMessage: String(error), errorDetails: undefined }
+
+  return (
+    <Wrapper>
+      <ContentContainer maxWidth="md">
+        <div>
+          <IconImg src="/logo.svg" alt="Armada Lookout" />
+        </div>
+        <Stack spacing={SPACING.sm} width="100%">
+          <StyledAlert
+            severity="error"
+            action={
+              retry ? (
+                <Button color="inherit" size="small" onClick={retry} endIcon={<Replay />}>
+                  Retry
+                </Button>
+              ) : undefined
+            }
+          >
+            <AlertTitle>{errorTitle}</AlertTitle>
+            <Typography component="p" gutterBottom>
+              {errorMessage}
+            </Typography>
+            {errorContextMessage && (
+              <Typography component="p" variant="body2">
+                {errorContextMessage}
+              </Typography>
+            )}
+          </StyledAlert>
+          <StyledAccordion>
+            <AccordionSummary>
+              <Typography>Error details</Typography>
+            </AccordionSummary>
+            <AccordionDetails>
+              {errorDetails && (
+                <CodeBlock
+                  language="text"
+                  loading={false}
+                  downloadable={false}
+                  showLineNumbers={false}
+                  code={errorDetails}
+                />
+              )}
+            </AccordionDetails>
+          </StyledAccordion>
+        </Stack>
+      </ContentContainer>
+    </Wrapper>
+  )
+}

--- a/internal/lookoutui/src/components/FullPageErrorFallback.tsx
+++ b/internal/lookoutui/src/components/FullPageErrorFallback.tsx
@@ -1,0 +1,11 @@
+import { FallbackProps } from "react-error-boundary"
+
+import { ErrorPage } from "./ErrorPage"
+
+export const FullPageErrorFallback = ({ error }: FallbackProps) => (
+  <ErrorPage
+    error={error}
+    errorTitle="Something went wrong on this page"
+    errorContextMessage="This is an unexpected error. Please reach out to the maintainers of Armada for help with this problem."
+  />
+)

--- a/internal/lookoutui/src/components/LoadingPage.tsx
+++ b/internal/lookoutui/src/components/LoadingPage.tsx
@@ -1,0 +1,53 @@
+import { Container, LinearProgress, styled, Typography } from "@mui/material"
+
+import { SPACING } from "../styling/spacing"
+
+const Wrapper = styled("main")(({ theme }) => ({
+  minHeight: "100vh",
+  backgroundColor: theme.palette.background.default,
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+}))
+
+const ContentContainer = styled(Container)(({ theme }) => ({
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  gap: theme.spacing(SPACING.xl),
+}))
+
+const ProgressContainer = styled("div")({
+  width: "100%",
+})
+
+const IconImg = styled("img")({
+  maxHeight: 200,
+})
+
+export interface LoadingPageProps {
+  loadingContextMessage: string
+}
+
+export const LoadingPage = ({ loadingContextMessage }: LoadingPageProps) => (
+  <Wrapper>
+    <ContentContainer maxWidth="md">
+      <div>
+        <IconImg src="/logo.svg" alt="Armada Lookout" />
+      </div>
+      <ProgressContainer>
+        <LinearProgress />
+      </ProgressContainer>
+      <div>
+        <Typography component="p" variant="h4" textAlign="center">
+          Armada Lookout
+        </Typography>
+        {loadingContextMessage && (
+          <Typography component="p" variant="h6" color="text.secondary" textAlign="center">
+            {loadingContextMessage}
+          </Typography>
+        )}
+      </div>
+    </ContentContainer>
+  </Wrapper>
+)

--- a/internal/lookoutui/src/components/SettingsDialog.tsx
+++ b/internal/lookoutui/src/components/SettingsDialog.tsx
@@ -20,6 +20,7 @@ import {
   Typography,
   useColorScheme,
 } from "@mui/material"
+import { ErrorBoundary } from "react-error-boundary"
 
 import { SPACING } from "../styling/spacing"
 import {
@@ -33,6 +34,7 @@ import {
   useJobRunLogsShowTimestamps,
   useJobRunLogsWrapLines,
 } from "../userSettings"
+import { AlertErrorFallback } from "./AlertErrorFallback"
 import { JobRunLogsTextSizeToggle } from "./JobRunLogsTextSizeToggle"
 import { LocaleSelector } from "./LocaleSelector"
 import { NumberNotationSelector } from "./NumberNotationSelector"
@@ -80,209 +82,211 @@ export const SettingsDialog = ({ open, onClose }: SettingsDialogProps) => {
       <DialogTitle>Settings</DialogTitle>
       <DialogContent>
         <DialogContentContainer>
-          <div>
+          <ErrorBoundary FallbackComponent={AlertErrorFallback}>
             <div>
-              <Typography variant="overline">Colour mode</Typography>
+              <div>
+                <Typography variant="overline">Colour mode</Typography>
+              </div>
+              <div>
+                <ToggleButtonGroup
+                  color="primary"
+                  disabled={mode === undefined}
+                  value={mode ?? "system"}
+                  exclusive
+                  aria-label="colour mode"
+                  onChange={(_, colorMode) => setMode(colorMode)}
+                  fullWidth
+                >
+                  <ToggleButton value="light">Light</ToggleButton>
+                  <ToggleButton value="system">System</ToggleButton>
+                  <ToggleButton value="dark">Dark</ToggleButton>
+                </ToggleButtonGroup>
+              </div>
             </div>
             <div>
-              <ToggleButtonGroup
-                color="primary"
-                disabled={mode === undefined}
-                value={mode ?? "system"}
-                exclusive
-                aria-label="colour mode"
-                onChange={(_, colorMode) => setMode(colorMode)}
-                fullWidth
-              >
-                <ToggleButton value="light">Light</ToggleButton>
-                <ToggleButton value="system">System</ToggleButton>
-                <ToggleButton value="dark">Dark</ToggleButton>
-              </ToggleButtonGroup>
+              <Divider />
             </div>
-          </div>
-          <div>
-            <Divider />
-          </div>
-          <div>
-            <SettingsGroupHeading variant="h2">Timestamp display</SettingsGroupHeading>
-          </div>
-          <div>
-            <FormGroup>
-              <FormControlLabel
-                control={
-                  <Switch
-                    checked={formatTimestampShouldFormat}
-                    onChange={({ target: { checked } }) => setFormatTimestampShouldFormat(checked)}
-                  />
-                }
-                label="Format timestamps"
-              />
-              {!formatTimestampShouldFormat && (
-                <FormHelperText>Timestamps will be displayed in the ISO 8601 format.</FormHelperText>
-              )}
-            </FormGroup>
-          </div>
-          {formatTimestampShouldFormat && (
-            <Grid2 container spacing={SPACING.sm}>
-              <Grid2 size={{ xs: 12, sm: 6 }}>
-                <LocaleSelector
-                  idPrefix="settings-dialog-timestamps"
-                  label="Locale for timestamps"
-                  value={formatTimestampLocale}
-                  onChange={setFormatTimestampLocale}
-                  fullWidth
-                  size="small"
-                />
-              </Grid2>
-              <Grid2 size={{ xs: 12, sm: 6 }}>
-                <TimeZoneSelector
-                  idPrefix="settings-dialog-timestamps"
-                  label="Time zone location for timestamps"
-                  value={formatTimestampTimeZone}
-                  onChange={setFormatTimestampTimeZone}
-                  fullWidth
-                  size="small"
-                />
-              </Grid2>
-            </Grid2>
-          )}
-          <Alert icon={false} severity="info">
-            {formatTimestampShouldFormat ? (
-              <>
-                <AlertTitle>Examples</AlertTitle>
-                <Stack direction="row" spacing={SPACING.sm} flexWrap="wrap">
-                  <ul>
-                    {TIMESTAMP_FORMATS.map((format) => (
-                      <li key={format}>
-                        {timestampFormatDisplayNames[format]}: {formatIsoTimestamp(new Date().toISOString(), format)}
-                      </li>
-                    ))}
-                  </ul>
-                </Stack>
-              </>
-            ) : (
-              <>
-                <AlertTitle>Example</AlertTitle>
-                <Stack direction="row" spacing={SPACING.sm} flexWrap="wrap">
-                  {formatIsoTimestamp(new Date().toISOString(), "full")}
-                </Stack>
-              </>
-            )}
-          </Alert>
-          <div>
-            <Divider />
-          </div>
-          <div>
-            <SettingsGroupHeading variant="h2">Number display</SettingsGroupHeading>
-          </div>
-          <div>
-            <FormGroup>
-              <FormControlLabel
-                control={
-                  <Switch
-                    checked={formatNumberShouldFormat}
-                    onChange={({ target: { checked } }) => setFormatNumberShouldFormat(checked)}
-                  />
-                }
-                label="Format numbers"
-              />
-            </FormGroup>
-          </div>
-          {formatNumberShouldFormat && (
-            <Grid2 container spacing={SPACING.sm}>
-              <Grid2 size={{ xs: 12, sm: 6 }}>
-                <LocaleSelector
-                  idPrefix="settings-dialog-numbers"
-                  label="Locale for numbers"
-                  value={formatNumberLocale}
-                  onChange={setFormatNumberLocale}
-                  fullWidth
-                  size="small"
-                />
-              </Grid2>
-              <Grid2 size={{ xs: 12, sm: 6 }}>
-                <NumberNotationSelector
-                  idPrefix="settings-dialog-numbers"
-                  label="Number notation"
-                  value={formatNumberNotation}
-                  onChange={setFormatNumberNotation}
-                  fullWidth
-                  size="small"
-                />
-              </Grid2>
-            </Grid2>
-          )}
-          <Alert icon={false} severity="info">
-            <AlertTitle>Examples</AlertTitle>
-            <Stack direction="row" spacing={SPACING.sm} flexWrap="wrap">
-              {FORMAT_NUMBER_PREVIEW_VALUES.map((v) => (
-                <div key={v}>{formatNumber(v)}</div>
-              ))}
-            </Stack>
-          </Alert>
-          <div>
-            <Divider />
-          </div>
-          <div>
-            <SettingsGroupHeading variant="h2">Job run logs</SettingsGroupHeading>
-          </div>
-          <Grid2 container spacing={SPACING.sm}>
-            <Grid2 size={{ xs: 12, sm: 6 }}>
+            <div>
+              <SettingsGroupHeading variant="h2">Timestamp display</SettingsGroupHeading>
+            </div>
+            <div>
               <FormGroup>
                 <FormControlLabel
                   control={
                     <Switch
-                      checked={jobRunLogsShowTimestamps}
-                      onChange={({ target: { checked } }) => setJobRunLogsShowTimestamps(checked)}
+                      checked={formatTimestampShouldFormat}
+                      onChange={({ target: { checked } }) => setFormatTimestampShouldFormat(checked)}
                     />
                   }
-                  label="Show timestamps"
+                  label="Format timestamps"
                 />
+                {!formatTimestampShouldFormat && (
+                  <FormHelperText>Timestamps will be displayed in the ISO 8601 format.</FormHelperText>
+                )}
               </FormGroup>
-            </Grid2>
-            <Grid2 size={{ xs: 12, sm: 6 }}>
+            </div>
+            {formatTimestampShouldFormat && (
+              <Grid2 container spacing={SPACING.sm}>
+                <Grid2 size={{ xs: 12, sm: 6 }}>
+                  <LocaleSelector
+                    idPrefix="settings-dialog-timestamps"
+                    label="Locale for timestamps"
+                    value={formatTimestampLocale}
+                    onChange={setFormatTimestampLocale}
+                    fullWidth
+                    size="small"
+                  />
+                </Grid2>
+                <Grid2 size={{ xs: 12, sm: 6 }}>
+                  <TimeZoneSelector
+                    idPrefix="settings-dialog-timestamps"
+                    label="Time zone location for timestamps"
+                    value={formatTimestampTimeZone}
+                    onChange={setFormatTimestampTimeZone}
+                    fullWidth
+                    size="small"
+                  />
+                </Grid2>
+              </Grid2>
+            )}
+            <Alert icon={false} severity="info">
+              {formatTimestampShouldFormat ? (
+                <>
+                  <AlertTitle>Examples</AlertTitle>
+                  <Stack direction="row" spacing={SPACING.sm} flexWrap="wrap">
+                    <ul>
+                      {TIMESTAMP_FORMATS.map((format) => (
+                        <li key={format}>
+                          {timestampFormatDisplayNames[format]}: {formatIsoTimestamp(new Date().toISOString(), format)}
+                        </li>
+                      ))}
+                    </ul>
+                  </Stack>
+                </>
+              ) : (
+                <>
+                  <AlertTitle>Example</AlertTitle>
+                  <Stack direction="row" spacing={SPACING.sm} flexWrap="wrap">
+                    {formatIsoTimestamp(new Date().toISOString(), "full")}
+                  </Stack>
+                </>
+              )}
+            </Alert>
+            <div>
+              <Divider />
+            </div>
+            <div>
+              <SettingsGroupHeading variant="h2">Number display</SettingsGroupHeading>
+            </div>
+            <div>
               <FormGroup>
                 <FormControlLabel
                   control={
                     <Switch
-                      checked={jobRunLogsWrapLines}
-                      onChange={({ target: { checked } }) => setJobRunLogsWrapLines(checked)}
+                      checked={formatNumberShouldFormat}
+                      onChange={({ target: { checked } }) => setFormatNumberShouldFormat(checked)}
+                    />
+                  }
+                  label="Format numbers"
+                />
+              </FormGroup>
+            </div>
+            {formatNumberShouldFormat && (
+              <Grid2 container spacing={SPACING.sm}>
+                <Grid2 size={{ xs: 12, sm: 6 }}>
+                  <LocaleSelector
+                    idPrefix="settings-dialog-numbers"
+                    label="Locale for numbers"
+                    value={formatNumberLocale}
+                    onChange={setFormatNumberLocale}
+                    fullWidth
+                    size="small"
+                  />
+                </Grid2>
+                <Grid2 size={{ xs: 12, sm: 6 }}>
+                  <NumberNotationSelector
+                    idPrefix="settings-dialog-numbers"
+                    label="Number notation"
+                    value={formatNumberNotation}
+                    onChange={setFormatNumberNotation}
+                    fullWidth
+                    size="small"
+                  />
+                </Grid2>
+              </Grid2>
+            )}
+            <Alert icon={false} severity="info">
+              <AlertTitle>Examples</AlertTitle>
+              <Stack direction="row" spacing={SPACING.sm} flexWrap="wrap">
+                {FORMAT_NUMBER_PREVIEW_VALUES.map((v) => (
+                  <div key={v}>{formatNumber(v)}</div>
+                ))}
+              </Stack>
+            </Alert>
+            <div>
+              <Divider />
+            </div>
+            <div>
+              <SettingsGroupHeading variant="h2">Job run logs</SettingsGroupHeading>
+            </div>
+            <Grid2 container spacing={SPACING.sm}>
+              <Grid2 size={{ xs: 12, sm: 6 }}>
+                <FormGroup>
+                  <FormControlLabel
+                    control={
+                      <Switch
+                        checked={jobRunLogsShowTimestamps}
+                        onChange={({ target: { checked } }) => setJobRunLogsShowTimestamps(checked)}
+                      />
+                    }
+                    label="Show timestamps"
+                  />
+                </FormGroup>
+              </Grid2>
+              <Grid2 size={{ xs: 12, sm: 6 }}>
+                <FormGroup>
+                  <FormControlLabel
+                    control={
+                      <Switch
+                        checked={jobRunLogsWrapLines}
+                        onChange={({ target: { checked } }) => setJobRunLogsWrapLines(checked)}
+                      />
+                    }
+                    label="Wrap lines"
+                  />
+                </FormGroup>
+              </Grid2>
+            </Grid2>
+            <div>
+              <div>
+                <Typography variant="overline">Text size</Typography>
+              </div>
+              <div>
+                <JobRunLogsTextSizeToggle />
+              </div>
+            </div>
+            <div></div>
+            <Divider />
+            <div>
+              <SettingsGroupHeading>Code snippets</SettingsGroupHeading>
+            </div>
+            <div>
+              <Typography component="p">These settings do not apply to job run logs.</Typography>
+            </div>
+            <div>
+              <FormGroup>
+                <FormControlLabel
+                  control={
+                    <Switch
+                      checked={codeSnippetsWrapLines}
+                      onChange={({ target: { checked } }) => setCodeSnippetsWrapLines(checked)}
                     />
                   }
                   label="Wrap lines"
                 />
               </FormGroup>
-            </Grid2>
-          </Grid2>
-          <div>
-            <div>
-              <Typography variant="overline">Text size</Typography>
             </div>
-            <div>
-              <JobRunLogsTextSizeToggle />
-            </div>
-          </div>
-          <div></div>
-          <Divider />
-          <div>
-            <SettingsGroupHeading>Code snippets</SettingsGroupHeading>
-          </div>
-          <div>
-            <Typography component="p">These settings do not apply to job run logs.</Typography>
-          </div>
-          <div>
-            <FormGroup>
-              <FormControlLabel
-                control={
-                  <Switch
-                    checked={codeSnippetsWrapLines}
-                    onChange={({ target: { checked } }) => setCodeSnippetsWrapLines(checked)}
-                  />
-                }
-                label="Wrap lines"
-              />
-            </FormGroup>
-          </div>
+          </ErrorBoundary>
         </DialogContentContainer>
       </DialogContent>
       <DialogActions>

--- a/internal/lookoutui/src/components/job-sets/JobSets.tsx
+++ b/internal/lookoutui/src/components/job-sets/JobSets.tsx
@@ -1,5 +1,6 @@
 import { Cancel, LowPriority } from "@mui/icons-material"
 import { Button, Container, FormControlLabel, Checkbox, Tooltip, styled } from "@mui/material"
+import { ErrorBoundary } from "react-error-boundary"
 
 import { JobSet, JobSetsOrderByColumn } from "../../services/JobService"
 import { RequestStatus } from "../../utils"
@@ -8,6 +9,7 @@ import RefreshButton from "../RefreshButton"
 import JobSetTable from "./JobSetTable"
 import "./JobSets.css"
 import { QueueSelector } from "./QueueSelector"
+import { AlertErrorFallback } from "../AlertErrorFallback"
 
 const HeaderStartContainer = styled("div")({
   display: "flex",
@@ -74,52 +76,56 @@ export default function JobSets(props: JobSetsProps) {
           </div>
         </HeaderStartContainer>
         <div className="job-sets-actions">
-          <div className="reprioritize-button">
-            <Button
-              disabled={!props.canReprioritize}
-              variant="contained"
-              color="primary"
-              startIcon={<LowPriority />}
-              onClick={props.onReprioritizeJobSetsClick}
-            >
-              Reprioritize
-            </Button>
-          </div>
-          <div className="cancel-button">
-            <Button
-              disabled={!props.canCancel}
-              variant="contained"
-              color="secondary"
-              startIcon={<Cancel />}
-              onClick={props.onCancelJobSetsClick}
-            >
-              Cancel
-            </Button>
-          </div>
-          {props.onToggleAutoRefresh && (
-            <div className="auto-refresh">
-              <AutoRefreshToggle autoRefresh={props.autoRefresh} onAutoRefreshChange={props.onToggleAutoRefresh} />
+          <ErrorBoundary FallbackComponent={AlertErrorFallback}>
+            <div className="reprioritize-button">
+              <Button
+                disabled={!props.canReprioritize}
+                variant="contained"
+                color="primary"
+                startIcon={<LowPriority />}
+                onClick={props.onReprioritizeJobSetsClick}
+              >
+                Reprioritize
+              </Button>
             </div>
-          )}
-          <div className="refresh-button">
-            <RefreshButton isLoading={props.getJobSetsRequestStatus === "Loading"} onClick={props.onRefresh} />
-          </div>
+            <div className="cancel-button">
+              <Button
+                disabled={!props.canCancel}
+                variant="contained"
+                color="secondary"
+                startIcon={<Cancel />}
+                onClick={props.onCancelJobSetsClick}
+              >
+                Cancel
+              </Button>
+            </div>
+            {props.onToggleAutoRefresh && (
+              <div className="auto-refresh">
+                <AutoRefreshToggle autoRefresh={props.autoRefresh} onAutoRefreshChange={props.onToggleAutoRefresh} />
+              </div>
+            )}
+            <div className="refresh-button">
+              <RefreshButton isLoading={props.getJobSetsRequestStatus === "Loading"} onClick={props.onRefresh} />
+            </div>
+          </ErrorBoundary>
         </div>
       </div>
       <div className="job-sets-content">
-        <JobSetTable
-          queue={props.queue}
-          jobSets={props.jobSets}
-          selectedJobSets={props.selectedJobSets}
-          orderByColumn={props.orderByColumn}
-          orderByDesc={props.orderByDesc}
-          onSelectJobSet={props.onSelectJobSet}
-          onShiftSelectJobSet={props.onShiftSelectJobSet}
-          onDeselectAllClick={props.onDeselectAllClick}
-          onSelectAllClick={props.onSelectAllClick}
-          onOrderChange={props.onOrderChange}
-          onJobSetStateClick={props.onJobSetStateClick}
-        />
+        <ErrorBoundary FallbackComponent={AlertErrorFallback}>
+          <JobSetTable
+            queue={props.queue}
+            jobSets={props.jobSets}
+            selectedJobSets={props.selectedJobSets}
+            orderByColumn={props.orderByColumn}
+            orderByDesc={props.orderByDesc}
+            onSelectJobSet={props.onSelectJobSet}
+            onShiftSelectJobSet={props.onShiftSelectJobSet}
+            onDeselectAllClick={props.onDeselectAllClick}
+            onSelectAllClick={props.onSelectAllClick}
+            onOrderChange={props.onOrderChange}
+            onJobSetStateClick={props.onJobSetStateClick}
+          />
+        </ErrorBoundary>
       </div>
     </Container>
   )

--- a/internal/lookoutui/src/components/lookout/CancelDialog.tsx
+++ b/internal/lookoutui/src/components/lookout/CancelDialog.tsx
@@ -4,6 +4,7 @@ import { Refresh, Dangerous } from "@mui/icons-material"
 import { Checkbox } from "@mui/material"
 import { Button, CircularProgress, Dialog, DialogActions, DialogContent, DialogTitle, Alert } from "@mui/material"
 import _ from "lodash"
+import { ErrorBoundary } from "react-error-boundary"
 
 import dialogStyles from "./DialogStyles.module.css"
 import { JobStatusTable } from "./JobStatusTable"
@@ -17,6 +18,7 @@ import { UpdateJobsService } from "../../services/lookout/UpdateJobsService"
 import { waitMillis, PlatformCancelReason } from "../../utils"
 import { getUniqueJobsMatchingFilters } from "../../utils/jobsDialogUtils"
 import { formatJobState } from "../../utils/jobsTableFormatters"
+import { AlertErrorFallback } from "../AlertErrorFallback"
 
 interface CancelDialogProps {
   onClose: () => void
@@ -134,43 +136,45 @@ export const CancelDialog = ({
       </DialogTitle>
 
       <DialogContent>
-        {isLoadingJobs && (
-          <div className={dialogStyles.loadingInfo}>
-            Fetching info on selected jobs...
-            <CircularProgress variant="indeterminate" />
-          </div>
-        )}
+        <ErrorBoundary FallbackComponent={AlertErrorFallback}>
+          {isLoadingJobs && (
+            <div className={dialogStyles.loadingInfo}>
+              Fetching info on selected jobs...
+              <CircularProgress variant="indeterminate" />
+            </div>
+          )}
 
-        {!isLoadingJobs && (
-          <>
-            {cancellableJobs.length > 0 && cancellableJobs.length < selectedJobs.length && (
-              <Alert severity="info" sx={{ marginBottom: "0.5em" }}>
-                {formatNumber(selectedJobsCount)} {selectedJobsCount === 1 ? "job is" : "jobs are"} selected, but only{" "}
-                {formatNumber(cancellableJobsCount)} {cancellableJobsCount === 1 ? "job is" : "jobs are"} in a
-                cancellable (non-terminated) state.
-              </Alert>
-            )}
+          {!isLoadingJobs && (
+            <>
+              {cancellableJobs.length > 0 && cancellableJobs.length < selectedJobs.length && (
+                <Alert severity="info" sx={{ marginBottom: "0.5em" }}>
+                  {formatNumber(selectedJobsCount)} {selectedJobsCount === 1 ? "job is" : "jobs are"} selected, but only{" "}
+                  {formatNumber(cancellableJobsCount)} {cancellableJobsCount === 1 ? "job is" : "jobs are"} in a
+                  cancellable (non-terminated) state.
+                </Alert>
+              )}
 
-            {cancellableJobs.length === 0 && (
-              <Alert severity="success">
-                All selected jobs are in a terminated state already, therefore there is nothing to cancel.
-              </Alert>
-            )}
+              {cancellableJobs.length === 0 && (
+                <Alert severity="success">
+                  All selected jobs are in a terminated state already, therefore there is nothing to cancel.
+                </Alert>
+              )}
 
-            {cancellableJobs.length > 0 && (
-              <JobStatusTable
-                jobsToRender={jobsToRender}
-                jobStatus={jobIdsToCancelResponses}
-                totalJobCount={cancellableJobs.length}
-                additionalColumnsToDisplay={[
-                  { displayName: "State", formatter: formatState },
-                  { displayName: "Submitted Time", formatter: formatSubmittedTime },
-                ]}
-                showStatus={Object.keys(jobIdsToCancelResponses).length > 0}
-              />
-            )}
-          </>
-        )}
+              {cancellableJobs.length > 0 && (
+                <JobStatusTable
+                  jobsToRender={jobsToRender}
+                  jobStatus={jobIdsToCancelResponses}
+                  totalJobCount={cancellableJobs.length}
+                  additionalColumnsToDisplay={[
+                    { displayName: "State", formatter: formatState },
+                    { displayName: "Submitted Time", formatter: formatSubmittedTime },
+                  ]}
+                  showStatus={Object.keys(jobIdsToCancelResponses).length > 0}
+                />
+              )}
+            </>
+          )}
+        </ErrorBoundary>
       </DialogContent>
 
       <DialogActions>

--- a/internal/lookoutui/src/components/lookout/ColumnConfigurationDialog/OrderableColumnListItem.tsx
+++ b/internal/lookoutui/src/components/lookout/ColumnConfigurationDialog/OrderableColumnListItem.tsx
@@ -67,8 +67,6 @@ export const OrderableColumnListItem = ({
     id: colId,
   })
 
-  throw new Error("argh")
-
   const [isEditing, setIsEditing] = useState(false)
 
   let listItemButtonNode = (

--- a/internal/lookoutui/src/components/lookout/ColumnConfigurationDialog/OrderableColumnListItem.tsx
+++ b/internal/lookoutui/src/components/lookout/ColumnConfigurationDialog/OrderableColumnListItem.tsx
@@ -67,6 +67,8 @@ export const OrderableColumnListItem = ({
     id: colId,
   })
 
+  throw new Error("argh")
+
   const [isEditing, setIsEditing] = useState(false)
 
   let listItemButtonNode = (

--- a/internal/lookoutui/src/components/lookout/ColumnConfigurationDialog/index.tsx
+++ b/internal/lookoutui/src/components/lookout/ColumnConfigurationDialog/index.tsx
@@ -17,6 +17,7 @@ import {
   styled,
   Typography,
 } from "@mui/material"
+import { ErrorBoundary } from "react-error-boundary"
 
 import { AddAnnotationColumnInput } from "./AddAnnotationColumnInput"
 import { OrderableColumnListItem } from "./OrderableColumnListItem"
@@ -30,6 +31,7 @@ import {
   PINNED_COLUMNS,
   toColId,
 } from "../../../utils/jobsTableColumns"
+import { AlertErrorFallback } from "../../AlertErrorFallback"
 
 const ScrollToAddAnnotationColumnChip = styled(Chip)({
   zIndex: 100,
@@ -184,71 +186,73 @@ export const ColumnConfigurationDialog = ({
         <Close />
       </CloseIconButton>
       <DialogContent>
-        <Stack spacing={SPACING.sm}>
-          <DialogContentText component="p">
-            Select which columns to view, any additional annotation columns, and the order of the columns.
-          </DialogContentText>
-          {groupedColumnIds.length > 0 && (
-            <>
-              <DialogContentText variant="body2">
-                The following columns cannot be hidden or re-ordered because they are currently grouped:
-              </DialogContentText>
-              <DialogContentText component="ul" variant="body2">
-                {groupedColumnIds
-                  .map((id) => allColumnsById[id])
-                  .map((column) => {
-                    const { displayName } = getColumnMetadata(column)
-                    return (
-                      <Typography key={column.id} component="li" variant="body2">
-                        {displayName}
-                      </Typography>
-                    )
-                  })}
-              </DialogContentText>
-            </>
-          )}
-          <Alert severity="info" variant="outlined">
-            Click and drag the columns into your desired order.
-          </Alert>
-          <div>
-            <DndContext
-              onDragEnd={handleDragEnd}
-              sensors={sensors}
-              modifiers={[restrictToVerticalAxis, restrictToWindowEdges]}
-            >
-              <SortableContext items={orderedColumns.map(({ id }) => toColId(id))}>
-                <List dense>
-                  {orderedColumns.map((column) => {
-                    const colId = toColId(column.id)
-                    return (
-                      <OrderableColumnListItem
-                        key={colId}
-                        column={column}
-                        isVisible={visibleColumnsSet.has(colId)}
-                        onToggleVisibility={() => toggleColumnVisibility(colId)}
-                        filtered={filterColumnsSet.has(colId)}
-                        sorted={sortColumnsSet.has(colId)}
-                        removeAnnotationColumn={() => onRemoveAnnotationColumn(colId)}
-                        editAnnotationColumn={(annotationKey) => onEditAnnotationColumn(colId, annotationKey)}
-                        existingAnnotationColumnKeysSet={annotationColumnKeysSet}
-                      />
-                    )
-                  })}
-                </List>
-              </SortableContext>
-            </DndContext>
-          </div>
-          <div ref={addAnnotationColumnContainerRef}>
-            <DialogContentText component="h3">Add annotation column</DialogContentText>
-            <DialogContentText variant="body2">
-              Annotations are metadata (key-value pairs) that you can add to your job.
+        <ErrorBoundary FallbackComponent={AlertErrorFallback}>
+          <Stack spacing={SPACING.sm}>
+            <DialogContentText component="p">
+              Select which columns to view, any additional annotation columns, and the order of the columns.
             </DialogContentText>
-            <AddAnnotationColumnInput
-              onCreate={onAddAnnotationColumn}
-              existingAnnotationColumnKeysSet={annotationColumnKeysSet}
-            />
-          </div>
-        </Stack>
+            {groupedColumnIds.length > 0 && (
+              <>
+                <DialogContentText variant="body2">
+                  The following columns cannot be hidden or re-ordered because they are currently grouped:
+                </DialogContentText>
+                <DialogContentText component="ul" variant="body2">
+                  {groupedColumnIds
+                    .map((id) => allColumnsById[id])
+                    .map((column) => {
+                      const { displayName } = getColumnMetadata(column)
+                      return (
+                        <Typography key={column.id} component="li" variant="body2">
+                          {displayName}
+                        </Typography>
+                      )
+                    })}
+                </DialogContentText>
+              </>
+            )}
+            <Alert severity="info" variant="outlined">
+              Click and drag the columns into your desired order.
+            </Alert>
+            <div>
+              <DndContext
+                onDragEnd={handleDragEnd}
+                sensors={sensors}
+                modifiers={[restrictToVerticalAxis, restrictToWindowEdges]}
+              >
+                <SortableContext items={orderedColumns.map(({ id }) => toColId(id))}>
+                  <List dense>
+                    {orderedColumns.map((column) => {
+                      const colId = toColId(column.id)
+                      return (
+                        <OrderableColumnListItem
+                          key={colId}
+                          column={column}
+                          isVisible={visibleColumnsSet.has(colId)}
+                          onToggleVisibility={() => toggleColumnVisibility(colId)}
+                          filtered={filterColumnsSet.has(colId)}
+                          sorted={sortColumnsSet.has(colId)}
+                          removeAnnotationColumn={() => onRemoveAnnotationColumn(colId)}
+                          editAnnotationColumn={(annotationKey) => onEditAnnotationColumn(colId, annotationKey)}
+                          existingAnnotationColumnKeysSet={annotationColumnKeysSet}
+                        />
+                      )
+                    })}
+                  </List>
+                </SortableContext>
+              </DndContext>
+            </div>
+            <div ref={addAnnotationColumnContainerRef}>
+              <DialogContentText component="h3">Add annotation column</DialogContentText>
+              <DialogContentText variant="body2">
+                Annotations are metadata (key-value pairs) that you can add to your job.
+              </DialogContentText>
+              <AddAnnotationColumnInput
+                onCreate={onAddAnnotationColumn}
+                existingAnnotationColumnKeysSet={annotationColumnKeysSet}
+              />
+            </div>
+          </Stack>
+        </ErrorBoundary>
       </DialogContent>
     </Dialog>
   )

--- a/internal/lookoutui/src/components/lookout/sidebar/Sidebar.tsx
+++ b/internal/lookoutui/src/components/lookout/sidebar/Sidebar.tsx
@@ -3,6 +3,7 @@ import { HTMLProps, memo, SyntheticEvent, useCallback, useEffect, useRef, useSta
 import { TabContext, TabPanel, TabPanelProps } from "@mui/lab"
 import { Divider, Drawer, DrawerProps, Stack, styled, Tab, Tabs } from "@mui/material"
 import { grey } from "@mui/material/colors"
+import { ErrorBoundary } from "react-error-boundary"
 
 import { SidebarHeader } from "./SidebarHeader"
 import { SidebarTabJobCommands } from "./SidebarTabJobCommands"
@@ -17,6 +18,7 @@ import { IGetJobInfoService } from "../../../services/lookout/GetJobInfoService"
 import { IGetRunInfoService } from "../../../services/lookout/GetRunInfoService"
 import { SPACING } from "../../../styling/spacing"
 import { CommandSpec } from "../../../utils"
+import { AlertErrorFallback } from "../../AlertErrorFallback"
 
 enum SidebarTab {
   JobDetails = "JobDetails",
@@ -256,56 +258,58 @@ export const Sidebar = memo(
             <SidebarHeader job={job} onClose={onClose} />
             <Divider />
             <SidebarTabContextContainer>
-              <TabContext value={openTab}>
-                <TabsContainer>
-                  <SidebarTabs value={openTab} onChange={handleTabChange}>
-                    <StyledSidebarTab label="Details" value={SidebarTab.JobDetails} />
-                    <StyledSidebarTab label="Result" value={SidebarTab.JobResult} />
-                    {job.state === JobState.Queued && (
-                      <StyledSidebarTab label="Scheduling" value={SidebarTab.Scheduling} />
-                    )}
-                    <StyledSidebarTab label="Yaml" value={SidebarTab.Yaml} />
-                    <StyledSidebarTab label="Logs" value={SidebarTab.Logs} disabled={job.state === JobState.Queued} />
-                    <StyledSidebarTab
-                      label="Commands"
-                      value={SidebarTab.Commands}
-                      disabled={job.state === JobState.Queued}
-                    />
-                  </SidebarTabs>
-                </TabsContainer>
+              <ErrorBoundary FallbackComponent={AlertErrorFallback}>
+                <TabContext value={openTab}>
+                  <TabsContainer>
+                    <SidebarTabs value={openTab} onChange={handleTabChange}>
+                      <StyledSidebarTab label="Details" value={SidebarTab.JobDetails} />
+                      <StyledSidebarTab label="Result" value={SidebarTab.JobResult} />
+                      {job.state === JobState.Queued && (
+                        <StyledSidebarTab label="Scheduling" value={SidebarTab.Scheduling} />
+                      )}
+                      <StyledSidebarTab label="Yaml" value={SidebarTab.Yaml} />
+                      <StyledSidebarTab label="Logs" value={SidebarTab.Logs} disabled={job.state === JobState.Queued} />
+                      <StyledSidebarTab
+                        label="Commands"
+                        value={SidebarTab.Commands}
+                        disabled={job.state === JobState.Queued}
+                      />
+                    </SidebarTabs>
+                  </TabsContainer>
 
-                <SidebarTabPanel value={SidebarTab.JobDetails}>
-                  <SidebarTabJobDetails key={job.jobId} job={job} />
-                </SidebarTabPanel>
-
-                <SidebarTabPanel value={SidebarTab.JobResult}>
-                  <SidebarTabJobResult
-                    key={job.jobId}
-                    job={job}
-                    jobInfoService={jobSpecService}
-                    runInfoService={runInfoService}
-                    cordonService={cordonService}
-                  />
-                </SidebarTabPanel>
-
-                {job.state === JobState.Queued && (
-                  <SidebarTabPanel value={SidebarTab.Scheduling}>
-                    <SidebarTabScheduling key={job.jobId} job={job} />
+                  <SidebarTabPanel value={SidebarTab.JobDetails}>
+                    <SidebarTabJobDetails key={job.jobId} job={job} />
                   </SidebarTabPanel>
-                )}
 
-                <SidebarTabPanel value={SidebarTab.Yaml}>
-                  <SidebarTabJobYaml key={job.jobId} job={job} />
-                </SidebarTabPanel>
+                  <SidebarTabPanel value={SidebarTab.JobResult}>
+                    <SidebarTabJobResult
+                      key={job.jobId}
+                      job={job}
+                      jobInfoService={jobSpecService}
+                      runInfoService={runInfoService}
+                      cordonService={cordonService}
+                    />
+                  </SidebarTabPanel>
 
-                <SidebarTabPanel value={SidebarTab.Logs}>
-                  <SidebarTabJobLogs key={job.jobId} job={job} />
-                </SidebarTabPanel>
+                  {job.state === JobState.Queued && (
+                    <SidebarTabPanel value={SidebarTab.Scheduling}>
+                      <SidebarTabScheduling key={job.jobId} job={job} />
+                    </SidebarTabPanel>
+                  )}
 
-                <SidebarTabPanel value={SidebarTab.Commands}>
-                  <SidebarTabJobCommands key={job.jobId} job={job} commandSpecs={commandSpecs} />
-                </SidebarTabPanel>
-              </TabContext>
+                  <SidebarTabPanel value={SidebarTab.Yaml}>
+                    <SidebarTabJobYaml key={job.jobId} job={job} />
+                  </SidebarTabPanel>
+
+                  <SidebarTabPanel value={SidebarTab.Logs}>
+                    <SidebarTabJobLogs key={job.jobId} job={job} />
+                  </SidebarTabPanel>
+
+                  <SidebarTabPanel value={SidebarTab.Commands}>
+                    <SidebarTabJobCommands key={job.jobId} job={job} commandSpecs={commandSpecs} />
+                  </SidebarTabPanel>
+                </TabContext>
+              </ErrorBoundary>
             </SidebarTabContextContainer>
           </SidebarContent>
         </SidebarContainer>

--- a/internal/lookoutui/src/components/lookout/sidebar/SidebarTabJobResult.tsx
+++ b/internal/lookoutui/src/components/lookout/sidebar/SidebarTabJobResult.tsx
@@ -15,6 +15,7 @@ import {
   Tooltip,
   Typography,
 } from "@mui/material"
+import { ErrorBoundary } from "react-error-boundary"
 
 import { KeyValuePairTable } from "./KeyValuePairTable"
 import { NoRunsAlert } from "./NoRunsAlert"
@@ -30,9 +31,8 @@ import { IGetRunInfoService } from "../../../services/lookout/GetRunInfoService"
 import { SPACING } from "../../../styling/spacing"
 import { getErrorMessage } from "../../../utils"
 import { formatJobRunState } from "../../../utils/jobsTableFormatters"
-import { CodeBlock } from "../../CodeBlock"
-import { ErrorBoundary } from "react-error-boundary"
 import { AlertErrorFallback } from "../../AlertErrorFallback"
+import { CodeBlock } from "../../CodeBlock"
 
 const MarkNodeUnschedulableButtonContainer = styled("div")(({ theme }) => ({
   display: "flex",

--- a/internal/lookoutui/src/components/lookout/sidebar/SidebarTabJobResult.tsx
+++ b/internal/lookoutui/src/components/lookout/sidebar/SidebarTabJobResult.tsx
@@ -31,6 +31,8 @@ import { SPACING } from "../../../styling/spacing"
 import { getErrorMessage } from "../../../utils"
 import { formatJobRunState } from "../../../utils/jobsTableFormatters"
 import { CodeBlock } from "../../CodeBlock"
+import { ErrorBoundary } from "react-error-boundary"
+import { AlertErrorFallback } from "../../AlertErrorFallback"
 
 const MarkNodeUnschedulableButtonContainer = styled("div")(({ theme }) => ({
   display: "flex",
@@ -319,26 +321,28 @@ export const SidebarTabJobResult = ({
                           </Tooltip>
                         </MarkNodeUnschedulableButtonContainer>
                         <Dialog open={open} onClose={handleClose} fullWidth maxWidth="md">
-                          <DialogTitle>Mark node as unschedulable</DialogTitle>
-                          <DialogContent>
-                            <Typography>
-                              Are you sure you want to take node <span>{node}</span> out of the farm?
-                            </Typography>
-                          </DialogContent>
-                          <DialogActions>
-                            <Button color="error" onClick={handleClose}>
-                              Cancel
-                            </Button>
-                            <Button
-                              onClick={async () => {
-                                await cordon(run.cluster, node)
-                                handleClose()
-                              }}
-                              autoFocus
-                            >
-                              Confirm
-                            </Button>
-                          </DialogActions>
+                          <ErrorBoundary FallbackComponent={AlertErrorFallback}>
+                            <DialogTitle>Mark node as unschedulable</DialogTitle>
+                            <DialogContent>
+                              <Typography>
+                                Are you sure you want to take node <span>{node}</span> out of the farm?
+                              </Typography>
+                            </DialogContent>
+                            <DialogActions>
+                              <Button color="error" onClick={handleClose}>
+                                Cancel
+                              </Button>
+                              <Button
+                                onClick={async () => {
+                                  await cordon(run.cluster, node)
+                                  handleClose()
+                                }}
+                                autoFocus
+                              >
+                                Confirm
+                              </Button>
+                            </DialogActions>
+                          </ErrorBoundary>
                         </Dialog>
                       </>
                     )}

--- a/internal/lookoutui/src/containers/CancelJobSetsDialog.tsx
+++ b/internal/lookoutui/src/containers/CancelJobSetsDialog.tsx
@@ -1,7 +1,9 @@
 import { useState } from "react"
 
 import { Dialog, DialogContent, DialogTitle } from "@mui/material"
+import { ErrorBoundary } from "react-error-boundary"
 
+import { AlertErrorFallback } from "../components/AlertErrorFallback"
 import CancelJobSets from "../components/job-sets/cancel-job-sets/CancelJobSets"
 import CancelJobSetsOutcome from "../components/job-sets/cancel-job-sets/CancelJobSetsOutcome"
 import { useGetAccessToken } from "../oidcAuth"
@@ -104,33 +106,35 @@ export default function CancelJobSetsDialog(props: CancelJobSetsDialogProps) {
     >
       <DialogTitle id="cancel-job-sets-dialog-title">Cancel Job Sets</DialogTitle>
       <DialogContent className="lookout-dialog">
-        {state === "CancelJobSets" && (
-          <CancelJobSets
-            queue={props.queue}
-            jobSets={jobSetsToCancel}
-            queuedSelected={includeQueued}
-            runningSelected={includeRunning}
-            isLoading={requestStatus === "Loading"}
-            onCancelJobSets={cancelJobSets}
-            onQueuedSelectedChange={setIncludeQueued}
-            onRunningSelectedChange={setIncludeRunning}
-            isPlatformCancel={isPlatformCancel}
-            setIsPlatformCancel={setIsPlatformCancel}
-          />
-        )}
-        {state === "CancelJobSetsResult" && (
-          <CancelJobSetsOutcome
-            cancelJobSetsResponse={response}
-            isLoading={requestStatus === "Loading"}
-            queuedSelected={includeQueued}
-            runningSelected={includeRunning}
-            onCancelJobs={cancelJobSets}
-            onQueuedSelectedChange={setIncludeQueued}
-            onRunningSelectedChange={setIncludeRunning}
-            isPlatformCancel={isPlatformCancel}
-            setIsPlatformCancel={setIsPlatformCancel}
-          />
-        )}
+        <ErrorBoundary FallbackComponent={AlertErrorFallback}>
+          {state === "CancelJobSets" && (
+            <CancelJobSets
+              queue={props.queue}
+              jobSets={jobSetsToCancel}
+              queuedSelected={includeQueued}
+              runningSelected={includeRunning}
+              isLoading={requestStatus === "Loading"}
+              onCancelJobSets={cancelJobSets}
+              onQueuedSelectedChange={setIncludeQueued}
+              onRunningSelectedChange={setIncludeRunning}
+              isPlatformCancel={isPlatformCancel}
+              setIsPlatformCancel={setIsPlatformCancel}
+            />
+          )}
+          {state === "CancelJobSetsResult" && (
+            <CancelJobSetsOutcome
+              cancelJobSetsResponse={response}
+              isLoading={requestStatus === "Loading"}
+              queuedSelected={includeQueued}
+              runningSelected={includeRunning}
+              onCancelJobs={cancelJobSets}
+              onQueuedSelectedChange={setIncludeQueued}
+              onRunningSelectedChange={setIncludeRunning}
+              isPlatformCancel={isPlatformCancel}
+              setIsPlatformCancel={setIsPlatformCancel}
+            />
+          )}
+        </ErrorBoundary>
       </DialogContent>
     </Dialog>
   )

--- a/internal/lookoutui/src/containers/JobSetsContainer.tsx
+++ b/internal/lookoutui/src/containers/JobSetsContainer.tsx
@@ -1,7 +1,10 @@
 import { Component } from "react"
 
+import { ErrorBoundary } from "react-error-boundary"
+
 import CancelJobSetsDialog, { getCancellableJobSets } from "./CancelJobSetsDialog"
 import ReprioritizeJobSetsDialog, { getReprioritizeableJobSets } from "./ReprioritizeJobSetsDialog"
+import { AlertErrorFallback } from "../components/AlertErrorFallback"
 import JobSets from "../components/job-sets/JobSets"
 import { JobState, Match } from "../models/lookoutModels"
 import IntervalService from "../services/IntervalService"
@@ -348,30 +351,32 @@ class JobSetsContainer extends Component<JobSetsContainerProps, JobSetsContainer
           onResult={this.handleApiResult}
           onClose={() => this.openReprioritizeJobSets(false)}
         />
-        <JobSets
-          canCancel={getCancellableJobSets(selectedJobSets).length > 0}
-          canReprioritize={getReprioritizeableJobSets(selectedJobSets).length > 0}
-          queue={this.state.queue}
-          jobSets={this.state.jobSets}
-          selectedJobSets={this.state.selectedJobSets}
-          getJobSetsRequestStatus={this.state.getJobSetsRequestStatus}
-          autoRefresh={this.state.autoRefresh}
-          orderByColumn={this.state.orderByColumn}
-          orderByDesc={this.state.orderByDesc}
-          activeOnly={this.state.activeOnly}
-          onQueueChange={this.setQueue}
-          onOrderChange={this.orderChange}
-          onActiveOnlyChange={this.activeOnlyChange}
-          onRefresh={this.loadJobSets}
-          onSelectJobSet={this.selectJobSet}
-          onShiftSelectJobSet={this.shiftSelectJobSet}
-          onDeselectAllClick={this.deselectAll}
-          onSelectAllClick={this.selectAll}
-          onCancelJobSetsClick={() => this.openCancelJobSets(true)}
-          onToggleAutoRefresh={this.autoRefreshService && this.toggleAutoRefresh}
-          onReprioritizeJobSetsClick={() => this.openReprioritizeJobSets(true)}
-          onJobSetStateClick={this.onJobSetStateClick}
-        />
+        <ErrorBoundary FallbackComponent={AlertErrorFallback}>
+          <JobSets
+            canCancel={getCancellableJobSets(selectedJobSets).length > 0}
+            canReprioritize={getReprioritizeableJobSets(selectedJobSets).length > 0}
+            queue={this.state.queue}
+            jobSets={this.state.jobSets}
+            selectedJobSets={this.state.selectedJobSets}
+            getJobSetsRequestStatus={this.state.getJobSetsRequestStatus}
+            autoRefresh={this.state.autoRefresh}
+            orderByColumn={this.state.orderByColumn}
+            orderByDesc={this.state.orderByDesc}
+            activeOnly={this.state.activeOnly}
+            onQueueChange={this.setQueue}
+            onOrderChange={this.orderChange}
+            onActiveOnlyChange={this.activeOnlyChange}
+            onRefresh={this.loadJobSets}
+            onSelectJobSet={this.selectJobSet}
+            onShiftSelectJobSet={this.shiftSelectJobSet}
+            onDeselectAllClick={this.deselectAll}
+            onSelectAllClick={this.selectAll}
+            onCancelJobSetsClick={() => this.openCancelJobSets(true)}
+            onToggleAutoRefresh={this.autoRefreshService && this.toggleAutoRefresh}
+            onReprioritizeJobSetsClick={() => this.openReprioritizeJobSets(true)}
+            onJobSetStateClick={this.onJobSetStateClick}
+          />
+        </ErrorBoundary>
       </>
     )
   }

--- a/internal/lookoutui/src/containers/ReprioritizeJobSetsDialog.tsx
+++ b/internal/lookoutui/src/containers/ReprioritizeJobSetsDialog.tsx
@@ -1,7 +1,9 @@
 import { useState } from "react"
 
 import { Dialog, DialogContent, DialogTitle } from "@mui/material"
+import { ErrorBoundary } from "react-error-boundary"
 
+import { AlertErrorFallback } from "../components/AlertErrorFallback"
 import ReprioritizeJobSets from "../components/job-sets/reprioritize-job-sets/ReprioritizeJobSets"
 import ReprioritizeJobSetsOutcome from "../components/job-sets/reprioritize-job-sets/ReprioritizeJobSetsOutcome"
 import { useGetAccessToken } from "../oidcAuth"
@@ -87,24 +89,26 @@ export default function ReprioritizeJobSetsDialog(props: ReprioritizeJobSetsDial
     >
       <DialogTitle id="-reprioritize-job-sets-dialog-title">Reprioritize Job Sets</DialogTitle>
       <DialogContent className="lookout-dialog">
-        {state === "ReprioritizeJobSets" && (
-          <ReprioritizeJobSets
-            queue={props.queue}
-            jobSets={jobSetsToReprioritize}
-            isLoading={requestStatus === "Loading"}
-            isValid={priorityIsValid(priority)}
-            onReprioritizeJobsSets={reprioritizeJobSets}
-            onPriorityChange={setPriority}
-          />
-        )}
-        {state === "ReprioritizeJobSetsResult" && (
-          <ReprioritizeJobSetsOutcome
-            reprioritizeJobSetResponse={response}
-            isLoading={requestStatus === "Loading"}
-            newPriority={priority}
-            onReprioritizeJobSets={reprioritizeJobSets}
-          />
-        )}
+        <ErrorBoundary FallbackComponent={AlertErrorFallback}>
+          {state === "ReprioritizeJobSets" && (
+            <ReprioritizeJobSets
+              queue={props.queue}
+              jobSets={jobSetsToReprioritize}
+              isLoading={requestStatus === "Loading"}
+              isValid={priorityIsValid(priority)}
+              onReprioritizeJobsSets={reprioritizeJobSets}
+              onPriorityChange={setPriority}
+            />
+          )}
+          {state === "ReprioritizeJobSetsResult" && (
+            <ReprioritizeJobSetsOutcome
+              reprioritizeJobSetResponse={response}
+              isLoading={requestStatus === "Loading"}
+              newPriority={priority}
+              onReprioritizeJobSets={reprioritizeJobSets}
+            />
+          )}
+        </ErrorBoundary>
       </DialogContent>
     </Dialog>
   )

--- a/internal/lookoutui/src/containers/lookout/JobsTableContainer.tsx
+++ b/internal/lookoutui/src/containers/lookout/JobsTableContainer.tsx
@@ -33,9 +33,11 @@ import {
   VisibilityState,
 } from "@tanstack/react-table"
 import _ from "lodash"
+import { ErrorBoundary } from "react-error-boundary"
 import { useLocation, useNavigate, useParams } from "react-router-dom"
 
 import styles from "./JobsTableContainer.module.css"
+import { AlertErrorFallback } from "../../components/AlertErrorFallback"
 import { JobsTableActionBar } from "../../components/lookout/JobsTableActionBar"
 import { HeaderCell } from "../../components/lookout/JobsTableCell"
 import { JobsTableRow } from "../../components/lookout/JobsTableRow"
@@ -801,120 +803,125 @@ export const JobsTableContainer = ({
     <Box sx={{ display: "flex", flexDirection: "row", height: "100%", width: "100%" }}>
       <Box sx={{ ...columnStyle, marginX: "0.5em", minWidth: 0 }}>
         <Box sx={{ ...columnStyle, marginY: "0.5em", minHeight: 0 }}>
-          <JobsTableActionBar
-            isLoading={rowsToFetch.length > 0}
-            allColumns={columnsForSelect}
-            groupedColumns={grouping}
-            filterColumns={filterColumns}
-            sortColumns={sortColumns}
-            visibleColumns={visibleColumnIds}
-            columnOrder={columnOrder}
-            setColumnOrder={setColumnOrder}
-            selectedItemFilters={selectedItemsFilters}
-            customViews={customViews}
-            activeJobSets={activeJobSets}
-            onActiveJobSetsChanged={(newVal) => {
-              setActiveJobSets(newVal)
-              setToFirstPage()
-              setSelectedRows({})
-              setRowsToFetch(pendingDataForAllVisibleData(expanded, data, pageSize))
-            }}
-            onRefresh={onRefresh}
-            autoRefresh={autoRefresh}
-            onAutoRefreshChange={autoRefreshMs === undefined ? undefined : onAutoRefreshChange}
-            onAddAnnotationColumn={addAnnotationCol}
-            onRemoveAnnotationColumn={removeAnnotationCol}
-            onEditAnnotationColumn={editAnnotationCol}
-            onGroupsChanged={onGroupingChange}
-            toggleColumnVisibility={onColumnVisibilityChange}
-            getJobsService={getJobsService}
-            updateJobsService={updateJobsService}
-            onClearFilters={clearFilters}
-            onClearGroups={clearGroups}
-            onAddCustomView={addCustomView}
-            onDeleteCustomView={deleteCustomView}
-            onLoadCustomView={loadCustomView}
-          />
-          <TableContainer component={Paper} style={{ height: "100%" }}>
-            <Table
-              stickyHeader
-              sx={{ tableLayout: "fixed" }}
-              aria-label="Jobs table"
-              style={{
-                width: table.getCenterTotalSize(),
-                borderLeft: "1px solid #cccccc",
-                maxHeight: "100%",
+          <ErrorBoundary FallbackComponent={AlertErrorFallback}>
+            <JobsTableActionBar
+              isLoading={rowsToFetch.length > 0}
+              allColumns={columnsForSelect}
+              groupedColumns={grouping}
+              filterColumns={filterColumns}
+              sortColumns={sortColumns}
+              visibleColumns={visibleColumnIds}
+              columnOrder={columnOrder}
+              setColumnOrder={setColumnOrder}
+              selectedItemFilters={selectedItemsFilters}
+              customViews={customViews}
+              activeJobSets={activeJobSets}
+              onActiveJobSetsChanged={(newVal) => {
+                setActiveJobSets(newVal)
+                setToFirstPage()
+                setSelectedRows({})
+                setRowsToFetch(pendingDataForAllVisibleData(expanded, data, pageSize))
               }}
-            >
-              <TableHead>
-                {table.getHeaderGroups().map((headerGroup) => (
-                  <TableRow key={headerGroup.id}>
-                    {headerGroup.headers.map((header) => (
-                      <HeaderCell
-                        header={header}
-                        key={header.id}
-                        parseError={header.id in parseErrors ? parseErrors[header.id] : undefined}
-                        columnResizeMode={columnResizeMode}
-                        deltaOffset={table.getState().columnSizingInfo.deltaOffset ?? 0}
-                        columnMatches={columnMatches}
-                        onColumnMatchChange={onColumnMatchChange}
-                        onSetTextFieldRef={(ref) => {
-                          setTextFieldRef(header.id, ref)
-                        }}
-                        groupedColumns={grouping}
-                      />
-                    ))}
-                  </TableRow>
-                ))}
-              </TableHead>
+              onRefresh={onRefresh}
+              autoRefresh={autoRefresh}
+              onAutoRefreshChange={autoRefreshMs === undefined ? undefined : onAutoRefreshChange}
+              onAddAnnotationColumn={addAnnotationCol}
+              onRemoveAnnotationColumn={removeAnnotationCol}
+              onEditAnnotationColumn={editAnnotationCol}
+              onGroupsChanged={onGroupingChange}
+              toggleColumnVisibility={onColumnVisibilityChange}
+              getJobsService={getJobsService}
+              updateJobsService={updateJobsService}
+              onClearFilters={clearFilters}
+              onClearGroups={clearGroups}
+              onAddCustomView={addCustomView}
+              onDeleteCustomView={deleteCustomView}
+              onLoadCustomView={loadCustomView}
+            />
+          </ErrorBoundary>
+          <ErrorBoundary FallbackComponent={AlertErrorFallback}>
+            <TableContainer component={Paper} style={{ height: "100%" }}>
+              <Table
+                stickyHeader
+                sx={{ tableLayout: "fixed" }}
+                aria-label="Jobs table"
+                style={{
+                  width: table.getCenterTotalSize(),
+                  borderLeft: "1px solid #cccccc",
+                  maxHeight: "100%",
+                }}
+              >
+                <TableHead>
+                  {table.getHeaderGroups().map((headerGroup) => (
+                    <TableRow key={headerGroup.id}>
+                      {headerGroup.headers.map((header) => (
+                        <HeaderCell
+                          header={header}
+                          key={header.id}
+                          parseError={header.id in parseErrors ? parseErrors[header.id] : undefined}
+                          columnResizeMode={columnResizeMode}
+                          deltaOffset={table.getState().columnSizingInfo.deltaOffset ?? 0}
+                          columnMatches={columnMatches}
+                          onColumnMatchChange={onColumnMatchChange}
+                          onSetTextFieldRef={(ref) => {
+                            setTextFieldRef(header.id, ref)
+                          }}
+                          groupedColumns={grouping}
+                        />
+                      ))}
+                    </TableRow>
+                  ))}
+                </TableHead>
 
-              <JobsTableBody
-                dataIsLoading={rowsToFetch.length > 0}
-                columns={table.getVisibleLeafColumns()}
-                topLevelRows={topLevelRows}
-                sidebarJobId={sidebarJobId}
-                onLoadMoreSubRows={onLoadMoreSubRows}
-                onClickRowCheckbox={(row) => selectRow(row, false)}
-                onClickJobRow={toggleSidebarForJobRow}
-                onClickRow={(row) => selectRow(row, true)}
-                onShiftClickRow={shiftSelectRow}
-                onControlClickRow={(row) => selectRow(row, false)}
-                onColumnMatchChange={onColumnMatchChange}
-              />
-            </Table>
-          </TableContainer>
-          <TablePagination
-            component="div"
-            rowsPerPageOptions={PAGE_SIZE_OPTIONS}
-            // If the total number rows in the database for the current filter
-            // is exactly equal to `pageSize`, then this is going to produce a
-            // misleading description (e.g., "1-50 of more than 50", even though
-            // there are exactly 50 rows).
-            count={data.length < pageSize ? pageIndex * pageSize + data.length : -1}
-            rowsPerPage={pageSize}
-            page={pageIndex}
-            onPageChange={(_, page) => table.setPageIndex(page)}
-            onRowsPerPageChange={(e) => table.setPageSize(Number(e.target.value))}
-            colSpan={table.getVisibleLeafColumns().length}
-            showFirstButton={true}
-            showLastButton={true}
-          />
-
-          {debug && <pre>{JSON.stringify(table.getState(), null, 2)}</pre>}
+                <JobsTableBody
+                  dataIsLoading={rowsToFetch.length > 0}
+                  columns={table.getVisibleLeafColumns()}
+                  topLevelRows={topLevelRows}
+                  sidebarJobId={sidebarJobId}
+                  onLoadMoreSubRows={onLoadMoreSubRows}
+                  onClickRowCheckbox={(row) => selectRow(row, false)}
+                  onClickJobRow={toggleSidebarForJobRow}
+                  onClickRow={(row) => selectRow(row, true)}
+                  onShiftClickRow={shiftSelectRow}
+                  onControlClickRow={(row) => selectRow(row, false)}
+                  onColumnMatchChange={onColumnMatchChange}
+                />
+              </Table>
+            </TableContainer>
+            <TablePagination
+              component="div"
+              rowsPerPageOptions={PAGE_SIZE_OPTIONS}
+              // If the total number rows in the database for the current filter
+              // is exactly equal to `pageSize`, then this is going to produce a
+              // misleading description (e.g., "1-50 of more than 50", even though
+              // there are exactly 50 rows).
+              count={data.length < pageSize ? pageIndex * pageSize + data.length : -1}
+              rowsPerPage={pageSize}
+              page={pageIndex}
+              onPageChange={(_, page) => table.setPageIndex(page)}
+              onRowsPerPageChange={(e) => table.setPageSize(Number(e.target.value))}
+              colSpan={table.getVisibleLeafColumns().length}
+              showFirstButton={true}
+              showLastButton={true}
+            />
+            {debug && <pre>{JSON.stringify(table.getState(), null, 2)}</pre>}
+          </ErrorBoundary>
         </Box>
       </Box>
 
       {sidebarJobDetails !== undefined && (
-        <Sidebar
-          job={sidebarJobDetails}
-          runInfoService={runInfoService}
-          jobSpecService={jobSpecService}
-          cordonService={cordonService}
-          sidebarWidth={sidebarWidth}
-          onClose={sideBarClose}
-          onWidthChange={setSidebarWidth}
-          commandSpecs={commandSpecs}
-        />
+        <ErrorBoundary FallbackComponent={AlertErrorFallback}>
+          <Sidebar
+            job={sidebarJobDetails}
+            runInfoService={runInfoService}
+            jobSpecService={jobSpecService}
+            cordonService={cordonService}
+            sidebarWidth={sidebarWidth}
+            onClose={sideBarClose}
+            onWidthChange={setSidebarWidth}
+            commandSpecs={commandSpecs}
+          />
+        </ErrorBoundary>
       )}
     </Box>
   )

--- a/internal/lookoutui/src/oidcAuth/OidcAuthProvider.tsx
+++ b/internal/lookoutui/src/oidcAuth/OidcAuthProvider.tsx
@@ -1,44 +1,17 @@
 import { ReactNode, useCallback, useEffect, useMemo, useState } from "react"
 
-import { Alert, AlertTitle, Button, Container, LinearProgress, styled, Typography } from "@mui/material"
 import { UserManager, WebStorageStateStore } from "oidc-client-ts"
 
-import { SPACING } from "../styling/spacing"
+import { ErrorPage } from "../components/ErrorPage"
 import { OidcConfig } from "../utils"
 import { OidcAuthContext, OidcAuthContextProps } from "./OidcAuthContext"
+import { LoadingPage } from "../components/LoadingPage"
 
 export const OIDC_REDIRECT_PATHNAME = "/oidc"
 
 const ELLIPSIS = "\u2026"
 
 const userManagerStore = new WebStorageStateStore({ store: window.localStorage })
-
-const Wrapper = styled("main")(({ theme }) => ({
-  minHeight: "100vh",
-  backgroundColor: theme.palette.background.default,
-  display: "flex",
-  justifyContent: "center",
-  alignItems: "center",
-}))
-
-const ContentContainer = styled(Container)(({ theme }) => ({
-  display: "flex",
-  flexDirection: "column",
-  alignItems: "center",
-  gap: theme.spacing(SPACING.xl),
-}))
-
-const ProgressContainer = styled("div")({
-  width: "100%",
-})
-
-const StyledAlert = styled(Alert)({
-  width: "100%",
-})
-
-const IconImg = styled("img")({
-  maxHeight: 200,
-})
 
 export interface OidcAuthProviderProps {
   children: ReactNode
@@ -105,49 +78,17 @@ export const OidcAuthProvider = ({ children, oidcConfig }: OidcAuthProviderProps
   const oidcAuthContextValue = useMemo<OidcAuthContextProps>(() => ({ userManager }), [userManager])
 
   if (isLoading) {
-    return (
-      <Wrapper>
-        <ContentContainer maxWidth="md">
-          <div>
-            <IconImg src="/logo.svg" alt="Armada Lookout" />
-          </div>
-          <ProgressContainer>
-            <LinearProgress />
-          </ProgressContainer>
-          <div>
-            <Typography component="p" variant="h4" textAlign="center">
-              Armada Lookout
-            </Typography>
-            <Typography component="p" variant="h6" color="text.secondary" textAlign="center">
-              Signing you in{ELLIPSIS}
-            </Typography>
-          </div>
-        </ContentContainer>
-      </Wrapper>
-    )
+    return <LoadingPage loadingContextMessage={`Signing you in${ELLIPSIS}`} />
   }
 
   if (authError) {
     return (
-      <Wrapper>
-        <ContentContainer maxWidth="md">
-          <div>
-            <IconImg src="/logo.svg" alt="Armada Lookout" />
-          </div>
-          <StyledAlert
-            severity="error"
-            action={
-              <Button color="inherit" size="small" onClick={() => authenticate().catch(handlerAuthenticationError)}>
-                Retry
-              </Button>
-            }
-          >
-            <AlertTitle>Sorry, there was an error signing you into Armada Lookout</AlertTitle>
-            <Typography component="p">{String(authError)}</Typography>
-            <Typography component="p">Please check the console for more details.</Typography>
-          </StyledAlert>
-        </ContentContainer>
-      </Wrapper>
+      <ErrorPage
+        error={authError}
+        errorTitle="Sorry, there was an error signing you into Armada Lookout"
+        retry={() => authenticate().catch(handlerAuthenticationError)}
+        errorContextMessage="Please check the console for more details."
+      />
     )
   }
 

--- a/internal/lookoutui/yarn.lock
+++ b/internal/lookoutui/yarn.lock
@@ -3678,6 +3678,13 @@ react-dom@^19:
   dependencies:
     scheduler "^0.25.0"
 
+react-error-boundary@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-5.0.0.tgz#6b6c7e075c922afb0283147e5b084efa44e68570"
+  integrity sha512-tnjAxG+IkpLephNcePNA7v6F/QpWLH8He65+DmedchDwg162JZqx4NmbXj0mlAYVVEd81OW7aFhmbsScYfiAFQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
There should never be any uncaught JavaScript errors in the Lookout UI React app. However, in a non-trivial app with ongoing development, it is probably inevitable that these will appear from time to time.

This change adds error boundaries to the application, so that such errors are caught and displayed to the user gracefully, rather than crashing the application (and the user seeing a blank white screen).

## Example screenshots (the errors have been manually thrown!)

![image](https://github.com/user-attachments/assets/ac88a56c-f825-4ed2-9500-e405357efcda)
![image](https://github.com/user-attachments/assets/ea1f3126-045e-4cdf-bd14-a8ed13caefab)
![image](https://github.com/user-attachments/assets/6dcdd5b0-150f-4730-9b62-3726b606d9d1)
![image](https://github.com/user-attachments/assets/1e18d7d6-677d-4879-94e6-4bbe3f8c8feb)
![image](https://github.com/user-attachments/assets/43dc3280-dfaf-45a2-8fa1-fb9a02da77a1)

