### PR TITLE
Prepare Scala client release v0.1.0

### DIFF
--- a/client/scala/armada-scala-client/pom.xml
+++ b/client/scala/armada-scala-client/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.armadaproject</groupId>
   <artifactId>armada-scala-client_2.13</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.1.0</version>
   <name>Armada Scala Client</name>
   <description>A Scala client for Armada.</description>
   <inceptionYear>2025</inceptionYear>


### PR DESCRIPTION
#### What type of PR is this?
Preparations to release the Scala client.

#### What this PR does / why we need it:
There has been only snapshot releases for the Scala client so far. The client is in a good shape for its first proper release.