### PR TITLE
Reducing scheduler startup memory allocations (#453)

### DIFF
--- a/internal/common/metrics/scheduler_metrics.go
+++ b/internal/common/metrics/scheduler_metrics.go
@@ -250,6 +250,13 @@ var QueuePriceBandPhaseBidDesc = prometheus.NewDesc(
 	nil,
 )
 
+var JobDBCumulativeInternedStrings = prometheus.NewDesc(
+	MetricPrefix+"scheduler_interned_strings",
+	"A cumulative count of interned strings",
+	[]string{},
+	nil,
+)
+
 var (
 	queueLabelMetricName        = MetricPrefix + "queue_labels"
 	queueLabelMetricDescription = "Queue labels"
@@ -295,6 +302,7 @@ var AllDescs = []*prometheus.Desc{
 	QueuePriorityDesc,
 	QueueLabelDesc,
 	QueuePriceBandPhaseBidDesc,
+	JobDBCumulativeInternedStrings,
 }
 
 func Describe(out chan<- *prometheus.Desc) {
@@ -536,6 +544,10 @@ func NewMedianQueuePriceRunningMetric(value float64, pool string, priorityClass 
 
 func NewQueuePriceBandBidMetric(value float64, pool string, queue string, phase, priceBand string) prometheus.Metric {
 	return prometheus.MustNewConstMetric(QueuePriceBandPhaseBidDesc, prometheus.GaugeValue, value, pool, queue, queue, phase, priceBand)
+}
+
+func NewJobDBCumulativeInternedStrings(value float64) prometheus.Metric {
+	return prometheus.MustNewConstMetric(JobDBCumulativeInternedStrings, prometheus.CounterValue, value)
 }
 
 func NewQueueLabelsMetric(queue string, labels map[string]string) prometheus.Metric {

--- a/internal/scheduler/metrics.go
+++ b/internal/scheduler/metrics.go
@@ -141,7 +141,8 @@ func (c *MetricsCollector) refresh(ctx *armadacontext.Context) error {
 	if err != nil {
 		return err
 	}
-	allMetrics := append(queueMetrics, clusterMetrics...)
+	jobDbMetrics := c.updateJobDBMetrics()
+	allMetrics := append(append(queueMetrics, clusterMetrics...), jobDbMetrics...)
 	c.state.Store(allMetrics)
 	ctx.Debugf("Refreshed prometheus metrics in %s", time.Since(start))
 	return nil
@@ -485,6 +486,10 @@ func (c *MetricsCollector) updateClusterMetrics(ctx *armadacontext.Context) ([]p
 		clusterMetrics = append(clusterMetrics, commonmetrics.NewClusterCordonedStatus(v.status, cluster, v.reason, v.setByUser))
 	}
 	return clusterMetrics, nil
+}
+
+func (c *MetricsCollector) updateJobDBMetrics() []prometheus.Metric {
+	return []prometheus.Metric{commonmetrics.NewJobDBCumulativeInternedStrings(float64(c.jobDb.CumulativeInternedStringsCount()))}
 }
 
 func addToResourceListMap[K comparable](m map[K]resource.ComputeResources, key K, value resource.ComputeResources) {

--- a/internal/scheduler/metrics_test.go
+++ b/internal/scheduler/metrics_test.go
@@ -106,7 +106,7 @@ func TestMetricsCollector_TestCollect_QueueMetrics(t *testing.T) {
 			},
 		},
 		"queued metrics for requeued job": {
-			// This job was been requeued and has a terminated run
+			// This job was requeued and has a terminated run
 			// The queue duration stats should count from the time the last run finished instead of job creation time
 			initialJobs: []*jobdb.Job{jobWithTerminatedRun},
 			queues:      []*api.Queue{queue},
@@ -293,6 +293,7 @@ func TestMetricsCollector_TestCollect_ClusterMetrics(t *testing.T) {
 				commonmetrics.NewClusterFarmCapacity(64, "cluster-1", testfixtures.TestPool, "cpu", "type-1"),
 				commonmetrics.NewClusterFarmCapacity(512*1024*1024*1024, "cluster-1", testfixtures.TestPool, "memory", "type-1"),
 				commonmetrics.NewClusterCordonedStatus(0.0, "cluster-1", "", ""),
+				commonmetrics.NewJobDBCumulativeInternedStrings(0.0),
 			},
 			expectedExecutorSettings: []*schedulerobjects.ExecutorSettings{},
 		},
@@ -317,6 +318,7 @@ func TestMetricsCollector_TestCollect_ClusterMetrics(t *testing.T) {
 				commonmetrics.NewClusterFarmCapacity(32, "cluster-1", testfixtures.TestPool, "cpu", "type-2"),
 				commonmetrics.NewClusterFarmCapacity(256*1024*1024*1024, "cluster-1", testfixtures.TestPool, "memory", "type-2"),
 				commonmetrics.NewClusterCordonedStatus(0.0, "cluster-1", "", ""),
+				commonmetrics.NewJobDBCumulativeInternedStrings(0.0),
 			},
 			expectedExecutorSettings: []*schedulerobjects.ExecutorSettings{},
 		},
@@ -333,6 +335,7 @@ func TestMetricsCollector_TestCollect_ClusterMetrics(t *testing.T) {
 				commonmetrics.NewClusterFarmCapacity(64, "cluster-1", testfixtures.TestPool, "cpu", "type-1"),
 				commonmetrics.NewClusterFarmCapacity(512*1024*1024*1024, "cluster-1", testfixtures.TestPool, "memory", "type-1"),
 				commonmetrics.NewClusterCordonedStatus(0.0, "cluster-1", "", ""),
+				commonmetrics.NewJobDBCumulativeInternedStrings(0.0),
 			},
 			expectedExecutorSettings: []*schedulerobjects.ExecutorSettings{},
 		},
@@ -355,6 +358,7 @@ func TestMetricsCollector_TestCollect_ClusterMetrics(t *testing.T) {
 				commonmetrics.NewClusterFarmCapacity(32, "cluster-1", testfixtures.TestPool, "cpu", "type-1"),
 				commonmetrics.NewClusterFarmCapacity(256*1024*1024*1024, "cluster-1", testfixtures.TestPool, "memory", "type-1"),
 				commonmetrics.NewClusterCordonedStatus(0.0, "cluster-1", "", ""),
+				commonmetrics.NewJobDBCumulativeInternedStrings(0.0),
 			},
 			expectedExecutorSettings: []*schedulerobjects.ExecutorSettings{},
 		},
@@ -373,6 +377,7 @@ func TestMetricsCollector_TestCollect_ClusterMetrics(t *testing.T) {
 				commonmetrics.NewClusterFarmCapacity(32, "cluster-1", testfixtures.TestPool, "cpu", "type-1"),
 				commonmetrics.NewClusterFarmCapacity(256*1024*1024*1024, "cluster-1", testfixtures.TestPool, "memory", "type-1"),
 				commonmetrics.NewClusterCordonedStatus(0.0, "cluster-1", "", ""),
+				commonmetrics.NewJobDBCumulativeInternedStrings(0.0),
 			},
 			expectedExecutorSettings: []*schedulerobjects.ExecutorSettings{},
 		},
@@ -383,6 +388,7 @@ func TestMetricsCollector_TestCollect_ClusterMetrics(t *testing.T) {
 			expected: []prometheus.Metric{
 				commonmetrics.NewClusterAvailableCapacity(10, "floating", "pool", "test-floating-resource", ""),
 				commonmetrics.NewClusterTotalCapacity(10, "floating", "pool", "test-floating-resource", ""),
+				commonmetrics.NewJobDBCumulativeInternedStrings(0.0),
 			},
 			expectedExecutorSettings: []*schedulerobjects.ExecutorSettings{},
 		},
@@ -399,6 +405,7 @@ func TestMetricsCollector_TestCollect_ClusterMetrics(t *testing.T) {
 				commonmetrics.NewClusterFarmCapacity(64, "cluster-1", testfixtures.TestPool, "cpu", "type-1"),
 				commonmetrics.NewClusterFarmCapacity(512*1024*1024*1024, "cluster-1", testfixtures.TestPool, "memory", "type-1"),
 				commonmetrics.NewClusterCordonedStatus(1.0, "cluster-1", "bad executor", ""),
+				commonmetrics.NewJobDBCumulativeInternedStrings(0.0),
 			},
 			expectedExecutorSettings: []*schedulerobjects.ExecutorSettings{
 				{

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -420,6 +420,17 @@ func (s *Scheduler) syncState(ctx *armadacontext.Context, initial, fullJobGc boo
 		}
 	}
 
+	latestJobSerial := s.jobsSerial
+	latestRunsSerial := s.runsSerial
+
+	// Update serial to include these updates.
+	if len(updatedJobs) > 0 {
+		latestJobSerial = updatedJobs[len(updatedJobs)-1].Serial
+	}
+	if len(updatedRuns) > 0 {
+		latestRunsSerial = updatedRuns[len(updatedRuns)-1].Serial
+	}
+
 	// Reconcile any differences between the updated jobs and runs.
 	jsts, err := s.jobDb.ReconcileDifferences(txn, updatedJobs, updatedRuns)
 	if err != nil {
@@ -462,13 +473,8 @@ func (s *Scheduler) syncState(ctx *armadacontext.Context, initial, fullJobGc boo
 
 	txn.Commit()
 
-	// Update serial to include these updates.
-	if len(updatedJobs) > 0 {
-		s.jobsSerial = updatedJobs[len(updatedJobs)-1].Serial
-	}
-	if len(updatedRuns) > 0 {
-		s.runsSerial = updatedRuns[len(updatedRuns)-1].Serial
-	}
+	s.jobsSerial = latestJobSerial
+	s.runsSerial = latestRunsSerial
 
 	return jobDbJobs, jsts, nil
 }


### PR DESCRIPTION
* ARMADA-3668 Numerous Scheduler Optimisations

Changes include: making transaction upserts faster and more memory efficient for the startup case, moving last use of job repository jobs earlier in syncState to allow for garbage collecting, interning Job ID on run.

* Correcting annotation and nodeSelector interning, not modifying the map in place

* Exposing cumulative interned strings as a metric

* Fixing tests, correctly calculating latest job&run serial in scheduler

<!--  Thanks for sending a pull request!  Here are some tips for you:

#### What type of PR is this?

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Summary of changes:
- Populating `Txn` jobs in a map at startup before creating immutable data structures, reducing garbage
- Exposing `scheduler_interned_strings` metric to help investigate production memory usage
- Setting last use of `updatedJobs` and `updatedRuns` to earlier so they can be GCed

