### PR TITLE
chore: update go to v1.25

### DIFF
--- a/.github/actions/setup-go-cache/action.yml
+++ b/.github/actions/setup-go-cache/action.yml
@@ -5,9 +5,9 @@ inputs:
     description: "Prefix for the cache key"
     required: true
   go-version:
-    description: "Version of Go. Default 1.24"
+    description: "Version of Go. Default 1.25"
     required: false
-    default: "1.24"
+    default: "1.25"
   cache-tools:
     description: "True/false flag to cache tools"
     required: false

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,7 +19,7 @@ env:
   # To use a builder other than "default", set this variable.
   # Necessary for, e.g., GitHub actions cache integration.
   - DOCKER_BUILDX_BUILDER={{ if index .Env "DOCKER_BUILDX_BUILDER"  }}{{ .Env.DOCKER_BUILDX_BUILDER }}{{ else }}default{{ end }}
-  - GOVERSION={{ if index .Env "GOVERSION"  }}{{ .Env.GOVERSION }}{{ else }}go1.24{{ end }}
+  - GOVERSION={{ if index .Env "GOVERSION"  }}{{ .Env.GOVERSION }}{{ else }}go1.25{{ end }}
 
 builds:
   - env: [CGO_ENABLED=0]

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -72,7 +72,7 @@ For more information about Armada's design, see the following pages:
 
 Before you can start using Armada, you first need to install the following items:
 
-- [`Go`](https://go.dev/doc/install) (version 1.23 or later)
+- [`Go`](https://go.dev/doc/install) (version 1.25 or later)
 - `gcc` (for Windows, [see `tdm-gcc`](https://jmeubank.github.io/tdm-gcc/))
 - [`mage`](https://magefile.org/)
 - [`docker`](https://docs.docker.com/get-docker/)

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/armadaproject/armada
 
-go 1.24
+go 1.25
 
-toolchain go1.24.1
+toolchain go1.25.3
 
 require (
 	github.com/apache/pulsar-client-go v0.14.0

--- a/internal/lookout/gen/models/filter.go
+++ b/internal/lookout/gen/models/filter.go
@@ -35,7 +35,7 @@ type Filter struct {
 
 	// value
 	// Required: true
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // Validate validates this filter
@@ -73,7 +73,7 @@ func (m *Filter) validateField(formats strfmt.Registry) error {
 	return nil
 }
 
-var filterTypeMatchPropEnum []interface{}
+var filterTypeMatchPropEnum []any
 
 func init() {
 	var res []string

--- a/internal/lookout/gen/models/group.go
+++ b/internal/lookout/gen/models/group.go
@@ -21,7 +21,7 @@ type Group struct {
 
 	// aggregates
 	// Required: true
-	Aggregates map[string]interface{} `json:"aggregates"`
+	Aggregates map[string]any `json:"aggregates"`
 
 	// count
 	// Required: true
@@ -74,7 +74,7 @@ func (m *Group) validateAggregates(formats strfmt.Registry) error {
 
 func (m *Group) validateCount(formats strfmt.Registry) error {
 
-	if err := validate.Required("count", "body", int64(m.Count)); err != nil {
+	if err := validate.Required("count", "body", m.Count); err != nil {
 		return err
 	}
 

--- a/internal/lookout/gen/models/job.go
+++ b/internal/lookout/gen/models/job.go
@@ -8,6 +8,7 @@ package models
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"strconv"
 
 	"github.com/go-openapi/errors"
@@ -238,7 +239,7 @@ func (m *Job) validateCluster(formats strfmt.Registry) error {
 
 func (m *Job) validateCPU(formats strfmt.Registry) error {
 
-	if err := validate.Required("cpu", "body", int64(m.CPU)); err != nil {
+	if err := validate.Required("cpu", "body", m.CPU); err != nil {
 		return err
 	}
 
@@ -247,7 +248,7 @@ func (m *Job) validateCPU(formats strfmt.Registry) error {
 
 func (m *Job) validateDuplicate(formats strfmt.Registry) error {
 
-	if err := validate.Required("duplicate", "body", bool(m.Duplicate)); err != nil {
+	if err := validate.Required("duplicate", "body", m.Duplicate); err != nil {
 		return err
 	}
 
@@ -256,7 +257,7 @@ func (m *Job) validateDuplicate(formats strfmt.Registry) error {
 
 func (m *Job) validateEphemeralStorage(formats strfmt.Registry) error {
 
-	if err := validate.Required("ephemeralStorage", "body", int64(m.EphemeralStorage)); err != nil {
+	if err := validate.Required("ephemeralStorage", "body", m.EphemeralStorage); err != nil {
 		return err
 	}
 
@@ -265,7 +266,7 @@ func (m *Job) validateEphemeralStorage(formats strfmt.Registry) error {
 
 func (m *Job) validateGpu(formats strfmt.Registry) error {
 
-	if err := validate.Required("gpu", "body", int64(m.Gpu)); err != nil {
+	if err := validate.Required("gpu", "body", m.Gpu); err != nil {
 		return err
 	}
 
@@ -300,7 +301,7 @@ func (m *Job) validateJobSet(formats strfmt.Registry) error {
 
 func (m *Job) validateLastTransitionTime(formats strfmt.Registry) error {
 
-	if err := validate.Required("lastTransitionTime", "body", strfmt.DateTime(m.LastTransitionTime)); err != nil {
+	if err := validate.Required("lastTransitionTime", "body", m.LastTransitionTime); err != nil {
 		return err
 	}
 
@@ -317,7 +318,7 @@ func (m *Job) validateLastTransitionTime(formats strfmt.Registry) error {
 
 func (m *Job) validateMemory(formats strfmt.Registry) error {
 
-	if err := validate.Required("memory", "body", int64(m.Memory)); err != nil {
+	if err := validate.Required("memory", "body", m.Memory); err != nil {
 		return err
 	}
 
@@ -339,7 +340,7 @@ func (m *Job) validateOwner(formats strfmt.Registry) error {
 
 func (m *Job) validatePriority(formats strfmt.Registry) error {
 
-	if err := validate.Required("priority", "body", int64(m.Priority)); err != nil {
+	if err := validate.Required("priority", "body", m.Priority); err != nil {
 		return err
 	}
 
@@ -372,11 +373,15 @@ func (m *Job) validateRuns(formats strfmt.Registry) error {
 
 		if m.Runs[i] != nil {
 			if err := m.Runs[i].Validate(formats); err != nil {
-				if ve, ok := err.(*errors.Validation); ok {
+				ve := new(errors.Validation)
+				if stderrors.As(err, &ve) {
 					return ve.ValidateName("runs" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
+				}
+				ce := new(errors.CompositeError)
+				if stderrors.As(err, &ce) {
 					return ce.ValidateName("runs" + "." + strconv.Itoa(i))
 				}
+
 				return err
 			}
 		}
@@ -388,14 +393,14 @@ func (m *Job) validateRuns(formats strfmt.Registry) error {
 
 func (m *Job) validateRuntimeSeconds(formats strfmt.Registry) error {
 
-	if err := validate.Required("runtimeSeconds", "body", int32(m.RuntimeSeconds)); err != nil {
+	if err := validate.Required("runtimeSeconds", "body", m.RuntimeSeconds); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-var jobTypeStatePropEnum []interface{}
+var jobTypeStatePropEnum []any
 
 func init() {
 	var res []string
@@ -461,7 +466,7 @@ func (m *Job) validateState(formats strfmt.Registry) error {
 
 func (m *Job) validateSubmitted(formats strfmt.Registry) error {
 
-	if err := validate.Required("submitted", "body", strfmt.DateTime(m.Submitted)); err != nil {
+	if err := validate.Required("submitted", "body", m.Submitted); err != nil {
 		return err
 	}
 
@@ -501,11 +506,15 @@ func (m *Job) contextValidateRuns(ctx context.Context, formats strfmt.Registry) 
 			}
 
 			if err := m.Runs[i].ContextValidate(ctx, formats); err != nil {
-				if ve, ok := err.(*errors.Validation); ok {
+				ve := new(errors.Validation)
+				if stderrors.As(err, &ve) {
 					return ve.ValidateName("runs" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
+				}
+				ce := new(errors.CompositeError)
+				if stderrors.As(err, &ce) {
 					return ce.ValidateName("runs" + "." + strconv.Itoa(i))
 				}
+
 				return err
 			}
 		}

--- a/internal/lookout/gen/models/order.go
+++ b/internal/lookout/gen/models/order.go
@@ -49,7 +49,7 @@ func (m *Order) Validate(formats strfmt.Registry) error {
 	return nil
 }
 
-var orderTypeDirectionPropEnum []interface{}
+var orderTypeDirectionPropEnum []any
 
 func init() {
 	var res []string

--- a/internal/lookout/gen/models/run.go
+++ b/internal/lookout/gen/models/run.go
@@ -123,7 +123,7 @@ func (m *Run) validateFinished(formats strfmt.Registry) error {
 	return nil
 }
 
-var runTypeJobRunStatePropEnum []interface{}
+var runTypeJobRunStatePropEnum []any
 
 func init() {
 	var res []string

--- a/internal/lookout/gen/restapi/operations/get_health.go
+++ b/internal/lookout/gen/restapi/operations/get_health.go
@@ -51,6 +51,7 @@ func (o *GetHealth) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
+
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }

--- a/internal/lookout/gen/restapi/operations/get_health_parameters.go
+++ b/internal/lookout/gen/restapi/operations/get_health_parameters.go
@@ -25,7 +25,6 @@ func NewGetHealthParams() GetHealthParams {
 //
 // swagger:parameters GetHealth
 type GetHealthParams struct {
-
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 }

--- a/internal/lookout/gen/restapi/operations/get_job_error.go
+++ b/internal/lookout/gen/restapi/operations/get_job_error.go
@@ -56,6 +56,7 @@ func (o *GetJobError) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
+
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }

--- a/internal/lookout/gen/restapi/operations/get_job_error_parameters.go
+++ b/internal/lookout/gen/restapi/operations/get_job_error_parameters.go
@@ -6,6 +6,7 @@ package operations
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	stderrors "errors"
 	"io"
 	"net/http"
 
@@ -28,7 +29,6 @@ func NewGetJobErrorParams() GetJobErrorParams {
 //
 // swagger:parameters getJobError
 type GetJobErrorParams struct {
-
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
@@ -49,10 +49,12 @@ func (o *GetJobErrorParams) BindRequest(r *http.Request, route *middleware.Match
 	o.HTTPRequest = r
 
 	if runtime.HasBody(r) {
-		defer r.Body.Close()
+		defer func() {
+			_ = r.Body.Close()
+		}()
 		var body GetJobErrorBody
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
-			if err == io.EOF {
+			if stderrors.Is(err, io.EOF) {
 				res = append(res, errors.Required("getJobErrorRequest", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("getJobErrorRequest", "body", "", err))

--- a/internal/lookout/gen/restapi/operations/get_job_run_debug_message.go
+++ b/internal/lookout/gen/restapi/operations/get_job_run_debug_message.go
@@ -56,6 +56,7 @@ func (o *GetJobRunDebugMessage) ServeHTTP(rw http.ResponseWriter, r *http.Reques
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
+
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }

--- a/internal/lookout/gen/restapi/operations/get_job_run_debug_message_parameters.go
+++ b/internal/lookout/gen/restapi/operations/get_job_run_debug_message_parameters.go
@@ -6,6 +6,7 @@ package operations
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	stderrors "errors"
 	"io"
 	"net/http"
 
@@ -28,7 +29,6 @@ func NewGetJobRunDebugMessageParams() GetJobRunDebugMessageParams {
 //
 // swagger:parameters getJobRunDebugMessage
 type GetJobRunDebugMessageParams struct {
-
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
@@ -49,10 +49,12 @@ func (o *GetJobRunDebugMessageParams) BindRequest(r *http.Request, route *middle
 	o.HTTPRequest = r
 
 	if runtime.HasBody(r) {
-		defer r.Body.Close()
+		defer func() {
+			_ = r.Body.Close()
+		}()
 		var body GetJobRunDebugMessageBody
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
-			if err == io.EOF {
+			if stderrors.Is(err, io.EOF) {
 				res = append(res, errors.Required("getJobRunDebugMessageRequest", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("getJobRunDebugMessageRequest", "body", "", err))

--- a/internal/lookout/gen/restapi/operations/get_job_run_error.go
+++ b/internal/lookout/gen/restapi/operations/get_job_run_error.go
@@ -56,6 +56,7 @@ func (o *GetJobRunError) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
+
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }

--- a/internal/lookout/gen/restapi/operations/get_job_run_error_parameters.go
+++ b/internal/lookout/gen/restapi/operations/get_job_run_error_parameters.go
@@ -6,6 +6,7 @@ package operations
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	stderrors "errors"
 	"io"
 	"net/http"
 
@@ -28,7 +29,6 @@ func NewGetJobRunErrorParams() GetJobRunErrorParams {
 //
 // swagger:parameters getJobRunError
 type GetJobRunErrorParams struct {
-
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
@@ -49,10 +49,12 @@ func (o *GetJobRunErrorParams) BindRequest(r *http.Request, route *middleware.Ma
 	o.HTTPRequest = r
 
 	if runtime.HasBody(r) {
-		defer r.Body.Close()
+		defer func() {
+			_ = r.Body.Close()
+		}()
 		var body GetJobRunErrorBody
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
-			if err == io.EOF {
+			if stderrors.Is(err, io.EOF) {
 				res = append(res, errors.Required("getJobRunErrorRequest", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("getJobRunErrorRequest", "body", "", err))

--- a/internal/lookout/gen/restapi/operations/get_job_spec.go
+++ b/internal/lookout/gen/restapi/operations/get_job_spec.go
@@ -56,6 +56,7 @@ func (o *GetJobSpec) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
+
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }
@@ -122,7 +123,7 @@ func (o *GetJobSpecBody) UnmarshalBinary(b []byte) error {
 type GetJobSpecOKBody struct {
 
 	// Job Spec object
-	Job interface{} `json:"job,omitempty"`
+	Job any `json:"job,omitempty"`
 }
 
 // Validate validates this get job spec o k body

--- a/internal/lookout/gen/restapi/operations/get_job_spec_parameters.go
+++ b/internal/lookout/gen/restapi/operations/get_job_spec_parameters.go
@@ -6,6 +6,7 @@ package operations
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	stderrors "errors"
 	"io"
 	"net/http"
 
@@ -28,7 +29,6 @@ func NewGetJobSpecParams() GetJobSpecParams {
 //
 // swagger:parameters getJobSpec
 type GetJobSpecParams struct {
-
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
@@ -49,10 +49,12 @@ func (o *GetJobSpecParams) BindRequest(r *http.Request, route *middleware.Matche
 	o.HTTPRequest = r
 
 	if runtime.HasBody(r) {
-		defer r.Body.Close()
+		defer func() {
+			_ = r.Body.Close()
+		}()
 		var body GetJobSpecBody
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
-			if err == io.EOF {
+			if stderrors.Is(err, io.EOF) {
 				res = append(res, errors.Required("getJobSpecRequest", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("getJobSpecRequest", "body", "", err))

--- a/internal/lookout/gen/restapi/operations/get_jobs.go
+++ b/internal/lookout/gen/restapi/operations/get_jobs.go
@@ -7,6 +7,7 @@ package operations
 
 import (
 	"context"
+	stderrors "errors"
 	"net/http"
 	"strconv"
 
@@ -59,6 +60,7 @@ func (o *GetJobs) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
+
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }
@@ -117,11 +119,15 @@ func (o *GetJobsBody) validateFilters(formats strfmt.Registry) error {
 
 		if o.Filters[i] != nil {
 			if err := o.Filters[i].Validate(formats); err != nil {
-				if ve, ok := err.(*errors.Validation); ok {
+				ve := new(errors.Validation)
+				if stderrors.As(err, &ve) {
 					return ve.ValidateName("getJobsRequest" + "." + "filters" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
+				}
+				ce := new(errors.CompositeError)
+				if stderrors.As(err, &ce) {
 					return ce.ValidateName("getJobsRequest" + "." + "filters" + "." + strconv.Itoa(i))
 				}
+
 				return err
 			}
 		}
@@ -139,11 +145,15 @@ func (o *GetJobsBody) validateOrder(formats strfmt.Registry) error {
 
 	if o.Order != nil {
 		if err := o.Order.Validate(formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
+			ve := new(errors.Validation)
+			if stderrors.As(err, &ve) {
 				return ve.ValidateName("getJobsRequest" + "." + "order")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
+			}
+			ce := new(errors.CompositeError)
+			if stderrors.As(err, &ce) {
 				return ce.ValidateName("getJobsRequest" + "." + "order")
 			}
+
 			return err
 		}
 	}
@@ -180,11 +190,15 @@ func (o *GetJobsBody) contextValidateFilters(ctx context.Context, formats strfmt
 			}
 
 			if err := o.Filters[i].ContextValidate(ctx, formats); err != nil {
-				if ve, ok := err.(*errors.Validation); ok {
+				ve := new(errors.Validation)
+				if stderrors.As(err, &ve) {
 					return ve.ValidateName("getJobsRequest" + "." + "filters" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
+				}
+				ce := new(errors.CompositeError)
+				if stderrors.As(err, &ce) {
 					return ce.ValidateName("getJobsRequest" + "." + "filters" + "." + strconv.Itoa(i))
 				}
+
 				return err
 			}
 		}
@@ -199,11 +213,15 @@ func (o *GetJobsBody) contextValidateOrder(ctx context.Context, formats strfmt.R
 	if o.Order != nil {
 
 		if err := o.Order.ContextValidate(ctx, formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
+			ve := new(errors.Validation)
+			if stderrors.As(err, &ve) {
 				return ve.ValidateName("getJobsRequest" + "." + "order")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
+			}
+			ce := new(errors.CompositeError)
+			if stderrors.As(err, &ce) {
 				return ce.ValidateName("getJobsRequest" + "." + "order")
 			}
+
 			return err
 		}
 	}
@@ -264,11 +282,15 @@ func (o *GetJobsOKBody) validateJobs(formats strfmt.Registry) error {
 
 		if o.Jobs[i] != nil {
 			if err := o.Jobs[i].Validate(formats); err != nil {
-				if ve, ok := err.(*errors.Validation); ok {
+				ve := new(errors.Validation)
+				if stderrors.As(err, &ve) {
 					return ve.ValidateName("getJobsOK" + "." + "jobs" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
+				}
+				ce := new(errors.CompositeError)
+				if stderrors.As(err, &ce) {
 					return ce.ValidateName("getJobsOK" + "." + "jobs" + "." + strconv.Itoa(i))
 				}
+
 				return err
 			}
 		}
@@ -303,11 +325,15 @@ func (o *GetJobsOKBody) contextValidateJobs(ctx context.Context, formats strfmt.
 			}
 
 			if err := o.Jobs[i].ContextValidate(ctx, formats); err != nil {
-				if ve, ok := err.(*errors.Validation); ok {
+				ve := new(errors.Validation)
+				if stderrors.As(err, &ve) {
 					return ve.ValidateName("getJobsOK" + "." + "jobs" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
+				}
+				ce := new(errors.CompositeError)
+				if stderrors.As(err, &ce) {
 					return ce.ValidateName("getJobsOK" + "." + "jobs" + "." + strconv.Itoa(i))
 				}
+
 				return err
 			}
 		}

--- a/internal/lookout/gen/restapi/operations/get_jobs_parameters.go
+++ b/internal/lookout/gen/restapi/operations/get_jobs_parameters.go
@@ -6,6 +6,7 @@ package operations
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	stderrors "errors"
 	"io"
 	"net/http"
 
@@ -29,7 +30,6 @@ func NewGetJobsParams() GetJobsParams {
 //
 // swagger:parameters getJobs
 type GetJobsParams struct {
-
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
@@ -37,6 +37,7 @@ type GetJobsParams struct {
 	  In: query
 	*/
 	Backend *string
+
 	/*
 	  Required: true
 	  In: body
@@ -52,7 +53,6 @@ func (o *GetJobsParams) BindRequest(r *http.Request, route *middleware.MatchedRo
 	var res []error
 
 	o.HTTPRequest = r
-
 	qs := runtime.Values(r.URL.Query())
 
 	qBackend, qhkBackend, _ := qs.GetOK("backend")
@@ -61,10 +61,12 @@ func (o *GetJobsParams) BindRequest(r *http.Request, route *middleware.MatchedRo
 	}
 
 	if runtime.HasBody(r) {
-		defer r.Body.Close()
+		defer func() {
+			_ = r.Body.Close()
+		}()
 		var body GetJobsBody
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
-			if err == io.EOF {
+			if stderrors.Is(err, io.EOF) {
 				res = append(res, errors.Required("getJobsRequest", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("getJobsRequest", "body", "", err))
@@ -115,10 +117,10 @@ func (o *GetJobsParams) bindBackend(rawData []string, hasKey bool, formats strfm
 	return nil
 }
 
-// validateBackend carries on validations for parameter Backend
+// validateBackend carries out validations for parameter Backend
 func (o *GetJobsParams) validateBackend(formats strfmt.Registry) error {
 
-	if err := validate.EnumCase("backend", "query", *o.Backend, []interface{}{"jsonb"}, true); err != nil {
+	if err := validate.EnumCase("backend", "query", *o.Backend, []any{"jsonb"}, true); err != nil {
 		return err
 	}
 

--- a/internal/lookout/gen/restapi/operations/group_jobs.go
+++ b/internal/lookout/gen/restapi/operations/group_jobs.go
@@ -8,6 +8,7 @@ package operations
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"net/http"
 	"strconv"
 
@@ -60,6 +61,7 @@ func (o *GroupJobs) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
+
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }
@@ -143,11 +145,15 @@ func (o *GroupJobsBody) validateFilters(formats strfmt.Registry) error {
 
 		if o.Filters[i] != nil {
 			if err := o.Filters[i].Validate(formats); err != nil {
-				if ve, ok := err.(*errors.Validation); ok {
+				ve := new(errors.Validation)
+				if stderrors.As(err, &ve) {
 					return ve.ValidateName("groupJobsRequest" + "." + "filters" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
+				}
+				ce := new(errors.CompositeError)
+				if stderrors.As(err, &ce) {
 					return ce.ValidateName("groupJobsRequest" + "." + "filters" + "." + strconv.Itoa(i))
 				}
+
 				return err
 			}
 		}
@@ -165,11 +171,15 @@ func (o *GroupJobsBody) validateGroupedField(formats strfmt.Registry) error {
 
 	if o.GroupedField != nil {
 		if err := o.GroupedField.Validate(formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
+			ve := new(errors.Validation)
+			if stderrors.As(err, &ve) {
 				return ve.ValidateName("groupJobsRequest" + "." + "groupedField")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
+			}
+			ce := new(errors.CompositeError)
+			if stderrors.As(err, &ce) {
 				return ce.ValidateName("groupJobsRequest" + "." + "groupedField")
 			}
+
 			return err
 		}
 	}
@@ -185,11 +195,15 @@ func (o *GroupJobsBody) validateOrder(formats strfmt.Registry) error {
 
 	if o.Order != nil {
 		if err := o.Order.Validate(formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
+			ve := new(errors.Validation)
+			if stderrors.As(err, &ve) {
 				return ve.ValidateName("groupJobsRequest" + "." + "order")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
+			}
+			ce := new(errors.CompositeError)
+			if stderrors.As(err, &ce) {
 				return ce.ValidateName("groupJobsRequest" + "." + "order")
 			}
+
 			return err
 		}
 	}
@@ -230,11 +244,15 @@ func (o *GroupJobsBody) contextValidateFilters(ctx context.Context, formats strf
 			}
 
 			if err := o.Filters[i].ContextValidate(ctx, formats); err != nil {
-				if ve, ok := err.(*errors.Validation); ok {
+				ve := new(errors.Validation)
+				if stderrors.As(err, &ve) {
 					return ve.ValidateName("groupJobsRequest" + "." + "filters" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
+				}
+				ce := new(errors.CompositeError)
+				if stderrors.As(err, &ce) {
 					return ce.ValidateName("groupJobsRequest" + "." + "filters" + "." + strconv.Itoa(i))
 				}
+
 				return err
 			}
 		}
@@ -249,11 +267,15 @@ func (o *GroupJobsBody) contextValidateGroupedField(ctx context.Context, formats
 	if o.GroupedField != nil {
 
 		if err := o.GroupedField.ContextValidate(ctx, formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
+			ve := new(errors.Validation)
+			if stderrors.As(err, &ve) {
 				return ve.ValidateName("groupJobsRequest" + "." + "groupedField")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
+			}
+			ce := new(errors.CompositeError)
+			if stderrors.As(err, &ce) {
 				return ce.ValidateName("groupJobsRequest" + "." + "groupedField")
 			}
+
 			return err
 		}
 	}
@@ -266,11 +288,15 @@ func (o *GroupJobsBody) contextValidateOrder(ctx context.Context, formats strfmt
 	if o.Order != nil {
 
 		if err := o.Order.ContextValidate(ctx, formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
+			ve := new(errors.Validation)
+			if stderrors.As(err, &ve) {
 				return ve.ValidateName("groupJobsRequest" + "." + "order")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
+			}
+			ce := new(errors.CompositeError)
+			if stderrors.As(err, &ce) {
 				return ce.ValidateName("groupJobsRequest" + "." + "order")
 			}
+
 			return err
 		}
 	}
@@ -333,11 +359,15 @@ func (o *GroupJobsOKBody) validateGroups(formats strfmt.Registry) error {
 
 		if o.Groups[i] != nil {
 			if err := o.Groups[i].Validate(formats); err != nil {
-				if ve, ok := err.(*errors.Validation); ok {
+				ve := new(errors.Validation)
+				if stderrors.As(err, &ve) {
 					return ve.ValidateName("groupJobsOK" + "." + "groups" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
+				}
+				ce := new(errors.CompositeError)
+				if stderrors.As(err, &ce) {
 					return ce.ValidateName("groupJobsOK" + "." + "groups" + "." + strconv.Itoa(i))
 				}
+
 				return err
 			}
 		}
@@ -372,11 +402,15 @@ func (o *GroupJobsOKBody) contextValidateGroups(ctx context.Context, formats str
 			}
 
 			if err := o.Groups[i].ContextValidate(ctx, formats); err != nil {
-				if ve, ok := err.(*errors.Validation); ok {
+				ve := new(errors.Validation)
+				if stderrors.As(err, &ve) {
 					return ve.ValidateName("groupJobsOK" + "." + "groups" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
+				}
+				ce := new(errors.CompositeError)
+				if stderrors.As(err, &ce) {
 					return ce.ValidateName("groupJobsOK" + "." + "groups" + "." + strconv.Itoa(i))
 				}
+
 				return err
 			}
 		}
@@ -448,7 +482,7 @@ func (o *GroupJobsParamsBodyGroupedField) validateField(formats strfmt.Registry)
 	return nil
 }
 
-var groupJobsParamsBodyGroupedFieldTypeLastTransitionTimeAggregatePropEnum []interface{}
+var groupJobsParamsBodyGroupedFieldTypeLastTransitionTimeAggregatePropEnum []any
 
 func init() {
 	var res []string

--- a/internal/lookout/gen/restapi/operations/group_jobs_parameters.go
+++ b/internal/lookout/gen/restapi/operations/group_jobs_parameters.go
@@ -6,6 +6,7 @@ package operations
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	stderrors "errors"
 	"io"
 	"net/http"
 
@@ -29,7 +30,6 @@ func NewGroupJobsParams() GroupJobsParams {
 //
 // swagger:parameters groupJobs
 type GroupJobsParams struct {
-
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
@@ -37,6 +37,7 @@ type GroupJobsParams struct {
 	  In: query
 	*/
 	Backend *string
+
 	/*
 	  Required: true
 	  In: body
@@ -52,7 +53,6 @@ func (o *GroupJobsParams) BindRequest(r *http.Request, route *middleware.Matched
 	var res []error
 
 	o.HTTPRequest = r
-
 	qs := runtime.Values(r.URL.Query())
 
 	qBackend, qhkBackend, _ := qs.GetOK("backend")
@@ -61,10 +61,12 @@ func (o *GroupJobsParams) BindRequest(r *http.Request, route *middleware.Matched
 	}
 
 	if runtime.HasBody(r) {
-		defer r.Body.Close()
+		defer func() {
+			_ = r.Body.Close()
+		}()
 		var body GroupJobsBody
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
-			if err == io.EOF {
+			if stderrors.Is(err, io.EOF) {
 				res = append(res, errors.Required("groupJobsRequest", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("groupJobsRequest", "body", "", err))
@@ -115,10 +117,10 @@ func (o *GroupJobsParams) bindBackend(rawData []string, hasKey bool, formats str
 	return nil
 }
 
-// validateBackend carries on validations for parameter Backend
+// validateBackend carries out validations for parameter Backend
 func (o *GroupJobsParams) validateBackend(formats strfmt.Registry) error {
 
-	if err := validate.EnumCase("backend", "query", *o.Backend, []interface{}{"jsonb"}, true); err != nil {
+	if err := validate.EnumCase("backend", "query", *o.Backend, []any{"jsonb"}, true); err != nil {
 		return err
 	}
 

--- a/internal/lookout/gen/restapi/operations/lookout_api.go
+++ b/internal/lookout/gen/restapi/operations/lookout_api.go
@@ -44,24 +44,44 @@ func NewLookoutAPI(spec *loads.Document) *LookoutAPI {
 		TxtProducer:  runtime.TextProducer(),
 
 		GetHealthHandler: GetHealthHandlerFunc(func(params GetHealthParams) middleware.Responder {
+			_ = params
+
 			return middleware.NotImplemented("operation GetHealth has not yet been implemented")
 		}),
+
 		GetJobErrorHandler: GetJobErrorHandlerFunc(func(params GetJobErrorParams) middleware.Responder {
+			_ = params
+
 			return middleware.NotImplemented("operation GetJobError has not yet been implemented")
 		}),
+
 		GetJobRunDebugMessageHandler: GetJobRunDebugMessageHandlerFunc(func(params GetJobRunDebugMessageParams) middleware.Responder {
+			_ = params
+
 			return middleware.NotImplemented("operation GetJobRunDebugMessage has not yet been implemented")
 		}),
+
 		GetJobRunErrorHandler: GetJobRunErrorHandlerFunc(func(params GetJobRunErrorParams) middleware.Responder {
+			_ = params
+
 			return middleware.NotImplemented("operation GetJobRunError has not yet been implemented")
 		}),
+
 		GetJobSpecHandler: GetJobSpecHandlerFunc(func(params GetJobSpecParams) middleware.Responder {
+			_ = params
+
 			return middleware.NotImplemented("operation GetJobSpec has not yet been implemented")
 		}),
+
 		GetJobsHandler: GetJobsHandlerFunc(func(params GetJobsParams) middleware.Responder {
+			_ = params
+
 			return middleware.NotImplemented("operation GetJobs has not yet been implemented")
 		}),
+
 		GroupJobsHandler: GroupJobsHandlerFunc(func(params GroupJobsParams) middleware.Responder {
+			_ = params
+
 			return middleware.NotImplemented("operation GroupJobs has not yet been implemented")
 		}),
 	}
@@ -134,7 +154,7 @@ type LookoutAPI struct {
 	CommandLineOptionsGroups []swag.CommandLineOptionsGroup
 
 	// User defined logger function.
-	Logger func(string, ...interface{})
+	Logger func(string, ...any)
 }
 
 // UseRedoc for documentation at /docs
@@ -242,12 +262,12 @@ func (o *LookoutAPI) Authorizer() runtime.Authorizer {
 }
 
 // ConsumersFor gets the consumers for the specified media types.
+//
 // MIME type parameters are ignored here.
 func (o *LookoutAPI) ConsumersFor(mediaTypes []string) map[string]runtime.Consumer {
 	result := make(map[string]runtime.Consumer, len(mediaTypes))
 	for _, mt := range mediaTypes {
-		switch mt {
-		case "application/json":
+		if mt == "application/json" {
 			result["application/json"] = o.JSONConsumer
 		}
 
@@ -255,10 +275,12 @@ func (o *LookoutAPI) ConsumersFor(mediaTypes []string) map[string]runtime.Consum
 			result[mt] = c
 		}
 	}
+
 	return result
 }
 
 // ProducersFor gets the producers for the specified media types.
+//
 // MIME type parameters are ignored here.
 func (o *LookoutAPI) ProducersFor(mediaTypes []string) map[string]runtime.Producer {
 	result := make(map[string]runtime.Producer, len(mediaTypes))
@@ -274,6 +296,7 @@ func (o *LookoutAPI) ProducersFor(mediaTypes []string) map[string]runtime.Produc
 			result[mt] = p
 		}
 	}
+
 	return result
 }
 

--- a/internal/lookout/gen/restapi/server.go
+++ b/internal/lookout/gen/restapi/server.go
@@ -7,7 +7,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
-	"fmt"
 	"log"
 	"net"
 	"net/http"
@@ -19,10 +18,11 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/go-openapi/runtime/flagext"
-	"github.com/go-openapi/swag"
 	flags "github.com/jessevdk/go-flags"
 	"golang.org/x/net/netutil"
+
+	"github.com/go-openapi/runtime/flagext"
+	"github.com/go-openapi/swag"
 
 	"github.com/armadaproject/armada/internal/lookout/gen/restapi/operations"
 )
@@ -104,7 +104,7 @@ type Server struct {
 }
 
 // Logf logs message either via defined user logger or via system one if no user logger is defined.
-func (s *Server) Logf(f string, args ...interface{}) {
+func (s *Server) Logf(f string, args ...any) {
 	if s.api != nil && s.api.Logger != nil {
 		s.api.Logger(f, args...)
 	} else {
@@ -114,7 +114,7 @@ func (s *Server) Logf(f string, args ...interface{}) {
 
 // Fatalf logs message either via defined user logger or via system one if no user logger is defined.
 // Exits with non-zero status after printing
-func (s *Server) Fatalf(f string, args ...interface{}) {
+func (s *Server) Fatalf(f string, args ...any) {
 	if s.api != nil && s.api.Logger != nil {
 		s.api.Logger(f, args...)
 		os.Exit(1)
@@ -188,8 +188,8 @@ func (s *Server) Serve() (err error) {
 		s.Logf("Serving lookout at unix://%s", s.SocketPath)
 		go func(l net.Listener) {
 			defer wg.Done()
-			if err := domainSocket.Serve(l); err != nil && err != http.ErrServerClosed {
-				s.Fatalf("%v", err)
+			if errServe := domainSocket.Serve(l); errServe != nil && !errors.Is(errServe, http.ErrServerClosed) {
+				s.Fatalf("%v", errServe)
 			}
 			s.Logf("Stopped serving lookout at unix://%s", s.SocketPath)
 		}(s.domainSocketL)
@@ -218,8 +218,8 @@ func (s *Server) Serve() (err error) {
 		s.Logf("Serving lookout at http://%s", s.httpServerL.Addr())
 		go func(l net.Listener) {
 			defer wg.Done()
-			if err := httpServer.Serve(l); err != nil && err != http.ErrServerClosed {
-				s.Fatalf("%v", err)
+			if errServe := httpServer.Serve(l); errServe != nil && !errors.Is(errServe, http.ErrServerClosed) {
+				s.Fatalf("%v", errServe)
 			}
 			s.Logf("Stopped serving lookout at http://%s", l.Addr())
 		}(s.httpServerL)
@@ -280,7 +280,7 @@ func (s *Server) Serve() (err error) {
 			caCertPool := x509.NewCertPool()
 			ok := caCertPool.AppendCertsFromPEM(caCert)
 			if !ok {
-				return fmt.Errorf("cannot parse CA certificate")
+				return errors.New("cannot parse CA certificate")
 			}
 			httpsServer.TLSConfig.ClientCAs = caCertPool
 			httpsServer.TLSConfig.ClientAuth = tls.RequireAndVerifyClientCert
@@ -311,8 +311,8 @@ func (s *Server) Serve() (err error) {
 		s.Logf("Serving lookout at https://%s", s.httpsServerL.Addr())
 		go func(l net.Listener) {
 			defer wg.Done()
-			if err := httpsServer.Serve(l); err != nil && err != http.ErrServerClosed {
-				s.Fatalf("%v", err)
+			if errServe := httpsServer.Serve(l); errServe != nil && !errors.Is(errServe, http.ErrServerClosed) {
+				s.Fatalf("%v", errServe)
 			}
 			s.Logf("Stopped serving lookout at https://%s", l.Addr())
 		}(tls.NewListener(s.httpsServerL, httpsServer.TLSConfig))

--- a/internal/server/mocks/mock_authorizer.go
+++ b/internal/server/mocks/mock_authorizer.go
@@ -57,15 +57,15 @@ func (mr *MockActionAuthorizerMockRecorder) AuthorizeAction(ctx, perm any) *gomo
 }
 
 // AuthorizeQueueAction mocks base method.
-func (m *MockActionAuthorizer) AuthorizeQueueAction(ctx *armadacontext.Context, queue queue.Queue, anyPerm permission.Permission, perm queue.PermissionVerb) error {
+func (m *MockActionAuthorizer) AuthorizeQueueAction(ctx *armadacontext.Context, arg1 queue.Queue, anyPerm permission.Permission, perm queue.PermissionVerb) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AuthorizeQueueAction", ctx, queue, anyPerm, perm)
+	ret := m.ctrl.Call(m, "AuthorizeQueueAction", ctx, arg1, anyPerm, perm)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AuthorizeQueueAction indicates an expected call of AuthorizeQueueAction.
-func (mr *MockActionAuthorizerMockRecorder) AuthorizeQueueAction(ctx, queue, anyPerm, perm any) *gomock.Call {
+func (mr *MockActionAuthorizerMockRecorder) AuthorizeQueueAction(ctx, arg1, anyPerm, perm any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthorizeQueueAction", reflect.TypeOf((*MockActionAuthorizer)(nil).AuthorizeQueueAction), ctx, queue, anyPerm, perm)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthorizeQueueAction", reflect.TypeOf((*MockActionAuthorizer)(nil).AuthorizeQueueAction), ctx, arg1, anyPerm, perm)
 }

--- a/magefiles/cmd.go
+++ b/magefiles/cmd.go
@@ -122,7 +122,7 @@ func go_CMD() ([]string, error) {
 		"GARCH=amd64",
 		"-v",
 		fmt.Sprintf("%s:/go", DOCKER_GOPATH_DIR),
-		"golang:1.24-bookworm",
+		"golang:1.25-bookworm",
 	}, nil
 }
 

--- a/magefiles/go.go
+++ b/magefiles/go.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-const GO_VERSION_CONSTRAINT = ">= 1.23.0"
+const GO_VERSION_CONSTRAINT = ">= 1.25.0"
 
 func goBinary() string {
 	return binaryWithExt("go")

--- a/pkg/api/api.swagger.go
+++ b/pkg/api/api.swagger.go
@@ -3843,7 +3843,8 @@ func SwaggerJsonTemplate() string {
 		"        \"time\": {\n" +
 		"          \"description\": \"Time is the timestamp of when the ManagedFields entry was added. The\\ntimestamp will also be updated if a field is added, the manager\\nchanges any of the owned fields value or removes a field. The\\ntimestamp does not update when a field is removed from the entry\\nbecause another manager took it over.\\n+optional\",\n" +
 		"          \"type\": \"string\",\n" +
-		"          \"x-go-name\": \"Time\"\n" +
+		"          \"x-go-name\": \"Time\",\n" +
+		"          \"x-go-type\": \"k8s.io/apimachinery/pkg/apis/meta/v1.Time\"\n" +
 		"        }\n" +
 		"      },\n" +
 		"      \"x-go-package\": \"k8s.io/apimachinery/pkg/apis/meta/v1\"\n" +
@@ -4009,7 +4010,8 @@ func SwaggerJsonTemplate() string {
 		"        \"creationTimestamp\": {\n" +
 		"          \"description\": \"CreationTimestamp is a timestamp representing the server time when this object was\\ncreated. It is not guaranteed to be set in happens-before order across separate operations.\\nClients may not set this value. It is represented in RFC3339 form and is in UTC.\\n\\nPopulated by the system.\\nRead-only.\\nNull for lists.\\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata\\n+optional\",\n" +
 		"          \"type\": \"string\",\n" +
-		"          \"x-go-name\": \"CreationTimestamp\"\n" +
+		"          \"x-go-name\": \"CreationTimestamp\",\n" +
+		"          \"x-go-type\": \"k8s.io/apimachinery/pkg/apis/meta/v1.Time\"\n" +
 		"        },\n" +
 		"        \"deletionGracePeriodSeconds\": {\n" +
 		"          \"description\": \"Number of seconds allowed for this object to gracefully terminate before\\nit will be removed from the system. Only set when deletionTimestamp is also set.\\nMay only be shortened.\\nRead-only.\\n+optional\",\n" +
@@ -4020,7 +4022,8 @@ func SwaggerJsonTemplate() string {
 		"        \"deletionTimestamp\": {\n" +
 		"          \"description\": \"DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This\\nfield is set by the server when a graceful deletion is requested by the user, and is not\\ndirectly settable by a client. The resource is expected to be deleted (no longer visible\\nfrom resource lists, and not reachable by name) after the time in this field, once the\\nfinalizers list is empty. As long as the finalizers list contains items, deletion is blocked.\\nOnce the deletionTimestamp is set, this value may not be unset or be set further into the\\nfuture, although it may be shortened or the resource may be deleted prior to this time.\\nFor example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react\\nby sending a graceful termination signal to the containers in the pod. After that 30 seconds,\\nthe Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup,\\nremove the pod from the API. In the presence of network partitions, this object may still\\nexist after this timestamp, until an administrator or automated process can determine the\\nresource is fully terminated.\\nIf not set, graceful deletion of the object has not been requested.\\n\\nPopulated by the system when a graceful deletion is requested.\\nRead-only.\\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata\\n+optional\",\n" +
 		"          \"type\": \"string\",\n" +
-		"          \"x-go-name\": \"DeletionTimestamp\"\n" +
+		"          \"x-go-name\": \"DeletionTimestamp\",\n" +
+		"          \"x-go-type\": \"k8s.io/apimachinery/pkg/apis/meta/v1.Time\"\n" +
 		"        },\n" +
 		"        \"finalizers\": {\n" +
 		"          \"description\": \"Must be empty before the object is deleted from the registry. Each entry\\nis an identifier for the responsible component that will remove the entry\\nfrom the list. If the deletionTimestamp of the object is non-nil, entries\\nin this list can only be removed.\\nFinalizers may be processed and removed in any order.  Order is NOT enforced\\nbecause it introduces significant risk of stuck finalizers.\\nfinalizers is a shared field, any actor with permission can reorder it.\\nIf the finalizer list is processed in order, then this can lead to a situation\\nin which the component responsible for the first finalizer in the list is\\nwaiting for a signal (field value, external system, or other) produced by a\\ncomponent responsible for a finalizer later in the list, resulting in a deadlock.\\nWithout enforced ordering finalizers are free to order amongst themselves and\\nare not vulnerable to ordering changes in the list.\\n+optional\\n+patchStrategy=merge\",\n" +
@@ -4186,7 +4189,8 @@ func SwaggerJsonTemplate() string {
 		"        \"creationTimestamp\": {\n" +
 		"          \"description\": \"CreationTimestamp is a timestamp representing the server time when this object was\\ncreated. It is not guaranteed to be set in happens-before order across separate operations.\\nClients may not set this value. It is represented in RFC3339 form and is in UTC.\\n\\nPopulated by the system.\\nRead-only.\\nNull for lists.\\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata\\n+optional\",\n" +
 		"          \"type\": \"string\",\n" +
-		"          \"x-go-name\": \"CreationTimestamp\"\n" +
+		"          \"x-go-name\": \"CreationTimestamp\",\n" +
+		"          \"x-go-type\": \"k8s.io/apimachinery/pkg/apis/meta/v1.Time\"\n" +
 		"        },\n" +
 		"        \"deletionGracePeriodSeconds\": {\n" +
 		"          \"description\": \"Number of seconds allowed for this object to gracefully terminate before\\nit will be removed from the system. Only set when deletionTimestamp is also set.\\nMay only be shortened.\\nRead-only.\\n+optional\",\n" +
@@ -4197,7 +4201,8 @@ func SwaggerJsonTemplate() string {
 		"        \"deletionTimestamp\": {\n" +
 		"          \"description\": \"DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This\\nfield is set by the server when a graceful deletion is requested by the user, and is not\\ndirectly settable by a client. The resource is expected to be deleted (no longer visible\\nfrom resource lists, and not reachable by name) after the time in this field, once the\\nfinalizers list is empty. As long as the finalizers list contains items, deletion is blocked.\\nOnce the deletionTimestamp is set, this value may not be unset or be set further into the\\nfuture, although it may be shortened or the resource may be deleted prior to this time.\\nFor example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react\\nby sending a graceful termination signal to the containers in the pod. After that 30 seconds,\\nthe Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup,\\nremove the pod from the API. In the presence of network partitions, this object may still\\nexist after this timestamp, until an administrator or automated process can determine the\\nresource is fully terminated.\\nIf not set, graceful deletion of the object has not been requested.\\n\\nPopulated by the system when a graceful deletion is requested.\\nRead-only.\\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata\\n+optional\",\n" +
 		"          \"type\": \"string\",\n" +
-		"          \"x-go-name\": \"DeletionTimestamp\"\n" +
+		"          \"x-go-name\": \"DeletionTimestamp\",\n" +
+		"          \"x-go-type\": \"k8s.io/apimachinery/pkg/apis/meta/v1.Time\"\n" +
 		"        },\n" +
 		"        \"finalizers\": {\n" +
 		"          \"description\": \"Must be empty before the object is deleted from the registry. Each entry\\nis an identifier for the responsible component that will remove the entry\\nfrom the list. If the deletionTimestamp of the object is non-nil, entries\\nin this list can only be removed.\\nFinalizers may be processed and removed in any order.  Order is NOT enforced\\nbecause it introduces significant risk of stuck finalizers.\\nfinalizers is a shared field, any actor with permission can reorder it.\\nIf the finalizer list is processed in order, then this can lead to a situation\\nin which the component responsible for the first finalizer in the list is\\nwaiting for a signal (field value, external system, or other) produced by a\\ncomponent responsible for a finalizer later in the list, resulting in a deadlock.\\nWithout enforced ordering finalizers are free to order amongst themselves and\\nare not vulnerable to ordering changes in the list.\\n+optional\\n+patchStrategy=merge\",\n" +

--- a/pkg/api/api.swagger.json
+++ b/pkg/api/api.swagger.json
@@ -3832,7 +3832,8 @@
         "time": {
           "description": "Time is the timestamp of when the ManagedFields entry was added. The\ntimestamp will also be updated if a field is added, the manager\nchanges any of the owned fields value or removes a field. The\ntimestamp does not update when a field is removed from the entry\nbecause another manager took it over.\n+optional",
           "type": "string",
-          "x-go-name": "Time"
+          "x-go-name": "Time",
+          "x-go-type": "k8s.io/apimachinery/pkg/apis/meta/v1.Time"
         }
       },
       "x-go-package": "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -3998,7 +3999,8 @@
         "creationTimestamp": {
           "description": "CreationTimestamp is a timestamp representing the server time when this object was\ncreated. It is not guaranteed to be set in happens-before order across separate operations.\nClients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system.\nRead-only.\nNull for lists.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata\n+optional",
           "type": "string",
-          "x-go-name": "CreationTimestamp"
+          "x-go-name": "CreationTimestamp",
+          "x-go-type": "k8s.io/apimachinery/pkg/apis/meta/v1.Time"
         },
         "deletionGracePeriodSeconds": {
           "description": "Number of seconds allowed for this object to gracefully terminate before\nit will be removed from the system. Only set when deletionTimestamp is also set.\nMay only be shortened.\nRead-only.\n+optional",
@@ -4009,7 +4011,8 @@
         "deletionTimestamp": {
           "description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This\nfield is set by the server when a graceful deletion is requested by the user, and is not\ndirectly settable by a client. The resource is expected to be deleted (no longer visible\nfrom resource lists, and not reachable by name) after the time in this field, once the\nfinalizers list is empty. As long as the finalizers list contains items, deletion is blocked.\nOnce the deletionTimestamp is set, this value may not be unset or be set further into the\nfuture, although it may be shortened or the resource may be deleted prior to this time.\nFor example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react\nby sending a graceful termination signal to the containers in the pod. After that 30 seconds,\nthe Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup,\nremove the pod from the API. In the presence of network partitions, this object may still\nexist after this timestamp, until an administrator or automated process can determine the\nresource is fully terminated.\nIf not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested.\nRead-only.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata\n+optional",
           "type": "string",
-          "x-go-name": "DeletionTimestamp"
+          "x-go-name": "DeletionTimestamp",
+          "x-go-type": "k8s.io/apimachinery/pkg/apis/meta/v1.Time"
         },
         "finalizers": {
           "description": "Must be empty before the object is deleted from the registry. Each entry\nis an identifier for the responsible component that will remove the entry\nfrom the list. If the deletionTimestamp of the object is non-nil, entries\nin this list can only be removed.\nFinalizers may be processed and removed in any order.  Order is NOT enforced\nbecause it introduces significant risk of stuck finalizers.\nfinalizers is a shared field, any actor with permission can reorder it.\nIf the finalizer list is processed in order, then this can lead to a situation\nin which the component responsible for the first finalizer in the list is\nwaiting for a signal (field value, external system, or other) produced by a\ncomponent responsible for a finalizer later in the list, resulting in a deadlock.\nWithout enforced ordering finalizers are free to order amongst themselves and\nare not vulnerable to ordering changes in the list.\n+optional\n+patchStrategy=merge",
@@ -4175,7 +4178,8 @@
         "creationTimestamp": {
           "description": "CreationTimestamp is a timestamp representing the server time when this object was\ncreated. It is not guaranteed to be set in happens-before order across separate operations.\nClients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system.\nRead-only.\nNull for lists.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata\n+optional",
           "type": "string",
-          "x-go-name": "CreationTimestamp"
+          "x-go-name": "CreationTimestamp",
+          "x-go-type": "k8s.io/apimachinery/pkg/apis/meta/v1.Time"
         },
         "deletionGracePeriodSeconds": {
           "description": "Number of seconds allowed for this object to gracefully terminate before\nit will be removed from the system. Only set when deletionTimestamp is also set.\nMay only be shortened.\nRead-only.\n+optional",
@@ -4186,7 +4190,8 @@
         "deletionTimestamp": {
           "description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This\nfield is set by the server when a graceful deletion is requested by the user, and is not\ndirectly settable by a client. The resource is expected to be deleted (no longer visible\nfrom resource lists, and not reachable by name) after the time in this field, once the\nfinalizers list is empty. As long as the finalizers list contains items, deletion is blocked.\nOnce the deletionTimestamp is set, this value may not be unset or be set further into the\nfuture, although it may be shortened or the resource may be deleted prior to this time.\nFor example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react\nby sending a graceful termination signal to the containers in the pod. After that 30 seconds,\nthe Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup,\nremove the pod from the API. In the presence of network partitions, this object may still\nexist after this timestamp, until an administrator or automated process can determine the\nresource is fully terminated.\nIf not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested.\nRead-only.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata\n+optional",
           "type": "string",
-          "x-go-name": "DeletionTimestamp"
+          "x-go-name": "DeletionTimestamp",
+          "x-go-type": "k8s.io/apimachinery/pkg/apis/meta/v1.Time"
         },
         "finalizers": {
           "description": "Must be empty before the object is deleted from the registry. Each entry\nis an identifier for the responsible component that will remove the entry\nfrom the list. If the deletionTimestamp of the object is non-nil, entries\nin this list can only be removed.\nFinalizers may be processed and removed in any order.  Order is NOT enforced\nbecause it introduces significant risk of stuck finalizers.\nfinalizers is a shared field, any actor with permission can reorder it.\nIf the finalizer list is processed in order, then this can lead to a situation\nin which the component responsible for the first finalizer in the list is\nwaiting for a signal (field value, external system, or other) produced by a\ncomponent responsible for a finalizer later in the list, resulting in a deadlock.\nWithout enforced ordering finalizers are free to order amongst themselves and\nare not vulnerable to ordering changes in the list.\n+optional\n+patchStrategy=merge",

--- a/pkg/api/binoculars/api.swagger.go
+++ b/pkg/api/binoculars/api.swagger.go
@@ -223,7 +223,8 @@ func SwaggerJsonTemplate() string {
 		"        \"sinceTime\": {\n" +
 		"          \"description\": \"An RFC3339 timestamp from which to show logs. If this value\\nprecedes the time a pod was started, only logs since the pod start will be returned.\\nIf this value is in the future, no logs will be returned.\\nOnly one of sinceSeconds or sinceTime may be specified.\\n+optional\",\n" +
 		"          \"type\": \"string\",\n" +
-		"          \"x-go-name\": \"SinceTime\"\n" +
+		"          \"x-go-name\": \"SinceTime\",\n" +
+		"          \"x-go-type\": \"k8s.io/apimachinery/pkg/apis/meta/v1.Time\"\n" +
 		"        },\n" +
 		"        \"tailLines\": {\n" +
 		"          \"description\": \"If set, the number of lines from the end of the logs to show. If not specified,\\nlogs are shown from the creation of the container or sinceSeconds or sinceTime\\n+optional\",\n" +

--- a/pkg/api/binoculars/api.swagger.json
+++ b/pkg/api/binoculars/api.swagger.json
@@ -212,7 +212,8 @@
         "sinceTime": {
           "description": "An RFC3339 timestamp from which to show logs. If this value\nprecedes the time a pod was started, only logs since the pod start will be returned.\nIf this value is in the future, no logs will be returned.\nOnly one of sinceSeconds or sinceTime may be specified.\n+optional",
           "type": "string",
-          "x-go-name": "SinceTime"
+          "x-go-name": "SinceTime",
+          "x-go-type": "k8s.io/apimachinery/pkg/apis/meta/v1.Time"
         },
         "tailLines": {
           "description": "If set, the number of lines from the end of the logs to show. If not specified,\nlogs are shown from the creation of the container or sinceSeconds or sinceTime\n+optional",

--- a/tools.yaml
+++ b/tools.yaml
@@ -1,8 +1,8 @@
 # Tools used to build and release Armada
 # TODO: Use latest goreleaser. After upgrading k8s.io packages.
 tools:
-- github.com/go-swagger/go-swagger/cmd/swagger@v0.31.0
-- go.uber.org/mock/mockgen@v0.5.0
+- github.com/go-swagger/go-swagger/cmd/swagger@v0.33.1
+- go.uber.org/mock/mockgen@v0.6.0
 - github.com/gordonklaus/ineffassign@v0.0.0-20210914165742-4cc7213b9bc8
 - github.com/goreleaser/goreleaser/v2@v2.8.1
 - github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway@v1.16.0
@@ -10,7 +10,7 @@ tools:
 - github.com/jstemmer/go-junit-report@v1.0.0
 - github.com/mitchellh/gox@v1.0.1
 - github.com/wlbr/templify@v0.0.0-20210816202250-7b8044ca19e9
-- golang.org/x/tools/cmd/goimports@v0.31.0
+- golang.org/x/tools/cmd/goimports@v0.38.0
 - sigs.k8s.io/kind@v0.25.0
 - github.com/sqlc-dev/sqlc/cmd/sqlc@v1.27.0
-- github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.6
+- github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0


### PR DESCRIPTION
#### What type of PR is this?

Chore

#### What this PR does / why we need it:

Update Go version to v1.25, this version introduces a couple of performance optimizations which would benefit Armada components, especially the scheduler.

`golang.org/x/tools/cmd/goimports` needed to be bumped to `v0.38.0` so it contains a version of `golang.org/x/tools` which is compatible with go1.25. 
`github.com/go-swagger/go-swagger/cmd/swagger` needed to be bumped to `v0.33.1` due to above reason.
`go.uber.org/mock/mockgen` needed to be bumped to `v0.6.0` due to above reason.
`github.com/golangci/golangci-lint/cmd/golangci-lint` needed to be bumped to `v2.5.0` due to above reason.

More info on `x/tools` compatibility issues here https://github.com/golang/go/issues/74462

All code changes are auto-generated from:
* `go run github.com/magefile/mage@v1.14.0 -v proto`
* `go run github.com/magefile/mage@v1.14.0 -v generate`