### PR TITLE
Scheduler: tests: minimise use of raw resources

### DIFF
--- a/internal/scheduler/floatingresources/floating_resource_types_test.go
+++ b/internal/scheduler/floatingresources/floating_resource_types_test.go
@@ -67,12 +67,12 @@ func TestGetTotalAvailableForPool(t *testing.T) {
 	sut := makeSut(t, makeRlFactory())
 
 	cpuPool := sut.GetTotalAvailableForPool("cpu")
-	assert.Equal(t, int64(200000), cpuPool.GetByNameZeroIfMissing("floating-resource-1"))
-	assert.Equal(t, int64(300000), cpuPool.GetByNameZeroIfMissing("floating-resource-2"))
+	assert.Equal(t, "200", qToStr(cpuPool.GetResourceByNameZeroIfMissing("floating-resource-1")))
+	assert.Equal(t, "300", qToStr(cpuPool.GetResourceByNameZeroIfMissing("floating-resource-2")))
 
 	gpuPool := sut.GetTotalAvailableForPool("gpu")
-	assert.Equal(t, int64(100000), gpuPool.GetByNameZeroIfMissing("floating-resource-1"))
-	assert.Equal(t, int64(0), gpuPool.GetByNameZeroIfMissing("floating-resource-2"))
+	assert.Equal(t, "100", qToStr(gpuPool.GetResourceByNameZeroIfMissing("floating-resource-1")))
+	assert.Equal(t, "0", qToStr(gpuPool.GetResourceByNameZeroIfMissing("floating-resource-2")))
 
 	notFound := sut.GetTotalAvailableForPool("some-invalid-value")
 	assert.True(t, notFound.IsEmpty())
@@ -198,4 +198,8 @@ func makeSut(t *testing.T, rlFactory *internaltypes.ResourceListFactory) *Floati
 	sut, err := NewFloatingResourceTypes(testConfig(), rlFactory)
 	assert.Nil(t, err)
 	return sut
+}
+
+func qToStr(q resource.Quantity) string {
+	return q.String()
 }

--- a/internal/scheduler/internaltypes/resource_list_map_util_test.go
+++ b/internal/scheduler/internaltypes/resource_list_map_util_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	k8sResource "k8s.io/apimachinery/pkg/api/resource"
 )
 
 func TestRlMapToString(t *testing.T) {
@@ -58,9 +59,11 @@ func TestNewAllocatableByPriorityAndResourceType(t *testing.T) {
 
 	result := NewAllocatableByPriorityAndResourceType([]int32{1, 2}, rl)
 	assert.Equal(t, 3, len(result))
-	assert.Equal(t, int64(2000), result[1].GetByNameZeroIfMissing("cpu"))
-	assert.Equal(t, int64(2000), result[2].GetByNameZeroIfMissing("cpu"))
-	assert.Equal(t, int64(2000), result[EvictedPriority].GetByNameZeroIfMissing("cpu"))
+
+	twoThousandMillis := *k8sResource.NewMilliQuantity(2000, k8sResource.DecimalSI)
+	assert.Equal(t, twoThousandMillis, result[1].GetResourceByNameZeroIfMissing("cpu"))
+	assert.Equal(t, twoThousandMillis, result[2].GetResourceByNameZeroIfMissing("cpu"))
+	assert.Equal(t, twoThousandMillis, result[EvictedPriority].GetResourceByNameZeroIfMissing("cpu"))
 }
 
 func TestMarkAllocated(t *testing.T) {

--- a/internal/scheduler/jobdb/job_test.go
+++ b/internal/scheduler/jobdb/job_test.go
@@ -472,15 +472,15 @@ func TestJob_TestWithJobSchedulingInfo(t *testing.T) {
 	assert.Equal(t, jobSchedulingInfo, baseJob.JobSchedulingInfo())
 	assert.Equal(t, newSchedInfo, newJob.JobSchedulingInfo())
 
-	assert.Equal(t, int64(1000), baseJob.AllResourceRequirements().GetByNameZeroIfMissing("cpu"))
-	assert.Equal(t, int64(1), baseJob.AllResourceRequirements().GetByNameZeroIfMissing("storage-connections"))
-	assert.Equal(t, int64(1000), baseJob.KubernetesResourceRequirements().GetByNameZeroIfMissing("cpu"))
-	assert.Equal(t, int64(0), baseJob.KubernetesResourceRequirements().GetByNameZeroIfMissing("storage-connections"))
+	assert.Equal(t, milliQuantity(1000), baseJob.AllResourceRequirements().GetResourceByNameZeroIfMissing("cpu"))
+	assert.Equal(t, quantity(1), baseJob.AllResourceRequirements().GetResourceByNameZeroIfMissing("storage-connections"))
+	assert.Equal(t, milliQuantity(1000), baseJob.KubernetesResourceRequirements().GetResourceByNameZeroIfMissing("cpu"))
+	assert.Equal(t, quantity(0), baseJob.KubernetesResourceRequirements().GetResourceByNameZeroIfMissing("storage-connections"))
 
-	assert.Equal(t, int64(2000), newJob.AllResourceRequirements().GetByNameZeroIfMissing("cpu"))
-	assert.Equal(t, int64(2), newJob.AllResourceRequirements().GetByNameZeroIfMissing("storage-connections"))
-	assert.Equal(t, int64(2000), newJob.KubernetesResourceRequirements().GetByNameZeroIfMissing("cpu"))
-	assert.Equal(t, int64(0), newJob.KubernetesResourceRequirements().GetByNameZeroIfMissing("storage-connections"))
+	assert.Equal(t, milliQuantity(2000), newJob.AllResourceRequirements().GetResourceByNameZeroIfMissing("cpu"))
+	assert.Equal(t, quantity(2), newJob.AllResourceRequirements().GetResourceByNameZeroIfMissing("storage-connections"))
+	assert.Equal(t, milliQuantity(2000), newJob.KubernetesResourceRequirements().GetResourceByNameZeroIfMissing("cpu"))
+	assert.Equal(t, quantity(0), newJob.KubernetesResourceRequirements().GetResourceByNameZeroIfMissing("storage-connections"))
 }
 
 func TestRequestsFloatingResources(t *testing.T) {
@@ -537,11 +537,19 @@ func TestJob_TestResolvedPools(t *testing.T) {
 }
 
 func TestJob_TestAllResourceRequirements(t *testing.T) {
-	assert.Equal(t, int64(1000), baseJob.AllResourceRequirements().GetByNameZeroIfMissing("cpu"))
-	assert.Equal(t, int64(1), baseJob.AllResourceRequirements().GetByNameZeroIfMissing("storage-connections"))
+	assert.Equal(t, milliQuantity(1000), baseJob.AllResourceRequirements().GetResourceByNameZeroIfMissing("cpu"))
+	assert.Equal(t, quantity(1), baseJob.AllResourceRequirements().GetResourceByNameZeroIfMissing("storage-connections"))
 }
 
 func TestJob_TestKubernetesResourceRequirements(t *testing.T) {
-	assert.Equal(t, int64(1000), baseJob.KubernetesResourceRequirements().GetByNameZeroIfMissing("cpu"))
-	assert.Equal(t, int64(0), baseJob.KubernetesResourceRequirements().GetByNameZeroIfMissing("storage-connections"))
+	assert.Equal(t, milliQuantity(1000), baseJob.KubernetesResourceRequirements().GetResourceByNameZeroIfMissing("cpu"))
+	assert.Equal(t, quantity(0), baseJob.KubernetesResourceRequirements().GetResourceByNameZeroIfMissing("storage-connections"))
+}
+
+func quantity(val int) k8sResource.Quantity {
+	return *k8sResource.NewQuantity(int64(val), k8sResource.DecimalSI)
+}
+
+func milliQuantity(millis int) k8sResource.Quantity {
+	return *k8sResource.NewMilliQuantity(int64(millis), k8sResource.DecimalSI)
 }


### PR DESCRIPTION
Ideally the raw `int64` value of `ResourceList` would be internal to `internaltypes`. This isn't quite possible, for example  `nodedb` indexes need an integer. However, for code that isn't performance-critical, let's minimise the use of raw `int64` values, and use `resource.Quantity` instead.