### PR TITLE
Lookout UI: prevent TypeError from poorly-formed query string

### DIFF
--- a/internal/lookoutui/src/services/lookout/JobsTablePreferencesService.ts
+++ b/internal/lookoutui/src/services/lookout/JobsTablePreferencesService.ts
@@ -121,12 +121,13 @@ export const toQueryStringSafe = (prefs: JobsTablePreferences): QueryStringPrefs
   }
 }
 
-const columnFiltersFromQueryStringFilters = (f: QueryStringJobFilter[]): ColumnFiltersState => {
-  return f.map((queryFilter) => ({
-    id: queryFilter.id,
-    value: queryFilter.value,
-  }))
-}
+const columnFiltersFromQueryStringFilters = (f: QueryStringJobFilter[]): ColumnFiltersState =>
+  f
+    .filter((queryFilter) => queryFilter.id && queryFilter.value)
+    .map((queryFilter) => ({
+      id: queryFilter.id,
+      value: queryFilter.value,
+    }))
 
 const columnMatchesFromQueryStringFilters = (f: QueryStringJobFilter[]): Record<string, Match> => {
   const columnMatches: Record<string, Match> = {}


### PR DESCRIPTION
This fixes the bug where on the jobs page of the Lookout UI, if the query string contains filter elements where one has a match type but no ID or value, a TypeError is thrown.

For example, going to _**/?f[0][id]=jobId&f[0][value]=01abcde&f[1][match]=exact**_ throws:
> TypeError: Cannot read properties of undefined (reading 'slice')