### PR TITLE
Add tests for job price updating

### DIFF
--- a/internal/scheduler/jobdb/job.go
+++ b/internal/scheduler/jobdb/job.go
@@ -431,6 +431,10 @@ func (job *Job) GetBidPrice(pool string) float64 {
 	return bidPrice.RunningBid
 }
 
+func (job *Job) GetAllBidPrices() map[string]pricing.Bid {
+	return maps.Clone(job.bidPricesPool)
+}
+
 func (job *Job) WithPriceBand(priceBand bidstore.PriceBand) *Job {
 	j := shallowCopyJob(*job)
 	j.priceBand = priceBand

--- a/internal/scheduler/jobdb/job_test.go
+++ b/internal/scheduler/jobdb/job_test.go
@@ -152,6 +152,22 @@ func TestJob_BidPrices(t *testing.T) {
 	assert.Equal(t, float64(4), newJob.GetBidPrice("pool2"))
 }
 
+func TestJob_GetAllBidPrices(t *testing.T) {
+	pool1Bid := pricing.Bid{QueuedBid: 1, RunningBid: 2}
+	pool2Bid := pricing.Bid{QueuedBid: 3, RunningBid: 4}
+	inputPrices := map[string]pricing.Bid{"pool1": pool1Bid, "pool2": pool2Bid}
+	expectedBidPrices := map[string]pricing.Bid{"pool1": pool1Bid, "pool2": pool2Bid}
+
+	job := baseJob.WithBidPrices(inputPrices)
+	assert.Equal(t, expectedBidPrices, job.GetAllBidPrices())
+
+	// Assert mutating external bid obj doesn't effect what the job returns
+	pool1Bid.RunningBid = 5
+	pool2Bid.RunningBid = 5
+	inputPrices["pool3"] = pricing.Bid{QueuedBid: 3, RunningBid: 7}
+	assert.Equal(t, expectedBidPrices, job.GetAllBidPrices())
+}
+
 func TestJob_TestHasRuns(t *testing.T) {
 	assert.Equal(t, false, baseJob.HasRuns())
 	assert.Equal(t, true, baseJob.WithNewRun("test-executor", "test-nodeId", "nodeId", "pool", 5).HasRuns())

--- a/internal/scheduler/jobdb/jobdb.go
+++ b/internal/scheduler/jobdb/jobdb.go
@@ -602,18 +602,6 @@ func (txn *Txn) GetAll() []*Job {
 	return allJobs
 }
 
-// ReplaceAll replaces all jobs in the jobDb with the supplied jobs
-func (txn *Txn) ReplaceAll(jobs []*Job) error {
-	unvalidatedJobs := immutable.NewSet[*Job](JobIdHasher{})
-	txn.jobsById = immutable.NewMap[string, *Job](nil)
-	txn.jobsByRunId = immutable.NewMap[string, string](nil)
-	txn.jobsByQueue = map[string]immutable.SortedSet[*Job]{}
-	txn.jobsByPoolAndQueue = map[string]map[string]immutable.SortedSet[*Job]{}
-	txn.unvalidatedJobs = &unvalidatedJobs
-
-	return txn.Upsert(jobs)
-}
-
 // BatchDelete deletes the jobs with the given ids from the database.
 // Any ids not in the database are ignored.
 func (txn *Txn) BatchDelete(jobIds []string) error {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -505,10 +505,12 @@ func (s *Scheduler) updateJobPrices(ctx *armadacontext.Context, txn *jobdb.Txn) 
 			if !present {
 				continue
 			}
-			nonPreemptibleUpdatedPrice := updatedPrice
-			for pool, bid := range nonPreemptibleUpdatedPrice {
-				bid.RunningBid = nonPreemptibleRunningPrice
-				nonPreemptibleUpdatedPrice[pool] = bid
+			nonPreemptibleUpdatedPrice := map[string]pricing.Bid{}
+			for pool, bid := range updatedPrice {
+				nonPreemptibleUpdatedPrice[pool] = pricing.Bid{
+					QueuedBid:  bid.QueuedBid,
+					RunningBid: nonPreemptibleRunningPrice,
+				}
 			}
 
 			// For now always update all jobs, as the jobDb isn't setting them as they come in


### PR DESCRIPTION
This also:
 - Fixes a bug for the running price set on preemptible jobs
   - All jobs were getting the running price set to 100000 (non preemptible running price)
 - Removes unused ReplaceAll from jobdb
 - Add GetAllBidPrices to job



