### PR TITLE
Allow pools to override which resources are considered for fairness

### DIFF
--- a/internal/scheduler/configuration/configuration.go
+++ b/internal/scheduler/configuration/configuration.go
@@ -283,11 +283,18 @@ type WellKnownNodeType struct {
 }
 
 type PoolConfig struct {
-	Name                                         string `validate:"required"`
-	AwayPools                                    []string
-	ProtectedFractionOfFairShare                 *float64
-	ExperimentalProtectUncappedAdjustedFairShare bool
-	ExperimentalOptimiser                        *OptimiserConfig
+	Name                         string `validate:"required"`
+	AwayPools                    []string
+	ProtectedFractionOfFairShare *float64
+	// List of resource names, e.g., []string{"cpu", "memory"}, to consider when computing DominantResourceFairness costs.
+	// Dominant resource fairness is the algorithm used to assign a cost to jobs and queues.
+	DominantResourceFairnessResourcesToConsider []string
+	// Experimental - subject to change
+	// List of resource names, (e.g. "cpu" or "memory"), to consider when computing DominantResourceFairness costs.
+	// Dominant resource fairness is the algorithm used to assign a cost to jobs and queues.
+	ExperimentalDominantResourceFairnessResourcesToConsider []DominantResourceFairnessResource
+	ExperimentalProtectUncappedAdjustedFairShare            bool
+	ExperimentalOptimiser                                   *OptimiserConfig
 }
 
 type OptimiserConfig struct {
@@ -334,6 +341,15 @@ func (sc *SchedulingConfig) GetOptimiserConfig(poolName string) *OptimiserConfig
 	for _, poolConfig := range sc.Pools {
 		if poolConfig.Name == poolName {
 			return poolConfig.ExperimentalOptimiser
+		}
+	}
+	return nil
+}
+
+func (sc *SchedulingConfig) GetPoolConfig(poolName string) *PoolConfig {
+	for _, poolConfig := range sc.Pools {
+		if poolConfig.Name == poolName {
+			return &poolConfig
 		}
 	}
 	return nil

--- a/internal/scheduler/configuration/configuration.go
+++ b/internal/scheduler/configuration/configuration.go
@@ -286,15 +286,11 @@ type PoolConfig struct {
 	Name                         string `validate:"required"`
 	AwayPools                    []string
 	ProtectedFractionOfFairShare *float64
-	// List of resource names, e.g., []string{"cpu", "memory"}, to consider when computing DominantResourceFairness costs.
-	// Dominant resource fairness is the algorithm used to assign a cost to jobs and queues.
-	DominantResourceFairnessResourcesToConsider []string
-	// Experimental - subject to change
 	// List of resource names, (e.g. "cpu" or "memory"), to consider when computing DominantResourceFairness costs.
 	// Dominant resource fairness is the algorithm used to assign a cost to jobs and queues.
-	ExperimentalDominantResourceFairnessResourcesToConsider []DominantResourceFairnessResource
-	ExperimentalProtectUncappedAdjustedFairShare            bool
-	ExperimentalOptimiser                                   *OptimiserConfig
+	DominantResourceFairnessResourcesToConsider  []DominantResourceFairnessResource
+	ExperimentalProtectUncappedAdjustedFairShare bool
+	ExperimentalOptimiser                        *OptimiserConfig
 }
 
 type OptimiserConfig struct {

--- a/internal/scheduler/metrics/cycle_metrics_test.go
+++ b/internal/scheduler/metrics/cycle_metrics_test.go
@@ -30,6 +30,7 @@ func TestReportStateTransitions(t *testing.T) {
 	ctx := armadacontext.Background()
 	fairnessCostProvider, err := fairness.NewDominantResourceFairness(
 		cpu(100),
+		poolLabel,
 		configuration.SchedulingConfig{DominantResourceFairnessResourcesToConsider: []string{"cpu"}},
 	)
 	require.NoError(t, err)
@@ -212,6 +213,7 @@ func TestPublishCycleMetrics(t *testing.T) {
 
 	fairnessCostProvider, err := fairness.NewDominantResourceFairness(
 		cpu(100),
+		poolLabel,
 		configuration.SchedulingConfig{DominantResourceFairnessResourcesToConsider: []string{"cpu"}},
 	)
 	require.NoError(t, err)

--- a/internal/scheduler/scheduling/context/scheduling_test.go
+++ b/internal/scheduler/scheduling/context/scheduling_test.go
@@ -19,7 +19,7 @@ func TestSchedulingContextAccounting(t *testing.T) {
 	totalResources := testfixtures.TestResourceListFactory.FromNodeProto(
 		map[string]*resource.Quantity{"cpu": pointer.MustParseResource("1")},
 	)
-	fairnessCostProvider, err := fairness.NewDominantResourceFairness(totalResources, configuration.SchedulingConfig{DominantResourceFairnessResourcesToConsider: []string{"cpu"}})
+	fairnessCostProvider, err := fairness.NewDominantResourceFairness(totalResources, "pool", configuration.SchedulingConfig{DominantResourceFairnessResourcesToConsider: []string{"cpu"}})
 	require.NoError(t, err)
 	sctx := NewSchedulingContext(
 		"pool",
@@ -186,7 +186,7 @@ func TestCalculateFairShares(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			fairnessCostProvider, err := fairness.NewDominantResourceFairness(tc.availableResources, configuration.SchedulingConfig{DominantResourceFairnessResourcesToConsider: []string{"cpu"}})
+			fairnessCostProvider, err := fairness.NewDominantResourceFairness(tc.availableResources, "pool", configuration.SchedulingConfig{DominantResourceFairnessResourcesToConsider: []string{"cpu"}})
 			require.NoError(t, err)
 			sctx := NewSchedulingContext(
 				"pool",
@@ -278,7 +278,7 @@ func TestCalculateTheoreticalShare(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			fairnessCostProvider, err := fairness.NewDominantResourceFairness(tc.availableResources, configuration.SchedulingConfig{DominantResourceFairnessResourcesToConsider: []string{"cpu"}})
+			fairnessCostProvider, err := fairness.NewDominantResourceFairness(tc.availableResources, "pool", configuration.SchedulingConfig{DominantResourceFairnessResourcesToConsider: []string{"cpu"}})
 			require.NoError(t, err)
 			sctx := NewSchedulingContext(
 				"pool",
@@ -376,7 +376,7 @@ func TestCalculateFairnessError(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			fairnessCostProvider, err := fairness.NewDominantResourceFairness(tc.availableResources, configuration.SchedulingConfig{DominantResourceFairnessResourcesToConsider: []string{"cpu"}})
+			fairnessCostProvider, err := fairness.NewDominantResourceFairness(tc.availableResources, "pool", configuration.SchedulingConfig{DominantResourceFairnessResourcesToConsider: []string{"cpu"}})
 			require.NoError(t, err)
 			sctx := NewSchedulingContext("pool", fairnessCostProvider, nil, tc.availableResources)
 			sctx.QueueSchedulingContexts = tc.queueCtxs

--- a/internal/scheduler/scheduling/fairness/fairness.go
+++ b/internal/scheduler/scheduling/fairness/fairness.go
@@ -50,10 +50,7 @@ func NewDominantResourceFairness(totalResources internaltypes.ResourceList, pool
 	poolConfig := config.GetPoolConfig(pool)
 	if poolConfig != nil {
 		if len(poolConfig.DominantResourceFairnessResourcesToConsider) > 0 {
-			resourcesToConsider = poolConfig.DominantResourceFairnessResourcesToConsider
-		}
-		if len(poolConfig.ExperimentalDominantResourceFairnessResourcesToConsider) > 0 {
-			experimentalResourcesToConsider = poolConfig.ExperimentalDominantResourceFairnessResourcesToConsider
+			experimentalResourcesToConsider = poolConfig.DominantResourceFairnessResourcesToConsider
 		}
 	}
 

--- a/internal/scheduler/scheduling/fairness/fairness.go
+++ b/internal/scheduler/scheduling/fairness/fairness.go
@@ -39,29 +39,44 @@ type DominantResourceFairness struct {
 	multipliers internaltypes.ResourceFractionList
 }
 
-func NewDominantResourceFairness(totalResources internaltypes.ResourceList, config configuration.SchedulingConfig) (*DominantResourceFairness, error) {
+func NewDominantResourceFairness(totalResources internaltypes.ResourceList, pool string, config configuration.SchedulingConfig) (*DominantResourceFairness, error) {
 	if totalResources.IsEmpty() {
 		return &DominantResourceFairness{}, nil
 	}
 
-	if len(config.DominantResourceFairnessResourcesToConsider) != 0 && len(config.ExperimentalDominantResourceFairnessResourcesToConsider) != 0 {
-		return nil, errors.New("config error - only one of DominantResourceFairnessResourcesToConsider and ExperimentalDominantResourceFairnessResourcesToConsider should be set")
+	resourcesToConsider := config.DominantResourceFairnessResourcesToConsider
+	experimentalResourcesToConsider := config.ExperimentalDominantResourceFairnessResourcesToConsider
+
+	poolConfig := config.GetPoolConfig(pool)
+	if poolConfig != nil {
+		if len(poolConfig.DominantResourceFairnessResourcesToConsider) > 0 {
+			resourcesToConsider = poolConfig.DominantResourceFairnessResourcesToConsider
+		}
+		if len(poolConfig.ExperimentalDominantResourceFairnessResourcesToConsider) > 0 {
+			experimentalResourcesToConsider = poolConfig.ExperimentalDominantResourceFairnessResourcesToConsider
+		}
 	}
-	for _, rtc := range config.ExperimentalDominantResourceFairnessResourcesToConsider {
+
+	if len(resourcesToConsider) != 0 && len(experimentalResourcesToConsider) != 0 {
+		return nil, errors.New(
+			fmt.Sprintf("config error for pool %s - only one of DominantResourceFairnessResourcesToConsider and ExperimentalDominantResourceFairnessResourcesToConsider should be set", pool),
+		)
+	}
+	for _, rtc := range experimentalResourcesToConsider {
 		if rtc.Multiplier < 0 {
 			return nil, fmt.Errorf("config error - ExperimentalDominantResourceFairnessResourcesToConsider has negative multiplier for resource %s", rtc.Name)
 		}
 	}
 
 	var multipliers map[string]float64
-	if len(config.DominantResourceFairnessResourcesToConsider) > 0 {
-		multipliers = maps.FromSlice(config.DominantResourceFairnessResourcesToConsider, func(n string) string {
+	if len(resourcesToConsider) > 0 {
+		multipliers = maps.FromSlice(resourcesToConsider, func(n string) string {
 			return n
 		}, func(n string) float64 {
 			return 1.0
 		})
-	} else if len(config.ExperimentalDominantResourceFairnessResourcesToConsider) > 0 {
-		multipliers = maps.FromSlice(config.ExperimentalDominantResourceFairnessResourcesToConsider, func(r configuration.DominantResourceFairnessResource) string {
+	} else if len(experimentalResourcesToConsider) > 0 {
+		multipliers = maps.FromSlice(experimentalResourcesToConsider, func(r configuration.DominantResourceFairnessResource) string {
 			return r.Name
 		}, func(r configuration.DominantResourceFairnessResource) float64 {
 			return defaultMultiplier(r.Multiplier)

--- a/internal/scheduler/scheduling/fairness/fairness_test.go
+++ b/internal/scheduler/scheduling/fairness/fairness_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/armadaproject/armada/internal/scheduler/internaltypes"
 )
 
+const poolName = "pool"
+
 type MinimalQueue struct {
 	allocation internaltypes.ResourceList
 	weight     float64
@@ -29,9 +31,56 @@ func TestNewDominantResourceFairness(t *testing.T) {
 	rlFactory := makeTestResourceListFactory()
 	_, err := NewDominantResourceFairness(
 		fooBarBaz(rlFactory, "1", "0", "0"),
+		poolName,
 		configuration.SchedulingConfig{DominantResourceFairnessResourcesToConsider: []string{}},
 	)
 	require.Error(t, err)
+}
+
+func TestNewDominantResourceFairness_InvalidConfig(t *testing.T) {
+	tests := map[string]struct {
+		config configuration.SchedulingConfig
+	}{
+		"must not provide both types of config": {
+			config: configuration.SchedulingConfig{
+				DominantResourceFairnessResourcesToConsider:             []string{"foo", "bar"},
+				ExperimentalDominantResourceFairnessResourcesToConsider: []configuration.DominantResourceFairnessResource{{"foo", 1}, {"bar", 1}},
+			},
+		},
+		"pool overrive - invalid combination": {
+			config: configuration.SchedulingConfig{
+				DominantResourceFairnessResourcesToConsider: []string{"foo", "bar"},
+				Pools: []configuration.PoolConfig{
+					{
+						Name: poolName,
+						ExperimentalDominantResourceFairnessResourcesToConsider: []configuration.DominantResourceFairnessResource{{"foo", 1}, {"bar", 0.5}},
+					},
+				},
+			},
+		},
+		"pool overrive - invalid combination 2": {
+			config: configuration.SchedulingConfig{
+				ExperimentalDominantResourceFairnessResourcesToConsider: []configuration.DominantResourceFairnessResource{{"foo", 1}, {"bar", 1}},
+				Pools: []configuration.PoolConfig{
+					{
+						Name: poolName,
+						DominantResourceFairnessResourcesToConsider: []string{"foo"},
+					},
+				},
+			},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			rlFactory := makeTestResourceListFactory()
+			_, err := NewDominantResourceFairness(
+				fooBarBaz(rlFactory, "1", "0", "0"),
+				poolName,
+				tc.config,
+			)
+			assert.Error(t, err)
+		})
+	}
 }
 
 func TestDominantResourceFairness(t *testing.T) {
@@ -52,6 +101,14 @@ func TestDominantResourceFairness(t *testing.T) {
 			expectedCost:   0.5,
 		},
 		"single resource 2": {
+			totalResources: fooBarBaz(rlFactory, "1", "2", "3"),
+			config:         configuration.SchedulingConfig{DominantResourceFairnessResourcesToConsider: []string{"foo", "bar"}},
+			allocation:     fooBarBaz(rlFactory, "0", "0.5", "0"),
+			weight:         1.0,
+			expectedCost:   0.25,
+		},
+
+		"pool override - experimental resource": {
 			totalResources: fooBarBaz(rlFactory, "1", "2", "3"),
 			config:         configuration.SchedulingConfig{DominantResourceFairnessResourcesToConsider: []string{"foo", "bar"}},
 			allocation:     fooBarBaz(rlFactory, "0", "0.5", "0"),
@@ -107,11 +164,41 @@ func TestDominantResourceFairness(t *testing.T) {
 			weight:         1.0,
 			expectedCost:   2,
 		},
+		"pool override - dominant config": {
+			totalResources: fooBarBaz(rlFactory, "1", "2", "3"),
+			config: configuration.SchedulingConfig{
+				DominantResourceFairnessResourcesToConsider: []string{"foo", "bar"},
+				Pools: []configuration.PoolConfig{
+					{
+						Name: poolName,
+						DominantResourceFairnessResourcesToConsider: []string{"foo"},
+					},
+				},
+			},
+			allocation:   fooBarBaz(rlFactory, "0.5", "2", "0"),
+			weight:       1.0,
+			expectedCost: 0.5,
+		},
+		"pool override - experimental config": {
+			totalResources: fooBarBaz(rlFactory, "1", "2", "3"),
+			config: configuration.SchedulingConfig{
+				ExperimentalDominantResourceFairnessResourcesToConsider: []configuration.DominantResourceFairnessResource{{"foo", 1}, {"bar", 1}},
+				Pools: []configuration.PoolConfig{
+					{
+						Name: poolName,
+						ExperimentalDominantResourceFairnessResourcesToConsider: []configuration.DominantResourceFairnessResource{{"foo", 1}, {"bar", 0.5}},
+					},
+				},
+			},
+			allocation:   fooBarBaz(rlFactory, "0.5", "2", "0"),
+			weight:       1.0,
+			expectedCost: 0.5,
+		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			f, err := NewDominantResourceFairness(tc.totalResources, tc.config)
+			f, err := NewDominantResourceFairness(tc.totalResources, poolName, tc.config)
 			require.NoError(t, err)
 			assert.Equal(
 				t,

--- a/internal/scheduler/scheduling/fairness/fairness_test.go
+++ b/internal/scheduler/scheduling/fairness/fairness_test.go
@@ -47,24 +47,13 @@ func TestNewDominantResourceFairness_InvalidConfig(t *testing.T) {
 				ExperimentalDominantResourceFairnessResourcesToConsider: []configuration.DominantResourceFairnessResource{{"foo", 1}, {"bar", 1}},
 			},
 		},
-		"pool overrive - invalid combination": {
+		"pool override - invalid combination": {
 			config: configuration.SchedulingConfig{
 				DominantResourceFairnessResourcesToConsider: []string{"foo", "bar"},
 				Pools: []configuration.PoolConfig{
 					{
 						Name: poolName,
-						ExperimentalDominantResourceFairnessResourcesToConsider: []configuration.DominantResourceFairnessResource{{"foo", 1}, {"bar", 0.5}},
-					},
-				},
-			},
-		},
-		"pool overrive - invalid combination 2": {
-			config: configuration.SchedulingConfig{
-				ExperimentalDominantResourceFairnessResourcesToConsider: []configuration.DominantResourceFairnessResource{{"foo", 1}, {"bar", 1}},
-				Pools: []configuration.PoolConfig{
-					{
-						Name: poolName,
-						DominantResourceFairnessResourcesToConsider: []string{"foo"},
+						DominantResourceFairnessResourcesToConsider: []configuration.DominantResourceFairnessResource{{"foo", 1}, {"bar", 0.5}},
 					},
 				},
 			},
@@ -164,21 +153,6 @@ func TestDominantResourceFairness(t *testing.T) {
 			weight:         1.0,
 			expectedCost:   2,
 		},
-		"pool override - dominant config": {
-			totalResources: fooBarBaz(rlFactory, "1", "2", "3"),
-			config: configuration.SchedulingConfig{
-				DominantResourceFairnessResourcesToConsider: []string{"foo", "bar"},
-				Pools: []configuration.PoolConfig{
-					{
-						Name: poolName,
-						DominantResourceFairnessResourcesToConsider: []string{"foo"},
-					},
-				},
-			},
-			allocation:   fooBarBaz(rlFactory, "0.5", "2", "0"),
-			weight:       1.0,
-			expectedCost: 0.5,
-		},
 		"pool override - experimental config": {
 			totalResources: fooBarBaz(rlFactory, "1", "2", "3"),
 			config: configuration.SchedulingConfig{
@@ -186,7 +160,7 @@ func TestDominantResourceFairness(t *testing.T) {
 				Pools: []configuration.PoolConfig{
 					{
 						Name: poolName,
-						ExperimentalDominantResourceFairnessResourcesToConsider: []configuration.DominantResourceFairnessResource{{"foo", 1}, {"bar", 0.5}},
+						DominantResourceFairnessResourcesToConsider: []configuration.DominantResourceFairnessResource{{"foo", 1}, {"bar", 0.5}},
 					},
 				},
 			},

--- a/internal/scheduler/scheduling/gang_scheduler_test.go
+++ b/internal/scheduler/scheduling/gang_scheduler_test.go
@@ -600,6 +600,7 @@ func TestGangScheduler(t *testing.T) {
 
 			fairnessCostProvider, err := fairness.NewDominantResourceFairness(
 				tc.TotalResources,
+				testfixtures.TestPool,
 				tc.SchedulingConfig,
 			)
 			require.NoError(t, err)

--- a/internal/scheduler/scheduling/optimiser/gang_scheduler_test.go
+++ b/internal/scheduler/scheduling/optimiser/gang_scheduler_test.go
@@ -438,6 +438,7 @@ func TestFairnessOptimisingScheduler_ScheduleGangsEvenly(t *testing.T) {
 func createSctx(t *testing.T, totalResource internaltypes.ResourceList, queues []*api.Queue, runningJobsByQueue map[string][]*jobdb.Job) *context.SchedulingContext {
 	fairnessCostProvider, err := fairness.NewDominantResourceFairness(
 		totalResource,
+		testfixtures.TestPool,
 		testfixtures.TestSchedulingConfig(),
 	)
 	require.NoError(t, err)

--- a/internal/scheduler/scheduling/optimiser/node_scheduler_test.go
+++ b/internal/scheduler/scheduling/optimiser/node_scheduler_test.go
@@ -208,6 +208,7 @@ func setUpSctx(t *testing.T, queues []*api.Queue, existingJobs []*jobdb.Job, tot
 	})
 	fairnessCostProvider, err := fairness.NewDominantResourceFairness(
 		totalResource,
+		testfixtures.TestPool,
 		testfixtures.TestSchedulingConfig(),
 	)
 	require.NoError(t, err)

--- a/internal/scheduler/scheduling/optimising_queue_scheduler_test.go
+++ b/internal/scheduler/scheduling/optimising_queue_scheduler_test.go
@@ -228,6 +228,7 @@ func TestOptimisingQueueScheduler_Schedule(t *testing.T) {
 
 			fairnessCostProvider, err := fairness.NewDominantResourceFairness(
 				tc.TotalSchedulingCapacity,
+				poolConfig.Name,
 				tc.SchedulingConfig,
 			)
 			require.NoError(t, err)

--- a/internal/scheduler/scheduling/preempting_queue_scheduler_test.go
+++ b/internal/scheduler/scheduling/preempting_queue_scheduler_test.go
@@ -2063,6 +2063,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 
 				fairnessCostProvider, err := fairness.NewDominantResourceFairness(
 					nodeDb.TotalKubernetesResources(),
+					testfixtures.TestPool,
 					tc.SchedulingConfig,
 				)
 				require.NoError(t, err)
@@ -2423,6 +2424,7 @@ func BenchmarkPreemptingQueueScheduler(b *testing.B) {
 
 			fairnessCostProvider, err := fairness.NewDominantResourceFairness(
 				nodeDb.TotalKubernetesResources(),
+				testfixtures.TestPool,
 				tc.SchedulingConfig,
 			)
 			require.NoError(b, err)

--- a/internal/scheduler/scheduling/queue_scheduler_test.go
+++ b/internal/scheduler/scheduling/queue_scheduler_test.go
@@ -514,6 +514,7 @@ func TestQueueScheduler(t *testing.T) {
 
 			fairnessCostProvider, err := fairness.NewDominantResourceFairness(
 				totalResources,
+				testfixtures.TestPool,
 				tc.SchedulingConfig,
 			)
 			require.NoError(t, err)

--- a/internal/scheduler/scheduling/scheduling_algo.go
+++ b/internal/scheduler/scheduling/scheduling_algo.go
@@ -464,7 +464,7 @@ func (l *FairSchedulingAlgo) constructSchedulingContext(
 	awayAllocationByQueueAndPriorityClass map[string]map[string]internaltypes.ResourceList,
 	queues map[string]*api.Queue,
 ) (*schedulercontext.SchedulingContext, error) {
-	fairnessCostProvider, err := fairness.NewDominantResourceFairness(totalCapacity, l.schedulingConfig)
+	fairnessCostProvider, err := fairness.NewDominantResourceFairness(totalCapacity, pool, l.schedulingConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/scheduler/simulator/simulator.go
+++ b/internal/scheduler/simulator/simulator.go
@@ -561,6 +561,7 @@ func (s *Simulator) handleScheduleEvent(ctx *armadacontext.Context) error {
 		totalResources := s.accounting.totalResourcesByPool[pool]
 		fairnessCostProvider, err := fairness.NewDominantResourceFairness(
 			totalResources,
+			pool,
 			s.schedulingConfig,
 		)
 		if err != nil {


### PR DESCRIPTION
This PR allows you to override the ExperimentalDominantResourceFairnessResourcesToConsider at the pool level
 - So you can have different resource fairness config for different pools

If the config is not set for the current pool, it'll use the global config - so the default behaviour should stay the same

Shortly we'll remove the standard DominantResourceFairnessResourcesToConsider config and replace it with  ExperimentalDominantResourceFairnessResourcesToConsider at the global level, so I haven't included that in the pool level config


