### PR TITLE
Fix Lookout: changing a filter type does not refresh the jobs table

### DIFF
--- a/internal/lookoutui/src/containers/lookout/JobsTableContainer.tsx
+++ b/internal/lookoutui/src/containers/lookout/JobsTableContainer.tsx
@@ -641,6 +641,7 @@ export const JobsTableContainer = ({
     }
     setColumnMatches(newColumnMatches)
     onFilterChange([...columnFilterState])
+    setRowsToFetch(pendingDataForAllVisibleData(expanded, data, pageSize))
   }
 
   const onSortingChange = (updater: Updater<SortingState>) => {

--- a/internal/lookoutui/src/hooks/useJobsTableData.ts
+++ b/internal/lookoutui/src/hooks/useJobsTableData.ts
@@ -242,7 +242,16 @@ export const useFetchJobsTableData = ({
     return () => {
       abortController.abort("Request is no longer needed")
     }
-  }, [pendingData, paginationState, groupedColumns, expandedState, lookoutFilters, lookoutOrder, allColumns])
+  }, [
+    pendingData,
+    paginationState,
+    groupedColumns,
+    expandedState,
+    lookoutFilters,
+    columnMatches,
+    lookoutOrder,
+    allColumns,
+  ])
 
   return {
     data,


### PR DESCRIPTION
On the jobs table page of the Lookout UI, when the user changes the filter type for a column (e.g. exact, starts with, contains), the table should refresh, reflecting this change. It does not. This change fixes this problem.