### PR TITLE
Lookout UI: enable grouping by namespace

### DIFF
--- a/internal/lookout/schema/migrations/024_create_job_queue_namespace_idx.sql
+++ b/internal/lookout/schema/migrations/024_create_job_queue_namespace_idx.sql
@@ -1,0 +1,2 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_job_queue_namespace ON job (queue, namespace)
+WITH (fillfactor = 80);

--- a/internal/lookoutui/src/common/jobsTableColumns.tsx
+++ b/internal/lookoutui/src/common/jobsTableColumns.tsx
@@ -77,7 +77,8 @@ export const fromAnnotationColId = (colId: AnnotationColumnId): string => colId.
 
 export const toColId = (columnId: string | undefined) => columnId as ColumnId
 
-export const isStandardColId = (columnId: string) => (Object.values(StandardColumnId) as string[]).includes(columnId)
+export const isStandardColId = (columnId: string): columnId is StandardColumnId =>
+  (Object.values(StandardColumnId) as string[]).includes(columnId)
 
 export const getColumnMetadata = (column: JobTableColumn) => (column.meta ?? {}) as JobTableColumnMetadata
 
@@ -90,7 +91,7 @@ export const PREREQUISITE_FILTER_COLUMNS: Record<StandardColumnId, StandardColum
   [StandardColumnId.State]: [],
   [StandardColumnId.Priority]: [],
   [StandardColumnId.Owner]: [],
-  [StandardColumnId.Namespace]: [],
+  [StandardColumnId.Namespace]: [StandardColumnId.Queue],
   [StandardColumnId.CPU]: [],
   [StandardColumnId.Memory]: [],
   [StandardColumnId.EphemeralStorage]: [],
@@ -249,7 +250,7 @@ export const GET_JOB_COLUMNS = ({
     accessor: "namespace",
     displayName: STANDARD_COLUMN_DISPLAY_NAMES[StandardColumnId.Namespace],
     additionalOptions: {
-      enableGrouping: false,
+      enableGrouping: true,
       enableColumnFilter: true,
       size: 300,
     },


### PR DESCRIPTION
Adds support for grouping by namespace, so long as queue is already being grouped-by.

This also makes filtering on the queue column a prerequisite to filtering by the namespace column, and enforces all filtering prerequisites in the group-by selector.

Add an index on job (queue, namespace) to enhance the query performance for filtering and grouping by namespace.