### PR TITLE
Serve source map in Lookout UI build

### DIFF
--- a/internal/lookoutui/vite.config.mts
+++ b/internal/lookoutui/vite.config.mts
@@ -59,5 +59,6 @@ export default defineConfig({
   },
   build: {
     outDir: "build",
+    sourcemap: true,
   },
 })


### PR DESCRIPTION
This allows error monitoring applications to deliver more informative error messages about the origin of the error, and so improves the ability to debug problems.