### PR TITLE
Add /jobs/{job ID} redirect links to Lookout

### DIFF
--- a/internal/lookoutui/src/App.tsx
+++ b/internal/lookoutui/src/App.tsx
@@ -8,10 +8,12 @@ import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom"
 
 import { AlertInPageContainerErrorFallback } from "./components/AlertInPageContainerErrorFallback"
 import { FullPageErrorFallback } from "./components/FullPageErrorFallback"
+import { JobIdRedirect } from "./components/JobIdRedirect"
 import NavBar from "./components/NavBar"
 import JobSetsContainer from "./containers/JobSetsContainer"
 import { JobsTableContainer } from "./containers/lookout/JobsTableContainer"
 import { OidcAuthProvider } from "./oidcAuth"
+import { JOB_REDIRECT, JOB_SETS, JOBS, V2_REDIRECT } from "./pathnames"
 import { ApiClientsProvider } from "./services/apiClients"
 import { Services, ServicesProvider } from "./services/context"
 import { theme } from "./theme/theme"
@@ -48,7 +50,7 @@ type AppProps = {
 
 // Version 2 of the Lookout UI used to be hosted under /v2, so we try our best
 // to redirect users to the new location while preserving the rest of the URL.
-const V2Redirect = withRouter(({ router }) => <Navigate to={{ ...router.location, pathname: "/" }} />)
+const V2Redirect = withRouter(({ router }) => <Navigate to={{ ...router.location, pathname: JOBS }} />)
 
 export function App(props: AppProps) {
   useEffect(() => {
@@ -77,7 +79,7 @@ export function App(props: AppProps) {
                         <AppContent>
                           <Routes>
                             <Route
-                              path="/"
+                              path={JOBS}
                               element={
                                 <ErrorBoundary FallbackComponent={AlertInPageContainerErrorFallback}>
                                   <JobsTableContainer
@@ -93,7 +95,15 @@ export function App(props: AppProps) {
                               }
                             />
                             <Route
-                              path="/job-sets"
+                              path={JOB_REDIRECT}
+                              element={
+                                <ErrorBoundary FallbackComponent={AlertInPageContainerErrorFallback}>
+                                  <JobIdRedirect />
+                                </ErrorBoundary>
+                              }
+                            />
+                            <Route
+                              path={JOB_SETS}
                               element={
                                 <ErrorBoundary FallbackComponent={AlertInPageContainerErrorFallback}>
                                   <JobSetsContainer
@@ -105,7 +115,7 @@ export function App(props: AppProps) {
                               }
                             />
                             <Route
-                              path="/v2"
+                              path={V2_REDIRECT}
                               element={
                                 <ErrorBoundary FallbackComponent={AlertInPageContainerErrorFallback}>
                                   <V2Redirect />
@@ -119,7 +129,7 @@ export function App(props: AppProps) {
                                 // links to /job-sets or /jobs see something other than
                                 // a blank page.
                                 <ErrorBoundary FallbackComponent={AlertInPageContainerErrorFallback}>
-                                  <Navigate to="/" />
+                                  <Navigate to={JOBS} />
                                 </ErrorBoundary>
                               }
                             />

--- a/internal/lookoutui/src/components/CopyIconButton.tsx
+++ b/internal/lookoutui/src/components/CopyIconButton.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react"
 
 import { ContentCopy } from "@mui/icons-material"
-import { IconButton, IconButtonProps, styled, Tooltip } from "@mui/material"
+import { IconButton, IconButtonProps, styled, SvgIcon, Tooltip } from "@mui/material"
 
 const LEAVE_DELAY_MS = 1_000
 
@@ -14,14 +14,23 @@ export interface CopyIconButtonProps {
   size?: IconButtonProps["size"]
   onClick?: IconButtonProps["onClick"]
   hidden?: boolean
+  Icon?: typeof SvgIcon
+  copiedTooltipTitle?: string
 }
 
-export const CopyIconButton = ({ content, size, onClick, hidden = false }: CopyIconButtonProps) => {
+export const CopyIconButton = ({
+  content,
+  size,
+  onClick,
+  hidden = false,
+  Icon = ContentCopy,
+  copiedTooltipTitle = "Copied!",
+}: CopyIconButtonProps) => {
   const [tooltipOpen, setTooltipOpen] = useState(false)
 
   return (
     <Tooltip
-      title="Copied!"
+      title={copiedTooltipTitle}
       onClose={() => setTooltipOpen(false)}
       open={tooltipOpen}
       leaveDelay={LEAVE_DELAY_MS}
@@ -37,7 +46,7 @@ export const CopyIconButton = ({ content, size, onClick, hidden = false }: CopyI
         aria-label="copy"
         hidden={hidden && !tooltipOpen}
       >
-        <ContentCopy fontSize="inherit" />
+        <Icon fontSize="inherit" />
       </StyledIconButton>
     </Tooltip>
   )

--- a/internal/lookoutui/src/components/JobIdRedirect.tsx
+++ b/internal/lookoutui/src/components/JobIdRedirect.tsx
@@ -1,0 +1,28 @@
+import _ from "lodash"
+import { useParams, Navigate } from "react-router-dom"
+
+import { JOBS } from "../pathnames"
+import {
+  JobsTablePreferences,
+  DEFAULT_PREFERENCES,
+  stringifyQueryParams,
+  toQueryStringSafe,
+  QueryStringPrefs,
+} from "../services/lookout/JobsTablePreferencesService"
+import { StandardColumnId } from "../utils/jobsTableColumns"
+
+const queryStringPrefsKeys: Array<keyof QueryStringPrefs> = ["f", "sb"]
+
+// Redirects to the jobs table page with the job ID filter set to the path param, and the sidebar open to the job with this ID
+export const JobIdRedirect = () => {
+  const { jobId } = useParams()
+  const jobsTablePreferences: Partial<JobsTablePreferences> = {
+    filters: [{ id: StandardColumnId.JobID, value: jobId }],
+    sidebarJobId: jobId,
+  }
+  const queryParams = _.pick(
+    toQueryStringSafe({ ...DEFAULT_PREFERENCES, ...jobsTablePreferences }),
+    queryStringPrefsKeys,
+  )
+  return <Navigate to={{ pathname: JOBS, search: `?${stringifyQueryParams(queryParams)}` }} />
+}

--- a/internal/lookoutui/src/components/NavBar.tsx
+++ b/internal/lookoutui/src/components/NavBar.tsx
@@ -6,6 +6,7 @@ import { Link } from "react-router-dom"
 
 import { SettingsDialog } from "./SettingsDialog"
 import { useUsername } from "../oidcAuth"
+import { JOB_SETS, JOBS } from "../pathnames"
 import { Router, withRouter } from "../utils"
 
 import "./NavBar.css"
@@ -18,11 +19,11 @@ interface Page {
 const PAGES: Page[] = [
   {
     title: "Jobs",
-    location: "/",
+    location: JOBS,
   },
   {
     title: "Job Sets",
-    location: "/job-sets",
+    location: JOB_SETS,
   },
 ]
 

--- a/internal/lookoutui/src/components/lookout/sidebar/SidebarHeader.tsx
+++ b/internal/lookoutui/src/components/lookout/sidebar/SidebarHeader.tsx
@@ -1,10 +1,12 @@
 import { memo, ReactNode } from "react"
 
-import { Close } from "@mui/icons-material"
+import { Close, Share } from "@mui/icons-material"
 import { IconButton, styled, Typography } from "@mui/material"
+import { generatePath } from "react-router-dom"
 
 import { formatTimestampRelative } from "../../../common/formatTime"
 import { Job } from "../../../models/lookoutModels"
+import { JOB_REDIRECT } from "../../../pathnames"
 import { CopyIconButton } from "../../CopyIconButton"
 import { JobStateChip } from "../JobStateChip"
 
@@ -40,6 +42,12 @@ export const SidebarHeader = memo(({ job, onClose }: SidebarHeaderProps) => (
           <JobId>{job.jobId}</JobId>
           <div>
             <CopyIconButton content={job.jobId} size="small" />
+            <CopyIconButton
+              content={window.location.origin + generatePath(JOB_REDIRECT, { jobId: job.jobId })}
+              size="small"
+              Icon={Share}
+              copiedTooltipTitle="Copied direct link to this job!"
+            />
           </div>
         </JobIdContainer>
       }

--- a/internal/lookoutui/src/containers/JobSetsContainer.tsx
+++ b/internal/lookoutui/src/containers/JobSetsContainer.tsx
@@ -8,6 +8,7 @@ import { AlertErrorFallback } from "../components/AlertErrorFallback"
 import JobSets from "../components/job-sets/JobSets"
 import { JobState, Match } from "../models/lookoutModels"
 import { useAuthenticatedFetch } from "../oidcAuth"
+import { JOBS } from "../pathnames"
 import IntervalService from "../services/IntervalService"
 import { GetJobSetsRequest, JobSet, JobSetsOrderByColumn } from "../services/JobService"
 import JobSetsLocalStorageService from "../services/JobSetsLocalStorageService"
@@ -261,7 +262,7 @@ class JobSetsContainer extends Component<JobSetsContainerProps, JobSetsContainer
     }
 
     this.props.router.navigate({
-      pathname: "/",
+      pathname: JOBS,
       search: stringifyQueryParams(toQueryStringSafe(prefs)),
     })
   }

--- a/internal/lookoutui/src/containers/lookout/JobsTableContainer.test.tsx
+++ b/internal/lookoutui/src/containers/lookout/JobsTableContainer.test.tsx
@@ -8,6 +8,7 @@ import { v4 as uuidv4 } from "uuid"
 import { JobsTableContainer } from "./JobsTableContainer"
 import { queryClient } from "../../App"
 import { Job, JobState } from "../../models/lookoutModels"
+import { JOBS, V2_REDIRECT } from "../../pathnames"
 import { FakeServicesProvider } from "../../services/fakeContext"
 import { IGetJobInfoService } from "../../services/lookout/GetJobInfoService"
 import { GetJobsResponse, IGetJobsService } from "../../services/lookout/GetJobsService"
@@ -128,18 +129,18 @@ describe("JobsTableContainer", () => {
         </QueryClientProvider>
       </SnackbarProvider>
     )
-    let initialEntry = "/v2"
+    let initialEntry = V2_REDIRECT
     if (search !== undefined) {
       initialEntry += search
     }
     const router = createMemoryRouter(
       [
         {
-          path: "/",
+          path: JOBS,
           element: <>Navigated from Start</>,
         },
         {
-          path: "/v2",
+          path: V2_REDIRECT,
           element: element,
         },
       ],

--- a/internal/lookoutui/src/oidcAuth/OidcAuthProvider.tsx
+++ b/internal/lookoutui/src/oidcAuth/OidcAuthProvider.tsx
@@ -6,8 +6,7 @@ import { ErrorPage } from "../components/ErrorPage"
 import { OidcConfig } from "../utils"
 import { OidcAuthContext, OidcAuthContextProps } from "./OidcAuthContext"
 import { LoadingPage } from "../components/LoadingPage"
-
-export const OIDC_REDIRECT_PATHNAME = "/oidc"
+import { OIDC_REDIRECT } from "../pathnames"
 
 const ELLIPSIS = "\u2026"
 
@@ -27,7 +26,7 @@ export const OidcAuthProvider = ({ children, oidcConfig }: OidcAuthProviderProps
         ? new UserManager({
             authority: oidcConfig.authority,
             client_id: oidcConfig.clientId,
-            redirect_uri: `${window.location.origin}${OIDC_REDIRECT_PATHNAME}`,
+            redirect_uri: `${window.location.origin}${OIDC_REDIRECT}`,
             scope: oidcConfig.scope,
             userStore: userManagerStore,
             loadUserInfo: true,
@@ -38,7 +37,7 @@ export const OidcAuthProvider = ({ children, oidcConfig }: OidcAuthProviderProps
 
   const [authError, setAuthError] = useState<any>(undefined)
 
-  const isOidcRedirectPath = window.location.pathname === OIDC_REDIRECT_PATHNAME
+  const isOidcRedirectPath = window.location.pathname === OIDC_REDIRECT
   const authenticate = useCallback(async () => {
     setAuthError(undefined)
     setIsLoading(true)

--- a/internal/lookoutui/src/pathnames.ts
+++ b/internal/lookoutui/src/pathnames.ts
@@ -1,0 +1,5 @@
+export const JOBS = "/"
+export const JOB_REDIRECT = "/jobs/:jobId"
+export const JOB_SETS = "/job-sets"
+export const V2_REDIRECT = "/v2"
+export const OIDC_REDIRECT = "/oidc"

--- a/internal/lookoutui/src/services/lookout/useGetUiConfig.ts
+++ b/internal/lookoutui/src/services/lookout/useGetUiConfig.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query"
 
+import { OIDC_REDIRECT } from "../../pathnames"
 import { getErrorMessage, OidcConfig, UIConfig } from "../../utils"
 
 const DEFAULT_OIDC_CONFIG: OidcConfig = {
@@ -85,8 +86,8 @@ export const useGetUiConfig = (enabled = true) => {
         throw await getErrorMessage(e)
       }
 
-      config.oidcEnabled =
-        searchParams.get("oidcEnabled") === JSON.stringify(true) || window.location.pathname === "/oidc"
+      if (window.location.pathname === OIDC_REDIRECT) config.oidcEnabled = true
+      if (searchParams.get("oidcEnabled")) config.oidcEnabled = true
 
       const backend = searchParams.get("backend")
       if (backend) config.backend = backend

--- a/internal/lookoutui/src/utils.tsx
+++ b/internal/lookoutui/src/utils.tsx
@@ -2,7 +2,7 @@ import { Component, FC } from "react"
 
 import { Location, NavigateFunction, Params, useLocation, useNavigate, useParams } from "react-router-dom"
 
-import { OIDC_REDIRECT_PATHNAME } from "./oidcAuth/OidcAuthProvider"
+import { OIDC_REDIRECT } from "./pathnames"
 
 export interface OidcConfig {
   authority: string
@@ -119,7 +119,7 @@ export async function getUIConfig(): Promise<UIConfig> {
       break
   }
 
-  if (window.location.pathname === OIDC_REDIRECT_PATHNAME) config.oidcEnabled = true
+  if (window.location.pathname === OIDC_REDIRECT) config.oidcEnabled = true
 
   const backend = searchParams.get("backend")
   if (backend) config.backend = backend


### PR DESCRIPTION
Links following this pattern will link to the jobs page, with the single filter - job id equals {job ID} - applied, and the job details sidebar open.

This also adds a "share" icon button to the top of the job sidebar, which copies this link to the user's clipboard for the open job.

| ![image](https://github.com/user-attachments/assets/6e205b7b-5da2-4840-9837-2e31a5aa88a7) | ![image](https://github.com/user-attachments/assets/e67341ec-b536-4106-b332-d944eb65be35) |
| - | - |

This commit additionally centralises the definition of pathnames across the app into a single file as the single source of truth for these.