### PR TITLE
fix: mage ui target trying to change to an invalid dir

### DIFF
--- a/magefiles/yarn.go
+++ b/magefiles/yarn.go
@@ -20,7 +20,7 @@ func yarnRun(args ...string) error {
 		return err
 	}
 
-	if err := os.Chdir("../../.."); err != nil {
+	if err := os.Chdir("../.."); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

Fix broken mage target.

#### What this PR does / why we need it:

`mage ui` was reporting:
```
Error: chdir internal/lookoutui: no such file or directory
```

The yarnRun function in `magefiles/yarn.go` had an incorrect path - it was trying to return to the wrong directory level after changing into `internal/lookoutui`
