### PR TITLE
Lookout UI: fix filter type display strings

### DIFF
--- a/internal/lookoutui/src/components/lookout/JobsTableFilter.tsx
+++ b/internal/lookoutui/src/components/lookout/JobsTableFilter.tsx
@@ -37,8 +37,8 @@ const FILTER_TYPE_DISPLAY_STRINGS: Record<Match, string> = {
   [Match.Contains]: `Contains${ELLIPSIS}`,
   [Match.GreaterThan]: `Greater than${ELLIPSIS}`,
   [Match.LessThan]: `Less than${ELLIPSIS}`,
-  [Match.GreaterThanOrEqual]: `Greater than${ELLIPSIS}`,
-  [Match.LessThanOrEqual]: `Less than${ELLIPSIS}`,
+  [Match.GreaterThanOrEqual]: `Greater than or equal to${ELLIPSIS}`,
+  [Match.LessThanOrEqual]: `Less than or equal to${ELLIPSIS}`,
   [Match.AnyOf]: `Filter${ELLIPSIS}`,
   [Match.Exists]: `Annotation exists`,
 }


### PR DESCRIPTION
### Before

| ![image](https://github.com/user-attachments/assets/1df37ec7-4da6-47a8-a511-4ab14aa6bbed) | ![image](https://github.com/user-attachments/assets/91af2af2-f969-41aa-b6b9-005984205f69) |
| -- | -- |

### Now

| ![image](https://github.com/user-attachments/assets/6828f2a6-82c6-4edc-94c7-d76ee63dc155) | ![image](https://github.com/user-attachments/assets/4cd38956-591a-4dad-8dfa-d6a014c7b055) |
| -- | -- |

