### PR TITLE
Lookout UI: enforce queue filter required for filtering on job set

### DIFF
--- a/internal/lookoutui/src/components/lookout/JobsTableCell.tsx
+++ b/internal/lookoutui/src/components/lookout/JobsTableCell.tsx
@@ -1,14 +1,23 @@
 import { ReactNode, RefObject, useCallback } from "react"
 
 import { KeyboardArrowRight, KeyboardArrowDown } from "@mui/icons-material"
-import { TableCell, IconButton, TableSortLabel, Box, styled } from "@mui/material"
+import { TableCell, IconButton, TableSortLabel, Box, styled, Typography } from "@mui/material"
 import { Cell, ColumnResizeMode, flexRender, Header, Row } from "@tanstack/react-table"
 
 import styles from "./JobsTableCell.module.css"
 import { JobsTableFilter } from "./JobsTableFilter"
 import { JobRow, JobTableRow } from "../../models/jobsTableModels"
 import { JobState, Match } from "../../models/lookoutModels"
-import { ColumnId, FilterType, getColumnMetadata, StandardColumnId, toColId } from "../../utils/jobsTableColumns"
+import {
+  ColumnId,
+  FilterType,
+  getColumnMetadata,
+  isStandardColId,
+  PREREQUISITE_FILTER_COLUMNS,
+  STANDARD_COLUMN_DISPLAY_NAMES,
+  StandardColumnId,
+  toColId,
+} from "../../utils/jobsTableColumns"
 import { matchForColumn } from "../../utils/jobsTableUtils"
 import { ActionableValueOnHover } from "../ActionableValueOnHover"
 import { JobGroupStateCountsColumnHeader } from "./JobGroupStateCountsColumnHeader"
@@ -102,6 +111,14 @@ export function HeaderCell({
     )
   }
 
+  const prerequisiteFilterColumns = isStandardColId(id) ? PREREQUISITE_FILTER_COLUMNS[id as StandardColumnId] : []
+  const prerequisiteFilterColumnsSatisfied = prerequisiteFilterColumns.every((pid) =>
+    header
+      .getContext()
+      .table.getState()
+      .columnFilters.some((f) => f.id === pid),
+  )
+
   return (
     <HeaderTableCell
       key={id}
@@ -180,19 +197,29 @@ export function HeaderCell({
             </div>
           )}
 
-          {header.column.getCanFilter() && metadata.filterType && (
-            <JobsTableFilter
-              id={header.id}
-              currentFilter={header.column.getFilterValue() as string | string[] | number}
-              filterType={metadata.filterType}
-              matchType={match}
-              enumFilterValues={metadata.enumFilterValues}
-              parseError={parseError}
-              onFilterChange={onFilterChange}
-              onColumnMatchChange={onColumnMatchChange}
-              onSetTextFieldRef={onSetTextFieldRef}
-            />
-          )}
+          {header.column.getCanFilter() &&
+            metadata.filterType &&
+            (prerequisiteFilterColumnsSatisfied ? (
+              <JobsTableFilter
+                id={header.id}
+                currentFilter={header.column.getFilterValue() as string | string[] | number}
+                filterType={metadata.filterType}
+                matchType={match}
+                enumFilterValues={metadata.enumFilterValues}
+                parseError={parseError}
+                onFilterChange={onFilterChange}
+                onColumnMatchChange={onColumnMatchChange}
+                onSetTextFieldRef={onSetTextFieldRef}
+              />
+            ) : (
+              <Typography component="div" variant="body2" color="textSecondary">
+                To filter by {metadata.displayName}, add a filter for{" "}
+                {prerequisiteFilterColumns
+                  .map((pid) => STANDARD_COLUMN_DISPLAY_NAMES[pid])
+                  .join(", ")
+                  .replace(/, ([^,]*)$/, " and $1")}
+              </Typography>
+            ))}
 
           {header.column.id === StandardColumnId.State &&
             groupedColumns.filter((id) => id !== StandardColumnId.State)?.length > 0 && (

--- a/internal/lookoutui/src/utils/jobsTableColumns.tsx
+++ b/internal/lookoutui/src/utils/jobsTableColumns.tsx
@@ -76,6 +76,58 @@ export const isStandardColId = (columnId: string) => (Object.values(StandardColu
 
 export const getColumnMetadata = (column: JobTableColumn) => (column.meta ?? {}) as JobTableColumnMetadata
 
+// Some standard columns may only be filtered on if there are active filters on other columns.
+// PREREQUISITE_FILTER_COLUMNS defines these relationships.
+export const PREREQUISITE_FILTER_COLUMNS: Record<StandardColumnId, StandardColumnId[]> = {
+  [StandardColumnId.JobSet]: [StandardColumnId.Queue],
+  [StandardColumnId.JobID]: [],
+  [StandardColumnId.Queue]: [],
+  [StandardColumnId.State]: [],
+  [StandardColumnId.Priority]: [],
+  [StandardColumnId.Owner]: [],
+  [StandardColumnId.Namespace]: [],
+  [StandardColumnId.CPU]: [],
+  [StandardColumnId.Memory]: [],
+  [StandardColumnId.EphemeralStorage]: [],
+  [StandardColumnId.GPU]: [],
+  [StandardColumnId.PriorityClass]: [],
+  [StandardColumnId.TimeSubmittedUtc]: [],
+  [StandardColumnId.TimeSubmittedAgo]: [],
+  [StandardColumnId.LastTransitionTimeUtc]: [],
+  [StandardColumnId.TimeInState]: [],
+  [StandardColumnId.SelectorCol]: [],
+  [StandardColumnId.Count]: [],
+  [StandardColumnId.Node]: [],
+  [StandardColumnId.Cluster]: [],
+  [StandardColumnId.ExitCode]: [],
+  [StandardColumnId.RuntimeSeconds]: [],
+}
+
+export const STANDARD_COLUMN_DISPLAY_NAMES: Record<StandardColumnId, string> = {
+  [StandardColumnId.JobID]: "Job ID",
+  [StandardColumnId.Queue]: "Queue",
+  [StandardColumnId.JobSet]: "Job Set",
+  [StandardColumnId.State]: "State",
+  [StandardColumnId.Priority]: "Priority",
+  [StandardColumnId.Owner]: "Owner",
+  [StandardColumnId.Namespace]: "Namespace",
+  [StandardColumnId.CPU]: "CPUs",
+  [StandardColumnId.Memory]: "Memory",
+  [StandardColumnId.EphemeralStorage]: "Ephemeral Storage",
+  [StandardColumnId.GPU]: "GPUs",
+  [StandardColumnId.PriorityClass]: "Priority Class",
+  [StandardColumnId.TimeSubmittedUtc]: "Time Submitted",
+  [StandardColumnId.TimeSubmittedAgo]: "Time Since Submitted",
+  [StandardColumnId.LastTransitionTimeUtc]: "Last State Change",
+  [StandardColumnId.TimeInState]: "Time In State",
+  [StandardColumnId.SelectorCol]: "",
+  [StandardColumnId.Count]: "Count",
+  [StandardColumnId.Node]: "Node",
+  [StandardColumnId.Cluster]: "Cluster",
+  [StandardColumnId.ExitCode]: "Exit Code",
+  [StandardColumnId.RuntimeSeconds]: "Runtime",
+}
+
 const columnHelper = createColumnHelper<JobTableRow>()
 
 interface AccessorColumnHelperArgs {
@@ -175,7 +227,7 @@ export const GET_JOB_COLUMNS = ({
   accessorColumn({
     id: StandardColumnId.Queue,
     accessor: "queue",
-    displayName: "Queue",
+    displayName: STANDARD_COLUMN_DISPLAY_NAMES[StandardColumnId.Queue],
     additionalOptions: {
       enableGrouping: true,
       enableColumnFilter: true,
@@ -190,7 +242,7 @@ export const GET_JOB_COLUMNS = ({
   accessorColumn({
     id: StandardColumnId.Namespace,
     accessor: "namespace",
-    displayName: "Namespace",
+    displayName: STANDARD_COLUMN_DISPLAY_NAMES[StandardColumnId.Namespace],
     additionalOptions: {
       enableGrouping: false,
       enableColumnFilter: true,
@@ -205,7 +257,7 @@ export const GET_JOB_COLUMNS = ({
   accessorColumn({
     id: StandardColumnId.JobSet,
     accessor: "jobSet",
-    displayName: "Job Set",
+    displayName: STANDARD_COLUMN_DISPLAY_NAMES[StandardColumnId.JobSet],
     additionalOptions: {
       enableSorting: true,
       enableGrouping: true,
@@ -221,7 +273,7 @@ export const GET_JOB_COLUMNS = ({
   accessorColumn({
     id: StandardColumnId.JobID,
     accessor: "jobId",
-    displayName: "Job ID",
+    displayName: STANDARD_COLUMN_DISPLAY_NAMES[StandardColumnId.JobID],
     additionalOptions: {
       enableColumnFilter: true,
       enableSorting: true,
@@ -236,7 +288,7 @@ export const GET_JOB_COLUMNS = ({
   accessorColumn({
     id: StandardColumnId.State,
     accessor: "state",
-    displayName: "State",
+    displayName: STANDARD_COLUMN_DISPLAY_NAMES[StandardColumnId.State],
     additionalOptions: {
       enableGrouping: true,
       enableColumnFilter: true,
@@ -297,7 +349,7 @@ export const GET_JOB_COLUMNS = ({
       }
       return ""
     },
-    displayName: "Count",
+    displayName: STANDARD_COLUMN_DISPLAY_NAMES[StandardColumnId.Count],
     additionalOptions: {
       size: 200,
       enableSorting: true,
@@ -309,7 +361,7 @@ export const GET_JOB_COLUMNS = ({
   accessorColumn({
     id: StandardColumnId.Priority,
     accessor: (jobTableRow) => (jobTableRow.priority !== undefined ? `${jobTableRow.priority}` : ""),
-    displayName: "Priority",
+    displayName: STANDARD_COLUMN_DISPLAY_NAMES[StandardColumnId.Priority],
     additionalOptions: {
       enableColumnFilter: true,
     },
@@ -320,7 +372,7 @@ export const GET_JOB_COLUMNS = ({
   accessorColumn({
     id: StandardColumnId.Owner,
     accessor: "owner",
-    displayName: "Owner",
+    displayName: STANDARD_COLUMN_DISPLAY_NAMES[StandardColumnId.Owner],
     additionalOptions: {
       enableColumnFilter: true,
     },
@@ -333,7 +385,7 @@ export const GET_JOB_COLUMNS = ({
   accessorColumn({
     id: StandardColumnId.CPU,
     accessor: (jobTableRow) => (jobTableRow.cpu !== undefined ? formatCpu(jobTableRow.cpu) : ""),
-    displayName: "CPUs",
+    displayName: STANDARD_COLUMN_DISPLAY_NAMES[StandardColumnId.CPU],
     additionalOptions: {
       enableColumnFilter: true,
     },
@@ -344,7 +396,7 @@ export const GET_JOB_COLUMNS = ({
   accessorColumn({
     id: StandardColumnId.Memory,
     accessor: (jobTableRow) => (jobTableRow.memory !== undefined ? formatBytes(jobTableRow.memory) : ""),
-    displayName: "Memory",
+    displayName: STANDARD_COLUMN_DISPLAY_NAMES[StandardColumnId.Memory],
     additionalOptions: {
       size: 200,
       enableColumnFilter: true,
@@ -357,7 +409,7 @@ export const GET_JOB_COLUMNS = ({
     id: StandardColumnId.EphemeralStorage,
     accessor: (jobTableRow) =>
       jobTableRow.ephemeralStorage !== undefined ? formatBytes(jobTableRow.ephemeralStorage) : "",
-    displayName: "Ephemeral Storage",
+    displayName: STANDARD_COLUMN_DISPLAY_NAMES[StandardColumnId.EphemeralStorage],
     additionalOptions: {
       size: 200,
       enableColumnFilter: true,
@@ -369,7 +421,7 @@ export const GET_JOB_COLUMNS = ({
   accessorColumn({
     id: StandardColumnId.GPU,
     accessor: (jobTableRow) => (jobTableRow.gpu !== undefined ? `${jobTableRow.gpu}` : ""),
-    displayName: "GPUs",
+    displayName: STANDARD_COLUMN_DISPLAY_NAMES[StandardColumnId.GPU],
     additionalOptions: {
       enableColumnFilter: true,
     },
@@ -380,7 +432,7 @@ export const GET_JOB_COLUMNS = ({
   accessorColumn({
     id: StandardColumnId.PriorityClass,
     accessor: "priorityClass",
-    displayName: "Priority Class",
+    displayName: STANDARD_COLUMN_DISPLAY_NAMES[StandardColumnId.PriorityClass],
     additionalOptions: {
       enableColumnFilter: true,
     },
@@ -392,7 +444,7 @@ export const GET_JOB_COLUMNS = ({
   accessorColumn({
     id: StandardColumnId.LastTransitionTimeUtc,
     accessor: ({ lastTransitionTime }) => formatIsoTimestamp(lastTransitionTime, "compact"),
-    displayName: `Last State Change (${displayedTimeZoneName})`,
+    displayName: `${STANDARD_COLUMN_DISPLAY_NAMES[StandardColumnId.LastTransitionTimeUtc]} (${displayedTimeZoneName})`,
     additionalOptions: {
       enableSorting: true,
     },
@@ -401,7 +453,7 @@ export const GET_JOB_COLUMNS = ({
     id: StandardColumnId.TimeInState,
     accessor: ({ lastTransitionTime }) =>
       lastTransitionTime ? formatTimestampRelative(lastTransitionTime, false) : "",
-    displayName: "Time In State",
+    displayName: STANDARD_COLUMN_DISPLAY_NAMES[StandardColumnId.TimeInState],
     additionalOptions: {
       enableSorting: true,
       size: 200,
@@ -410,7 +462,7 @@ export const GET_JOB_COLUMNS = ({
   accessorColumn({
     id: StandardColumnId.TimeSubmittedUtc,
     accessor: ({ submitted }) => formatIsoTimestamp(submitted, "compact"),
-    displayName: `Time Submitted (${displayedTimeZoneName})`,
+    displayName: `${STANDARD_COLUMN_DISPLAY_NAMES[StandardColumnId.TimeSubmittedUtc]} (${displayedTimeZoneName})`,
     additionalOptions: {
       enableSorting: true,
     },
@@ -418,7 +470,7 @@ export const GET_JOB_COLUMNS = ({
   accessorColumn({
     id: StandardColumnId.TimeSubmittedAgo,
     accessor: ({ submitted }) => (submitted ? formatTimestampRelative(submitted, false) : ""),
-    displayName: "Time Since Submitted",
+    displayName: STANDARD_COLUMN_DISPLAY_NAMES[StandardColumnId.TimeSubmittedAgo],
     additionalOptions: {
       enableSorting: true,
     },
@@ -426,7 +478,7 @@ export const GET_JOB_COLUMNS = ({
   accessorColumn({
     id: StandardColumnId.Node,
     accessor: "node",
-    displayName: "Node",
+    displayName: STANDARD_COLUMN_DISPLAY_NAMES[StandardColumnId.Node],
     additionalOptions: {
       size: 200,
     },
@@ -437,7 +489,7 @@ export const GET_JOB_COLUMNS = ({
   accessorColumn({
     id: StandardColumnId.Cluster,
     accessor: "cluster",
-    displayName: "Cluster",
+    displayName: STANDARD_COLUMN_DISPLAY_NAMES[StandardColumnId.Cluster],
     additionalOptions: {
       size: 200,
     },
@@ -448,7 +500,7 @@ export const GET_JOB_COLUMNS = ({
   accessorColumn({
     id: StandardColumnId.ExitCode,
     accessor: "exitCode",
-    displayName: "Exit Code",
+    displayName: STANDARD_COLUMN_DISPLAY_NAMES[StandardColumnId.ExitCode],
     additionalOptions: {
       size: 100,
     },
@@ -456,7 +508,7 @@ export const GET_JOB_COLUMNS = ({
   accessorColumn({
     id: StandardColumnId.RuntimeSeconds,
     accessor: "runtimeSeconds",
-    displayName: "Runtime",
+    displayName: STANDARD_COLUMN_DISPLAY_NAMES[StandardColumnId.RuntimeSeconds],
     additionalOptions: {
       size: 100,
       cell: (cellInfo) =>


### PR DESCRIPTION
This will allow us, in future, to remove the index on job set, in favour of the existing one on (queue, job set), moving us closer to being able to shard by queue.
<img width="768" height="377" alt="image" src="https://github.com/user-attachments/assets/8f23cc65-09de-4eb7-af4c-b78835ca6123" />
