### PR TITLE
Ensure non-preemptible running jobs return correct bid price

### DIFF
--- a/internal/scheduler/jobdb/job.go
+++ b/internal/scheduler/jobdb/job.go
@@ -421,6 +421,9 @@ func (job *Job) WithBidPrices(bids map[string]pricing.Bid) *Job {
 }
 
 func (job *Job) GetBidPrice(pool string) float64 {
+	if !job.queued && !job.priorityClass.Preemptible {
+		return pricing.NonPreemptibleRunningPrice
+	}
 	bidPrice, present := job.bidPricesPool[pool]
 	if !present {
 		return 0
@@ -431,6 +434,9 @@ func (job *Job) GetBidPrice(pool string) float64 {
 	return bidPrice.RunningBid
 }
 
+// GetAllBidPrices
+// This should not be used to determine the bid price, use GetBidPrice for an accurate price
+// Expected this will only be used for testing purposes
 func (job *Job) GetAllBidPrices() map[string]pricing.Bid {
 	return maps.Clone(job.bidPricesPool)
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -503,23 +503,11 @@ func (s *Scheduler) updateJobPrices(ctx *armadacontext.Context, txn *jobdb.Txn) 
 			if !present {
 				continue
 			}
-			nonPreemptibleUpdatedPrice := map[string]pricing.Bid{}
-			for pool, bid := range updatedPrice {
-				nonPreemptibleUpdatedPrice[pool] = pricing.Bid{
-					QueuedBid:  bid.QueuedBid,
-					RunningBid: pricing.NonPreemptibleRunningPrice,
-				}
-			}
 
 			// For now always update all jobs, as the jobDb isn't setting them as they come in
 			for _, job := range jobs {
-				if job.PriorityClass().Preemptible {
-					job = job.WithBidPrices(updatedPrice)
-					updatedJobs = append(updatedJobs, job)
-				} else {
-					job = job.WithBidPrices(nonPreemptibleUpdatedPrice)
-					updatedJobs = append(updatedJobs, job)
-				}
+				job = job.WithBidPrices(updatedPrice)
+				updatedJobs = append(updatedJobs, job)
 			}
 		}
 	}


### PR DESCRIPTION
Currently if a queue has no bid prices, we won't set any bid prices on the job

However we want non-preemptible running jobs to always have a bid price of 1000000, regardless if the queue has bids
 - Otherwise what happens if non-preemptible jobs end up unexpected getting preempted



