### PR TITLE
Using bitnamilegacy rather than bitnami for kubectl images

### DIFF
--- a/magefiles/kind.go
+++ b/magefiles/kind.go
@@ -25,7 +25,7 @@ func getImagesUsedInTestsOrControllers() []string {
 	return []string{
 		"nginx:1.27.0", // Used by ingress-controller
 		"alpine:3.20.0",
-		"bitnami/kubectl:1.30",
+		"bitnamilegacy/kubectl:1.30",
 	}
 }
 

--- a/testsuite/testcases/basic/gang.yaml
+++ b/testsuite/testcases/basic/gang.yaml
@@ -12,7 +12,7 @@ jobs:
       containers:
         - name: sleep
           imagePullPolicy: IfNotPresent
-          image: bitnami/kubectl:1.24.8
+          image: bitnamilegacy/kubectl:1.24.8
           command: ["bash", "-c"]
           args:
             - |

--- a/testsuite/testcases/basic/service_headless.yaml
+++ b/testsuite/testcases/basic/service_headless.yaml
@@ -14,7 +14,7 @@ jobs:
       containers:
         - name: client
           imagePullPolicy: IfNotPresent
-          image: bitnami/kubectl:1.24.8
+          image: bitnamilegacy/kubectl:1.24.8
           command: ["bash", "-c"]
           args:
             - |


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

#### What type of PR is this?

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Pulling kubectl from the bitnamilegacy repo rather than the bitnami repo as per advice from: https://hub.docker.com/r/bitnami/kubectl

