### PR TITLE
Fix billing for away jobs scheduled and preempted in the same round

### DIFF
--- a/internal/scheduler/metrics/cycle_metrics.go
+++ b/internal/scheduler/metrics/cycle_metrics.go
@@ -400,7 +400,7 @@ func (m *cycleMetrics) ReportSchedulerResult(ctx *armadacontext.Context, result 
 			currentCycle.shortJobPenalty.WithLabelValues(pool, queue).Set(shortJobPenalty)
 			currentCycle.queueWeight.WithLabelValues(pool, queue).Set(queueContext.Weight)
 			currentCycle.rawQueueWeight.WithLabelValues(pool, queue).Set(queueContext.RawWeight)
-			for _, r := range queueContext.BillableAllocation.GetResources() {
+			for _, r := range queueContext.GetBillableResource().GetResources() {
 				currentCycle.billableResource.WithLabelValues(pool, queue, r.Name).Set(float64(r.RawValue))
 			}
 		}
@@ -575,7 +575,7 @@ func (m *cycleMetrics) publishCycleMetrics(ctx *armadacontext.Context, result sc
 				DemandByResourceType:             armadamaps.MapValues(qCtx.Demand.ToMap(), toQtyPtr),
 				ConstrainedDemandByResourceType:  armadamaps.MapValues(qCtx.ConstrainedDemand.ToMap(), toQtyPtr),
 				ShortJobPenalty:                  sc.FairnessCostProvider.UnweightedCostFromAllocation(qCtx.ShortJobPenalty),
-				BillableAllocationByResourceType: armadamaps.MapValues(qCtx.BillableAllocation.ToMap(), toQtyPtr),
+				BillableAllocationByResourceType: armadamaps.MapValues(qCtx.GetBillableResource().ToMap(), toQtyPtr),
 			}
 		}
 		events[i] = &metricevents.Event{

--- a/internal/scheduler/nodedb/nodedb_test.go
+++ b/internal/scheduler/nodedb/nodedb_test.go
@@ -290,11 +290,14 @@ func TestEviction(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(node.EvictedJobRunIds))
 	assert.Equal(t, map[int32]internaltypes.ResourceList{
-		-1: testfixtures.CpuMem("30", "248Gi"),
-		0:  testfixtures.CpuMem("30", "248Gi"),
-		1:  testfixtures.CpuMem("31", "252Gi"),
-		2:  testfixtures.CpuMem("31", "252Gi"),
-		3:  testfixtures.CpuMem("31", "252Gi"),
+		-1:    testfixtures.CpuMem("30", "248Gi"),
+		0:     testfixtures.CpuMem("30", "248Gi"),
+		1:     testfixtures.CpuMem("31", "252Gi"),
+		2:     testfixtures.CpuMem("31", "252Gi"),
+		3:     testfixtures.CpuMem("31", "252Gi"),
+		28000: testfixtures.CpuMem("32", "256Gi"),
+		29000: testfixtures.CpuMem("32", "256Gi"),
+		30000: testfixtures.CpuMem("32", "256Gi"),
 	}, node.AllocatableByPriority)
 
 	returnedNode, err := nodeDb.EvictJobsFromNode(jobs, node)
@@ -303,19 +306,25 @@ func TestEviction(t *testing.T) {
 	assert.Equal(t, len(jobs), len(returnedNode.EvictedJobRunIds))
 
 	assert.Equal(t, map[int32]internaltypes.ResourceList{
-		-1: testfixtures.CpuMem("30", "248Gi"),
-		0:  testfixtures.CpuMem("30", "248Gi"),
-		1:  testfixtures.CpuMem("31", "252Gi"),
-		2:  testfixtures.CpuMem("31", "252Gi"),
-		3:  testfixtures.CpuMem("31", "252Gi"),
+		-1:    testfixtures.CpuMem("30", "248Gi"),
+		0:     testfixtures.CpuMem("30", "248Gi"),
+		1:     testfixtures.CpuMem("31", "252Gi"),
+		2:     testfixtures.CpuMem("31", "252Gi"),
+		3:     testfixtures.CpuMem("31", "252Gi"),
+		28000: testfixtures.CpuMem("32", "256Gi"),
+		29000: testfixtures.CpuMem("32", "256Gi"),
+		30000: testfixtures.CpuMem("32", "256Gi"),
 	}, node.AllocatableByPriority)
 
 	assert.Equal(t, map[int32]internaltypes.ResourceList{
-		-1: testfixtures.CpuMem("30", "248Gi"),
-		0:  testfixtures.CpuMem("32", "256Gi"),
-		1:  testfixtures.CpuMem("32", "256Gi"),
-		2:  testfixtures.CpuMem("32", "256Gi"),
-		3:  testfixtures.CpuMem("32", "256Gi"),
+		-1:    testfixtures.CpuMem("30", "248Gi"),
+		0:     testfixtures.CpuMem("32", "256Gi"),
+		1:     testfixtures.CpuMem("32", "256Gi"),
+		2:     testfixtures.CpuMem("32", "256Gi"),
+		3:     testfixtures.CpuMem("32", "256Gi"),
+		28000: testfixtures.CpuMem("32", "256Gi"),
+		29000: testfixtures.CpuMem("32", "256Gi"),
+		30000: testfixtures.CpuMem("32", "256Gi"),
 	}, returnedNode.AllocatableByPriority)
 }
 

--- a/internal/scheduler/scheduling/context/job.go
+++ b/internal/scheduler/scheduling/context/job.go
@@ -66,6 +66,8 @@ type JobSchedulingContext struct {
 	PreemptionType PreemptionType
 	// Description of the cause of preemption
 	PreemptionDescription string
+	// If this job context should contribute to the billable resource of the queue
+	Billable bool
 }
 
 func (jctx *JobSchedulingContext) IsHomeJob(currentPool string) bool {

--- a/internal/scheduler/scheduling/queue_scheduler.go
+++ b/internal/scheduler/scheduling/queue_scheduler.go
@@ -142,7 +142,7 @@ func (sch *QueueScheduler) Schedule(ctx *armadacontext.Context) (*SchedulerResul
 
 					sctx.SpotPrice = &price
 					for _, qctx := range sctx.QueueSchedulingContexts {
-						qctx.BillableAllocation = qctx.Allocated
+						qctx.SetCurrentAllocationAsBillable()
 					}
 				}
 			}

--- a/internal/scheduler/testfixtures/testfixtures.go
+++ b/internal/scheduler/testfixtures/testfixtures.go
@@ -83,7 +83,7 @@ var (
 		PriorityClass6Preemptible:                {Priority: 30000, Preemptible: true},
 	}
 	TestDefaultPriorityClass = PriorityClass3
-	TestPriorities           = []int32{0, 1, 2, 3}
+	TestPriorities           = []int32{0, 1, 2, 3, 28000, 29000, 30000}
 	TestResources            = []schedulerconfiguration.ResourceType{
 		{Name: "cpu", Resolution: resource.MustParse("1")},
 		{Name: "memory", Resolution: resource.MustParse("128Mi")},
@@ -516,9 +516,24 @@ func setPricing(job *jobdb.Job) *jobdb.Job {
 }
 
 func N1Cpu4GiJobsWithPriceBand(queue string, priceBand bidstore.PriceBand, n int) []*jobdb.Job {
+	return N1Cpu4GiJobsWithPriceBandAndPriorityClass(queue, priceBand, PriorityClass0, n)
+}
+
+func N1Cpu4GiJobsWithPriceBandAndPriorityClass(queue string, priceBand bidstore.PriceBand, priorityClass string, n int) []*jobdb.Job {
 	rv := make([]*jobdb.Job, n)
 	for i := 0; i < n; i++ {
-		j := Test1Cpu4GiJob(queue, PriorityClass0)
+		j := Test1Cpu4GiJob(queue, priorityClass)
+		j = j.WithPriceBand(priceBand)
+		j = setPricing(j)
+		rv[i] = j
+	}
+	return rv
+}
+
+func N1GpuJobsWithPriceBandAndPriorityClass(queue string, priceBand bidstore.PriceBand, priorityClass string, n int) []*jobdb.Job {
+	rv := make([]*jobdb.Job, n)
+	for i := 0; i < n; i++ {
+		j := Test1GpuJob(queue, priorityClass)
 		j = j.WithPriceBand(priceBand)
 		j = setPricing(j)
 		rv[i] = j


### PR DESCRIPTION
Currently we snapshot the resource allocated to a queue when the spot price is calculated

However at this point there can be jobs scheduled that will be evicted before the end of the scheduling round

Now we snapshot the allocated + mark scheduled jctx's as "billable"
 - If these scheduled jctx's subsequently get evicted/preempted, we'll remove that from the billable resource


