### PR TITLE
Also validation and add defaults to init containers in submit requests

### DIFF
--- a/internal/server/submit/conversion/post_process_test.go
+++ b/internal/server/submit/conversion/post_process_test.go
@@ -479,9 +479,18 @@ func TestDefaultResource(t *testing.T) {
 		"All Containers need defaults": {
 			config: defaultConfig,
 			podSpec: &v1.PodSpec{
-				Containers: []v1.Container{{}, {}},
+				InitContainers: []v1.Container{{}},
+				Containers:     []v1.Container{{}, {}},
 			},
 			expected: &v1.PodSpec{
+				InitContainers: []v1.Container{
+					{
+						Resources: v1.ResourceRequirements{
+							Requests: defaultExpected,
+							Limits:   defaultExpected,
+						},
+					},
+				},
 				Containers: []v1.Container{
 					{
 						Resources: v1.ResourceRequirements{
@@ -498,9 +507,24 @@ func TestDefaultResource(t *testing.T) {
 				},
 			},
 		},
-		"One container needs defaults": {
+		"Main and init containers needs defaults": {
 			config: defaultConfig,
 			podSpec: &v1.PodSpec{
+				InitContainers: []v1.Container{
+					{},
+					{
+						Resources: v1.ResourceRequirements{
+							Requests: map[v1.ResourceName]resource.Quantity{
+								"cpu":    resource.MustParse("20"),
+								"memory": resource.MustParse("2Gi"),
+							},
+							Limits: map[v1.ResourceName]resource.Quantity{
+								"cpu":    resource.MustParse("20"),
+								"memory": resource.MustParse("2Gi"),
+							},
+						},
+					},
+				},
 				Containers: []v1.Container{
 					{},
 					{
@@ -518,6 +542,26 @@ func TestDefaultResource(t *testing.T) {
 				},
 			},
 			expected: &v1.PodSpec{
+				InitContainers: []v1.Container{
+					{
+						Resources: v1.ResourceRequirements{
+							Requests: defaultExpected,
+							Limits:   defaultExpected,
+						},
+					},
+					{
+						Resources: v1.ResourceRequirements{
+							Requests: map[v1.ResourceName]resource.Quantity{
+								"cpu":    resource.MustParse("20"),
+								"memory": resource.MustParse("2Gi"),
+							},
+							Limits: map[v1.ResourceName]resource.Quantity{
+								"cpu":    resource.MustParse("20"),
+								"memory": resource.MustParse("2Gi"),
+							},
+						},
+					},
+				},
 				Containers: []v1.Container{
 					{
 						Resources: v1.ResourceRequirements{

--- a/internal/server/submit/validation/submit_request.go
+++ b/internal/server/submit/validation/submit_request.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"strings"
 
-	armadaslices "github.com/armadaproject/armada/internal/common/slices"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/component-helpers/scheduling/corev1/nodeaffinity"
 
+	armadaslices "github.com/armadaproject/armada/internal/common/slices"
 	"github.com/armadaproject/armada/internal/scheduler/jobdb"
 	"github.com/armadaproject/armada/internal/server/configuration"
 	"github.com/armadaproject/armada/pkg/api"

--- a/internal/server/submit/validation/submit_request.go
+++ b/internal/server/submit/validation/submit_request.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	armadaslices "github.com/armadaproject/armada/internal/common/slices"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/component-helpers/scheduling/corev1/nodeaffinity"
@@ -157,7 +158,7 @@ func validateHasQueue(r *api.JobSubmitRequest, _ configuration.SubmissionConfig)
 	return nil
 }
 
-// Ensures that each container exposes a given port at most once.
+// Ensures that each pod exposes a given port at most once.
 func validatePorts(j *api.JobSubmitRequestItem, _ configuration.SubmissionConfig) error {
 	spec := j.GetMainPodSpec()
 	existingPortSet := make(map[int32]int)
@@ -250,8 +251,7 @@ func validateResources(j *api.JobSubmitRequestItem, config configuration.Submiss
 	if maxOversubscriptionByResource == nil {
 		maxOversubscriptionByResource = map[string]float64{}
 	}
-	for _, container := range spec.Containers {
-
+	for _, container := range armadaslices.Concatenate(spec.Containers, spec.InitContainers) {
 		if len(container.Resources.Requests) == 0 && len(container.Resources.Requests) == 0 {
 			return fmt.Errorf("container %v has no resources specified", container.Name)
 		}

--- a/internal/server/submit/validation/submit_request_test.go
+++ b/internal/server/submit/validation/submit_request_test.go
@@ -885,6 +885,10 @@ func TestValidateResources(t *testing.T) {
 		v1.ResourceCPU: resource.MustParse("2"),
 	}
 
+	negativeOneCpu := v1.ResourceList{
+		v1.ResourceCPU: resource.MustParse("-1"),
+	}
+
 	tests := map[string]struct {
 		req                                  *api.JobSubmitRequestItem
 		minJobResources                      v1.ResourceList
@@ -968,6 +972,33 @@ func TestValidateResources(t *testing.T) {
 			maxOversubscriptionByResourceRequest: map[string]float64{
 				"cpu": 1.9,
 			},
+			expectSuccess: false,
+		},
+		"Negative resources request": {
+			req: reqFromContainer(v1.Container{
+				Resources: v1.ResourceRequirements{
+					Requests: negativeOneCpu,
+					Limits:   oneCpu,
+				},
+			}),
+			expectSuccess: false,
+		},
+		"Negative resource limit": {
+			req: reqFromContainer(v1.Container{
+				Resources: v1.ResourceRequirements{
+					Requests: oneCpu,
+					Limits:   negativeOneCpu,
+				},
+			}),
+			expectSuccess: false,
+		},
+		"Negative resources": {
+			req: reqFromContainer(v1.Container{
+				Resources: v1.ResourceRequirements{
+					Requests: negativeOneCpu,
+					Limits:   negativeOneCpu,
+				},
+			}),
 			expectSuccess: false,
 		},
 		"Request and limits the same": {

--- a/internal/server/submit/validation/submit_request_test.go
+++ b/internal/server/submit/validation/submit_request_test.go
@@ -1001,33 +1001,6 @@ func TestValidateResources(t *testing.T) {
 			}},
 			expectSuccess: false,
 		},
-		"Negative resources request": {
-			req: reqFromContainer(v1.Container{
-				Resources: v1.ResourceRequirements{
-					Requests: negativeOneCpu,
-					Limits:   oneCpu,
-				},
-			}),
-			expectSuccess: false,
-		},
-		"Negative resource limit": {
-			req: reqFromContainer(v1.Container{
-				Resources: v1.ResourceRequirements{
-					Requests: oneCpu,
-					Limits:   negativeOneCpu,
-				},
-			}),
-			expectSuccess: false,
-		},
-		"Negative resources": {
-			req: reqFromContainer(v1.Container{
-				Resources: v1.ResourceRequirements{
-					Requests: negativeOneCpu,
-					Limits:   negativeOneCpu,
-				},
-			}),
-			expectSuccess: false,
-		},
 		"Request and limits the same": {
 			containers: []v1.Container{{
 				Resources: v1.ResourceRequirements{

--- a/internal/server/submit/validation/submit_request_test.go
+++ b/internal/server/submit/validation/submit_request_test.go
@@ -890,41 +890,41 @@ func TestValidateResources(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		req                                  *api.JobSubmitRequestItem
+		containers                           []v1.Container
 		minJobResources                      v1.ResourceList
 		maxOversubscriptionByResourceRequest map[string]float64
 		expectSuccess                        bool
 	}{
 		"Requests Missing": {
-			req: reqFromContainer(v1.Container{
+			containers: []v1.Container{{
 				Resources: v1.ResourceRequirements{
 					Limits: oneCpu,
 				},
-			}),
+			}},
 			expectSuccess: false,
 		},
 		"Limits Missing": {
-			req: reqFromContainer(v1.Container{
+			containers: []v1.Container{{
 				Resources: v1.ResourceRequirements{
 					Requests: oneCpu,
 				},
-			}),
+			}},
 			expectSuccess: false,
 		},
 		"Limits Less Than Request": {
-			req: reqFromContainer(v1.Container{
+			containers: []v1.Container{{
 				Resources: v1.ResourceRequirements{
 					Requests: twoCpu,
 					Limits:   oneCpu,
 				},
-			}),
+			}},
 			expectSuccess: false,
 			maxOversubscriptionByResourceRequest: map[string]float64{
 				"cpu": 2.0,
 			},
 		},
 		"Limits And Requests specify different resources": {
-			req: reqFromContainer(v1.Container{
+			containers: []v1.Container{{
 				Resources: v1.ResourceRequirements{
 					Requests: v1.ResourceList{
 						v1.ResourceCPU: resource.MustParse("1"),
@@ -934,7 +934,7 @@ func TestValidateResources(t *testing.T) {
 						v1.ResourceMemory: resource.MustParse("2Gi"),
 					},
 				},
-			}),
+			}},
 			expectSuccess: false,
 			maxOversubscriptionByResourceRequest: map[string]float64{
 				"cpu":    2.0,
@@ -942,76 +942,76 @@ func TestValidateResources(t *testing.T) {
 			},
 		},
 		"Requests and limits different with MaxResourceOversubscriptionByResourceRequest undefined": {
-			req: reqFromContainer(v1.Container{
+			containers: []v1.Container{{
 				Resources: v1.ResourceRequirements{
 					Requests: oneCpu,
 					Limits:   twoCpu,
 				},
-			}),
+			}},
 			expectSuccess: false,
 		},
 		"Requests and limits different, passes MaxResourceOversubscriptionByResourceRequest": {
-			req: reqFromContainer(v1.Container{
+			containers: []v1.Container{{
 				Resources: v1.ResourceRequirements{
 					Requests: oneCpu,
 					Limits:   twoCpu,
 				},
-			}),
+			}},
 			maxOversubscriptionByResourceRequest: map[string]float64{
 				"cpu": 2.0,
 			},
 			expectSuccess: true,
 		},
 		"Requests and limits different, fails MaxResourceOversubscriptionByResourceRequest": {
-			req: reqFromContainer(v1.Container{
+			containers: []v1.Container{{
 				Resources: v1.ResourceRequirements{
 					Requests: oneCpu,
 					Limits:   twoCpu,
 				},
-			}),
+			}},
+			expectSuccess: false,
 			maxOversubscriptionByResourceRequest: map[string]float64{
 				"cpu": 1.9,
 			},
-			expectSuccess: false,
 		},
 		"Negative resources request": {
-			req: reqFromContainer(v1.Container{
+			containers: []v1.Container{{
 				Resources: v1.ResourceRequirements{
 					Requests: negativeOneCpu,
 					Limits:   oneCpu,
 				},
-			}),
+			}},
 			expectSuccess: false,
 		},
 		"Negative resource limit": {
-			req: reqFromContainer(v1.Container{
+			containers: []v1.Container{{
 				Resources: v1.ResourceRequirements{
 					Requests: oneCpu,
 					Limits:   negativeOneCpu,
 				},
-			}),
+			}},
 			expectSuccess: false,
 		},
 		"Negative resources": {
-			req: reqFromContainer(v1.Container{
+			containers: []v1.Container{{
 				Resources: v1.ResourceRequirements{
 					Requests: negativeOneCpu,
 					Limits:   negativeOneCpu,
 				},
-			}),
+			}},
 			expectSuccess: false,
 		},
 		"Request and limits the same": {
-			req: reqFromContainer(v1.Container{
+			containers: []v1.Container{{
 				Resources: v1.ResourceRequirements{
 					Requests: oneCpu,
 					Limits:   oneCpu,
 				},
-			}),
+			}},
 			expectSuccess: true,
 		},
 		"Request and limits the same with two containers": {
-			req: reqFromContainers([]v1.Container{
+			containers: []v1.Container{
 				{
 					Resources: v1.ResourceRequirements{
 						Requests: oneCpu,
@@ -1024,23 +1024,30 @@ func TestValidateResources(t *testing.T) {
 						Limits:   twoCpu,
 					},
 				},
-			}),
+			},
 			expectSuccess: true,
 		},
 	}
 	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			submitConfg := configuration.SubmissionConfig{}
-			if tc.maxOversubscriptionByResourceRequest != nil {
-				submitConfg.MaxOversubscriptionByResourceRequest = tc.maxOversubscriptionByResourceRequest
-			}
-			err := validateResources(tc.req, submitConfg)
-			if tc.expectSuccess {
-				assert.NoError(t, err)
-			} else {
-				assert.Error(t, err)
-			}
-		})
+		runTest := func(name string, req *api.JobSubmitRequestItem) {
+			t.Run(name, func(t *testing.T) {
+				submitConfg := configuration.SubmissionConfig{}
+				if tc.maxOversubscriptionByResourceRequest != nil {
+					submitConfg.MaxOversubscriptionByResourceRequest = tc.maxOversubscriptionByResourceRequest
+				}
+				err := validateResources(req, submitConfg)
+				if tc.expectSuccess {
+					assert.NoError(t, err)
+				} else {
+					assert.Error(t, err)
+				}
+			})
+		}
+
+		// Run the tests for a request with main containers, a request with init containers and a request containing both
+		runTest(name+" - main containers", reqWithContainers(nil, tc.containers))
+		runTest(name+" - init containers", reqWithContainers(tc.containers, nil))
+		runTest(name+" - combined containers", reqWithContainers(tc.containers, tc.containers))
 	}
 }
 
@@ -1285,13 +1292,12 @@ func TestValidateRestrictedTolerations(t *testing.T) {
 	}
 }
 
-func reqFromContainer(container v1.Container) *api.JobSubmitRequestItem {
-	return reqFromContainers([]v1.Container{container})
-}
-
-func reqFromContainers(containers []v1.Container) *api.JobSubmitRequestItem {
+func reqWithContainers(initContainers []v1.Container, containers []v1.Container) *api.JobSubmitRequestItem {
 	return &api.JobSubmitRequestItem{
-		PodSpec: &v1.PodSpec{Containers: containers},
+		PodSpec: &v1.PodSpec{
+			InitContainers: initContainers,
+			Containers:     containers,
+		},
 	}
 }
 


### PR DESCRIPTION
We run validation against the containers in a submit request, however we don't validate or add defaults to init containers

This could result in unexpected pods getting through to the scheduler and causing bugs

