### PR TITLE
fix edge case panic when ResourceList tries to subtract a missing resource

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -407,7 +407,7 @@ func (s *Scheduler) syncState(ctx *armadacontext.Context, initial, fullJobGc boo
 
 		if len(initialRuns) > 0 {
 			updatedRuns = initialRuns
-		} else if maxJobSerial != nil {
+		} else if maxRunSerial != nil {
 			s.runsSerial = *maxRunSerial // Allow the next sync to start from the highest serial possible.
 		}
 

--- a/internal/scheduler/schedulerobjects/resourcelist.go
+++ b/internal/scheduler/schedulerobjects/resourcelist.go
@@ -35,6 +35,13 @@ func (a *ResourceList) Sub(b *ResourceList) {
 	a.initialise()
 	for t, qb := range b.Resources {
 		qa := a.Resources[t]
+		if qa == nil {
+			// Skip resources that don't exist in the resource list.
+			// This is an edge case which can happen with aliased resource advertisements.
+			// E.g. if a node advertises "nvidia.com/a100" instead of "nvidia.com/gpu",
+			// but Kubernetes still schedules pods with "nvidia.com/gpu" requests.
+			continue
+		}
 		qa.Sub(*qb)
 		a.Resources[t] = qa
 	}

--- a/internal/scheduler/schedulerobjects/resourcelist_test.go
+++ b/internal/scheduler/schedulerobjects/resourcelist_test.go
@@ -119,3 +119,74 @@ func TestResourceListEqual(t *testing.T) {
 		})
 	}
 }
+
+func TestResourceListSub(t *testing.T) {
+	tests := map[string]struct {
+		a        *ResourceList
+		b        *ResourceList
+		expected *ResourceList
+	}{
+		"basic subtraction": {
+			a: &ResourceList{
+				Resources: map[string]*resource.Quantity{
+					"cpu":    pointer.MustParseResource("10"),
+					"memory": pointer.MustParseResource("100Gi"),
+				},
+			},
+			b: &ResourceList{
+				Resources: map[string]*resource.Quantity{
+					"cpu":    pointer.MustParseResource("3"),
+					"memory": pointer.MustParseResource("20Gi"),
+				},
+			},
+			expected: &ResourceList{
+				Resources: map[string]*resource.Quantity{
+					"cpu":    pointer.MustParseResource("7"),
+					"memory": pointer.MustParseResource("80Gi"),
+				},
+			},
+		},
+		"subtract with missing resource type": {
+			a: &ResourceList{
+				Resources: map[string]*resource.Quantity{
+					"cpu":             pointer.MustParseResource("10"),
+					"nvidia.com/a100": pointer.MustParseResource("8"),
+				},
+			},
+			b: &ResourceList{
+				Resources: map[string]*resource.Quantity{
+					"cpu":            pointer.MustParseResource("2"),
+					"nvidia.com/gpu": pointer.MustParseResource("1"),
+				},
+			},
+			expected: &ResourceList{
+				Resources: map[string]*resource.Quantity{
+					"cpu":             pointer.MustParseResource("8"),
+					"nvidia.com/a100": pointer.MustParseResource("8"),
+				},
+			},
+		},
+		"subtract empty from non-empty": {
+			a: &ResourceList{
+				Resources: map[string]*resource.Quantity{
+					"cpu": pointer.MustParseResource("10"),
+				},
+			},
+			b: &ResourceList{
+				Resources: map[string]*resource.Quantity{},
+			},
+			expected: &ResourceList{
+				Resources: map[string]*resource.Quantity{
+					"cpu": pointer.MustParseResource("10"),
+				},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			tc.a.Sub(tc.b)
+			assert.True(t, tc.a.Equal(tc.expected))
+		})
+	}
+}


### PR DESCRIPTION
The scheduler panics with a nil pointer dereference when processing nodes that have pods requesting different GPU resource types than what the node advertises.

This happens in clusters using custom GPU device plugins that expose specific GPU models as separate resources (e.g., `nvidia.com/a100` instead of generic `nvidia.com/gpu`).

There are some edge cases in which Kubernetes schedules a Pod requesting `nvidia.com/gpu` on a Node advertising `nvidia.com/a100`.

Original issue was reported here https://github.com/armadaproject/armada/issues/4446