### PR TITLE
fix: replace default helm chart repositories from gresearchdev to gresearch; replace default image tags from 0.0.0-latest to latest

### DIFF
--- a/deployment/armada/README.md
+++ b/deployment/armada/README.md
@@ -58,7 +58,7 @@ helm uninstall armada-server
 | env | object | `{}` | Additional environment variables for Armada Server Deployment resource |
 | fullnameOverride | string | `""` |  |
 | hostnames | list | `[]` | Hostnames for which to create gRPC and REST Ingress rules |
-| image.repository | string | `"gresearchdev/armada-server"` |  |
+| image.repository | string | `"gresearch/armada-server"` |  |
 | image.tag | string | `"0.0.0-latest"` |  |
 | ingress.annotations | object | `{}` | Additional annotations for Ingress resource |
 | ingress.enabled | bool | `true` | Toggle whether to create gRPC and HTTP Ingress for Armada Server |

--- a/deployment/armada/values.yaml
+++ b/deployment/armada/values.yaml
@@ -2,8 +2,8 @@ nameOverride: ""
 fullnameOverride: ""
 
 image:
-  repository: gresearchdev/armada-server
-  tag: 0.0.0-latest
+  repository: gresearch/armada-server
+  tag: latest
 
 resources:
   limits:

--- a/deployment/binoculars/README.md
+++ b/deployment/binoculars/README.md
@@ -19,7 +19,7 @@ A helm chart for Armada Binoculars component
 | applicationConfig.httpPort | int | `8080` |  |
 | applicationConfig.metricsPort | int | `9000` |  |
 | customServiceAccount | string | `nil` |  |
-| image.repository | string | `"gresearchdev/armada-binoculars"` |  |
+| image.repository | string | `"gresearch/armada-binoculars"` |  |
 | image.tag | string | `"0.0.0-latest"` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.labels | object | `{}` |  |

--- a/deployment/binoculars/values.yaml
+++ b/deployment/binoculars/values.yaml
@@ -1,6 +1,6 @@
 image:
-  repository: gresearchdev/armada-binoculars
-  tag: 0.0.0-latest
+  repository: gresearch/armada-binoculars
+  tag: latest
 resources:
   limits:
     memory: 1Gi

--- a/deployment/event-ingester/README.md
+++ b/deployment/event-ingester/README.md
@@ -16,7 +16,7 @@ A helm chart for Armada Event Ingester component
 | applicationConfig.metricsPort | int | `9000` |  |
 | applicationConfig.pulsar.authenticationEnabled | bool | `false` |  |
 | customServiceAccount | string | `nil` |  |
-| image.repository | string | `"gresearchdev/event-ingester-ingester"` |  |
+| image.repository | string | `"gresearch/event-ingester-ingester"` |  |
 | image.tag | string | `"0.0.0-latest"` |  |
 | prometheus.enabled | bool | `false` |  |
 | prometheus.labels | object | `{}` |  |

--- a/deployment/event-ingester/values.yaml
+++ b/deployment/event-ingester/values.yaml
@@ -1,6 +1,6 @@
 image:
-  repository: gresearchdev/event-ingester-ingester
-  tag: 0.0.0-latest
+  repository: gresearch/event-ingester-ingester
+  tag: latest
 resources:
   limits:
     memory: 1Gi

--- a/deployment/executor/README.md
+++ b/deployment/executor/README.md
@@ -16,7 +16,7 @@ A helm chart for armada-executor component
 | applicationConfig.httpPort | int | `8080` |  |
 | customServiceAccount | string | `nil` |  |
 | healthcheck.enabled | bool | `false` |  |
-| image.repository | string | `"gresearchdev/armada-executor"` |  |
+| image.repository | string | `"gresearch/armada-executor"` |  |
 | image.tag | string | `"0.0.0-latest"` |  |
 | nodeSelector | object | `{}` |  |
 | priorityClassName | string | `""` |  |

--- a/deployment/executor/values.yaml
+++ b/deployment/executor/values.yaml
@@ -1,6 +1,6 @@
 image:
-  repository: gresearchdev/armada-executor
-  tag: 0.0.0-latest
+  repository: gresearch/armada-executor
+  tag: latest
 resources:
   limits:
     memory: 1Gi

--- a/deployment/lookout-ingester/README.md
+++ b/deployment/lookout-ingester/README.md
@@ -14,7 +14,7 @@ A helm chart for Armada Lookout Ingester component
 | applicationConfig.metricsPort | int | `9000` |  |
 | applicationConfig.pulsar.authenticationEnabled | bool | `false` |  |
 | customServiceAccount | string | `nil` |  |
-| image.repository | string | `"gresearchdev/armada-lookout-ingester"` |  |
+| image.repository | string | `"gresearch/armada-lookout-ingester"` |  |
 | image.tag | string | `"0.0.0-latest"` |  |
 | prometheus.enabled | bool | `false` |  |
 | prometheus.labels | object | `{}` |  |

--- a/deployment/lookout-ingester/values.yaml
+++ b/deployment/lookout-ingester/values.yaml
@@ -1,6 +1,6 @@
 image:
-  repository: gresearchdev/armada-lookout-ingester
-  tag: 0.0.0-latest
+  repository: gresearch/armada-lookout-ingester
+  tag: latest
 resources:
   limits:
     memory: 1Gi

--- a/deployment/lookout-migration/README.md
+++ b/deployment/lookout-migration/README.md
@@ -13,7 +13,7 @@ A Helm chart for the Armada Lookout  database migration
 | additionalVolumes | list | `[]` |  |
 | applicationConfig | object | `{}` |  |
 | customServiceAccount | string | `nil` |  |
-| image.repository | string | `"gresearchdev/armada-lookout"` |  |
+| image.repository | string | `"gresearch/armada-lookout"` |  |
 | image.tag | string | `"0.0.0-latest"` |  |
 | resources.limits.cpu | string | `"200m"` |  |
 | resources.limits.memory | string | `"256Mi"` |  |

--- a/deployment/lookout-migration/values.yaml
+++ b/deployment/lookout-migration/values.yaml
@@ -1,6 +1,6 @@
 image:
-  repository: gresearchdev/armada-lookout
-  tag: 0.0.0-latest
+  repository: gresearch/armada-lookout
+  tag: latest
 resources:
   limits:
     memory: 256Mi

--- a/deployment/lookout/README.md
+++ b/deployment/lookout/README.md
@@ -16,7 +16,7 @@ A helm chart for Armada Lookout component
 | applicationConfig.tls.enabled | bool | `false` |  |
 | customServiceAccount | string | `nil` |  |
 | dbPruningEnabled | bool | `true` |  |
-| image.repository | string | `"gresearchdev/armada-lookout-dev"` |  |
+| image.repository | string | `"gresearch/armada-lookout-dev"` |  |
 | image.tag | string | `"0.0.0-latest"` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.labels | object | `{}` |  |

--- a/deployment/lookout/values.yaml
+++ b/deployment/lookout/values.yaml
@@ -1,6 +1,6 @@
 image:
-  repository: gresearchdev/armada-lookout-dev
-  tag: 0.0.0-latest
+  repository: gresearch/armada-lookout
+  tag: latest
 resources:
   limits:
     memory: 1Gi

--- a/deployment/scheduler-migration/README.md
+++ b/deployment/scheduler-migration/README.md
@@ -14,7 +14,7 @@ A Helm chart for the Armada Scheduler database migration
 | applicationConfig | object | `{}` |  |
 | args.timeout | string | `"5m"` |  |
 | customServiceAccount | string | `nil` |  |
-| image.repository | string | `"gresearchdev/armada-scheduler"` |  |
+| image.repository | string | `"gresearch/armada-scheduler"` |  |
 | image.tag | string | `"0.0.0-latest"` |  |
 | resources.limits.cpu | string | `"200m"` |  |
 | resources.limits.memory | string | `"256Mi"` |  |

--- a/deployment/scheduler-migration/values.yaml
+++ b/deployment/scheduler-migration/values.yaml
@@ -1,6 +1,6 @@
 image:
-  repository: gresearchdev/armada-scheduler
-  tag: 0.0.0-latest
+  repository: gresearch/armada-scheduler
+  tag: latest
 resources:
   limits:
     memory: 256Mi

--- a/deployment/scheduler/README.md
+++ b/deployment/scheduler/README.md
@@ -14,7 +14,7 @@ A helm chart for Armada Scheduler component
 | ingester.applicationConfig.metricsPort | int | `9003` |  |
 | ingester.applicationConfig.pulsar | object | `{}` |  |
 | ingester.customServiceAccount | string | `nil` |  |
-| ingester.image.repository | string | `"gresearchdev/armada-scheduler-ingester"` |  |
+| ingester.image.repository | string | `"gresearch/armada-scheduler-ingester"` |  |
 | ingester.image.tag | string | `"0.0.0-latest"` |  |
 | ingester.prometheus.enabled | bool | `false` |  |
 | ingester.prometheus.labels | object | `{}` |  |
@@ -49,7 +49,7 @@ A helm chart for Armada Scheduler component
 | scheduler.applicationConfig.metrics.port | int | `9001` |  |
 | scheduler.applicationConfig.pulsar | object | `{}` |  |
 | scheduler.customServiceAccount | string | `nil` |  |
-| scheduler.image.repository | string | `"gresearchdev/armada-scheduler"` |  |
+| scheduler.image.repository | string | `"gresearch/armada-scheduler"` |  |
 | scheduler.image.tag | string | `"0.0.0-latest"` |  |
 | scheduler.ingress.annotations | object | `{}` |  |
 | scheduler.ingress.labels | object | `{}` |  |

--- a/deployment/scheduler/values.yaml
+++ b/deployment/scheduler/values.yaml
@@ -5,8 +5,8 @@ additionalLabels: {}
 scheduler:
   replicas: 1
   image:
-    repository: gresearchdev/armada-scheduler
-    tag: 0.0.0-latest
+    repository: gresearch/armada-scheduler
+    tag: latest
   resources:
     limits:
       memory: 1Gi
@@ -49,8 +49,8 @@ scheduler:
 ingester:
   replicas: 1
   image:
-    repository: gresearchdev/armada-scheduler-ingester
-    tag: 0.0.0-latest
+    repository: gresearch/armada-scheduler-ingester
+    tag: latest
   resources:
     limits:
       memory: 1Gi


### PR DESCRIPTION
#### What type of PR is this?

Fix PR for fixing default values in Helm charts.

#### What this PR does / why we need it:

`gresearchdev` repository was deprecated two years ago and `gresearch` should be used.
`0.0.0-latest` tag does not exist so `latest` should be default.