### PR TITLE
Publish test results for fork PRs

### DIFF
--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -1,0 +1,30 @@
+name: Test results
+on:
+  workflow_run:
+    workflows: [ CI ]
+    types: [ completed ]
+
+permissions:
+  checks: write
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Test Report
+        uses: dawidd6/action-download-artifact@v9
+        with:
+          name: '.*-test-reports'
+          name_is_regexp: true
+          path: test-results
+          workflow: ${{ github.event.workflow.id }}
+          run_id: ${{ github.event.workflow_run.id }}
+
+      - name: Publish JUnit Report
+        uses: mikepenz/action-junit-report@v5
+        with:
+          report_paths: ./test-results/*/*.xml
+          fail_on_failure: true
+          require_tests: true
+          detailed_summary: true
+          commit: ${{github.event.workflow_run.head_sha}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,16 +28,6 @@ jobs:
           yarn install --frozen-lockfile && yarn openapi && yarn typecheck && CI=true yarn test --reporter=junit
         working-directory: ./internal/lookoutui
 
-      - name: Publish JUnit Report
-        uses: mikepenz/action-junit-report@v4
-        if: always()
-        with:
-          report_paths: ./internal/lookoutui/junit.xml
-          fail_on_failure: true
-          require_tests: true
-          detailed_summary: true
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Upload Test Reports Artifacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -63,16 +53,6 @@ jobs:
       - name: Unit Tests
         id: unit_test
         run: go run github.com/magefile/mage@v1.14.0 -v tests
-
-      - name: Publish JUnit Report
-        uses: mikepenz/action-junit-report@v4
-        if: always()
-        with:
-          report_paths: test-reports/unit-tests.xml
-          fail_on_failure: true
-          require_tests: true
-          detailed_summary: true
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Test Reports Artifacts
         if: always()
@@ -140,16 +120,6 @@ jobs:
           path: |
             ./logs/
           if-no-files-found: error
-
-      - name: Publish JUnit Report
-        uses: mikepenz/action-junit-report@v4
-        if: always()
-        with:
-          report_paths: junit.xml
-          fail_on_failure: true
-          require_tests: true
-          detailed_summary: true
-          token: ${{ secrets.GITHUB_TOKEN }}
 
   go-mod-up-to-date:
     name: Golang Mod Up To Date


### PR DESCRIPTION
#### What type of PR is this?
Purely CI

#### What this PR does / why we need it:
Test results of pull requests from fork repositories are currently not published. The current setup makes them fail:

    Resource not accessible by integration 

https://github.com/armadaproject/armada/actions/runs/14449584216/job/40518701460#step:5:2282

This is because the CI is executed in the context of the fork repository, where Github Actions does not have permissions to write to the upstream pull request (required by the publish action).

#### Which issue(s) this PR fixes:
This applies the pattern documented at https://github.com/mikepenz/action-junit-report#pr-run-permissions.