### PR TITLE
fix typo in executor when it logs available resources

### DIFF
--- a/internal/executor/service/cluster_allocation.go
+++ b/internal/executor/service/cluster_allocation.go
@@ -149,7 +149,7 @@ func formatResources(availableResource armadaresource.ComputeResources) string {
 	}
 	amdGpu := availableResource["amd.com/gpu"]
 	if amdGpu.Value() > 0 {
-		resources += fmt.Sprintf(", amd.com/gpu: %d", nvidiaGpu.Value())
+		resources += fmt.Sprintf(", amd.com/gpu: %d", amdGpu.Value())
 	}
 	return resources
 }


### PR DESCRIPTION
Typo was reporting NVIDIA GPU count for AMD GPUs.