### PR TITLE
Use mod replacement to switch from gogo/protobuf to cockroachdb fork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.24
 
 toolchain go1.24.1
 
+replace github.com/gogo/protobuf => github.com/cockroachdb/gogoproto v1.3.2
+
 require (
 	github.com/apache/pulsar-client-go v0.14.0
 	github.com/coreos/go-oidc/v3 v3.12.0

--- a/go.sum
+++ b/go.sum
@@ -128,6 +128,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cloudflare/circl v1.3.8 h1:j+V8jJt09PoeMFIu2uh5JUyEaIHTXVOHslFoLNAKqwI=
 github.com/cloudflare/circl v1.3.8/go.mod h1:PDRU+oXvdD7KCtgKxW95M5Z8BpSCJXQORiZFnBQS5QU=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/cockroachdb/gogoproto v1.3.2 h1:8o1rLP3itLgFcEHOD5FWGgz3Rb7AyJTd59XvryuorTY=
+github.com/cockroachdb/gogoproto v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/colinmarc/hdfs/v2 v2.1.1/go.mod h1:M3x+k8UKKmxtFu++uAZ0OtDU8jR3jnaZIAc6yK4Ue0c=
 github.com/containerd/containerd v1.7.18 h1:jqjZTQNfXGoEaZdW1WwPU0RqSn1Bm2Ay/KJPUuO8nao=
 github.com/containerd/containerd v1.7.18/go.mod h1:IYEk9/IO6wAPUz2bCMVUbsfXjzw5UNP5fLz4PsUygQ4=
@@ -254,8 +256,6 @@ github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2/go.mod h1:bBOAhwG1umN6
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/googleapis v0.0.0-20180223154316-0cd9801be74a h1:dR8+Q0uO5S2ZBcs2IH6VBKYwSxPo2vYCYq0ot0mu7xA=
 github.com/gogo/googleapis v0.0.0-20180223154316-0cd9801be74a/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
-github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
-github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/gogo/status v1.1.1 h1:DuHXlSFHNKqTQ+/ACf5Vs6r4X/dH2EgIzR9Vr+H65kg=
 github.com/gogo/status v1.1.1/go.mod h1:jpG3dM5QPcqu19Hg8lkUhBFBa3TcLs1DG7+2Jqci7oU=
 github.com/golang-jwt/jwt v3.2.1+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=

--- a/magefiles/go.go
+++ b/magefiles/go.go
@@ -60,8 +60,9 @@ func goModuleVersion(name string) (string, error) {
 		return "", err
 	}
 	fields := strings.Fields(out)
-	if len(fields) != 2 {
-		return "", errors.Errorf("unexpected go list output: %v", fields)
+	// allow for 2 tokens, or mod replacement
+	if len(fields) == 2 || strings.Contains(out, "=>") {
+		return fields[1], nil
 	}
-	return fields[1], nil
+	return "", errors.Errorf("unexpected go list output: %v", fields)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

#### What type of PR is this?
Simple solution to remove dependence on deprecated gogo/protobuf library. Use go mod replacement to swap in the cochroachdb fork.

#### What this PR does / why we need it:
This uses a somewhat more maintained library for generating protos. However, it does not resolve some underlying issues with the gogo/protobuf library (compatibility with more recent Google protobuf releases).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes [#940](https://github.com/G-Research/gr-oss/issues/940)

#### Special notes for your reviewer:

