### PR TITLE
Lookout UI (fix location of job run error and debug message)

### DIFF
--- a/internal/lookoutui/src/App.tsx
+++ b/internal/lookoutui/src/App.tsx
@@ -86,7 +86,6 @@ export function App(props: AppProps) {
                                     getJobsService={props.services.v2GetJobsService}
                                     groupJobsService={props.services.v2GroupJobsService}
                                     updateJobsService={props.services.v2UpdateJobsService}
-                                    jobSpecService={props.services.v2JobSpecService}
                                     debug={props.debugEnabled}
                                     autoRefreshMs={props.jobsAutoRefreshMs}
                                     commandSpecs={props.commandSpecs}

--- a/internal/lookoutui/src/components/lookout/sidebar/JobRunDetails.tsx
+++ b/internal/lookoutui/src/components/lookout/sidebar/JobRunDetails.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useMemo, useState } from "react"
+
 import {
   Accordion,
   AccordionDetails,
@@ -12,9 +14,10 @@ import {
   Tooltip,
   Typography,
 } from "@mui/material"
-import { useEffect, useMemo, useState } from "react"
 import { ErrorBoundary } from "react-error-boundary"
 
+import { KeyValuePairTable } from "./KeyValuePairTable"
+import { SidebarTabSubheading } from "./sidebarTabContentComponents"
 import { formatDuration, TimestampFormat } from "../../../common/formatTime"
 import { useFormatIsoTimestampWithUserSettings } from "../../../hooks/formatTimeWithUserSettings"
 import { useCustomSnackbar } from "../../../hooks/useCustomSnackbar"
@@ -26,8 +29,6 @@ import { SPACING } from "../../../styling/spacing"
 import { formatJobRunState } from "../../../utils/jobsTableFormatters"
 import { AlertErrorFallback } from "../../AlertErrorFallback"
 import { CodeBlock } from "../../CodeBlock"
-import { KeyValuePairTable } from "./KeyValuePairTable"
-import { SidebarTabSubheading } from "./sidebarTabContentComponents"
 
 const MarkNodeUnschedulableButtonContainer = styled("div")(({ theme }) => ({
   display: "flex",

--- a/internal/lookoutui/src/components/lookout/sidebar/JobRunDetails.tsx
+++ b/internal/lookoutui/src/components/lookout/sidebar/JobRunDetails.tsx
@@ -1,0 +1,251 @@
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Skeleton,
+  styled,
+  Tooltip,
+  Typography,
+} from "@mui/material"
+import { useEffect, useMemo, useState } from "react"
+import { ErrorBoundary } from "react-error-boundary"
+
+import { formatDuration, TimestampFormat } from "../../../common/formatTime"
+import { useFormatIsoTimestampWithUserSettings } from "../../../hooks/formatTimeWithUserSettings"
+import { useCustomSnackbar } from "../../../hooks/useCustomSnackbar"
+import { JobRun } from "../../../models/lookoutModels"
+import { useCordonNode } from "../../../services/lookout/useCordonNode"
+import { useGetJobRunDebugMessage } from "../../../services/lookout/useGetJobRunDebugMessage"
+import { useGetJobRunError } from "../../../services/lookout/useGetJobRunError"
+import { SPACING } from "../../../styling/spacing"
+import { formatJobRunState } from "../../../utils/jobsTableFormatters"
+import { AlertErrorFallback } from "../../AlertErrorFallback"
+import { CodeBlock } from "../../CodeBlock"
+import { KeyValuePairTable } from "./KeyValuePairTable"
+import { SidebarTabSubheading } from "./sidebarTabContentComponents"
+
+const MarkNodeUnschedulableButtonContainer = styled("div")(({ theme }) => ({
+  display: "flex",
+  justifyContent: "center",
+  padding: theme.spacing(SPACING.sm),
+}))
+
+const makeKeyValuePairsData = (
+  formatIsoTimestamp: (isoTimestampString: string | undefined, format: TimestampFormat) => string,
+  {
+    runId,
+    jobRunState,
+    leased,
+    pending,
+    started,
+    finished,
+    exitCode,
+    cluster,
+    node,
+  }: Pick<
+    JobRun,
+    "runId" | "jobRunState" | "leased" | "pending" | "started" | "finished" | "exitCode" | "cluster" | "node"
+  >,
+): KeyValuePairTable["data"] => {
+  const d = [] as KeyValuePairTable["data"]
+
+  if (runId) {
+    d.push({ key: "Run ID", value: runId, allowCopy: true })
+  }
+  if (jobRunState) {
+    d.push({ key: "State", value: formatJobRunState(jobRunState) })
+  }
+  if (leased) {
+    d.push({ key: "Leased", value: formatIsoTimestamp(leased, "full") })
+  }
+  if (pending) {
+    d.push({ key: "Pending", value: formatIsoTimestamp(pending, "full") })
+  }
+  if (started) {
+    d.push({ key: "Started", value: formatIsoTimestamp(started, "full") })
+  }
+  if (finished) {
+    d.push({ key: "Finished", value: formatIsoTimestamp(finished, "full") })
+  }
+  if (started && finished) {
+    const runtimeMs = new Date(finished).getTime() - new Date(started).getTime()
+    d.push({ key: "Runtime", value: formatDuration(runtimeMs / 1000) })
+  }
+  if (exitCode !== undefined) {
+    d.push({ key: "Exit code", value: exitCode.toString() })
+  }
+  if (cluster) {
+    d.push({ key: "Cluster", value: cluster, allowCopy: true })
+  }
+  if (node) {
+    d.push({ key: "Node", value: node, allowCopy: true })
+  }
+
+  return d
+}
+
+export interface JobRunDetailsProps {
+  run: JobRun
+  runIndex: number
+  defaultExpanded: boolean
+  setRunError: undefined | ((runError: string) => void)
+}
+
+export const JobRunDetails = ({
+  run: { node, cluster, started, pending, leased, finished, jobRunState, runId, exitCode },
+  runIndex,
+  defaultExpanded,
+  setRunError,
+}: JobRunDetailsProps) => {
+  const formatIsoTimestamp = useFormatIsoTimestampWithUserSettings()
+  const openSnackbar = useCustomSnackbar()
+
+  const [markUnschedulableDialogOpen, setMarkUnschedulableDialogOpen] = useState(false)
+
+  const { mutateAsync: cordonNode, status: cordonNodeStatus, error: cordonNodeError } = useCordonNode()
+
+  useEffect(() => {
+    if (cordonNodeStatus === "success") {
+      openSnackbar(`Successfully cordoned node ${node}`, "success")
+    }
+    if (cordonNodeStatus === "error") {
+      openSnackbar(`Failed to cordon node ${node}: ${cordonNodeError}`, "error")
+    }
+  }, [cordonNodeStatus, cordonNodeError, node])
+
+  // Ignore any errors from this call - the API returns an error if there is no error message, which is happy-path
+  const { data: runError, status: runErrorStatus } = useGetJobRunError(runId)
+  useEffect(() => {
+    if (setRunError && runErrorStatus === "success") {
+      setRunError(runError)
+    }
+  }, [setRunError, runError, runErrorStatus])
+
+  // Ignore any errors from this call - the API returns an error if there is no debug message, which is happy-path
+  const { data: debugMessage, status: debugMessageStatus } = useGetJobRunDebugMessage(runId)
+
+  const headingTextParts = ["Run", (runIndex + 1).toString()]
+  const runIndicativeTimestamp = started || pending || leased || ""
+  if (runIndicativeTimestamp) {
+    headingTextParts.push(formatIsoTimestamp(runIndicativeTimestamp, "full"))
+  }
+  headingTextParts.push(`(${formatJobRunState(jobRunState)})`)
+  const headingText = headingTextParts.join(" ")
+
+  const tableData = useMemo(
+    () =>
+      makeKeyValuePairsData(formatIsoTimestamp, {
+        runId,
+        jobRunState,
+        leased,
+        pending,
+        started,
+        finished,
+        exitCode,
+        cluster,
+        node,
+      }),
+    [formatIsoTimestamp, runId, jobRunState, leased, pending, started, finished, exitCode, cluster, node],
+  )
+
+  return (
+    <Accordion defaultExpanded={defaultExpanded}>
+      <AccordionSummary>
+        <SidebarTabSubheading>{headingText}</SidebarTabSubheading>
+      </AccordionSummary>
+      <AccordionDetails>
+        <KeyValuePairTable data={tableData} />
+        {node && (
+          <>
+            <MarkNodeUnschedulableButtonContainer>
+              <Tooltip title={`Take node ${node} out of the farm`} placement="bottom">
+                <Button color="secondary" onClick={() => setMarkUnschedulableDialogOpen(true)} variant="outlined">
+                  Mark node as unschedulable
+                </Button>
+              </Tooltip>
+            </MarkNodeUnschedulableButtonContainer>
+            <Dialog
+              open={markUnschedulableDialogOpen}
+              onClose={() => setMarkUnschedulableDialogOpen(false)}
+              fullWidth
+              maxWidth="md"
+            >
+              <ErrorBoundary FallbackComponent={AlertErrorFallback}>
+                <DialogTitle>Mark node as unschedulable</DialogTitle>
+                <DialogContent>
+                  <Typography>
+                    Are you sure you want to take node <strong>{node}</strong> out of the farm?
+                  </Typography>
+                </DialogContent>
+                <DialogActions>
+                  <Button color="error" onClick={() => setMarkUnschedulableDialogOpen(false)}>
+                    Cancel
+                  </Button>
+                  <Button
+                    onClick={async () => {
+                      await cordonNode({ cluster: cluster, node: node })
+                      setMarkUnschedulableDialogOpen(false)
+                    }}
+                    autoFocus
+                    loading={cordonNodeStatus === "pending"}
+                  >
+                    Confirm
+                  </Button>
+                </DialogActions>
+              </ErrorBoundary>
+            </Dialog>
+          </>
+        )}
+        <div>
+          {runErrorStatus === "pending" && (
+            <Accordion variant="elevation" square>
+              <AccordionSummary disabled>
+                <Skeleton width="5ch" />
+              </AccordionSummary>
+            </Accordion>
+          )}
+          {runErrorStatus === "success" && runError && (
+            <Accordion variant="elevation" square>
+              <AccordionSummary>Error</AccordionSummary>
+              <AccordionDetails>
+                <CodeBlock
+                  code={runError}
+                  language="text"
+                  downloadable={false}
+                  showLineNumbers={false}
+                  loading={false}
+                />
+              </AccordionDetails>
+            </Accordion>
+          )}
+          {debugMessageStatus === "pending" && (
+            <Accordion variant="elevation" square>
+              <AccordionSummary disabled>
+                <Skeleton width="5ch" />
+              </AccordionSummary>
+            </Accordion>
+          )}
+          {debugMessageStatus === "success" && debugMessage && (
+            <Accordion variant="elevation" square>
+              <AccordionSummary>Debug</AccordionSummary>
+              <AccordionDetails>
+                <CodeBlock
+                  code={debugMessage}
+                  language="text"
+                  downloadable={false}
+                  showLineNumbers={false}
+                  loading={false}
+                />
+              </AccordionDetails>
+            </Accordion>
+          )}
+        </div>
+      </AccordionDetails>
+    </Accordion>
+  )
+}

--- a/internal/lookoutui/src/components/lookout/sidebar/Sidebar.test.tsx
+++ b/internal/lookoutui/src/components/lookout/sidebar/Sidebar.test.tsx
@@ -8,7 +8,6 @@ import { queryClient } from "../../../App"
 import { Job, JobRunState, JobState } from "../../../models/lookoutModels"
 import { ApiClientsProvider } from "../../../services/apiClients"
 import { FakeServicesProvider } from "../../../services/fakeContext"
-import FakeGetJobInfoService from "../../../services/lookout/mocks/FakeGetJobInfoService"
 import { MockServer } from "../../../services/lookout/mocks/mockServer"
 import { makeTestJob } from "../../../utils/fakeJobsUtils"
 
@@ -62,7 +61,6 @@ describe("Sidebar", () => {
             <FakeServicesProvider fakeJobs={[job]}>
               <Sidebar
                 job={job}
-                jobSpecService={new FakeGetJobInfoService()}
                 sidebarWidth={600}
                 onClose={onClose}
                 onWidthChange={() => undefined}

--- a/internal/lookoutui/src/components/lookout/sidebar/SidebarTabJobResult.tsx
+++ b/internal/lookoutui/src/components/lookout/sidebar/SidebarTabJobResult.tsx
@@ -1,305 +1,82 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useMemo, useState } from "react"
 
-import { ExpandMore } from "@mui/icons-material"
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  Skeleton,
-  styled,
-  Tooltip,
-  Typography,
-} from "@mui/material"
-import { ErrorBoundary } from "react-error-boundary"
+import { Alert, AlertTitle, Button } from "@mui/material"
 
-import { KeyValuePairTable } from "./KeyValuePairTable"
+import { JobRunDetails } from "./JobRunDetails"
 import { NoRunsAlert } from "./NoRunsAlert"
-import { SidebarTabHeading, SidebarTabSubheading } from "./sidebarTabContentComponents"
-import { formatDuration } from "../../../common/formatTime"
-import { useFormatIsoTimestampWithUserSettings } from "../../../hooks/formatTimeWithUserSettings"
-import { useCustomSnackbar } from "../../../hooks/useCustomSnackbar"
+import { SidebarTabHeading } from "./sidebarTabContentComponents"
 import { Job, JobState } from "../../../models/lookoutModels"
-import { useAuthenticatedFetch } from "../../../oidcAuth"
-import { IGetJobInfoService } from "../../../services/lookout/GetJobInfoService"
-import { useCordonNode } from "../../../services/lookout/useCordonNode"
-import { useBatchGetJobRunDebugMessages } from "../../../services/lookout/useGetJobRunDebugMessage"
-import { useBatchGetJobRunErrors } from "../../../services/lookout/useGetJobRunError"
-import { SPACING } from "../../../styling/spacing"
-import { getErrorMessage } from "../../../utils"
-import { formatJobRunState } from "../../../utils/jobsTableFormatters"
-import { AlertErrorFallback } from "../../AlertErrorFallback"
+import { useGetJobError } from "../../../services/lookout/useGetJobError"
 import { CodeBlock } from "../../CodeBlock"
-
-const MarkNodeUnschedulableButtonContainer = styled("div")(({ theme }) => ({
-  display: "flex",
-  justifyContent: "center",
-  padding: theme.spacing(SPACING.sm),
-}))
-
-const loadingAccordion = (
-  <Accordion>
-    <AccordionDetails>
-      <Skeleton />
-    </AccordionDetails>
-  </Accordion>
-)
 
 export interface SidebarTabJobResultProps {
   job: Job
-  jobInfoService: IGetJobInfoService
 }
 
-export const SidebarTabJobResult = ({ job, jobInfoService }: SidebarTabJobResultProps) => {
-  const mounted = useRef(false)
-  const openSnackbar = useCustomSnackbar()
-
-  const formatIsoTimestamp = useFormatIsoTimestampWithUserSettings()
+export const SidebarTabJobResult = ({ job }: SidebarTabJobResultProps) => {
+  const [lastJobRunError, setLastJobRunError] = useState<string | undefined>(undefined)
 
   const runsNewestFirst = useMemo(() => [...job.runs].reverse(), [job])
-  const [jobError, setJobError] = useState<string>("")
-  const [open, setOpen] = useState(false)
-  const authenticatedFetch = useAuthenticatedFetch()
 
-  const fetchJobError = useCallback(async () => {
-    if (job.state != JobState.Failed && job.state != JobState.Rejected) {
-      setJobError("")
-      return
+  const {
+    data: jobError,
+    status: jobErrorStatus,
+    error: jobErrorError,
+    refetch: refetchJobError,
+  } = useGetJobError(job.jobId, job.state == JobState.Failed || job.state == JobState.Rejected)
+
+  const topLevelError = useMemo<{ title: string; content: string } | undefined>(() => {
+    if (jobErrorStatus === "success" && jobError) {
+      return { title: "Job Error", content: jobError }
     }
-    const getJobErrorResultPromise = jobInfoService.getJobError(authenticatedFetch, job.jobId)
-    getJobErrorResultPromise
-      .then((errorString) => {
-        if (!mounted.current) {
-          return
-        }
-        setJobError(errorString)
-      })
-      .catch(async (e) => {
-        const errMsg = await getErrorMessage(e)
-        console.error(errMsg)
-        if (!mounted.current) {
-          return
-        }
-        openSnackbar("Failed to retrieve Job error for Job with ID: " + job.jobId + ": " + errMsg, "error")
-      })
-  }, [job])
-
-  const batchGetJobRunErrorResults = useBatchGetJobRunErrors((job.runs ?? []).map(({ runId }) => runId))
-  useEffect(() => {
-    batchGetJobRunErrorResults.forEach(({ status, error }, i) => {
-      if (status === "error") {
-        openSnackbar(
-          `Failed to retrieve Job Run error for Run with ID: ${(job.runs ?? [])[i].runId}: ${error.message}`,
-          "error",
-        )
-      }
-    })
-  }, [batchGetJobRunErrorResults, openSnackbar])
-
-  const batchGetJobRunDebugMessagesResults = useBatchGetJobRunDebugMessages((job.runs ?? []).map(({ runId }) => runId))
-  useEffect(() => {
-    batchGetJobRunDebugMessagesResults.forEach(({ status, error }, i) => {
-      if (status === "error") {
-        openSnackbar(
-          `Failed to retrieve Job Run debug message for Run with ID: ${(job.runs ?? [])[i].runId}: ${error.message}`,
-          "error",
-        )
-      }
-    })
-  }, [batchGetJobRunDebugMessagesResults, openSnackbar])
-
-  let topLevelError = ""
-  let topLevelErrorTitle = ""
-  if (jobError != "") {
-    topLevelError = jobError
-    topLevelErrorTitle = "Job Error"
-  } else {
-    job.runs.forEach((_, i) => {
-      if (batchGetJobRunErrorResults[i]?.data) {
-        topLevelError = batchGetJobRunErrorResults[i].data
-        topLevelErrorTitle = "Last Job Run Error"
-      }
-    })
-  }
-
-  useEffect(() => {
-    mounted.current = true
-    fetchJobError()
-    return () => {
-      mounted.current = false
+    if (lastJobRunError) {
+      return { title: "Last Job Run Error", content: lastJobRunError }
     }
-  }, [job])
+    return undefined
+  }, [jobErrorStatus, jobError, lastJobRunError])
 
-  const handleClickOpen = () => {
-    setOpen(true)
-  }
-
-  const handleClose = () => {
-    setOpen(false)
-  }
-
-  const cordonNode = useCordonNode()
-
-  const cordon = async (cluster: string, node: string) => {
-    try {
-      await cordonNode.mutateAsync({ cluster, node })
-      openSnackbar("Successfully cordoned node " + node, "success")
-    } catch (e) {
-      const errMsg = await getErrorMessage(e)
-      console.error(errMsg)
-      if (!mounted.current) {
-        return
-      }
-      openSnackbar("Failed to cordon node " + node + ": " + errMsg, "error")
-    }
-  }
   return (
     <>
-      {topLevelError !== "" ? (
+      {jobErrorStatus === "error" && (
+        <Alert
+          severity="error"
+          action={
+            <Button color="inherit" size="small" onClick={() => refetchJobError()}>
+              Retry
+            </Button>
+          }
+        >
+          <AlertTitle>Failed to list available queues.</AlertTitle>
+          {jobErrorError}
+        </Alert>
+      )}
+      {topLevelError && (
         <>
-          <SidebarTabHeading>{topLevelErrorTitle}</SidebarTabHeading>
+          <SidebarTabHeading>{topLevelError.title}</SidebarTabHeading>
           <CodeBlock
-            code={topLevelError}
+            code={topLevelError.content}
             language="text"
             downloadable={false}
             showLineNumbers={false}
             loading={false}
           />
         </>
-      ) : null}
+      )}
       {runsNewestFirst.length === 0 ? (
         <NoRunsAlert jobState={job.state} />
       ) : (
         <>
           <SidebarTabHeading>Runs</SidebarTabHeading>
           <div>
-            {runsNewestFirst.map((run, i) => {
-              const node = run.node || undefined // set to undefined if it is an empty string
-              const runErrorLoading = batchGetJobRunErrorResults[i]?.status === "pending"
-              const runError = batchGetJobRunErrorResults[i]?.data
-              const runDebugMessageLoading = batchGetJobRunDebugMessagesResults[i]?.status === "pending"
-              const runDebugMessage = batchGetJobRunDebugMessagesResults[i]?.data
-
-              const runIndicativeTimestamp = run.started || run.pending || run.leased || ""
-              return (
-                <Accordion key={run.runId} defaultExpanded={i === 0}>
-                  <AccordionSummary>
-                    <SidebarTabSubheading>
-                      Run {i + 1}
-                      {runIndicativeTimestamp && <>: {formatIsoTimestamp(runIndicativeTimestamp, "full")}</>} (
-                      {formatJobRunState(run.jobRunState)})
-                    </SidebarTabSubheading>
-                  </AccordionSummary>
-                  <AccordionDetails>
-                    <KeyValuePairTable
-                      data={[
-                        { key: "Run ID", value: run.runId, allowCopy: true },
-                        { key: "State", value: formatJobRunState(run.jobRunState) },
-                        {
-                          key: "Leased",
-                          value: formatIsoTimestamp(run.leased, "full"),
-                        },
-                        {
-                          key: "Pending",
-                          value: formatIsoTimestamp(run.pending, "full"),
-                        },
-                        {
-                          key: "Started",
-                          value: formatIsoTimestamp(run.started, "full"),
-                        },
-                        {
-                          key: "Finished",
-                          value: formatIsoTimestamp(run.finished, "full"),
-                        },
-                        {
-                          key: "Runtime",
-                          value:
-                            run.started && run.finished
-                              ? formatDuration(
-                                  (new Date(run.finished).getTime() - new Date(run.started).getTime()) / 1000,
-                                )
-                              : "",
-                        },
-                        { key: "Cluster", value: run.cluster, allowCopy: true },
-                        { key: "Node", value: run.node ?? "", allowCopy: true },
-                        { key: "Exit code", value: run.exitCode?.toString() ?? "" },
-                      ].filter((pair) => pair.value !== "")}
-                    />
-                    {node && (
-                      <>
-                        <MarkNodeUnschedulableButtonContainer>
-                          <Tooltip title={`Take node ${node} out of the farm`} placement="bottom">
-                            <Button color="secondary" onClick={handleClickOpen} variant="outlined">
-                              Mark node as unschedulable
-                            </Button>
-                          </Tooltip>
-                        </MarkNodeUnschedulableButtonContainer>
-                        <Dialog open={open} onClose={handleClose} fullWidth maxWidth="md">
-                          <ErrorBoundary FallbackComponent={AlertErrorFallback}>
-                            <DialogTitle>Mark node as unschedulable</DialogTitle>
-                            <DialogContent>
-                              <Typography>
-                                Are you sure you want to take node <span>{node}</span> out of the farm?
-                              </Typography>
-                            </DialogContent>
-                            <DialogActions>
-                              <Button color="error" onClick={handleClose}>
-                                Cancel
-                              </Button>
-                              <Button
-                                onClick={async () => {
-                                  await cordon(run.cluster, node)
-                                  handleClose()
-                                }}
-                                autoFocus
-                              >
-                                Confirm
-                              </Button>
-                            </DialogActions>
-                          </ErrorBoundary>
-                        </Dialog>
-                      </>
-                    )}
-                  </AccordionDetails>
-                  {runErrorLoading && <div>{loadingAccordion}</div>}
-                  {runError && (
-                    <Accordion key={run.runId + "error"}>
-                      <AccordionSummary>Error</AccordionSummary>
-                      <AccordionDetails>
-                        <CodeBlock
-                          code={runError}
-                          language="text"
-                          downloadable={false}
-                          showLineNumbers={false}
-                          loading={false}
-                        />
-                      </AccordionDetails>
-                    </Accordion>
-                  )}
-                  {runDebugMessageLoading && <div>{loadingAccordion}</div>}
-                  {runDebugMessage && (
-                    <Accordion key={run.runId + "debug"}>
-                      <AccordionSummary expandIcon={<ExpandMore />} aria-controls="panel1d-content" id="panel1d-header">
-                        Debug
-                      </AccordionSummary>
-                      <AccordionDetails>
-                        <CodeBlock
-                          code={runDebugMessage}
-                          language="text"
-                          downloadable={false}
-                          showLineNumbers={false}
-                          loading={false}
-                        />
-                      </AccordionDetails>
-                    </Accordion>
-                  )}
-                </Accordion>
-              )
-            })}
+            {runsNewestFirst.map((run, i) => (
+              <JobRunDetails
+                key={run.runId}
+                run={run}
+                runIndex={runsNewestFirst.length - 1 - i}
+                defaultExpanded={i === 0}
+                setRunError={i === 0 ? setLastJobRunError : undefined}
+              />
+            ))}
           </div>
         </>
       )}

--- a/internal/lookoutui/src/containers/lookout/JobsTableContainer.test.tsx
+++ b/internal/lookoutui/src/containers/lookout/JobsTableContainer.test.tsx
@@ -15,7 +15,6 @@ import { GetJobsResponse, IGetJobsService } from "../../services/lookout/GetJobs
 import { IGroupJobsService } from "../../services/lookout/GroupJobsService"
 import { UpdateJobSetsService } from "../../services/lookout/UpdateJobSetsService"
 import { UpdateJobsService } from "../../services/lookout/UpdateJobsService"
-import FakeGetJobInfoService from "../../services/lookout/mocks/FakeGetJobInfoService"
 import FakeGetJobsService from "../../services/lookout/mocks/FakeGetJobsService"
 import FakeGroupJobsService from "../../services/lookout/mocks/FakeGroupJobsService"
 import { MockServer } from "../../services/lookout/mocks/mockServer"
@@ -69,18 +68,13 @@ function makeTestJobs(
 }
 
 describe("JobsTableContainer", () => {
-  let getJobsService: IGetJobsService,
-    groupJobsService: IGroupJobsService,
-    jobSpecService: IGetJobInfoService,
-    updateJobsService: UpdateJobsService
+  let getJobsService: IGetJobsService, groupJobsService: IGroupJobsService, updateJobsService: UpdateJobsService
 
   beforeAll(() => {
     mockServer.listen()
   })
 
   beforeEach(() => {
-    jobSpecService = new FakeGetJobInfoService(false)
-
     localStorage.clear()
     localStorage.setItem(FORMAT_NUMBER_SHOULD_FORMAT_KEY, JSON.stringify(false))
     localStorage.setItem(FORMAT_TIMESTAMP_SHOULD_FORMAT_KEY, JSON.stringify(false))
@@ -120,7 +114,6 @@ describe("JobsTableContainer", () => {
               getJobsService={fakeServices.v2GetJobsService ?? getJobsService}
               groupJobsService={fakeServices.v2GroupJobsService ?? groupJobsService}
               updateJobsService={fakeServices.v2UpdateJobsService ?? updateJobsService}
-              jobSpecService={fakeServices.v2JobSpecService ?? jobSpecService}
               debug={false}
               autoRefreshMs={30000}
               commandSpecs={[]}

--- a/internal/lookoutui/src/containers/lookout/JobsTableContainer.tsx
+++ b/internal/lookoutui/src/containers/lookout/JobsTableContainer.tsx
@@ -52,7 +52,6 @@ import { columnIsAggregatable, useFetchJobsTableData } from "../../hooks/useJobs
 import { isJobGroupRow, JobRow, JobTableRow } from "../../models/jobsTableModels"
 import { Job, JobFiltersWithExcludes, JobId, Match, SortDirection } from "../../models/lookoutModels"
 import { CustomViewsService } from "../../services/lookout/CustomViewsService"
-import { IGetJobInfoService } from "../../services/lookout/GetJobInfoService"
 import { IGetJobsService } from "../../services/lookout/GetJobsService"
 import { IGroupJobsService } from "../../services/lookout/GroupJobsService"
 import { JobsTablePreferences, JobsTablePreferencesService } from "../../services/lookout/JobsTablePreferencesService"
@@ -88,7 +87,6 @@ interface JobsTableContainerProps {
   getJobsService: IGetJobsService
   groupJobsService: IGroupJobsService
   updateJobsService: UpdateJobsService
-  jobSpecService: IGetJobInfoService
   debug: boolean
   autoRefreshMs: number | undefined
   commandSpecs: CommandSpec[]
@@ -130,7 +128,6 @@ export const JobsTableContainer = ({
   getJobsService,
   groupJobsService,
   updateJobsService,
-  jobSpecService,
   debug,
   autoRefreshMs,
   commandSpecs,
@@ -908,7 +905,6 @@ export const JobsTableContainer = ({
         <ErrorBoundary FallbackComponent={AlertErrorFallback}>
           <Sidebar
             job={sidebarJobDetails}
-            jobSpecService={jobSpecService}
             sidebarWidth={sidebarWidth}
             onClose={sideBarClose}
             onWidthChange={setSidebarWidth}

--- a/internal/lookoutui/src/services/lookout/GetJobInfoService.ts
+++ b/internal/lookoutui/src/services/lookout/GetJobInfoService.ts
@@ -1,7 +1,6 @@
 // TODO(mauriceyap): remove this in favour of custom hooks using @tanstack/react-query
 export interface IGetJobInfoService {
   getJobSpec(fetchFunc: GlobalFetch["fetch"], jobId: string, abortSignal?: AbortSignal): Promise<Record<string, any>>
-  getJobError(fetchFunc: GlobalFetch["fetch"], jobId: string, abortSignal?: AbortSignal): Promise<string>
 }
 
 export class GetJobInfoService implements IGetJobInfoService {
@@ -21,18 +20,5 @@ export class GetJobInfoService implements IGetJobInfoService {
 
     const json = await response.json()
     return json.job ?? {}
-  }
-  async getJobError(fetchFunc: GlobalFetch["fetch"], jobId: string, abortSignal?: AbortSignal): Promise<string> {
-    const response = await fetchFunc("/api/v1/jobError", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        jobId,
-      }),
-      signal: abortSignal,
-    })
-
-    const json = await response.json()
-    return json.errorString ?? ""
   }
 }

--- a/internal/lookoutui/src/services/lookout/mocks/FakeGetJobInfoService.ts
+++ b/internal/lookoutui/src/services/lookout/mocks/FakeGetJobInfoService.ts
@@ -12,14 +12,4 @@ export default class FakeGetJobInfoService implements IGetJobInfoService {
       `{"id":"${jobId}","clientId":"01gvgjbr0jrzvschp2f8jhk6n5","jobSetId":"alices-project-0","queue":"alice","namespace":"default","owner":"anonymous","podSpec":{"containers":[{"name":"cpu-burner","image":"containerstack/alpine-stress:latest","command":["sh"],"args":["-c","echo FAILED && echo hello world > /dev/termination-log && exit 137"],"resources":{"limits":{"cpu":"200m","ephemeral-storage":"8Gi","memory":"128Mi","nvidia.com/gpu":"8"},"requests":{"cpu":"200m","ephemeral-storage":"8Gi","memory":"128Mi","nvidia.com/gpu":"8"}},"imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Never","terminationGracePeriodSeconds":1,"tolerations":[{"key":"armadaproject.io/armada","operator":"Equal","value":"true","effect":"NoSchedule"},{"key":"armadaproject.io/pc-armada-default","operator":"Equal","value":"true","effect":"NoSchedule"}],"priorityClassName":"armada-default"},"created":"2023-03-14T17:23:21.29874Z"}`,
     )
   }
-
-  async getJobError(_: GlobalFetch["fetch"], jobId: string, abortSignal?: AbortSignal): Promise<string> {
-    if (this.simulateApiWait) {
-      await simulateApiWait(abortSignal)
-    }
-    if (jobId === "doesnotexist") {
-      throw new Error("Failed to retrieve job because of reasons")
-    }
-    return Promise.resolve("something has gone wrong with this job")
-  }
 }

--- a/internal/lookoutui/src/services/lookout/mocks/fakeData.ts
+++ b/internal/lookoutui/src/services/lookout/mocks/fakeData.ts
@@ -111,3 +111,7 @@ export const fakeRunError =
   "    at com.mchange.v2.c3p0.impl.NewProxyPreparedStatement.executeUpdate(NewProxyPreparedStatement.java:105)\n" +
   "    at org.hibernate.id.insert.AbstractSelectingDelegate.performInsert(AbstractSelectingDelegate.java:57)\n" +
   "    ... 54 more"
+
+export const fakeRunDebugMessage = "Failed to pull image from registry: RateLimitExceeded"
+
+export const fakeJobError = "something has gone wrong with this job"

--- a/internal/lookoutui/src/services/lookout/useCordonNode.ts
+++ b/internal/lookoutui/src/services/lookout/useCordonNode.ts
@@ -16,6 +16,7 @@ export const useCordonNode = () => {
   return useMutation<object, string, CordonNodeVariables>({
     mutationFn: async ({ node, cluster }: CordonNodeVariables) => {
       if (uiConfig?.fakeDataEnabled) {
+        await new Promise((r) => setTimeout(r, 1_000))
         console.log(`Cordoned node ${node} in cluster ${cluster}`)
         return {}
       }

--- a/internal/lookoutui/src/services/lookout/useGetJobError.ts
+++ b/internal/lookoutui/src/services/lookout/useGetJobError.ts
@@ -1,0 +1,37 @@
+import { useQuery } from "@tanstack/react-query"
+
+import { useAuthenticatedFetch } from "../../oidcAuth"
+import { getErrorMessage } from "../../utils"
+import { fakeJobError } from "./mocks/fakeData"
+import { useGetUiConfig } from "./useGetUiConfig"
+
+export const useGetJobError = (jobId: string, enabled = true) => {
+  const { data: uiConfig } = useGetUiConfig()
+  const authenticatedFetch = useAuthenticatedFetch()
+
+  return useQuery<string, string>({
+    queryKey: ["getJobError", jobId],
+    queryFn: async ({ signal }) => {
+      try {
+        if (uiConfig?.fakeDataEnabled) {
+          return fakeJobError
+        }
+
+        const response = await authenticatedFetch("/api/v1/jobError", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ jobId }),
+          signal,
+        })
+
+        const json = await response.json()
+        return json.errorString ?? ""
+      } catch (e) {
+        throw await getErrorMessage(e)
+      }
+    },
+    enabled,
+    refetchOnMount: false,
+    staleTime: 30_000,
+  })
+}

--- a/internal/lookoutui/src/services/lookout/useGetJobRunDebugMessage.ts
+++ b/internal/lookoutui/src/services/lookout/useGetJobRunDebugMessage.ts
@@ -2,10 +2,10 @@ import { useMemo } from "react"
 
 import { QueryFunction, QueryKey, useQueries, useQuery } from "@tanstack/react-query"
 
-import { getErrorMessage } from "../../utils"
-import { fakeRunError } from "./mocks/fakeData"
-import { useGetUiConfig } from "./useGetUiConfig"
 import { useAuthenticatedFetch } from "../../oidcAuth"
+import { getErrorMessage } from "../../utils"
+import { fakeRunDebugMessage } from "./mocks/fakeData"
+import { useGetUiConfig } from "./useGetUiConfig"
 
 const getQueryFn =
   (runId: string, fetchFunc: GlobalFetch["fetch"], fakeDataEnabled: boolean): QueryFunction<string, QueryKey, never> =>
@@ -15,7 +15,7 @@ const getQueryFn =
         if (runId === "doesnotexist") {
           throw new Error("Failed to retrieve job run because of reasons")
         }
-        return fakeRunError
+        return fakeRunDebugMessage
       }
 
       const response = await fetchFunc("/api/v1/jobRunDebugMessage", {

--- a/internal/lookoutui/src/utils/fakeJobsUtils.ts
+++ b/internal/lookoutui/src/utils/fakeJobsUtils.ts
@@ -92,17 +92,24 @@ function createJobRuns(n: number, jobId: string, rand: () => number, uuid: () =>
     if (runState !== JobRunState.RunPending && runState !== JobRunState.RunLeased) {
       node = uuid()
     }
+
+    const startedDateSeconds = 14 + 117 * i
+    const started = new Date(2022, 11, 13, 12, 15, startedDateSeconds, 123).toISOString()
+    const leased = new Date(2022, 11, 13, 12, 15, startedDateSeconds + 40, 123).toISOString()
+    const pending = new Date(2022, 11, 13, 12, 15, startedDateSeconds + 45, 123).toISOString()
+    const finished = new Date(2022, 11, 13, 12, 15, startedDateSeconds + 90, 123).toISOString()
+
     runs.push({
+      runId: uuid(),
       cluster: uuid(),
       exitCode: randomInt(0, 64, rand),
-      finished: "2022-12-13T12:19:14.956Z",
       jobId: jobId,
       jobRunState: runState,
       node: node,
-      leased: "2022-12-13T12:16:14.956Z",
-      pending: "2022-12-13T12:16:14.956Z",
-      runId: uuid(),
-      started: "2022-12-13T12:15:14.956Z",
+      started,
+      leased,
+      pending,
+      finished,
     })
   }
   return runs


### PR DESCRIPTION
For a job which has one or more errored runs, we display each errored run's logs and its debug message from Armada if present, in the *Result* tab of the sidebar. The order of these errors and debug messages is not consistent with the order of the runs. This fixes this discrepancy.

This commit also performs some refactoring of the component where this is displayed, as well as the mechanism to execute the fetch requests to obtain the data.

<img width="689" alt="Screenshot 2025-06-23 at 10 43 34" src="https://github.com/user-attachments/assets/52258fb1-840b-4866-9853-95852ab71723" />
<img width="621" alt="Screenshot 2025-06-23 at 10 44 11" src="https://github.com/user-attachments/assets/88951d6d-8cfd-4e57-b736-e3dcebf0ed6f" />
