### PR TITLE
feat: add indexes to speed up cancellation in scheduler database

### DIFF
--- a/internal/scheduler/database/migrations/025_add_cancellation_index.sql
+++ b/internal/scheduler/database/migrations/025_add_cancellation_index.sql
@@ -1,2 +1,4 @@
--- Add an index to optimize queries that cancel jobs by queue and job set.
-CREATE INDEX CONCURRENTLY idx_jobs_queue_jobset_id (fillfactor = 80) ON jobs (queue, job_set, job_id);
+-- Add index to speed up job cancellation queries
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_queue_job_set_cancelled_succeeded_failed
+ON jobs (queue, job_set, cancelled, succeeded, failed)
+WITH (fillfactor = 80);

--- a/internal/scheduler/database/query.sql.go
+++ b/internal/scheduler/database/query.sql.go
@@ -162,6 +162,21 @@ func (q *Queries) MarkJobsCancelRequestedById(ctx context.Context, arg MarkJobsC
 	return err
 }
 
+const markJobsCancelRequestedBySet = `-- name: MarkJobsCancelRequestedBySet :exec
+UPDATE jobs SET cancel_by_jobset_requested = true, cancel_user = $1 WHERE job_set = $2 and queue = $3 and cancelled = false and succeeded = false and failed = false
+`
+
+type MarkJobsCancelRequestedBySetParams struct {
+	CancelUser *string `db:"cancel_user"`
+	JobSet     string  `db:"job_set"`
+	Queue      string  `db:"queue"`
+}
+
+func (q *Queries) MarkJobsCancelRequestedBySet(ctx context.Context, arg MarkJobsCancelRequestedBySetParams) error {
+	_, err := q.db.Exec(ctx, markJobsCancelRequestedBySet, arg.CancelUser, arg.JobSet, arg.Queue)
+	return err
+}
+
 const markJobsCancelRequestedBySetAndQueuedState = `-- name: MarkJobsCancelRequestedBySetAndQueuedState :exec
 UPDATE jobs SET cancel_by_jobset_requested = true, cancel_user = $1 WHERE job_set = $2 and queue = $3 and queued = ANY($4::bool[]) and cancelled = false and succeeded = false and failed = false
 `

--- a/internal/scheduler/database/query/query.sql
+++ b/internal/scheduler/database/query/query.sql
@@ -22,6 +22,9 @@ UPDATE jobs SET priority = $1 WHERE job_set = $2 and queue = $3 and cancelled = 
 -- name: MarkJobsCancelRequestedBySetAndQueuedState :exec
 UPDATE jobs SET cancel_by_jobset_requested = true, cancel_user = $1 WHERE job_set = sqlc.arg(job_set) and queue = sqlc.arg(queue) and queued = ANY(sqlc.arg(queued_states)::bool[]) and cancelled = false and succeeded = false and failed = false;
 
+-- name: MarkJobsCancelRequestedBySet :exec
+UPDATE jobs SET cancel_by_jobset_requested = true, cancel_user = $1 WHERE job_set = sqlc.arg(job_set) and queue = sqlc.arg(queue) and cancelled = false and succeeded = false and failed = false;
+
 -- name: MarkJobsSucceededById :exec
 UPDATE jobs SET succeeded = true WHERE job_id = ANY(sqlc.arg(job_ids)::text[]);
 

--- a/internal/scheduleringester/schedulerdb.go
+++ b/internal/scheduleringester/schedulerdb.go
@@ -161,26 +161,41 @@ func (s *SchedulerDb) WriteDbOp(ctx *armadacontext.Context, tx pgx.Tx, op DbOper
 		}
 	case MarkJobSetsCancelRequested:
 		for jobSetInfo, cancelDetails := range o.jobSets {
-			queuedStatesToCancel := make([]bool, 0, 2)
-			if cancelDetails.cancelQueued {
-				// Cancel all jobs in a queued state
-				queuedStatesToCancel = append(queuedStatesToCancel, true)
-			}
-			if cancelDetails.cancelLeased {
-				// Cancel all jobs in a non-queued state
-				queuedStatesToCancel = append(queuedStatesToCancel, false)
-			}
-			err := queries.MarkJobsCancelRequestedBySetAndQueuedState(
-				ctx,
-				schedulerdb.MarkJobsCancelRequestedBySetAndQueuedStateParams{
-					Queue:        jobSetInfo.queue,
-					JobSet:       jobSetInfo.jobSet,
-					QueuedStates: queuedStatesToCancel,
-					CancelUser:   &o.cancelUser,
-				},
-			)
-			if err != nil {
-				return errors.WithStack(err)
+			// If cancelling both queued and leased jobs, avoid ANY([true,false]) redundancy
+			if cancelDetails.cancelQueued && cancelDetails.cancelLeased {
+				// Cancel all jobs regardless of queued state - more efficient
+				err := queries.MarkJobsCancelRequestedBySet(
+					ctx,
+					schedulerdb.MarkJobsCancelRequestedBySetParams{
+						Queue:      jobSetInfo.queue,
+						JobSet:     jobSetInfo.jobSet,
+						CancelUser: &o.cancelUser,
+					},
+				)
+				if err != nil {
+					return errors.WithStack(err)
+				}
+			} else {
+				// Cancel specific queued states
+				queuedStatesToCancel := make([]bool, 0, 2)
+				if cancelDetails.cancelQueued {
+					queuedStatesToCancel = append(queuedStatesToCancel, true)
+				}
+				if cancelDetails.cancelLeased {
+					queuedStatesToCancel = append(queuedStatesToCancel, false)
+				}
+				err := queries.MarkJobsCancelRequestedBySetAndQueuedState(
+					ctx,
+					schedulerdb.MarkJobsCancelRequestedBySetAndQueuedStateParams{
+						Queue:        jobSetInfo.queue,
+						JobSet:       jobSetInfo.jobSet,
+						QueuedStates: queuedStatesToCancel,
+						CancelUser:   &o.cancelUser,
+					},
+				)
+				if err != nil {
+					return errors.WithStack(err)
+				}
 			}
 		}
 	case MarkJobsCancelRequested:


### PR DESCRIPTION
#### What type of PR is this?

Enhancement

#### What this PR does / why we need it:

Speeds up cancellation due to database bottlenecks which occur because of missing indexes.