### PR TITLE
Post-release version bump for Scala client

### DIFF
--- a/client/scala/armada-scala-client/pom.xml
+++ b/client/scala/armada-scala-client/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.armadaproject</groupId>
   <artifactId>armada-scala-client_2.13</artifactId>
-  <version>0.1.0</version>
+  <version>0.2.0-SNAPSHOT</version>
   <name>Armada Scala Client</name>
   <description>A Scala client for Armada.</description>
   <inceptionYear>2025</inceptionYear>


### PR DESCRIPTION
#### What type of PR is this?
Bumps the version of the Scala client post v0.1.0 release.

#### What this PR does / why we need it:
To mark the v0.2.0 development and to allow for snapshot releases any time.