### PR TITLE
Scheduler: rename methods on resource list to discourage use of raw values

### DIFF
--- a/internal/scheduler/floatingresources/floating_resource_types.go
+++ b/internal/scheduler/floatingresources/floating_resource_types.go
@@ -88,7 +88,7 @@ func (frt *FloatingResourceTypes) GetTotalAvailableForPool(poolName string) inte
 func (frt *FloatingResourceTypes) GetTotalAvailableForPoolAsMap(poolName string) map[string]resource.Quantity {
 	limits := frt.GetTotalAvailableForPool(poolName)
 	result := map[string]resource.Quantity{}
-	for _, res := range limits.GetResources() {
+	for _, res := range limits.GetAll() {
 		if res.Type != internaltypes.Floating {
 			continue
 		}

--- a/internal/scheduler/floatingresources/floating_resource_types_test.go
+++ b/internal/scheduler/floatingresources/floating_resource_types_test.go
@@ -67,12 +67,12 @@ func TestGetTotalAvailableForPool(t *testing.T) {
 	sut := makeSut(t, makeRlFactory())
 
 	cpuPool := sut.GetTotalAvailableForPool("cpu")
-	assert.Equal(t, "200", qToStr(cpuPool.GetResourceByNameZeroIfMissing("floating-resource-1")))
-	assert.Equal(t, "300", qToStr(cpuPool.GetResourceByNameZeroIfMissing("floating-resource-2")))
+	assert.Equal(t, "200", qToStr(cpuPool.GetByNameZeroIfMissing("floating-resource-1")))
+	assert.Equal(t, "300", qToStr(cpuPool.GetByNameZeroIfMissing("floating-resource-2")))
 
 	gpuPool := sut.GetTotalAvailableForPool("gpu")
-	assert.Equal(t, "100", qToStr(gpuPool.GetResourceByNameZeroIfMissing("floating-resource-1")))
-	assert.Equal(t, "0", qToStr(gpuPool.GetResourceByNameZeroIfMissing("floating-resource-2")))
+	assert.Equal(t, "100", qToStr(gpuPool.GetByNameZeroIfMissing("floating-resource-1")))
+	assert.Equal(t, "0", qToStr(gpuPool.GetByNameZeroIfMissing("floating-resource-2")))
 
 	notFound := sut.GetTotalAvailableForPool("some-invalid-value")
 	assert.True(t, notFound.IsEmpty())

--- a/internal/scheduler/internaltypes/resource_list.go
+++ b/internal/scheduler/internaltypes/resource_list.go
@@ -40,7 +40,7 @@ func (rl ResourceList) String() string {
 	return "(" + strings.Join(parts, ",") + ")"
 }
 
-func (rl ResourceList) GetByName(name string) (int64, error) {
+func (rl ResourceList) GetRawByName(name string) (int64, error) {
 	if rl.IsEmpty() {
 		return 0, fmt.Errorf("resource type %s not found as resource list is empty", name)
 	}
@@ -51,7 +51,7 @@ func (rl ResourceList) GetByName(name string) (int64, error) {
 	return rl.resources[index], nil
 }
 
-func (rl ResourceList) GetByNameZeroIfMissing(name string) int64 {
+func (rl ResourceList) GetRawByNameZeroIfMissing(name string) int64 {
 	if rl.IsEmpty() {
 		return 0
 	}
@@ -62,7 +62,7 @@ func (rl ResourceList) GetByNameZeroIfMissing(name string) int64 {
 	return rl.resources[index]
 }
 
-func (rl ResourceList) GetResourceByNameZeroIfMissing(name string) k8sResource.Quantity {
+func (rl ResourceList) GetByNameZeroIfMissing(name string) k8sResource.Quantity {
 	if rl.IsEmpty() {
 		return k8sResource.Quantity{}
 	}
@@ -75,7 +75,7 @@ func (rl ResourceList) GetResourceByNameZeroIfMissing(name string) k8sResource.Q
 	return *rl.asQuantity(index)
 }
 
-func (rl ResourceList) GetResources() []Resource {
+func (rl ResourceList) GetAll() []Resource {
 	if rl.IsEmpty() {
 		return []Resource{}
 	}

--- a/internal/scheduler/internaltypes/resource_list_factory_test.go
+++ b/internal/scheduler/internaltypes/resource_list_factory_test.go
@@ -137,7 +137,7 @@ func TestMakeAllMax(t *testing.T) {
 	factory := testFactory()
 	allMax := factory.MakeAllMax()
 	assert.False(t, allMax.IsEmpty())
-	for _, res := range allMax.GetResources() {
+	for _, res := range allMax.GetAll() {
 		expected := *k8sResource.NewScaledQuantity(int64(math.MaxInt64), res.Scale)
 		assert.Equal(t, expected, res.Value)
 	}
@@ -160,7 +160,7 @@ func testFactory() *ResourceListFactory {
 }
 
 func testGet(rl *ResourceList, name string) int64 {
-	val, err := rl.GetByName(name)
+	val, err := rl.GetRawByName(name)
 	if err != nil {
 		return math.MinInt64
 	}

--- a/internal/scheduler/internaltypes/resource_list_map_util_test.go
+++ b/internal/scheduler/internaltypes/resource_list_map_util_test.go
@@ -61,9 +61,9 @@ func TestNewAllocatableByPriorityAndResourceType(t *testing.T) {
 	assert.Equal(t, 3, len(result))
 
 	twoThousandMillis := *k8sResource.NewMilliQuantity(2000, k8sResource.DecimalSI)
-	assert.Equal(t, twoThousandMillis, result[1].GetResourceByNameZeroIfMissing("cpu"))
-	assert.Equal(t, twoThousandMillis, result[2].GetResourceByNameZeroIfMissing("cpu"))
-	assert.Equal(t, twoThousandMillis, result[EvictedPriority].GetResourceByNameZeroIfMissing("cpu"))
+	assert.Equal(t, twoThousandMillis, result[1].GetByNameZeroIfMissing("cpu"))
+	assert.Equal(t, twoThousandMillis, result[2].GetByNameZeroIfMissing("cpu"))
+	assert.Equal(t, twoThousandMillis, result[EvictedPriority].GetByNameZeroIfMissing("cpu"))
 }
 
 func TestMarkAllocated(t *testing.T) {

--- a/internal/scheduler/jobdb/job_test.go
+++ b/internal/scheduler/jobdb/job_test.go
@@ -472,15 +472,15 @@ func TestJob_TestWithJobSchedulingInfo(t *testing.T) {
 	assert.Equal(t, jobSchedulingInfo, baseJob.JobSchedulingInfo())
 	assert.Equal(t, newSchedInfo, newJob.JobSchedulingInfo())
 
-	assert.Equal(t, milliQuantity(1000), baseJob.AllResourceRequirements().GetResourceByNameZeroIfMissing("cpu"))
-	assert.Equal(t, quantity(1), baseJob.AllResourceRequirements().GetResourceByNameZeroIfMissing("storage-connections"))
-	assert.Equal(t, milliQuantity(1000), baseJob.KubernetesResourceRequirements().GetResourceByNameZeroIfMissing("cpu"))
-	assert.Equal(t, quantity(0), baseJob.KubernetesResourceRequirements().GetResourceByNameZeroIfMissing("storage-connections"))
+	assert.Equal(t, milliQuantity(1000), baseJob.AllResourceRequirements().GetByNameZeroIfMissing("cpu"))
+	assert.Equal(t, quantity(1), baseJob.AllResourceRequirements().GetByNameZeroIfMissing("storage-connections"))
+	assert.Equal(t, milliQuantity(1000), baseJob.KubernetesResourceRequirements().GetByNameZeroIfMissing("cpu"))
+	assert.Equal(t, quantity(0), baseJob.KubernetesResourceRequirements().GetByNameZeroIfMissing("storage-connections"))
 
-	assert.Equal(t, milliQuantity(2000), newJob.AllResourceRequirements().GetResourceByNameZeroIfMissing("cpu"))
-	assert.Equal(t, quantity(2), newJob.AllResourceRequirements().GetResourceByNameZeroIfMissing("storage-connections"))
-	assert.Equal(t, milliQuantity(2000), newJob.KubernetesResourceRequirements().GetResourceByNameZeroIfMissing("cpu"))
-	assert.Equal(t, quantity(0), newJob.KubernetesResourceRequirements().GetResourceByNameZeroIfMissing("storage-connections"))
+	assert.Equal(t, milliQuantity(2000), newJob.AllResourceRequirements().GetByNameZeroIfMissing("cpu"))
+	assert.Equal(t, quantity(2), newJob.AllResourceRequirements().GetByNameZeroIfMissing("storage-connections"))
+	assert.Equal(t, milliQuantity(2000), newJob.KubernetesResourceRequirements().GetByNameZeroIfMissing("cpu"))
+	assert.Equal(t, quantity(0), newJob.KubernetesResourceRequirements().GetByNameZeroIfMissing("storage-connections"))
 }
 
 func TestRequestsFloatingResources(t *testing.T) {
@@ -537,13 +537,13 @@ func TestJob_TestResolvedPools(t *testing.T) {
 }
 
 func TestJob_TestAllResourceRequirements(t *testing.T) {
-	assert.Equal(t, milliQuantity(1000), baseJob.AllResourceRequirements().GetResourceByNameZeroIfMissing("cpu"))
-	assert.Equal(t, quantity(1), baseJob.AllResourceRequirements().GetResourceByNameZeroIfMissing("storage-connections"))
+	assert.Equal(t, milliQuantity(1000), baseJob.AllResourceRequirements().GetByNameZeroIfMissing("cpu"))
+	assert.Equal(t, quantity(1), baseJob.AllResourceRequirements().GetByNameZeroIfMissing("storage-connections"))
 }
 
 func TestJob_TestKubernetesResourceRequirements(t *testing.T) {
-	assert.Equal(t, milliQuantity(1000), baseJob.KubernetesResourceRequirements().GetResourceByNameZeroIfMissing("cpu"))
-	assert.Equal(t, quantity(0), baseJob.KubernetesResourceRequirements().GetResourceByNameZeroIfMissing("storage-connections"))
+	assert.Equal(t, milliQuantity(1000), baseJob.KubernetesResourceRequirements().GetByNameZeroIfMissing("cpu"))
+	assert.Equal(t, quantity(0), baseJob.KubernetesResourceRequirements().GetByNameZeroIfMissing("storage-connections"))
 }
 
 func quantity(val int) k8sResource.Quantity {

--- a/internal/scheduler/metrics/cycle_metrics.go
+++ b/internal/scheduler/metrics/cycle_metrics.go
@@ -463,10 +463,10 @@ func (m *cycleMetrics) ReportSchedulerResult(ctx *armadacontext.Context, result 
 			currentCycle.rawQueueWeight.WithLabelValues(pool, queue).Set(queueContext.RawWeight)
 			currentCycle.idealisedScheduledValue.WithLabelValues(pool, queue).Set(queueContext.IdealisedValue)
 			currentCycle.realisedScheduledValue.WithLabelValues(pool, queue).Set(queueContext.RealisedValue)
-			for _, r := range queueContext.GetBillableResource().GetResources() {
+			for _, r := range queueContext.GetBillableResource().GetAll() {
 				currentCycle.billableResource.WithLabelValues(pool, queue, r.Name).Set(r.Value.AsApproximateFloat64())
 			}
-			for _, r := range queueContext.IdealisedAllocated.GetResources() {
+			for _, r := range queueContext.IdealisedAllocated.GetAll() {
 				currentCycle.idealisedAllocatedResource.WithLabelValues(pool, queue, r.Name).Set(r.Value.AsApproximateFloat64())
 			}
 		}
@@ -507,7 +507,7 @@ func (m *cycleMetrics) ReportSchedulerResult(ctx *armadacontext.Context, result 
 		for queue, s := range schedulingStats.EvictorResult.GetStatsPerQueue() {
 			currentCycle.evictedJobs.WithLabelValues(pool, queue).Set(float64(s.EvictedJobCount))
 
-			for _, r := range s.EvictedResources.GetResources() {
+			for _, r := range s.EvictedResources.GetAll() {
 				currentCycle.evictedResources.WithLabelValues(pool, queue, r.Name).Set(r.Value.AsApproximateFloat64())
 			}
 		}
@@ -529,12 +529,12 @@ func (m *cycleMetrics) ReportSchedulerResult(ctx *armadacontext.Context, result 
 			for _, node := range nodes {
 				isSchedulable := strconv.FormatBool(!node.IsUnschedulable())
 				isOverallocated := strconv.FormatBool(node.IsOverAllocated())
-				for _, resource := range node.GetAllocatableResources().GetResources() {
+				for _, resource := range node.GetAllocatableResources().GetAll() {
 					currentCycle.nodeAllocatableResource.WithLabelValues(node.GetPool(), node.GetName(), node.GetExecutor(), node.GetReportingNodeType(), resource.Name, isSchedulable, isOverallocated).Set(resource.Value.AsApproximateFloat64())
 				}
 
 				allocated := node.GetAllocatableResources().Subtract(node.AllocatableByPriority[internaltypes.EvictedPriority])
-				for _, resource := range allocated.GetResources() {
+				for _, resource := range allocated.GetAll() {
 					allocatableValue := math.Max(resource.Value.AsApproximateFloat64(), 0)
 					currentCycle.nodeAllocatedResource.WithLabelValues(node.GetPool(), node.GetName(), node.GetExecutor(), node.GetReportingNodeType(), resource.Name, isSchedulable, isOverallocated).Set(allocatableValue)
 				}

--- a/internal/scheduler/metrics/state_metrics.go
+++ b/internal/scheduler/metrics/state_metrics.go
@@ -189,7 +189,7 @@ func (m *jobStateMetrics) recordPreemptedSecondsLost(job *jobdb.Job, duration fl
 	requests := job.AllResourceRequirements()
 
 	for _, res := range m.trackedResourceNames {
-		resQty := requests.GetResourceByNameZeroIfMissing(string(res))
+		resQty := requests.GetByNameZeroIfMissing(string(res))
 		resSeconds := duration * float64(resQty.MilliValue()) / 1000
 		m.jobResourceSecondsLostToPreemptionByQueue.
 			WithLabelValues(job.Queue(), run.Pool(), checkpointLabel, res.String()).Add(resSeconds)
@@ -284,7 +284,7 @@ func (m *jobStateMetrics) updateStateDuration(job *jobdb.Job, state string, prio
 
 	// Resource Seconds
 	for _, res := range m.trackedResourceNames {
-		resQty := requests.GetResourceByNameZeroIfMissing(string(res))
+		resQty := requests.GetByNameZeroIfMissing(string(res))
 		resSeconds := duration * float64(resQty.MilliValue()) / 1000
 		m.jobStateResourceSecondsByQueue.
 			WithLabelValues(queue, pool, state, priorState, res.String()).Add(resSeconds)

--- a/internal/scheduler/nodedb/encoding.go
+++ b/internal/scheduler/nodedb/encoding.go
@@ -45,7 +45,7 @@ func RoundedNodeIndexKeyFromResourceList(
 	out = EncodeUint64(out, nodeTypeId)
 	for i, name := range resourceNames {
 		resolution := resourceResolution[i]
-		q := rl.GetByNameZeroIfMissing(name)
+		q := rl.GetRawByNameZeroIfMissing(name)
 		q = roundQuantityToResolution(q, resolution)
 		out = EncodeInt64(out, q)
 	}

--- a/internal/scheduler/nodedb/nodedb.go
+++ b/internal/scheduler/nodedb/nodedb.go
@@ -620,7 +620,7 @@ func (nodeDb *NodeDb) selectNodeForPodAtPriority(
 ) (*internaltypes.Node, error) {
 	indexResourceRequests := make([]int64, len(nodeDb.indexedResources))
 	for i, t := range nodeDb.indexedResources {
-		indexResourceRequests[i] = jctx.KubernetesResourceRequirements.GetByNameZeroIfMissing(t)
+		indexResourceRequests[i] = jctx.KubernetesResourceRequirements.GetRawByNameZeroIfMissing(t)
 	}
 	indexName, ok := nodeDb.indexNameByPriority[priority]
 	if !ok {

--- a/internal/scheduler/nodedb/nodeiteration.go
+++ b/internal/scheduler/nodedb/nodeiteration.go
@@ -171,8 +171,8 @@ func (it *nodeTypesIteratorPQ) less(a, b *internaltypes.Node) bool {
 	allocatableByPriorityA := a.AllocatableByPriority[it.priority]
 	allocatableByPriorityB := b.AllocatableByPriority[it.priority]
 	for _, t := range it.indexedResources {
-		qa := allocatableByPriorityA.GetByNameZeroIfMissing(t)
-		qb := allocatableByPriorityB.GetByNameZeroIfMissing(t)
+		qa := allocatableByPriorityA.GetRawByNameZeroIfMissing(t)
+		qb := allocatableByPriorityB.GetRawByNameZeroIfMissing(t)
 
 		if qa < qb {
 			return true
@@ -343,7 +343,7 @@ func (it *NodeTypeIterator) NextNode() (*internaltypes.Node, error) {
 			return nil, errors.Errorf("node %s has no resources registered at priority %d: %v", node.GetId(), it.priority, node.AllocatableByPriority)
 		}
 		for i, t := range it.indexedResources {
-			nodeQuantity := allocatableByPriority.GetByNameZeroIfMissing(t)
+			nodeQuantity := allocatableByPriority.GetRawByNameZeroIfMissing(t)
 			requestQuantity := it.indexedResourceRequests[i]
 			it.newLowerBound[i] = roundQuantityToResolution(nodeQuantity, it.indexedResourceResolution[i])
 

--- a/internal/scheduler/nodedb/nodeiteration_test.go
+++ b/internal/scheduler/nodedb/nodeiteration_test.go
@@ -326,7 +326,7 @@ func TestNodeTypeIterator(t *testing.T) {
 
 			assert.Nil(t, err)
 			for i, resourceName := range nodeDb.indexedResources {
-				indexedResourceRequests[i], err = tc.resourceRequests.GetByName(resourceName)
+				indexedResourceRequests[i], err = tc.resourceRequests.GetRawByName(resourceName)
 				assert.Nil(t, err)
 			}
 			keyIndex := -1
@@ -656,7 +656,7 @@ func TestNodeTypesIterator(t *testing.T) {
 
 			indexedResourceRequests := make([]int64, len(testfixtures.TestResources))
 			for i, resourceName := range testfixtures.TestResourceNames {
-				indexedResourceRequests[i], err = rr.GetByName(resourceName)
+				indexedResourceRequests[i], err = rr.GetRawByName(resourceName)
 				assert.Nil(t, err)
 			}
 			it, err := NewNodeTypesIterator(

--- a/internal/scheduler/scheduling/market_driven_preempting_queue_scheduler_test.go
+++ b/internal/scheduler/scheduling/market_driven_preempting_queue_scheduler_test.go
@@ -782,7 +782,7 @@ func TestMarketDrivenPreemptingQueueScheduler(t *testing.T) {
 				require.NoError(t, err)
 				for node := it.NextNode(); node != nil; node = it.NextNode() {
 					for _, p := range priorities {
-						for _, r := range node.AllocatableByPriority[p].GetResources() {
+						for _, r := range node.AllocatableByPriority[p].GetAll() {
 							assert.False(t, r.IsNegative(), "resource oversubscribed by %s on node %s", r.String(), node.GetId())
 						}
 					}

--- a/internal/scheduler/scheduling/optimiser/node_scheduler.go
+++ b/internal/scheduler/scheduling/optimiser/node_scheduler.go
@@ -256,11 +256,11 @@ func isTooLargeToEvict(job *jobdb.Job, limit *internaltypes.ResourceList) bool {
 	if jobResources.Factory() != limit.Factory() {
 		panic("mismatched ResourceListFactory in node_scheduler")
 	}
-	for i, resource := range limit.GetResources() {
+	for i, resource := range limit.GetAll() {
 		if resource.Value.IsZero() {
 			continue
 		}
-		result := resource.Value.Cmp(jobResources.GetResources()[i].Value)
+		result := resource.Value.Cmp(jobResources.GetAll()[i].Value)
 		if result < 0 {
 			return true
 		}

--- a/internal/scheduler/scheduling/preempting_queue_scheduler_test.go
+++ b/internal/scheduler/scheduling/preempting_queue_scheduler_test.go
@@ -76,7 +76,7 @@ func TestEvictOversubscribed(t *testing.T) {
 
 	for nodeId, node := range result.AffectedNodesById {
 		for _, p := range priorities {
-			for _, r := range node.AllocatableByPriority[p].GetResources() {
+			for _, r := range node.AllocatableByPriority[p].GetAll() {
 				assert.False(t, r.IsNegative(), "resource oversubscribed by %s on node %s", r.String(), nodeId)
 			}
 		}
@@ -2209,7 +2209,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 				require.NoError(t, err)
 				for node := it.NextNode(); node != nil; node = it.NextNode() {
 					for _, p := range priorities {
-						for _, r := range node.AllocatableByPriority[p].GetResources() {
+						for _, r := range node.AllocatableByPriority[p].GetAll() {
 							assert.False(t, r.IsNegative(), "resource oversubscribed by %s on node %s", r.String(), node.GetId())
 						}
 					}

--- a/internal/scheduler/simulator/sink/job_writer.go
+++ b/internal/scheduler/simulator/sink/job_writer.go
@@ -76,10 +76,10 @@ func (j *JobWriter) createJobRunRow(st *model.StateTransition) ([]*JobRunRow, er
 		associatedJob := jobsList[i]
 		if event.GetCancelledJob() != nil || event.GetJobSucceeded() != nil || event.GetJobRunPreempted() != nil {
 			// Resource requirements
-			cpuLimit := associatedJob.AllResourceRequirements().GetResourceByNameZeroIfMissing("cpu")
-			memoryLimit := associatedJob.AllResourceRequirements().GetResourceByNameZeroIfMissing("memory")
-			ephemeralStorageLimit := associatedJob.AllResourceRequirements().GetResourceByNameZeroIfMissing("ephemeral-storage")
-			gpuLimit := associatedJob.AllResourceRequirements().GetResourceByNameZeroIfMissing("nvidia.com/gpu")
+			cpuLimit := associatedJob.AllResourceRequirements().GetByNameZeroIfMissing("cpu")
+			memoryLimit := associatedJob.AllResourceRequirements().GetByNameZeroIfMissing("memory")
+			ephemeralStorageLimit := associatedJob.AllResourceRequirements().GetByNameZeroIfMissing("ephemeral-storage")
+			gpuLimit := associatedJob.AllResourceRequirements().GetByNameZeroIfMissing("nvidia.com/gpu")
 			eventTime := protoutil.ToStdTime(event.Created)
 
 			rows = append(rows, &JobRunRow{

--- a/internal/scheduler/simulator/sink/queue_stats_writer.go
+++ b/internal/scheduler/simulator/sink/queue_stats_writer.go
@@ -90,12 +90,12 @@ func (j *QueueStatsWriter) Close(ctx *armadacontext.Context) {
 }
 
 func calculateResourceShare(sctx *context.SchedulingContext, qctx *context.QueueSchedulingContext, resource string) float64 {
-	total := sctx.Allocated.GetResourceByNameZeroIfMissing(resource)
-	allocated := qctx.Allocated.GetResourceByNameZeroIfMissing(resource)
+	total := sctx.Allocated.GetByNameZeroIfMissing(resource)
+	allocated := qctx.Allocated.GetByNameZeroIfMissing(resource)
 	return allocated.AsApproximateFloat64() / total.AsApproximateFloat64()
 }
 
 func allocatedResources(qctx *context.QueueSchedulingContext, resource string) int {
-	allocated := qctx.Allocated.GetResourceByNameZeroIfMissing(resource)
+	allocated := qctx.Allocated.GetByNameZeroIfMissing(resource)
 	return int(allocated.AsApproximateFloat64())
 }


### PR DESCRIPTION
Gently discourage use of raw resource values by 
- adding `Raw` to the names of methods that return raw values
- removing `Resource` from the names of methods that return `resource.Quantity`.

Raw values remain available for where they are needed, for example in `nodedb` indexes.