### PR TITLE
feat: try to truncate long events and not fail immediatelly

### DIFF
--- a/internal/executor/service/pod_issue_handler.go
+++ b/internal/executor/service/pod_issue_handler.go
@@ -302,6 +302,9 @@ func (p *PodIssueHandler) detectPodIssues(allManagedPods []*v1.Pod) {
 	}
 }
 
+// Maximum size for debug messages to prevent Pulsar message overflow
+const maxDebugMessageSize = 10 * 1024
+
 func createDebugMessage(podEvents []*v1.Event) string {
 	events := make([]v1.Event, 0, len(podEvents))
 	for _, e := range podEvents {
@@ -313,7 +316,12 @@ func createDebugMessage(podEvents []*v1.Event) string {
 	prefixWriter := describe.NewPrefixWriter(&writer)
 
 	describe.DescribeEvents(&eventList, prefixWriter)
-	return writer.String()
+
+	message := writer.String()
+	if len(message) > maxDebugMessageSize {
+		message = "[truncated]..." + message[len(message)-maxDebugMessageSize:]
+	}
+	return message
 }
 
 // Returns true if the pod has been running longer than its activeDeadlineSeconds + grace period


### PR DESCRIPTION
#### What type of PR is this?
Bug fix / Enhancement

#### What this PR does / why we need it:
Prevents executor from losing events when in case of event storms exceeding the max event squence size limit.

Also fixes a bug where the executor was using a hardcoded 4MB limit instead of the configured value.

#### How to test
1. Set a low message size limit in `_local/executor/config.yaml` (if using the localdev):
```yaml
client:
  maxMessageSizeBytes: 20000  # 20KB for testing
```

2. Submit a job that will get stuck (e.g., using a nonexistent image):
```yaml
queue: queue-a
jobSetId: stuck-job-set
jobs:
  - namespace: default
    priority: 0
    podSpec:
      terminationGracePeriodSeconds: 0
      restartPolicy: Never
      containers:
        - name: stuck
          image: nonexistent-image:latest  # This will cause image pull failures
          command:
            - sh
          args:
            - -c
            - sleep 60
          resources:
            limits:
              memory: 128Mi
              cpu: 0.2
            requests:
              memory: 128Mi
              cpu: 0.2
```

3. Generate many K8s events for the pod to trigger truncation:
```bash
# Get pod name and UID
kubectl get pods | grep stuck
POD_NAME=<pod-name>
POD_UID=$(kubectl get pod $POD_NAME -o jsonpath='{.metadata.uid}')

# Create 200+ events to trigger truncation (example below, repeat ~200 times with unique names)
for i in {1..200}; do
kubectl apply -f - <<EOF
apiVersion: v1
kind: Event
metadata:
  name: test-event-$i-$(date +%s)
  namespace: default
involvedObject:
  apiVersion: v1
  kind: Pod
  name: $POD_NAME
  namespace: default
  uid: $POD_UID
type: Warning
reason: FailedScheduling
message: "0/100 nodes are available: Insufficient cpu (50), Insufficient memory (30), node(s) had taint {dedicated: gpu}, that the pod didn't tolerate (20)."
firstTimestamp: "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
lastTimestamp: "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
count: 1
source:
  component: test-event-generator
  host: $(hostname)
EOF
done
```

4. Check executor logs for truncation - events should be sent successfully with warning:
```
WARN Truncated event from 41509 bytes to 17330 bytes to fit within 19950 byte limit
```

The event will be delivered instead of failing completely.