### PR TITLE
Make executor ignore all scheduling events when determining if no action is taken on Pending pod

### DIFF
--- a/internal/executor/podchecks/kubernetes_constants.go
+++ b/internal/executor/podchecks/kubernetes_constants.go
@@ -1,3 +1,4 @@
 package podchecks
 
 const EventReasonScheduled = "Scheduled"
+const EvenReasonFailedScheduling = "FailedScheduling"

--- a/internal/executor/podchecks/pod_checks.go
+++ b/internal/executor/podchecks/pod_checks.go
@@ -81,9 +81,9 @@ func (pc *PodChecks) GetAction(pod *v1.Pod, podEvents []*v1.Event, timeInState t
 
 // This func is trying to determine if the node is bad based on the kubelet not updating the pod at all
 func (pc *PodChecks) isBadNode(pod *v1.Pod, podEvents []*v1.Event) bool {
-	// Ignore the Scheduled event as this comes from the kube-scheduler
+	// Ignore the scheduling events as this comes from the kube-scheduler
 	podEvents = slices.Filter(podEvents, func(e *v1.Event) bool {
-		return e.Reason != EventReasonScheduled
+		return e.Reason != EventReasonScheduled && e.Reason != EvenReasonFailedScheduling
 	})
 
 	containerStatus := util.GetPodContainerStatuses(pod)

--- a/internal/executor/podchecks/pod_checks_test.go
+++ b/internal/executor/podchecks/pod_checks_test.go
@@ -76,6 +76,14 @@ func Test_GetAction_BadNode_ShouldIgnoreScheduledEvents(t *testing.T) {
 	assert.Equal(t, message, "Pod has received no updates within 1m0s deadline - likely the node is bad. Retrying")
 }
 
+func Test_GetAction_BadNode_ShouldIgnoreFailedSchedulingEvents(t *testing.T) {
+	podChecks := podChecksWithMocks(ActionWait, ActionWait)
+	result, cause, message := podChecks.GetAction(createBasicPod(true), []*v1.Event{{Message: "Failed to schedule onto node", Reason: EvenReasonFailedScheduling}}, 10*time.Minute)
+	assert.Equal(t, result, ActionRetry)
+	assert.Equal(t, cause, NoStatusUpdates)
+	assert.Equal(t, message, "Pod has received no updates within 1m0s deadline - likely the node is bad. Retrying")
+}
+
 func Test_GetAction_BadNodeButUnderTimeLimit(t *testing.T) {
 	podChecks := podChecksWithMocks(ActionWait, ActionWait)
 	result, cause, message := podChecks.GetAction(createBasicPod(true), []*v1.Event{}, 10*time.Second)


### PR DESCRIPTION

The executor aims to return the lease of a pod if the kubelet has taken no action for X minutes

We currently filter our scheduling events of this check (as the kube-scheduler sends these), however we're not filtering failed scheduling events
 - Our pods often get failed scheduling events due to needing to wait for a preempted pod to be deleted first

This pod simply changes that to now filter all scheduling events (including failed) - as otherwise the "no action" check gets confused and pods can sit around for a long time (until k8s cleans up the events)

Longer term this needs a more thorough rework - but this will alleviate a key known issue for minimal change


