### PR TITLE
Set timeout on ReportEvents call in executor

### DIFF
--- a/internal/executor/reporter/event_sender.go
+++ b/internal/executor/reporter/event_sender.go
@@ -1,6 +1,8 @@
 package reporter
 
 import (
+	"time"
+
 	"github.com/gogo/protobuf/proto"
 
 	"github.com/armadaproject/armada/internal/common/armadacontext"
@@ -45,12 +47,19 @@ func (eventSender *ExecutorApiEventSender) SendEvents(events []EventMessage) err
 	}
 
 	for _, eventList := range eventLists {
-		_, err = eventSender.eventClient.ReportEvents(armadacontext.Background(), eventList)
+		err = eventSender.reportEvents(eventList)
 		if err != nil {
 			return err
 		}
 	}
 
+	return err
+}
+
+func (eventSender *ExecutorApiEventSender) reportEvents(eventList *executorapi.EventList) error {
+	timeout, cancel := armadacontext.WithTimeout(armadacontext.Background(), time.Second*30)
+	defer cancel()
+	_, err := eventSender.eventClient.ReportEvents(timeout, eventList)
 	return err
 }
 


### PR DESCRIPTION
This just sets a timeout so if the api has an outage that the executor calls end and retry


