### PR TITLE
fix: define rest port in executor deployment if healthcheck is enabled

### DIFF
--- a/deployment/executor/templates/deployment.yaml
+++ b/deployment/executor/templates/deployment.yaml
@@ -52,6 +52,11 @@ spec:
             - containerPort: 9001
               protocol: TCP
               name: metrics
+            {{- if .Values.healthcheck.enabled }}
+            - containerPort: {{ .Values.applicationConfig.httpPort }}
+              protocol: TCP
+              name: rest
+            {{- end }}
             {{- if and .Values.applicationConfig.profiling .Values.applicationConfig.profiling.port }}
             - containerPort: {{ .Values.applicationConfig.profiling.port }}
               protocol: TCP


### PR DESCRIPTION
#### What type of PR is this?

This is a fix PR as executor does not define a port if `healthcheck.enabled: true` is configured.

#### What this PR does / why we need it:

If healthcheck is enabled and the healthcheck (rest) port is not defined, K8s probes cannot reach it and report an issue:
```
  Warning  Unhealthy  7s (x6 over 57s)  kubelet            Liveness probe errored and resulted in unknown state: strconv.Atoi: parsing "rest": invalid syntax
  Warning  Unhealthy  4s (x7 over 62s)  kubelet            Readiness probe errored and resulted in unknown state: strconv.Atoi: parsing "rest": invalid syntax
```

And the pod will never reach Healthy state:
```
armada-executor-64f9d74dc5-8hssg   0/1     Running   0          59s
```