### PR TITLE
Fix double counting, add idealised resource allocation

### DIFF
--- a/internal/scheduler/scheduling/context/queue.go
+++ b/internal/scheduler/scheduling/context/queue.go
@@ -59,6 +59,9 @@ type QueueSchedulingContext struct {
 	// IdealisedValue is the total value of jobs that would be scheduled from this queue if there was no fragmentation.
 	// This only applies if the pool was market priced
 	IdealisedValue float64
+	// IdealisedAllocated are the resources that would be allocated from this queue if there was no fragmentation.
+	// This only applies if the pool was market priced
+	IdealisedAllocated internaltypes.ResourceList
 	// RealisedValue is the total value of jobs that were actually scheduled.  Note that this us only populated
 	// on market driven pools
 	RealisedValue float64

--- a/internal/scheduler/scheduling/idealised_value.go
+++ b/internal/scheduler/scheduling/idealised_value.go
@@ -93,10 +93,15 @@ func CalculateIdealisedValue(
 		return err
 	}
 	idealisedValues := valueFromSchedulingResult(dummySchedulingContext, resourceUnit)
+	idealisedAllocations := allocationFromSchedulingResult(dummySchedulingContext)
 	for _, qctx := range sctx.QueueSchedulingContexts {
 		qctx.IdealisedValue = idealisedValues[qctx.Queue]
+		idealisedAlloc, ok := idealisedAllocations[qctx.Queue]
+		if !ok {
+			idealisedAlloc = rlf.MakeAllZero()
+		}
+		qctx.IdealisedAllocated = idealisedAlloc
 	}
-
 	return nil
 }
 
@@ -117,6 +122,14 @@ func valueFromSchedulingResult(sctx *schedulercontext.SchedulingContext, resourc
 		}
 	}
 	return valueByQueue
+}
+
+func allocationFromSchedulingResult(sctx *schedulercontext.SchedulingContext) map[string]internaltypes.ResourceList {
+	allocationByQueue := make(map[string]internaltypes.ResourceList, len(sctx.QueueSchedulingContexts))
+	for _, qtx := range sctx.QueueSchedulingContexts {
+		allocationByQueue[qtx.Queue] = qtx.Allocated
+	}
+	return allocationByQueue
 }
 
 type schedulingConstraints struct {

--- a/internal/scheduler/scheduling/idealised_value_scheduler.go
+++ b/internal/scheduler/scheduling/idealised_value_scheduler.go
@@ -133,11 +133,7 @@ func createMegaNode(pool string, nodes []*internaltypes.Node, schedulingConfig c
 	for _, node := range nodes {
 		if !node.IsUnschedulable() {
 			totalResources = totalResources.Add(node.GetTotalResources())
-			availableOnNode := node.GetAllocatableResources()
-			for _, allocatedToJob := range node.AllocatedByJobId {
-				availableOnNode = availableOnNode.Add(allocatedToJob)
-			}
-			allocatableResources = allocatableResources.Add(availableOnNode)
+			allocatableResources = allocatableResources.Add(node.GetAllocatableResources())
 			for priority := range node.AllocatableByPriority {
 				priorityClasses[priority] = true
 			}


### PR DESCRIPTION
The new idealised resource metric was incorrect becuase we were creating the "mega node" with the available resources *and* the resources freed from runnning jobs.  This is incorrect and we only needed to use the available resources.

This pr also adds idealised resource-level metrics. 