### PR TITLE
Update DAG parameter (schedule_interval -> schedule)

### DIFF
--- a/third_party/airflow/examples/bad_armada.py
+++ b/third_party/airflow/examples/bad_armada.py
@@ -45,7 +45,7 @@ def submit_sleep_container(image: str):
 with DAG(
     dag_id="error_armada",
     start_date=pendulum.datetime(2016, 1, 1, tz="UTC"),
-    schedule_interval="@daily",
+    schedule="@daily",
     catchup=False,
     default_args={"retries": 2},
 ) as dag:

--- a/third_party/airflow/examples/hello_armada.py
+++ b/third_party/airflow/examples/hello_armada.py
@@ -52,7 +52,7 @@ This is an example of a Airflow dag that uses a BashOperator and an ArmadaOperat
 with DAG(
     dag_id="hello_armada",
     start_date=pendulum.datetime(2016, 1, 1, tz="UTC"),
-    schedule_interval="@daily",
+    schedule="@daily",
     catchup=False,
     default_args={"retries": 2},
 ) as dag:

--- a/third_party/airflow/examples/hello_armada_deferrable.py
+++ b/third_party/airflow/examples/hello_armada_deferrable.py
@@ -53,7 +53,7 @@ an ArmadaDeferrableOperator
 with DAG(
     dag_id="hello_armada_deferrable",
     start_date=pendulum.datetime(2016, 1, 1, tz="UTC"),
-    schedule_interval="@daily",
+    schedule="@daily",
     catchup=False,
     default_args={"retries": 2},
 ) as dag:


### PR DESCRIPTION
#### What type of PR is this?

This is updates our usage of the airflow.DAG initializer, so that it works with current release.

#### What this PR does / why we need it:

The PR simply uses the new name for the paramger.

#### Which issue(s) this PR fixes:

Fixes #4397


