### PR TITLE
Add support for native preemption retries

### DIFF
--- a/internal/common/preemption/utils.go
+++ b/internal/common/preemption/utils.go
@@ -1,0 +1,39 @@
+package preemption
+
+import (
+	"github.com/armadaproject/armada/internal/server/configuration"
+	"strconv"
+)
+
+// AreRetriesEnabled determines whether preemption retries are enabled at the job level. Also returns whether the
+// annotation was set.
+func AreRetriesEnabled(annotations map[string]string) (bool, bool) {
+	preemptionRetryEnabledStr, exists := annotations[configuration.PreemptionRetryEnabledAnnotation]
+	if !exists {
+		return false, false
+	}
+
+	preemptionRetryEnabled, err := strconv.ParseBool(preemptionRetryEnabledStr)
+	if err != nil {
+		return false, true
+	}
+	return preemptionRetryEnabled, true
+}
+
+// GetMaxRetryCount gets the max preemption retry count at a job level. Also returns whether the annotation was set.
+func GetMaxRetryCount(annotations map[string]string) (uint, bool) {
+	var preemptionRetryCountMax uint = 0
+	preemptionRetryCountMaxStr, exists := annotations[configuration.PreemptionRetryCountMaxAnnotation]
+
+	if !exists {
+		return 0, false
+	}
+	maybePreemptionRetryCountMax, err := strconv.Atoi(preemptionRetryCountMaxStr)
+	if err != nil {
+		return 0, true
+	} else {
+		preemptionRetryCountMax = uint(maybePreemptionRetryCountMax)
+	}
+
+	return preemptionRetryCountMax, true
+}

--- a/internal/executor/service/job_state_reporter.go
+++ b/internal/executor/service/job_state_reporter.go
@@ -93,6 +93,11 @@ func (stateReporter *JobStateReporter) reportCurrentStatus(pod *v1.Pod) {
 	}
 
 	if pod.Status.Phase == v1.PodFailed {
+
+		if util.IsPodPreempted(pod) {
+			return
+		}
+
 		hasIssue := stateReporter.podIssueHandler.HasIssue(util.ExtractJobRunId(pod))
 		if hasIssue {
 			// Pod already being handled by issue handler

--- a/internal/executor/service/job_state_reporter_test.go
+++ b/internal/executor/service/job_state_reporter_test.go
@@ -166,6 +166,27 @@ func TestJobStateReporter_HandlesFailedPod_WithRetryableError(t *testing.T) {
 	assertExpectedEvents(t, before, eventReporter.ReceivedEvents, reflect.TypeOf(&armadaevents.EventSequence_Event_JobRunErrors{}))
 }
 
+func TestJobStateReporter_IgnoresPreemptedPod(t *testing.T) {
+	_, _, eventReporter, fakeClusterContext := setUpJobStateReporterTest(t)
+
+	before := makeTestPod(v1.PodStatus{Phase: v1.PodRunning})
+	after := before.DeepCopy()
+	after.Status = v1.PodStatus{
+		Phase: v1.PodFailed,
+		Conditions: []v1.PodCondition{
+			{
+				Type:   v1.DisruptionTarget,
+				Status: v1.ConditionTrue,
+				Reason: util.PreemptedReason,
+			},
+		},
+	}
+
+	fakeClusterContext.SimulateUpdateAddEvent(before, after)
+	time.Sleep(time.Millisecond * 100) // Give time for async routine to process message
+	assert.Len(t, eventReporter.ReceivedEvents, 0)
+}
+
 func setUpJobStateReporterTest(t *testing.T) (*JobStateReporter, *stubIssueHandler, *mocks.FakeEventReporter, *fakecontext.SyncFakeClusterContext) {
 	fakeClusterContext := fakecontext.NewSyncFakeClusterContext()
 	eventReporter := mocks.NewFakeEventReporter()

--- a/internal/executor/service/pod_issue_handler.go
+++ b/internal/executor/service/pod_issue_handler.go
@@ -521,7 +521,7 @@ func createStuckPodMessage(retryable bool, originalMessage string) string {
 func (p *PodIssueHandler) handleDeletedPod(pod *v1.Pod) {
 	jobId := util.ExtractJobId(pod)
 	if jobId != "" {
-		isUnexpectedDeletion := !util.IsMarkedForDeletion(pod) && !util.IsPodFinishedAndReported(pod)
+		isUnexpectedDeletion := !util.IsMarkedForDeletion(pod) && !util.IsPodFinishedAndReported(pod) && !util.IsPodPreempted(pod)
 		if isUnexpectedDeletion {
 			p.attemptToRegisterIssue(&runIssue{
 				JobId: jobId,

--- a/internal/executor/service/pod_issue_handler_test.go
+++ b/internal/executor/service/pod_issue_handler_test.go
@@ -329,6 +329,27 @@ func TestPodIssueService_ReportsFailed_IfDeletedExternally(t *testing.T) {
 	assert.Equal(t, jobId, failedEvent.JobRunErrors.JobId)
 }
 
+func TestPodIssueService_IgnoresFailed_IfDeletedExternallyDueToPreemption(t *testing.T) {
+	podIssueService, _, fakeClusterContext, eventsReporter, err := setupTestComponents([]*job.RunState{})
+	require.NoError(t, err)
+	preemptedPod := makeTestPod(v1.PodStatus{
+		Phase: v1.PodFailed,
+		Conditions: []v1.PodCondition{
+			{
+				Type:   v1.DisruptionTarget,
+				Status: v1.ConditionTrue,
+				Reason: util.PreemptedReason,
+			},
+		},
+	})
+	fakeClusterContext.SimulateDeletionEvent(preemptedPod)
+
+	podIssueService.HandlePodIssues()
+
+	assert.Len(t, eventsReporter.ReceivedEvents, 0)
+	assert.Len(t, podIssueService.knownPodIssues, 0)
+}
+
 func TestPodIssueService_ReportsFailed_IfPodOfActiveRunGoesMissing(t *testing.T) {
 	baseTime := time.Now()
 	fakeClock := clock.NewFakeClock(baseTime)

--- a/internal/executor/util/pod_status.go
+++ b/internal/executor/util/pod_status.go
@@ -15,6 +15,7 @@ const (
 	oomKilledReason  = "OOMKilled"
 	evictedReason    = "Evicted"
 	deadlineExceeded = "DeadlineExceeded"
+	PreemptedReason  = "PreemptionByScheduler"
 )
 
 // TODO: Need to detect pod preemption. So that job failed events can include a string indicating a pod was preempted.

--- a/internal/executor/util/pod_util.go
+++ b/internal/executor/util/pod_util.go
@@ -370,3 +370,15 @@ func GroupByQueue(pods []*v1.Pod) map[string][]*v1.Pod {
 	}
 	return podsByQueue
 }
+
+func IsPodPreempted(pod *v1.Pod) bool {
+	for _, containerCondition := range pod.Status.Conditions {
+		if containerCondition.Type == v1.DisruptionTarget && containerCondition.Status == v1.ConditionTrue {
+			if containerCondition.Reason == PreemptedReason {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/internal/executor/util/pod_util_test.go
+++ b/internal/executor/util/pod_util_test.go
@@ -13,6 +13,55 @@ import (
 	"github.com/armadaproject/armada/internal/server/configuration"
 )
 
+func TestIsPodPreempted(t *testing.T) {
+
+	t.Run("preempted pod is preempted", func(t *testing.T) {
+		pod := v1.Pod{
+			Status: v1.PodStatus{
+				Phase: v1.PodFailed,
+				Conditions: []v1.PodCondition{
+					{
+						Type:   v1.DisruptionTarget,
+						Status: v1.ConditionTrue,
+						Reason: PreemptedReason,
+					},
+				},
+			},
+		}
+
+		assert.True(t, IsPodPreempted(&pod))
+	})
+
+	t.Run("failed pod is not preempted", func(t *testing.T) {
+		pod := v1.Pod{
+			Status: v1.PodStatus{
+				Phase: v1.PodFailed,
+				ContainerStatuses: []v1.ContainerStatus{
+					{
+						State: v1.ContainerState{
+							Terminated: &v1.ContainerStateTerminated{
+								ExitCode: 1,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		assert.False(t, IsPodPreempted(&pod))
+	})
+
+	t.Run("successful pod is not preempted", func(t *testing.T) {
+		pod := v1.Pod{
+			Status: v1.PodStatus{
+				Phase: v1.PodSucceeded,
+			},
+		}
+
+		assert.False(t, IsPodPreempted(&pod))
+	})
+}
+
 func TestIsInTerminalState_ShouldReturnTrueWhenPodInSucceededPhase(t *testing.T) {
 	pod := v1.Pod{
 		Status: v1.PodStatus{

--- a/internal/scheduler/configuration/configuration.go
+++ b/internal/scheduler/configuration/configuration.go
@@ -248,6 +248,8 @@ type SchedulingConfig struct {
 	Pools                         []PoolConfig
 	ExperimentalIndicativePricing ExperimentalIndicativePricing
 	ExperimentalIndicativeShare   ExperimentalIndicativeShare
+	// Default preemption retries settings so you don't have to annotate all jobs with reties.
+	DefaultPreemptionRetry PreemptionRetryConfig
 }
 
 const (
@@ -353,4 +355,9 @@ type PriorityOverrideConfig struct {
 	UpdateFrequency time.Duration
 	ServiceUrl      string
 	ForceNoTls      bool
+}
+
+type PreemptionRetryConfig struct {
+	Enabled              bool
+	DefaultMaxRetryCount *uint
 }

--- a/internal/scheduler/database/job_repository.go
+++ b/internal/scheduler/database/job_repository.go
@@ -283,6 +283,7 @@ func (r *PostgresJobRepository) FindInactiveRuns(ctx *armadacontext.Context, run
 		WHERE runs.run_id IS NULL
 		OR runs.succeeded = true
  		OR runs.failed = true
+		OR runs.preempted = true
 		OR runs.cancelled = true;`
 
 		rows, err := tx.Query(ctx, fmt.Sprintf(query, tmpTable))
@@ -331,6 +332,7 @@ func (r *PostgresJobRepository) FetchJobRunLeases(ctx *armadacontext.Context, ex
 				AND jr.succeeded = false
 				AND jr.failed = false
 				AND jr.cancelled = false
+				AND jr.preempted = false
 				ORDER BY jr.serial
 				LIMIT %d;
 `

--- a/internal/scheduler/database/job_repository_test.go
+++ b/internal/scheduler/database/job_repository_test.go
@@ -526,6 +526,15 @@ func TestFindInactiveRuns(t *testing.T) {
 			},
 			expectedInactive: []string{runIds[1]},
 		},
+		"run preempted": {
+			runsToCheck: runIds,
+			dbRuns: []Run{
+				{RunID: runIds[0]},
+				{RunID: runIds[1], Preempted: true},
+				{RunID: runIds[2]},
+			},
+			expectedInactive: []string{runIds[1]},
+		},
 		"run missing": {
 			runsToCheck: runIds,
 			dbRuns: []Run{
@@ -626,6 +635,14 @@ func TestFetchJobRunLeases(t *testing.T) {
 			Executor:  executorName,
 			Pool:      "test-pool",
 			Succeeded: true, // should be ignored as terminal
+		},
+		{
+			RunID:     uuid.NewString(),
+			JobID:     dbJobs[0].JobID,
+			JobSet:    "test-jobset",
+			Executor:  executorName,
+			Pool:      "test-pool",
+			Preempted: true, // should be ignored as terminal
 		},
 	}
 	expectedLeases := make([]*JobRunLease, 4)

--- a/internal/scheduler/jobdb/job.go
+++ b/internal/scheduler/jobdb/job.go
@@ -2,6 +2,8 @@ package jobdb
 
 import (
 	"fmt"
+	"github.com/armadaproject/armada/internal/common/preemption"
+	"github.com/armadaproject/armada/internal/scheduler/configuration"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -732,6 +734,60 @@ func (job *Job) NumAttempts() uint {
 		}
 	}
 	return attempts
+}
+
+// IsEligibleForPreemptionRetry determines whether the job is eligible for preemption retries. It checks whether the
+// scheduler or the job has opted in for preemption retries. It then checks whether the job has exhausted the number
+// of retries.
+func (job *Job) IsEligibleForPreemptionRetry(defaultPreemptionRetryConfig configuration.PreemptionRetryConfig) bool {
+
+	var enabled = false
+
+	// Check for platform default first
+	if defaultPreemptionRetryConfig.Enabled {
+		enabled = true
+	}
+
+	// Check if job explicitly enabled/disabled retries
+	jobRetryEnabled, exists := preemption.AreRetriesEnabled(job.Annotations())
+	if exists {
+		enabled = jobRetryEnabled
+	}
+
+	if !enabled {
+		return false
+	}
+
+	maxRetryCount := job.MaxPreemptionRetryCount(defaultPreemptionRetryConfig)
+
+	return job.NumPreemptedRuns() <= maxRetryCount
+}
+
+func (job *Job) NumPreemptedRuns() uint {
+	preemptCount := uint(0)
+	for _, run := range job.runsById {
+		if run.preempted {
+			preemptCount++
+		}
+	}
+	return preemptCount
+}
+
+func (job *Job) MaxPreemptionRetryCount(defaultPreemptionRetryConfig configuration.PreemptionRetryConfig) uint {
+	var maxRetryCount uint = 0
+
+	// Check for platform default first
+	if defaultPreemptionRetryConfig.DefaultMaxRetryCount != nil {
+		platformDefaultMaxRetryCount := *defaultPreemptionRetryConfig.DefaultMaxRetryCount
+		maxRetryCount = platformDefaultMaxRetryCount
+	}
+
+	// Allow jobs to set a custom max retry count
+	jobMaxRetryCount, exists := preemption.GetMaxRetryCount(job.Annotations())
+	if exists {
+		maxRetryCount = jobMaxRetryCount
+	}
+	return maxRetryCount
 }
 
 // AllRuns returns all runs associated with job.

--- a/internal/scheduler/jobdb/job_run.go
+++ b/internal/scheduler/jobdb/job_run.go
@@ -501,7 +501,7 @@ func (run *JobRun) WithoutTerminal() *JobRun {
 
 // InTerminalState returns true if the JobRun is in a terminal state
 func (run *JobRun) InTerminalState() bool {
-	return run.succeeded || run.failed || run.cancelled || run.returned
+	return run.succeeded || run.failed || run.cancelled || run.returned || run.preempted
 }
 
 func (run *JobRun) DeepCopy() *JobRun {

--- a/internal/scheduler/jobdb/job_test.go
+++ b/internal/scheduler/jobdb/job_test.go
@@ -10,6 +10,9 @@ import (
 
 	"github.com/armadaproject/armada/internal/common/types"
 	"github.com/armadaproject/armada/internal/scheduler/internaltypes"
+
+	configuration2 "github.com/armadaproject/armada/internal/scheduler/configuration"
+	"github.com/armadaproject/armada/internal/server/configuration"
 )
 
 var jobSchedulingInfo = &internaltypes.JobSchedulingInfo{
@@ -26,12 +29,73 @@ var jobSchedulingInfo = &internaltypes.JobSchedulingInfo{
 	},
 }
 
+var jobSchedulingInfoWithRetryEnabled = &internaltypes.JobSchedulingInfo{
+	PodRequirements: &internaltypes.PodRequirements{
+		ResourceRequirements: v1.ResourceRequirements{
+			Requests: v1.ResourceList{
+				"cpu":                 k8sResource.MustParse("1"),
+				"storage-connections": k8sResource.MustParse("1"),
+			},
+		},
+		Annotations: map[string]string{
+			configuration.PreemptionRetryEnabledAnnotation:  "true",
+			configuration.PreemptionRetryCountMaxAnnotation: "1",
+		},
+	},
+}
+
+var jobSchedulingInfoWithRetryDisabled = &internaltypes.JobSchedulingInfo{
+	PodRequirements: &internaltypes.PodRequirements{
+		ResourceRequirements: v1.ResourceRequirements{
+			Requests: v1.ResourceList{
+				"cpu":                 k8sResource.MustParse("1"),
+				"storage-connections": k8sResource.MustParse("1"),
+			},
+		},
+		Annotations: map[string]string{
+			configuration.PreemptionRetryEnabledAnnotation: "false",
+		},
+	},
+}
+
 var baseJob, _ = jobDb.NewJob(
 	"test-job",
 	"test-jobSet",
 	"test-queue",
 	2,
 	jobSchedulingInfo,
+	true,
+	0,
+	false,
+	false,
+	false,
+	3,
+	false,
+	[]string{},
+)
+
+var baseJobWithRetryEnabled, _ = jobDb.NewJob(
+	"test-job",
+	"test-jobSet",
+	"test-queue",
+	2,
+	jobSchedulingInfoWithRetryEnabled,
+	true,
+	0,
+	false,
+	false,
+	false,
+	3,
+	false,
+	[]string{},
+)
+
+var baseJobWithRetryDisabled, _ = jobDb.NewJob(
+	"test-job",
+	"test-jobSet",
+	"test-queue",
+	2,
+	jobSchedulingInfoWithRetryDisabled,
 	true,
 	0,
 	false,
@@ -424,4 +488,87 @@ func TestJob_TestAllResourceRequirements(t *testing.T) {
 func TestJob_TestKubernetesResourceRequirements(t *testing.T) {
 	assert.Equal(t, int64(1000), baseJob.KubernetesResourceRequirements().GetByNameZeroIfMissing("cpu"))
 	assert.Equal(t, int64(0), baseJob.KubernetesResourceRequirements().GetByNameZeroIfMissing("storage-connections"))
+}
+
+func TestIsEligibleForPreemptionRetry(t *testing.T) {
+
+	var premptedRun1 = &JobRun{
+		id:        uuid.New().String(),
+		created:   3,
+		executor:  "test-executor",
+		preempted: true,
+	}
+
+	var premptedRun2 = &JobRun{
+		id:        uuid.New().String(),
+		created:   5,
+		executor:  "test-executor",
+		preempted: true,
+	}
+
+	defaultMaxRetryCountEnabled := uint(5)
+	var platformDefaultEnabled = configuration2.PreemptionRetryConfig{
+		Enabled:              true,
+		DefaultMaxRetryCount: &defaultMaxRetryCountEnabled,
+	}
+
+	defaultMaxRetryCountDisabled := uint(0)
+	var platformDefaultDisabled = configuration2.PreemptionRetryConfig{
+		Enabled:              false,
+		DefaultMaxRetryCount: &defaultMaxRetryCountDisabled,
+	}
+
+	// no runs
+	t.Run("job with retry enabled and platform disabled and no runs", func(t *testing.T) {
+		assert.True(t, baseJobWithRetryEnabled.IsEligibleForPreemptionRetry(platformDefaultDisabled))
+	})
+
+	t.Run("job with retry disabled and platform enabled and no runs", func(t *testing.T) {
+		assert.False(t, baseJobWithRetryDisabled.IsEligibleForPreemptionRetry(platformDefaultEnabled))
+	})
+
+	t.Run("job with platform retry enabled and no runs", func(t *testing.T) {
+		assert.True(t, baseJob.IsEligibleForPreemptionRetry(platformDefaultEnabled))
+	})
+
+	t.Run("job with platform retry disabled and no runs", func(t *testing.T) {
+		assert.False(t, baseJob.IsEligibleForPreemptionRetry(platformDefaultDisabled))
+	})
+
+	// runs but none are preempted
+	t.Run("job with retry enabled and platform disabled runs but no preempted runs", func(t *testing.T) {
+		updatedJob := baseJobWithRetryEnabled.WithUpdatedRun(baseRun).WithUpdatedRun(baseRun)
+		assert.True(t, updatedJob.IsEligibleForPreemptionRetry(platformDefaultDisabled))
+	})
+
+	t.Run("job with platform enabled runs but no preempted runs", func(t *testing.T) {
+		updatedJob := baseJob.WithUpdatedRun(baseRun).WithUpdatedRun(baseRun)
+		assert.True(t, updatedJob.IsEligibleForPreemptionRetry(platformDefaultEnabled))
+	})
+
+	t.Run("job with retry enabled and platform disabled and one run", func(t *testing.T) {
+		updatedJob := baseJobWithRetryEnabled.WithUpdatedRun(premptedRun1)
+		assert.True(t, updatedJob.IsEligibleForPreemptionRetry(platformDefaultDisabled))
+	})
+
+	t.Run("job with platform enabled and one run", func(t *testing.T) {
+		updatedJob := baseJob.WithUpdatedRun(premptedRun1)
+		assert.True(t, updatedJob.IsEligibleForPreemptionRetry(platformDefaultEnabled))
+	})
+
+	// runs that are preempted
+	t.Run("job with retry enabled and platform disabled and out of retries", func(t *testing.T) {
+		updatedJob := baseJobWithRetryEnabled.WithUpdatedRun(premptedRun1).WithUpdatedRun(premptedRun2)
+		assert.False(t, updatedJob.IsEligibleForPreemptionRetry(platformDefaultDisabled))
+	})
+
+	t.Run("job with retry enabled with platform enabled and out of retries", func(t *testing.T) {
+		updatedJob := baseJobWithRetryEnabled.WithUpdatedRun(premptedRun1).WithUpdatedRun(premptedRun2)
+		assert.False(t, updatedJob.IsEligibleForPreemptionRetry(platformDefaultEnabled))
+	})
+
+	t.Run("job with platform enabled and retries left", func(t *testing.T) {
+		updatedJob := baseJob.WithUpdatedRun(premptedRun1).WithUpdatedRun(premptedRun2)
+		assert.True(t, updatedJob.IsEligibleForPreemptionRetry(platformDefaultEnabled))
+	})
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -490,20 +490,24 @@ func AppendEventSequencesFromPreemptedJobs(eventSequences []*armadaevents.EventS
 		eventSequences = append(eventSequences, &armadaevents.EventSequence{
 			Queue:      jctx.Job.Queue(),
 			JobSetName: jctx.Job.Jobset(),
-			Events:     createEventsForPreemptedJob(jctx.JobId, run.Id(), jctx.PreemptionDescription, time),
+			Events:     createEventsForPreemptedJob(jctx.Job, run.Id(), jctx.PreemptionDescription, time),
 		})
 	}
 	return eventSequences, nil
 }
 
-func createEventsForPreemptedJob(jobId string, runId string, reason string, time time.Time) []*armadaevents.EventSequence_Event {
-	return []*armadaevents.EventSequence_Event{
+func createEventsForPreemptedJob(job *jobdb.Job, runId string, reason string, time time.Time) []*armadaevents.EventSequence_Event {
+
+	// Check for job failure in case of API preemption
+	terminal := job.Failed()
+
+	events := []*armadaevents.EventSequence_Event{
 		{
 			Created: protoutil.ToTimestamp(time),
 			Event: &armadaevents.EventSequence_Event_JobRunPreempted{
 				JobRunPreempted: &armadaevents.JobRunPreempted{
 					PreemptedRunId: runId,
-					PreemptedJobId: jobId,
+					PreemptedJobId: job.Id(),
 					Reason:         reason,
 				},
 			},
@@ -513,28 +517,10 @@ func createEventsForPreemptedJob(jobId string, runId string, reason string, time
 			Event: &armadaevents.EventSequence_Event_JobRunErrors{
 				JobRunErrors: &armadaevents.JobRunErrors{
 					RunId: runId,
-					JobId: jobId,
+					JobId: job.Id(),
 					Errors: []*armadaevents.Error{
 						{
-							Terminal: true,
-							Reason: &armadaevents.Error_JobRunPreemptedError{
-								JobRunPreemptedError: &armadaevents.JobRunPreemptedError{
-									Reason: reason,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			Created: protoutil.ToTimestamp(time),
-			Event: &armadaevents.EventSequence_Event_JobErrors{
-				JobErrors: &armadaevents.JobErrors{
-					JobId: jobId,
-					Errors: []*armadaevents.Error{
-						{
-							Terminal: true,
+							Terminal: terminal,
 							Reason: &armadaevents.Error_JobRunPreemptedError{
 								JobRunPreemptedError: &armadaevents.JobRunPreemptedError{
 									Reason: reason,
@@ -546,6 +532,44 @@ func createEventsForPreemptedJob(jobId string, runId string, reason string, time
 			},
 		},
 	}
+
+	if terminal {
+		// Only send a job error event if the job is in a terminal state
+		events = append(events, &armadaevents.EventSequence_Event{
+			Created: protoutil.ToTimestamp(time),
+			Event: &armadaevents.EventSequence_Event_JobErrors{
+				JobErrors: &armadaevents.JobErrors{
+					JobId: job.Id(),
+					Errors: []*armadaevents.Error{
+						{
+							Terminal: true,
+							Reason: &armadaevents.Error_JobRunPreemptedError{
+								JobRunPreemptedError: &armadaevents.JobRunPreemptedError{
+									Reason: reason,
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+	}
+
+	if job.Queued() {
+		// Assume the job has already been marked as queued and the version has been bumped
+		events = append(events, &armadaevents.EventSequence_Event{
+			Created: protoutil.ToTimestamp(time),
+			Event: &armadaevents.EventSequence_Event_JobRequeued{
+				JobRequeued: &armadaevents.JobRequeued{
+					JobId:                job.Id(),
+					SchedulingInfo:       internaltypes.ToSchedulerObjectsJobSchedulingInfo(job.JobSchedulingInfo()),
+					UpdateSequenceNumber: job.QueuedVersion(),
+				},
+			},
+		})
+	}
+
+	return events
 }
 
 func AppendEventSequencesFromScheduledJobs(eventSequences []*armadaevents.EventSequence, jctxs []*schedulercontext.JobSchedulingContext) ([]*armadaevents.EventSequence, error) {
@@ -797,7 +821,7 @@ func (s *Scheduler) generateUpdateMessagesFromJob(ctx *armadacontext.Context, jo
 			}
 		} else if lastRun.PreemptRequested() && job.PriorityClass().Preemptible {
 			job = job.WithQueued(false).WithFailed(true).WithUpdatedRun(lastRun.WithoutTerminal().WithFailed(true))
-			events = append(events, createEventsForPreemptedJob(job.Id(), lastRun.Id(), "Preempted - preemption requested via API", s.clock.Now())...)
+			events = append(events, createEventsForPreemptedJob(job, lastRun.Id(), "Preempted - preemption requested via API", s.clock.Now())...)
 		}
 	}
 

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"fmt"
+	"github.com/armadaproject/armada/internal/scheduler/configuration"
 	"sync"
 	"testing"
 	"time"
@@ -89,8 +90,26 @@ var (
 		},
 		Version: 1,
 	}
-	schedulingInfoBytes   = protoutil.MustMarshall(schedulingInfo)
-	updatedSchedulingInfo = &schedulerobjects.JobSchedulingInfo{
+	schedulingInfoBytes            = protoutil.MustMarshall(schedulingInfo)
+	schedulingInfoWithRetryEnabled = &schedulerobjects.JobSchedulingInfo{
+		AtMostOnce:        true,
+		PriorityClassName: testfixtures.PriorityClass1,
+		ObjectRequirements: []*schedulerobjects.ObjectRequirements{
+			{
+				Requirements: &schedulerobjects.ObjectRequirements_PodRequirements{
+					PodRequirements: &schedulerobjects.PodRequirements{
+						Annotations: map[string]string{
+							apiconfig.PreemptionRetryEnabledAnnotation:  "true",
+							apiconfig.PreemptionRetryCountMaxAnnotation: "1",
+						},
+					},
+				},
+			},
+		},
+		Version: 1,
+	}
+	schedulingInfoWithRetryEnabledBytes = protoutil.MustMarshall(schedulingInfoWithRetryEnabled)
+	updatedSchedulingInfo               = &schedulerobjects.JobSchedulingInfo{
 		AtMostOnce: true,
 		ObjectRequirements: []*schedulerobjects.ObjectRequirements{
 			{
@@ -140,6 +159,21 @@ var leasedJob = testfixtures.NewJob(
 	"testQueue",
 	0,
 	toInternalSchedulingInfo(schedulingInfo),
+	false,
+	1,
+	false,
+	false,
+	false,
+	1,
+	true,
+).WithNewRun("testExecutor", "test-node", "node", "pool", 5)
+
+var leasedJobWithRetryEnabled = testfixtures.NewJob(
+	util.NewULID(),
+	"testJobset",
+	"testQueue",
+	0,
+	toInternalSchedulingInfo(schedulingInfoWithRetryEnabled),
 	false,
 	1,
 	false,
@@ -776,6 +810,17 @@ func TestScheduler_TestCycle(t *testing.T) {
 			expectedJobRunErrors:      []string{leasedJob.Id()},
 			expectedTerminal:          []string{leasedJob.Id()},
 			expectedQueuedVersion:     leasedJob.QueuedVersion(),
+		},
+		"Job preempted with retry enabled": {
+			initialJobs:               []*jobdb.Job{leasedJobWithRetryEnabled},
+			expectedJobsRunsToPreempt: []string{leasedJobWithRetryEnabled.Id()},
+			expectedJobRunPreempted:   []string{leasedJobWithRetryEnabled.Id()},
+			expectedJobErrors:         []string{},
+			expectedJobRunErrors:      []string{leasedJobWithRetryEnabled.Id()},
+			expectedTerminal:          []string{},
+			expectedQueued:            []string{leasedJobWithRetryEnabled.Id()},
+			expectedRequeued:          []string{leasedJobWithRetryEnabled.Id()},
+			expectedQueuedVersion:     leasedJob.QueuedVersion() + 1,
 		},
 		"Fetch fails": {
 			initialJobs:           []*jobdb.Job{leasedJob},
@@ -1507,11 +1552,16 @@ func (t *testSchedulingAlgo) Schedule(_ *armadacontext.Context, txn *jobdb.Txn) 
 			return nil, errors.Errorf("was asked to preempt job %s but job is still queued", job.Id())
 		}
 		if run := job.LatestRun(); run != nil {
-			job = job.WithUpdatedRun(run.WithFailed(true))
+			now := time.Now()
+			job = job.WithUpdatedRun(run.WithPreempted(true).WithPreemptedTime(&now))
 		} else {
 			return nil, errors.Errorf("attempting to preempt job %s with no associated runs", job.Id())
 		}
-		job = job.WithQueued(false).WithFailed(true)
+		if job.IsEligibleForPreemptionRetry(configuration.PreemptionRetryConfig{}) {
+			job = job.WithQueued(true).WithQueuedVersion(job.QueuedVersion() + 1)
+		} else {
+			job = job.WithQueued(false).WithFailed(true)
+		}
 		preemptedJobs = append(preemptedJobs, job)
 	}
 	for _, id := range t.jobsToSchedule {
@@ -1648,6 +1698,16 @@ var (
 		QueuedVersion:         1,
 		SchedulingInfo:        schedulingInfoBytes,
 		SchedulingInfoVersion: int32(schedulingInfo.Version),
+		Validated:             true,
+		Serial:                0,
+	}
+	runningAndRetryableJobA = &database.Job{
+		JobID:                 queuedJobA.JobID,
+		JobSet:                "testJobSet",
+		Queue:                 "testQueue",
+		QueuedVersion:         1,
+		SchedulingInfo:        schedulingInfoWithRetryEnabledBytes,
+		SchedulingInfoVersion: int32(schedulingInfoWithRetryEnabled.Version),
 		Validated:             true,
 		Serial:                0,
 	}
@@ -2336,6 +2396,83 @@ func TestCycleConsistency(t *testing.T) {
 											},
 										},
 									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"Running job is preempted and requeued with retry enabled": {
+			firstSchedulerDbUpdate: schedulerDbUpdate{
+				jobUpdates: []*database.Job{
+					runningAndRetryableJobA,
+				},
+				runUpdates: []*database.Run{
+					newRunA,
+				},
+			},
+			idsOfJobsToPreempt:      []string{queuedJobA.JobID},
+			expectedJobDbCycleThree: make([]*jobdb.Job, 0),
+			expectedEventSequencesCycleThree: []*armadaevents.EventSequence{
+				{
+					Queue:      queuedJobA.Queue,
+					JobSetName: queuedJobA.JobSet,
+					Events: []*armadaevents.EventSequence_Event{
+						{
+							Created: &types.Timestamp{},
+							Event: &armadaevents.EventSequence_Event_JobRunPreempted{
+								JobRunPreempted: &armadaevents.JobRunPreempted{
+									PreemptedRunId: testfixtures.UUIDFromInt(1).String(),
+									PreemptedJobId: queuedJobA.JobID,
+								},
+							},
+						},
+						{
+							Created: &types.Timestamp{},
+							Event: &armadaevents.EventSequence_Event_JobRunErrors{
+								JobRunErrors: &armadaevents.JobRunErrors{
+									JobId: queuedJobA.JobID,
+									RunId: testfixtures.UUIDFromInt(1).String(),
+									Errors: []*armadaevents.Error{
+										{
+											Terminal: false,
+											Reason: &armadaevents.Error_JobRunPreemptedError{
+												JobRunPreemptedError: &armadaevents.JobRunPreemptedError{},
+											},
+										},
+									},
+								},
+							},
+						},
+						{
+							Created: &types.Timestamp{},
+							Event: &armadaevents.EventSequence_Event_JobRequeued{
+								JobRequeued: &armadaevents.JobRequeued{
+									SchedulingInfo: &schedulerobjects.JobSchedulingInfo{
+										SubmitTime: &types.Timestamp{
+											Seconds: -62135596800,
+											Nanos:   0,
+										},
+										PriorityClassName: testfixtures.PriorityClass1,
+										ObjectRequirements: []*schedulerobjects.ObjectRequirements{
+											{
+												Requirements: &schedulerobjects.ObjectRequirements_PodRequirements{
+													PodRequirements: &schedulerobjects.PodRequirements{
+														ResourceRequirements: &v1.ResourceRequirements{},
+														NodeSelector:         map[string]string{},
+														Annotations: map[string]string{
+															apiconfig.PreemptionRetryEnabledAnnotation:  "true",
+															apiconfig.PreemptionRetryCountMaxAnnotation: "1",
+														},
+													},
+												},
+											},
+										},
+										Version: 1,
+									},
+									UpdateSequenceNumber: int32(2),
+									JobId:                queuedJobA.JobID,
 								},
 							},
 						},

--- a/internal/scheduler/testfixtures/testfixtures.go
+++ b/internal/scheduler/testfixtures/testfixtures.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -449,6 +450,16 @@ func WithGangAnnotationsJobs(jobs []*jobdb.Job) []*jobdb.Job {
 	gangCardinality := fmt.Sprintf("%d", len(jobs))
 	return WithAnnotationsJobs(
 		map[string]string{configuration.GangIdAnnotation: gangId, configuration.GangCardinalityAnnotation: gangCardinality},
+		jobs,
+	)
+}
+
+func WithPreemptionRetryAnnotationsJobs(jobs []*jobdb.Job, retryCount int) []*jobdb.Job {
+	return WithAnnotationsJobs(
+		map[string]string{
+			configuration.PreemptionRetryEnabledAnnotation:  "true",
+			configuration.PreemptionRetryCountMaxAnnotation: strconv.Itoa(retryCount),
+		},
 		jobs,
 	)
 }

--- a/internal/server/configuration/constants.go
+++ b/internal/server/configuration/constants.go
@@ -16,6 +16,9 @@ const (
 	// Instead, the job the pod is part of fails immediately.
 	FailFastAnnotation = "armadaproject.io/failFast"
 	PoolAnnotation     = "armadaproject.io/pool"
+
+	PreemptionRetryCountMaxAnnotation = "armadaproject.io/preemptionRetryCountMax"
+	PreemptionRetryEnabledAnnotation  = "armadaproject.io/preemptionRetryEnabled"
 )
 
 var schedulingAnnotations = map[string]bool{


### PR DESCRIPTION
#### What type of PR is this?
New feature

#### What this PR does / why we need it:
This pull request add support for native Armada Preemption Retry Handling. Retry handling can be configured at the platform level as a default in the scheduling config as well as with two annotations:

armadaproject.io/preemptionRetryCountMax (defaults to 0 for now, ie. disabled if not configured)
armadaproject.io/preemptionRetryEnabled

The scheduler has been modified to only submit terminal job events when a job is preempted and is not retryable. If the job is preempted and retryable the job is requeued. 

The executor has two different code paths that send events when pods enter a failed state:

1. The job state reporter handles pod events and sends job failed events when jobs fail.
2. The pod issue handler handles pod deletion events and sends job failed events when a pod is unexpectedly deleted.

Both of these code paths have been updated not to send job failed events when the pod has been preempted as this would fail the overall job. 

Note: This introduces a subtle behavior regression where pods that are preempted out from underneath Armada (ie. system pods preempting armada jobs) will no longer fail the job. I have some ideas for how to fix that but I think it is a pretty exceptional case. 

#### Which issue(s) this PR fixes:
Fixes: https://github.com/armadaproject/armada/issues/4340

#### Special notes for your reviewer:

