### PR TITLE
Support silent OIDC signin in Lookout UI

### DIFF
--- a/internal/lookoutui/src/App.tsx
+++ b/internal/lookoutui/src/App.tsx
@@ -3,7 +3,6 @@ import { useEffect } from "react"
 import { CssBaseline, styled, ThemeProvider } from "@mui/material"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { SnackbarProvider } from "notistack"
-import { UserManager, WebStorageStateStore, UserManagerSettings } from "oidc-client-ts"
 import { ErrorBoundary } from "react-error-boundary"
 import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom"
 
@@ -13,7 +12,6 @@ import NavBar from "./components/NavBar"
 import JobSetsContainer from "./containers/JobSetsContainer"
 import { JobsTableContainer } from "./containers/lookout/JobsTableContainer"
 import { OidcAuthProvider } from "./oidcAuth"
-import { OIDC_REDIRECT_PATHNAME } from "./oidcAuth/OidcAuthProvider"
 import { ApiClientsProvider } from "./services/apiClients"
 import { Services, ServicesProvider } from "./services/context"
 import { theme } from "./theme/theme"
@@ -46,19 +44,6 @@ type AppProps = {
   jobsAutoRefreshMs: number | undefined
   debugEnabled: boolean
   commandSpecs: CommandSpec[]
-}
-
-export function createUserManager(config: OidcConfig): UserManager {
-  const userManagerSettings: UserManagerSettings = {
-    authority: config.authority,
-    client_id: config.clientId,
-    redirect_uri: `${window.location.origin}${OIDC_REDIRECT_PATHNAME}`,
-    scope: config.scope,
-    userStore: new WebStorageStateStore({ store: window.localStorage }),
-    loadUserInfo: true,
-  }
-
-  return new UserManager(userManagerSettings)
 }
 
 // Version 2 of the Lookout UI used to be hosted under /v2, so we try our best


### PR DESCRIPTION
Adds support and fixes the behaviour for silently refreshing the OIDC token in the Lookout UI. The `oidc-client-ts` library we use uses an iframe to refetch the auth token from the configured OIDC provider silently in the background one minute before the stored token expires.

Also remove unused code.