### PR TITLE
Allow pods to be retried when failed containers match regex

### DIFF
--- a/internal/executor/configuration/podchecks/types.go
+++ b/internal/executor/configuration/podchecks/types.go
@@ -49,8 +49,9 @@ type ContainerStatusCheck struct {
 }
 
 type FailedChecks struct {
-	Events      []PodEventCheck
-	PodStatuses []PodStatusCheck
+	Events            []PodEventCheck
+	PodStatuses       []PodStatusCheck
+	ContainerStatuses []FailedContainerStatusCheck
 }
 
 type PodEventCheck struct {
@@ -62,4 +63,9 @@ type PodEventCheck struct {
 type PodStatusCheck struct {
 	Regexp string
 	Reason string
+}
+
+type FailedContainerStatusCheck struct {
+	ContainerNameRegexp string
+	MessageRegexp       string
 }

--- a/internal/executor/podchecks/failedpodchecks/failed_container_status_checks.go
+++ b/internal/executor/podchecks/failedpodchecks/failed_container_status_checks.go
@@ -1,0 +1,67 @@
+package failedpodchecks
+
+import (
+	"fmt"
+	"regexp"
+
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/armadaproject/armada/internal/executor/configuration/podchecks"
+)
+
+type failedContainerStatusRetryChecker interface {
+	IsRetryable(pod *v1.Pod) (bool, string)
+}
+
+type failedContainerStatusCheck struct {
+	containerNameRegexp *regexp.Regexp
+	messageRegexp       *regexp.Regexp
+}
+
+type FailedContainerStatusChecker struct {
+	checks []failedContainerStatusCheck
+}
+
+func NewFailedContainerStatusChecker(checks []podchecks.FailedContainerStatusCheck) (*FailedContainerStatusChecker, error) {
+	podContainerStatusChecks := make([]failedContainerStatusCheck, 0, len(checks))
+
+	for _, check := range checks {
+		containerNameRegex, err := regexp.Compile(check.ContainerNameRegexp)
+		if err != nil {
+			return nil, fmt.Errorf("cannot parse regexp \"%s\": %+v", check.ContainerNameRegexp, err)
+		}
+		messageRegex, err := regexp.Compile(check.MessageRegexp)
+		if err != nil {
+			return nil, fmt.Errorf("cannot parse regexp \"%s\": %+v", check.MessageRegexp, err)
+		}
+
+		podContainerStatusChecks = append(podContainerStatusChecks, failedContainerStatusCheck{
+			containerNameRegexp: containerNameRegex,
+			messageRegexp:       messageRegex,
+		})
+	}
+	return &FailedContainerStatusChecker{
+		checks: podContainerStatusChecks,
+	}, nil
+}
+
+func (f *FailedContainerStatusChecker) IsRetryable(pod *v1.Pod) (bool, string) {
+	containers := pod.Status.ContainerStatuses
+	containers = append(containers, pod.Status.InitContainerStatuses...)
+
+	for _, check := range f.checks {
+		for _, container := range containers {
+			terminatedContainer := container.State.Terminated
+			if terminatedContainer != nil {
+				if check.containerNameRegexp.MatchString(container.Name) {
+					if check.messageRegexp.MatchString(terminatedContainer.Message) {
+						return true, terminatedContainer.Message
+					}
+				}
+			}
+
+		}
+	}
+
+	return false, ""
+}

--- a/internal/executor/podchecks/failedpodchecks/failed_container_status_checks_test.go
+++ b/internal/executor/podchecks/failedpodchecks/failed_container_status_checks_test.go
@@ -1,0 +1,138 @@
+package failedpodchecks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/armadaproject/armada/internal/executor/configuration/podchecks"
+)
+
+func TestFailedContainerStatusChecker_IsRetryable(t *testing.T) {
+	tests := map[string]struct {
+		input          *v1.Pod
+		checks         []podchecks.FailedContainerStatusCheck
+		expectedResult bool
+		expectMessage  bool
+	}{
+		"empty checks": {
+			input:          makePodInitContainerWithNameAndMessage("orange", "message"),
+			expectedResult: false,
+			expectMessage:  false,
+		},
+		"matches on name regex": {
+			input:          makePodContainerWithNameAndMessage("apple", ""),
+			checks:         []podchecks.FailedContainerStatusCheck{{ContainerNameRegexp: "app.*"}},
+			expectedResult: true,
+			expectMessage:  false,
+		},
+		"matches on message regex": {
+			input:          makePodInitContainerWithNameAndMessage("apple", "message"),
+			checks:         []podchecks.FailedContainerStatusCheck{{ContainerNameRegexp: ".*", MessageRegexp: "mess.*"}},
+			expectedResult: true,
+			expectMessage:  true,
+		},
+		"matches on name and message if supplied": {
+			input:          makePodContainerWithNameAndMessage("banana", "message"),
+			checks:         []podchecks.FailedContainerStatusCheck{{ContainerNameRegexp: "ban.*", MessageRegexp: "mess.*"}},
+			expectedResult: true,
+			expectMessage:  true,
+		},
+		"matches on name - no match": {
+			input:          makePodInitContainerWithNameAndMessage("plum", "message"),
+			checks:         []podchecks.FailedContainerStatusCheck{{ContainerNameRegexp: "app.*", MessageRegexp: ""}},
+			expectedResult: false,
+			expectMessage:  false,
+		},
+		"matches on message- no match": {
+			input:          makePodContainerWithNameAndMessage("plum", "message"),
+			checks:         []podchecks.FailedContainerStatusCheck{{ContainerNameRegexp: "plum", MessageRegexp: "memo.*"}},
+			expectedResult: false,
+			expectMessage:  false,
+		},
+		"multiple checks - no match": {
+			input: makePodInitContainerWithNameAndMessage("name", "message"),
+			checks: []podchecks.FailedContainerStatusCheck{
+				{ContainerNameRegexp: "nomenclature.*", MessageRegexp: ""},
+				{ContainerNameRegexp: "name", MessageRegexp: "memo.*"},
+				{ContainerNameRegexp: "nomenclature.*", MessageRegexp: "message2"},
+			},
+			expectedResult: false,
+			expectMessage:  false,
+		},
+		"multiple checks - match": {
+			input: makePodContainerWithNameAndMessage("name", "message"),
+			checks: []podchecks.FailedContainerStatusCheck{
+				{ContainerNameRegexp: ".*", MessageRegexp: ""},
+				{ContainerNameRegexp: "na.*", MessageRegexp: "message"},
+				{ContainerNameRegexp: "mess.*", MessageRegexp: ""},
+			},
+			expectedResult: true,
+			expectMessage:  true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			checker, err := NewFailedContainerStatusChecker(tc.checks)
+			require.NoError(t, err)
+
+			isRetryable, message := checker.IsRetryable(tc.input)
+
+			assert.Equal(t, tc.expectedResult, isRetryable)
+			if tc.expectMessage {
+				assert.NotEmpty(t, message)
+			} else {
+				assert.Empty(t, message)
+			}
+		})
+	}
+}
+
+func TestFailedContainerStatusChecker_Initialisation(t *testing.T) {
+	// Empty
+	_, err := NewFailedContainerStatusChecker([]podchecks.FailedContainerStatusCheck{})
+	assert.NoError(t, err)
+	// Valid
+	_, err = NewFailedContainerStatusChecker([]podchecks.FailedContainerStatusCheck{{ContainerNameRegexp: ".*"}})
+	assert.NoError(t, err)
+	// Invalid regex
+	_, err = NewFailedContainerStatusChecker([]podchecks.FailedContainerStatusCheck{{ContainerNameRegexp: ".*", MessageRegexp: "["}})
+	assert.Error(t, err)
+}
+
+func makePodInitContainerWithNameAndMessage(name string, message string) *v1.Pod {
+	return &v1.Pod{
+		Status: v1.PodStatus{
+			InitContainerStatuses: []v1.ContainerStatus{
+				{
+					Name: name,
+					State: v1.ContainerState{
+						Terminated: &v1.ContainerStateTerminated{
+							Message: message,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func makePodContainerWithNameAndMessage(name string, message string) *v1.Pod {
+	return &v1.Pod{
+		Status: v1.PodStatus{
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					Name: name,
+					State: v1.ContainerState{
+						Terminated: &v1.ContainerStateTerminated{
+							Message: message,
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/executor/podchecks/failedpodchecks/pod_checks_test.go
+++ b/internal/executor/podchecks/failedpodchecks/pod_checks_test.go
@@ -144,7 +144,7 @@ func TestPodRetryCheckerIsRetryable_ChecksPodHasNotStartedAnyContainers(t *testi
 			checker := PodRetryChecker{
 				podEventChecker:              &stubEventRetryChecker{isRetryable: true, message: "fallthrough"},
 				podStatusChecker:             &stubPodStatusRetryChecker{isRetryable: true, message: "fallthrough"},
-				failedContainerStatusChecker: &stubFailedContainerStatusChecker{isRetryable: false, message: ""}, //if this reaches evaluation, then failure results in a non-retryable state overall
+				failedContainerStatusChecker: &stubFailedContainerStatusChecker{isRetryable: false, message: ""}, // if this reaches evaluation, then failure results in a non-retryable state overall
 			}
 
 			isRetryable, message := checker.IsRetryable(tc.pod, []*v1.Event{})

--- a/internal/executor/podchecks/failedpodchecks/pod_checks_test.go
+++ b/internal/executor/podchecks/failedpodchecks/pod_checks_test.go
@@ -142,8 +142,9 @@ func TestPodRetryCheckerIsRetryable_ChecksPodHasNotStartedAnyContainers(t *testi
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			checker := PodRetryChecker{
-				podEventChecker:  &stubEventRetryChecker{isRetryable: true, message: "fallthrough"},
-				podStatusChecker: &stubPodStatusRetryChecker{isRetryable: true, message: "fallthrough"},
+				podEventChecker:              &stubEventRetryChecker{isRetryable: true, message: "fallthrough"},
+				podStatusChecker:             &stubPodStatusRetryChecker{isRetryable: true, message: "fallthrough"},
+				failedContainerStatusChecker: &stubFailedContainerStatusChecker{isRetryable: false, message: ""}, //if this reaches evaluation, then failure results in a non-retryable state overall
 			}
 
 			isRetryable, message := checker.IsRetryable(tc.pod, []*v1.Event{})
@@ -205,5 +206,14 @@ type stubPodStatusRetryChecker struct {
 }
 
 func (s *stubPodStatusRetryChecker) IsRetryable(pod *v1.Pod) (bool, string) {
+	return s.isRetryable, s.message
+}
+
+type stubFailedContainerStatusChecker struct {
+	isRetryable bool
+	message     string
+}
+
+func (s *stubFailedContainerStatusChecker) IsRetryable(pod *v1.Pod) (bool, string) {
 	return s.isRetryable, s.message
 }


### PR DESCRIPTION
This adds functionality to the executor to allow Armada to be configured such that pods that have failed and have entered "user" code, i.e any initContainers or Containers in non-pending state, can be retried if they match configured regex.

This regex is for the container name and the container message. For any retrying of this type to occur, both the container name regex and the message regex must match. Given the nature of regex, not setting the regex value results in that regex matching all string values.
For example, this configuration would retry any container where 'test' is in the termination message, regardless of the container name.
```
failedPodChecks:
  containerStatuses:
      messageRegexp: "test"
```
whereas this configuration would match any container, regardless of what the termination message is or if there is a termination message value at all. (The message string can be empty.)
```
failedPodChecks:
  containerStatuses:
    - containerNameRegexp: ".*"
```

