### PR TITLE
Remove priority class name override

### DIFF
--- a/config/scheduler/config.yaml
+++ b/config/scheduler/config.yaml
@@ -93,7 +93,6 @@ scheduling:
       priority: 1000
       preemptible: true
   defaultPriorityClassName: "armada-default"
-  priorityClassNameOverride: "armada-default"
   maxQueueLookback: 100000
   maximumResourceFractionToSchedule:
     memory: 1.0


### PR DESCRIPTION
This pull request removes the default configuration which adds a priority class name override. 

This configuration is puzzling to me since there is already a default priority class name set. I don't see why the intended priority class should be overridden when sent down to the executor. This can also conflict with the preemptible label that is unconditionally set prior to the priority class name override. 

I mainly find this problematic because we are unable to unset this when managing Armada using the Armada Operator. 