### PR TITLE
Move constants to their own package in common

### DIFF
--- a/internal/common/constants/constants.go
+++ b/internal/common/constants/constants.go
@@ -1,4 +1,4 @@
-package configuration
+package constants
 
 const (
 	// GangIdAnnotation maps to a unique id of the gang the job is part of; jobs with equal value make up a gang.

--- a/internal/common/ingest/testfixtures/event.go
+++ b/internal/common/ingest/testfixtures/event.go
@@ -8,11 +8,11 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
+	"github.com/armadaproject/armada/internal/common/constants"
 	protoutil "github.com/armadaproject/armada/internal/common/proto"
 	armadaslices "github.com/armadaproject/armada/internal/common/slices"
 	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
 	"github.com/armadaproject/armada/internal/scheduler/testfixtures"
-	"github.com/armadaproject/armada/internal/server/configuration"
 	"github.com/armadaproject/armada/pkg/armadaevents"
 	"github.com/armadaproject/armada/pkg/controlplaneevents"
 )
@@ -92,17 +92,17 @@ var Submit = &armadaevents.EventSequence_Event{
 				Namespace: Namespace,
 				Name:      "test-job",
 				Annotations: map[string]string{
-					"foo":                            "bar",
-					configuration.FailFastAnnotation: "true",
-					configuration.JobPriceBand:       "A",
+					"foo":                        "bar",
+					constants.FailFastAnnotation: "true",
+					constants.JobPriceBand:       "A",
 				},
 			},
 			MainObject: &armadaevents.KubernetesMainObject{
 				ObjectMeta: &armadaevents.ObjectMeta{
 					Annotations: map[string]string{
-						"foo":                            "bar",
-						configuration.FailFastAnnotation: "true",
-						configuration.JobPriceBand:       "A",
+						"foo":                        "bar",
+						constants.FailFastAnnotation: "true",
+						constants.JobPriceBand:       "A",
 					},
 				},
 				Object: &armadaevents.KubernetesMainObject_PodSpec{
@@ -150,21 +150,21 @@ var SubmitWithIrrelevantAnnotations = &armadaevents.EventSequence_Event{
 				Namespace: Namespace,
 				Name:      "test-job",
 				Annotations: map[string]string{
-					"foo":                            "bar",
-					"fizz":                           "buzz",
-					"buzz":                           "fizz",
-					configuration.FailFastAnnotation: "true",
-					configuration.JobPriceBand:       "A",
+					"foo":                        "bar",
+					"fizz":                       "buzz",
+					"buzz":                       "fizz",
+					constants.FailFastAnnotation: "true",
+					constants.JobPriceBand:       "A",
 				},
 			},
 			MainObject: &armadaevents.KubernetesMainObject{
 				ObjectMeta: &armadaevents.ObjectMeta{
 					Annotations: map[string]string{
-						"foo":                            "bar",
-						"fizz":                           "buzz",
-						"buzz":                           "fizz",
-						configuration.FailFastAnnotation: "true",
-						configuration.JobPriceBand:       "A",
+						"foo":                        "bar",
+						"fizz":                       "buzz",
+						"buzz":                       "fizz",
+						constants.FailFastAnnotation: "true",
+						constants.JobPriceBand:       "A",
 					},
 				},
 				Object: &armadaevents.KubernetesMainObject_PodSpec{

--- a/internal/executor/util/kubernetes_object.go
+++ b/internal/executor/util/kubernetes_object.go
@@ -9,10 +9,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/armadaproject/armada/internal/common"
+	serverconfiguration "github.com/armadaproject/armada/internal/common/constants"
 	"github.com/armadaproject/armada/internal/common/util"
 	"github.com/armadaproject/armada/internal/executor/configuration"
 	"github.com/armadaproject/armada/internal/executor/domain"
-	serverconfiguration "github.com/armadaproject/armada/internal/server/configuration"
 	"github.com/armadaproject/armada/pkg/api"
 	"github.com/armadaproject/armada/pkg/armadaevents"
 	"github.com/armadaproject/armada/pkg/executorapi"

--- a/internal/executor/util/kubernetes_objects_test.go
+++ b/internal/executor/util/kubernetes_objects_test.go
@@ -4,17 +4,16 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/armadaproject/armada/internal/common/util"
-
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/armadaproject/armada/internal/common"
+	serverconfiguration "github.com/armadaproject/armada/internal/common/constants"
+	"github.com/armadaproject/armada/internal/common/util"
 	"github.com/armadaproject/armada/internal/executor/configuration"
 	"github.com/armadaproject/armada/internal/executor/domain"
-	serverconfiguration "github.com/armadaproject/armada/internal/server/configuration"
 	"github.com/armadaproject/armada/pkg/api"
 	"github.com/armadaproject/armada/pkg/armadaevents"
 	"github.com/armadaproject/armada/pkg/executorapi"

--- a/internal/executor/util/pod_util.go
+++ b/internal/executor/util/pod_util.go
@@ -10,10 +10,10 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 
+	"github.com/armadaproject/armada/internal/common/constants"
 	log "github.com/armadaproject/armada/internal/common/logging"
 	"github.com/armadaproject/armada/internal/common/util"
 	"github.com/armadaproject/armada/internal/executor/domain"
-	"github.com/armadaproject/armada/internal/server/configuration"
 )
 
 var managedPodSelector labels.Selector
@@ -111,7 +111,7 @@ func ExtractQueue(pod *v1.Pod) string {
 }
 
 func ExtractPool(pod *v1.Pod) string {
-	return pod.Annotations[configuration.PoolAnnotation]
+	return pod.Annotations[constants.PoolAnnotation]
 }
 
 func ExtractJobSet(pod *v1.Pod) string {

--- a/internal/executor/util/pod_util_test.go
+++ b/internal/executor/util/pod_util_test.go
@@ -8,9 +8,9 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/armadaproject/armada/internal/common/constants"
 	"github.com/armadaproject/armada/internal/common/util"
 	"github.com/armadaproject/armada/internal/executor/domain"
-	"github.com/armadaproject/armada/internal/server/configuration"
 )
 
 func TestIsInTerminalState_ShouldReturnTrueWhenPodInSucceededPhase(t *testing.T) {
@@ -371,7 +371,7 @@ func TestExtractQueue(t *testing.T) {
 }
 
 func TestExtractPool(t *testing.T) {
-	podWithPool := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{configuration.PoolAnnotation: "pool-1"}}}
+	podWithPool := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{constants.PoolAnnotation: "pool-1"}}}
 	podWithoutPool := &v1.Pod{}
 
 	assert.Equal(t, ExtractPool(podWithPool), "pool-1")

--- a/internal/scheduler/api.go
+++ b/internal/scheduler/api.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"strconv"
 
-	protoutil "github.com/armadaproject/armada/internal/common/proto"
-
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
@@ -18,13 +16,14 @@ import (
 	"github.com/armadaproject/armada/internal/common/armadaerrors"
 	"github.com/armadaproject/armada/internal/common/auth"
 	"github.com/armadaproject/armada/internal/common/compress"
+	"github.com/armadaproject/armada/internal/common/constants"
 	log "github.com/armadaproject/armada/internal/common/logging"
 	"github.com/armadaproject/armada/internal/common/maps"
+	protoutil "github.com/armadaproject/armada/internal/common/proto"
 	"github.com/armadaproject/armada/internal/common/pulsarutils"
 	priorityTypes "github.com/armadaproject/armada/internal/common/types"
 	"github.com/armadaproject/armada/internal/scheduler/database"
 	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
-	"github.com/armadaproject/armada/internal/server/configuration"
 	"github.com/armadaproject/armada/internal/server/permissions"
 	"github.com/armadaproject/armada/pkg/armadaevents"
 	"github.com/armadaproject/armada/pkg/executorapi"
@@ -142,7 +141,7 @@ func (srv *ExecutorApi) LeaseJobRuns(stream executorapi.ExecutorApi_LeaseJobRuns
 		}
 
 		srv.addNodeIdSelector(submitMsg, lease.Node)
-		addAnnotations(submitMsg, map[string]string{configuration.PoolAnnotation: lease.Pool})
+		addAnnotations(submitMsg, map[string]string{constants.PoolAnnotation: lease.Pool})
 
 		if len(lease.PodRequirementsOverlay) > 0 {
 			PodRequirementsOverlay := schedulerobjects.PodRequirements{}

--- a/internal/scheduler/api_test.go
+++ b/internal/scheduler/api_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/armadaproject/armada/internal/common/armadaerrors"
 	"github.com/armadaproject/armada/internal/common/auth/permission"
 	"github.com/armadaproject/armada/internal/common/compress"
+	"github.com/armadaproject/armada/internal/common/constants"
 	"github.com/armadaproject/armada/internal/common/mocks"
 	protoutil "github.com/armadaproject/armada/internal/common/proto"
 	"github.com/armadaproject/armada/internal/common/slices"
@@ -30,7 +31,6 @@ import (
 	schedulermocks "github.com/armadaproject/armada/internal/scheduler/mocks"
 	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
 	"github.com/armadaproject/armada/internal/scheduler/testfixtures"
-	"github.com/armadaproject/armada/internal/server/configuration"
 	servermocks "github.com/armadaproject/armada/internal/server/mocks"
 	"github.com/armadaproject/armada/internal/server/permissions"
 	"github.com/armadaproject/armada/pkg/api"
@@ -98,7 +98,7 @@ func TestExecutorApi_LeaseJobRuns(t *testing.T) {
 		t,
 		&armadaevents.ObjectMeta{
 			Labels:      map[string]string{armadaJobPreemptibleLabel: "false"},
-			Annotations: map[string]string{configuration.PoolAnnotation: "test-pool"},
+			Annotations: map[string]string{constants.PoolAnnotation: "test-pool"},
 		},
 		&v1.PodSpec{
 			NodeSelector: map[string]string{nodeIdName: "node-id"},
@@ -118,7 +118,7 @@ func TestExecutorApi_LeaseJobRuns(t *testing.T) {
 	submitWithoutNodeSelector, compressedSubmitNoNodeSelector := submitMsg(t,
 		&armadaevents.ObjectMeta{
 			Labels:      map[string]string{armadaJobPreemptibleLabel: "false"},
-			Annotations: map[string]string{configuration.PoolAnnotation: "test-pool"},
+			Annotations: map[string]string{constants.PoolAnnotation: "test-pool"},
 		},
 		nil,
 	)
@@ -136,7 +136,7 @@ func TestExecutorApi_LeaseJobRuns(t *testing.T) {
 		t,
 		&armadaevents.ObjectMeta{
 			Labels:      map[string]string{armadaJobPreemptibleLabel: "true"},
-			Annotations: map[string]string{configuration.PoolAnnotation: "test-pool"},
+			Annotations: map[string]string{constants.PoolAnnotation: "test-pool"},
 		},
 
 		&v1.PodSpec{
@@ -178,14 +178,14 @@ func TestExecutorApi_LeaseJobRuns(t *testing.T) {
 				Tolerations: armadaslices.Map(tolerations, func(t v1.Toleration) *v1.Toleration {
 					return &t
 				}),
-				Annotations: map[string]string{configuration.PoolAnnotation: "test-pool", "runtime_gang_cardinality": "3"},
+				Annotations: map[string]string{constants.PoolAnnotation: "test-pool", "runtime_gang_cardinality": "3"},
 			},
 		),
 	}
 	submitWithOverlay, _ := submitMsg(
 		t,
 		&armadaevents.ObjectMeta{
-			Annotations: map[string]string{configuration.PoolAnnotation: "test-pool", "runtime_gang_cardinality": "3"},
+			Annotations: map[string]string{constants.PoolAnnotation: "test-pool", "runtime_gang_cardinality": "3"},
 			Labels:      map[string]string{armadaJobPreemptibleLabel: "false"},
 		},
 		&v1.PodSpec{

--- a/internal/scheduler/jobdb/gang.go
+++ b/internal/scheduler/jobdb/gang.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/armadaproject/armada/internal/common/constants"
 	"github.com/armadaproject/armada/internal/scheduler/interfaces"
-	"github.com/armadaproject/armada/internal/server/configuration"
 )
 
 type GangInfo struct {
@@ -63,7 +63,7 @@ func (g GangInfo) String() string {
 func GangInfoFromMinimalJob(job interfaces.MinimalJob) (*GangInfo, error) {
 	basicGangInfo := BasicJobGangInfo()
 	annotations := job.Annotations()
-	gangId, ok := annotations[configuration.GangIdAnnotation]
+	gangId, ok := annotations[constants.GangIdAnnotation]
 	if !ok {
 		// Not a gang, default to basic gang info
 		return &basicGangInfo, nil
@@ -72,9 +72,9 @@ func GangInfoFromMinimalJob(job interfaces.MinimalJob) (*GangInfo, error) {
 		return nil, errors.Errorf("gang id is empty")
 	}
 
-	gangCardinalityString, ok := annotations[configuration.GangCardinalityAnnotation]
+	gangCardinalityString, ok := annotations[constants.GangCardinalityAnnotation]
 	if !ok {
-		return nil, errors.Errorf("gang cardinality annotation %s is missing", configuration.GangCardinalityAnnotation)
+		return nil, errors.Errorf("gang cardinality annotation %s is missing", constants.GangCardinalityAnnotation)
 	}
 	gangCardinality, err := strconv.Atoi(gangCardinalityString)
 	if err != nil {
@@ -88,7 +88,7 @@ func GangInfoFromMinimalJob(job interfaces.MinimalJob) (*GangInfo, error) {
 		return &basicGangInfo, nil
 	}
 
-	nodeUniformityLabel := job.Annotations()[configuration.GangNodeUniformityLabelAnnotation]
+	nodeUniformityLabel := job.Annotations()[constants.GangNodeUniformityLabelAnnotation]
 	gangInfo := CreateGangInfo(gangId, gangCardinality, nodeUniformityLabel)
 	return &gangInfo, nil
 }

--- a/internal/scheduler/jobdb/job_test.go
+++ b/internal/scheduler/jobdb/job_test.go
@@ -8,10 +8,10 @@ import (
 	v1 "k8s.io/api/core/v1"
 	k8sResource "k8s.io/apimachinery/pkg/api/resource"
 
+	armadaconfiguration "github.com/armadaproject/armada/internal/common/constants"
 	"github.com/armadaproject/armada/internal/common/types"
 	"github.com/armadaproject/armada/internal/scheduler/internaltypes"
 	"github.com/armadaproject/armada/internal/scheduler/pricing"
-	armadaconfiguration "github.com/armadaproject/armada/internal/server/configuration"
 	"github.com/armadaproject/armada/pkg/bidstore"
 )
 

--- a/internal/scheduler/jobdb/jobdb_test.go
+++ b/internal/scheduler/jobdb/jobdb_test.go
@@ -14,11 +14,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 
+	armadaconfiguration "github.com/armadaproject/armada/internal/common/constants"
 	"github.com/armadaproject/armada/internal/common/stringinterner"
 	"github.com/armadaproject/armada/internal/common/types"
 	"github.com/armadaproject/armada/internal/common/util"
 	"github.com/armadaproject/armada/internal/scheduler/internaltypes"
-	armadaconfiguration "github.com/armadaproject/armada/internal/server/configuration"
 )
 
 func NewTestJobDb() *JobDb {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/utils/clock"
 
 	"github.com/armadaproject/armada/internal/common/armadacontext"
+	"github.com/armadaproject/armada/internal/common/constants"
 	protoutil "github.com/armadaproject/armada/internal/common/proto"
 	armadaslices "github.com/armadaproject/armada/internal/common/slices"
 	"github.com/armadaproject/armada/internal/scheduler/database"
@@ -24,7 +25,6 @@ import (
 	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
 	"github.com/armadaproject/armada/internal/scheduler/scheduling"
 	schedulercontext "github.com/armadaproject/armada/internal/scheduler/scheduling/context"
-	"github.com/armadaproject/armada/internal/server/configuration"
 	"github.com/armadaproject/armada/pkg/armadaevents"
 	"github.com/armadaproject/armada/pkg/bidstore"
 )
@@ -844,7 +844,7 @@ func (s *Scheduler) generateUpdateMessagesFromJob(ctx *armadacontext.Context, jo
 			}
 			events = append(events, jobSucceeded)
 		} else if lastRun.Failed() && !job.Queued() {
-			failFast := job.Annotations()[configuration.FailFastAnnotation] == "true"
+			failFast := job.Annotations()[constants.FailFastAnnotation] == "true"
 			requeueJob := !failFast && lastRun.Returned() && job.NumAttempts() < s.maxAttemptedRuns
 
 			if requeueJob && lastRun.RunAttempted() {
@@ -1201,7 +1201,7 @@ func getGangNodeUniformityAnnotations(jctx *schedulercontext.JobSchedulingContex
 	}
 
 	return map[string]string{
-		configuration.GangNodeUniformityLabelNameEnvVar:  jctx.GangNodeUniformityLabelName,
-		configuration.GangNodeUniformityLabelValueEnvVar: jctx.GangNodeUniformityLabelValue,
+		constants.GangNodeUniformityLabelNameEnvVar:  jctx.GangNodeUniformityLabelName,
+		constants.GangNodeUniformityLabelValueEnvVar: jctx.GangNodeUniformityLabelValue,
 	}
 }

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	"github.com/armadaproject/armada/internal/common/armadacontext"
+	apiconfig "github.com/armadaproject/armada/internal/common/constants"
 	"github.com/armadaproject/armada/internal/common/ingest/utils"
 	protoutil "github.com/armadaproject/armada/internal/common/proto"
 	"github.com/armadaproject/armada/internal/common/pulsarutils"
@@ -35,7 +36,6 @@ import (
 	schedulercontext "github.com/armadaproject/armada/internal/scheduler/scheduling/context"
 	"github.com/armadaproject/armada/internal/scheduler/testfixtures"
 	"github.com/armadaproject/armada/internal/scheduleringester"
-	apiconfig "github.com/armadaproject/armada/internal/server/configuration"
 	"github.com/armadaproject/armada/pkg/api"
 	"github.com/armadaproject/armada/pkg/armadaevents"
 	"github.com/armadaproject/armada/pkg/bidstore"

--- a/internal/scheduler/scheduling/market_driven_indicative_pricer.go
+++ b/internal/scheduler/scheduling/market_driven_indicative_pricer.go
@@ -7,6 +7,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/armadaproject/armada/internal/common/armadacontext"
+	armadaconfiguration "github.com/armadaproject/armada/internal/common/constants"
 	"github.com/armadaproject/armada/internal/common/util"
 	"github.com/armadaproject/armada/internal/scheduler/configuration"
 	"github.com/armadaproject/armada/internal/scheduler/floatingresources"
@@ -15,7 +16,6 @@ import (
 	schedulerconstraints "github.com/armadaproject/armada/internal/scheduler/scheduling/constraints"
 	schedulercontext "github.com/armadaproject/armada/internal/scheduler/scheduling/context"
 	"github.com/armadaproject/armada/internal/scheduler/scheduling/pricer"
-	armadaconfiguration "github.com/armadaproject/armada/internal/server/configuration"
 )
 
 type IndicativeGangPricesByJobShape map[string]pricer.GangPricingResult

--- a/internal/scheduler/scheduling/preemption_description_test.go
+++ b/internal/scheduler/scheduling/preemption_description_test.go
@@ -7,12 +7,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/armadaproject/armada/internal/common/constants"
 	"github.com/armadaproject/armada/internal/scheduler/internaltypes"
 	"github.com/armadaproject/armada/internal/scheduler/jobdb"
 	"github.com/armadaproject/armada/internal/scheduler/pricing"
 	"github.com/armadaproject/armada/internal/scheduler/scheduling/context"
 	"github.com/armadaproject/armada/internal/scheduler/testfixtures"
-	"github.com/armadaproject/armada/internal/server/configuration"
 )
 
 func TestPopulatePreemptionDescriptions(t *testing.T) {
@@ -149,9 +149,9 @@ func makeJob(t *testing.T, jobId string, isGang bool) *jobdb.Job {
 func makeJobWithPrice(t *testing.T, jobId string, isGang bool, price float64) *jobdb.Job {
 	annotations := map[string]string{}
 	if isGang {
-		annotations[configuration.GangIdAnnotation] = "gang"
-		annotations[configuration.GangCardinalityAnnotation] = "2"
-		annotations[configuration.GangNodeUniformityLabelAnnotation] = "uniformity"
+		annotations[constants.GangIdAnnotation] = "gang"
+		annotations[constants.GangCardinalityAnnotation] = "2"
+		annotations[constants.GangNodeUniformityLabelAnnotation] = "uniformity"
 	}
 	schedulingInfo := &internaltypes.JobSchedulingInfo{
 		PodRequirements: &internaltypes.PodRequirements{

--- a/internal/scheduler/scheduling/queue_scheduler_test.go
+++ b/internal/scheduler/scheduling/queue_scheduler_test.go
@@ -13,6 +13,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/armadaproject/armada/internal/common/armadacontext"
+	armadaconfiguration "github.com/armadaproject/armada/internal/common/constants"
 	armadaslices "github.com/armadaproject/armada/internal/common/slices"
 	"github.com/armadaproject/armada/internal/common/stringinterner"
 	"github.com/armadaproject/armada/internal/scheduler/configuration"
@@ -23,7 +24,6 @@ import (
 	"github.com/armadaproject/armada/internal/scheduler/scheduling/context"
 	"github.com/armadaproject/armada/internal/scheduler/scheduling/fairness"
 	"github.com/armadaproject/armada/internal/scheduler/testfixtures"
-	armadaconfiguration "github.com/armadaproject/armada/internal/server/configuration"
 	"github.com/armadaproject/armada/pkg/api"
 )
 

--- a/internal/scheduler/simulator/simulator.go
+++ b/internal/scheduler/simulator/simulator.go
@@ -18,6 +18,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/armadaproject/armada/internal/common/armadacontext"
+	serverconfig "github.com/armadaproject/armada/internal/common/constants"
 	"github.com/armadaproject/armada/internal/common/logging"
 	protoutil "github.com/armadaproject/armada/internal/common/proto"
 	armadaslices "github.com/armadaproject/armada/internal/common/slices"
@@ -37,7 +38,6 @@ import (
 	"github.com/armadaproject/armada/internal/scheduler/simulator/model"
 	"github.com/armadaproject/armada/internal/scheduler/simulator/sink"
 	"github.com/armadaproject/armada/internal/scheduleringester"
-	serverconfig "github.com/armadaproject/armada/internal/server/configuration"
 	"github.com/armadaproject/armada/pkg/armadaevents"
 )
 

--- a/internal/scheduler/testfixtures/testfixtures.go
+++ b/internal/scheduler/testfixtures/testfixtures.go
@@ -15,6 +15,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
+	"github.com/armadaproject/armada/internal/common/constants"
 	"github.com/armadaproject/armada/internal/common/pointer"
 	protoutil "github.com/armadaproject/armada/internal/common/proto"
 	"github.com/armadaproject/armada/internal/common/slices"
@@ -27,7 +28,6 @@ import (
 	"github.com/armadaproject/armada/internal/scheduler/jobdb"
 	"github.com/armadaproject/armada/internal/scheduler/pricing"
 	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
-	"github.com/armadaproject/armada/internal/server/configuration"
 	"github.com/armadaproject/armada/pkg/api"
 	"github.com/armadaproject/armada/pkg/bidstore"
 )
@@ -466,7 +466,7 @@ func WithNodeUniformityGangAnnotationsJobs(jobs []*jobdb.Job, nodeUniformityLabe
 func WithGangJobDetails(jobs []*jobdb.Job, gangId string, gangCardinality int, nodeUniformityLabel string) []*jobdb.Job {
 	gangCardinalityStr := fmt.Sprintf("%d", gangCardinality)
 	updatedJobs := WithAnnotationsJobs(
-		map[string]string{configuration.GangIdAnnotation: gangId, configuration.GangCardinalityAnnotation: gangCardinalityStr, configuration.GangNodeUniformityLabelAnnotation: nodeUniformityLabel},
+		map[string]string{constants.GangIdAnnotation: gangId, constants.GangCardinalityAnnotation: gangCardinalityStr, constants.GangNodeUniformityLabelAnnotation: nodeUniformityLabel},
 		jobs,
 	)
 

--- a/internal/scheduleringester/instructions.go
+++ b/internal/scheduleringester/instructions.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/armadaproject/armada/internal/common/armadacontext"
 	"github.com/armadaproject/armada/internal/common/compress"
+	"github.com/armadaproject/armada/internal/common/constants"
 	"github.com/armadaproject/armada/internal/common/ingest/metrics"
 	"github.com/armadaproject/armada/internal/common/ingest/utils"
 	log "github.com/armadaproject/armada/internal/common/logging"
@@ -18,7 +19,6 @@ import (
 	"github.com/armadaproject/armada/internal/scheduler/adapters"
 	schedulerdb "github.com/armadaproject/armada/internal/scheduler/database"
 	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
-	"github.com/armadaproject/armada/internal/server/configuration"
 	"github.com/armadaproject/armada/pkg/armadaevents"
 	"github.com/armadaproject/armada/pkg/bidstore"
 	"github.com/armadaproject/armada/pkg/controlplaneevents"
@@ -167,7 +167,7 @@ func (c *JobSetEventsInstructionConverter) handleSubmitJob(job *armadaevents.Sub
 
 	pricingBand := int32(0)
 	if job.ObjectMeta != nil {
-		pricingBandValue, ok := job.ObjectMeta.Annotations[configuration.JobPriceBand]
+		pricingBandValue, ok := job.ObjectMeta.Annotations[constants.JobPriceBand]
 		if ok {
 			priceBandValue, exists := bidstore.PriceBandFromShortName[strings.ToUpper(pricingBandValue)]
 			if !exists {
@@ -545,19 +545,19 @@ func SchedulingInfoFromSubmitJob(submitJob *armadaevents.SubmitJob, submitTime t
 		schedulingInfo.PriorityClassName = podSpec.PriorityClassName
 		podRequirements := adapters.PodRequirementsFromPodSpec(podSpec)
 		if podRequirements.Annotations == nil {
-			podRequirements.Annotations = make(map[string]string, configuration.SchedulingAnnotationCount())
+			podRequirements.Annotations = make(map[string]string, constants.SchedulingAnnotationCount())
 		}
 
 		if submitJob.ObjectMeta != nil {
 			for k, v := range submitJob.ObjectMeta.Annotations {
-				if configuration.IsSchedulingAnnotation(k) {
+				if constants.IsSchedulingAnnotation(k) {
 					podRequirements.Annotations[k] = v
 				}
 			}
 		}
 		if submitJob.MainObject.ObjectMeta != nil {
 			for k, v := range submitJob.MainObject.ObjectMeta.Annotations {
-				if configuration.IsSchedulingAnnotation(k) {
+				if constants.IsSchedulingAnnotation(k) {
 					podRequirements.Annotations[k] = v
 				}
 			}

--- a/internal/scheduleringester/instructions_test.go
+++ b/internal/scheduleringester/instructions_test.go
@@ -11,13 +11,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/armadaproject/armada/internal/common/compress"
+	"github.com/armadaproject/armada/internal/common/constants"
 	"github.com/armadaproject/armada/internal/common/ingest/metrics"
 	f "github.com/armadaproject/armada/internal/common/ingest/testfixtures"
 	protoutil "github.com/armadaproject/armada/internal/common/proto"
 	armadaslices "github.com/armadaproject/armada/internal/common/slices"
 	schedulerdb "github.com/armadaproject/armada/internal/scheduler/database"
 	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
-	"github.com/armadaproject/armada/internal/server/configuration"
 	"github.com/armadaproject/armada/pkg/armadaevents"
 	"github.com/armadaproject/armada/pkg/controlplaneevents"
 )
@@ -473,8 +473,8 @@ func getExpectedSubmitMessageSchedulingInfo(t *testing.T) *schedulerobjects.JobS
 						},
 						Annotations: map[string]string{
 							// Only certain annotations permitted, determined by configuration.IsSchedulingAnnotation()
-							configuration.FailFastAnnotation: "true",
-							configuration.JobPriceBand:       "A",
+							constants.FailFastAnnotation: "true",
+							constants.JobPriceBand:       "A",
 						},
 					},
 				},

--- a/internal/server/submit/conversion/post_process.go
+++ b/internal/server/submit/conversion/post_process.go
@@ -7,6 +7,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
+	"github.com/armadaproject/armada/internal/common/constants"
 	log "github.com/armadaproject/armada/internal/common/logging"
 	armadaresource "github.com/armadaproject/armada/internal/common/resource"
 	"github.com/armadaproject/armada/internal/scheduler/jobdb"
@@ -189,8 +190,8 @@ func defaultGangNodeUniformityLabel(msg *armadaevents.SubmitJob, config configur
 		return
 	}
 	if isGang(msg) {
-		if _, ok := annotations[configuration.GangNodeUniformityLabelAnnotation]; !ok {
-			annotations[configuration.GangNodeUniformityLabelAnnotation] = config.DefaultGangNodeUniformityLabel
+		if _, ok := annotations[constants.GangNodeUniformityLabelAnnotation]; !ok {
+			annotations[constants.GangNodeUniformityLabelAnnotation] = config.DefaultGangNodeUniformityLabel
 		}
 	}
 }
@@ -202,8 +203,8 @@ func defaultGangFailFastFlag(msg *armadaevents.SubmitJob, config configuration.S
 		return
 	}
 	if isGang(msg) {
-		if _, ok := annotations[configuration.FailFastAnnotation]; !ok {
-			annotations[configuration.FailFastAnnotation] = "true"
+		if _, ok := annotations[constants.FailFastAnnotation]; !ok {
+			annotations[constants.FailFastAnnotation] = "true"
 		}
 	}
 }
@@ -225,13 +226,13 @@ func addGangIdLabel(msg *armadaevents.SubmitJob, config configuration.Submission
 		return
 	}
 
-	gangId := msg.GetObjectMeta().GetAnnotations()[configuration.GangIdAnnotation]
+	gangId := msg.GetObjectMeta().GetAnnotations()[constants.GangIdAnnotation]
 	if gangId != "" {
 		labels := msg.GetObjectMeta().GetLabels()
 		if labels == nil {
 			labels = map[string]string{}
 		}
-		labels[configuration.GangIdAnnotation] = gangId
+		labels[constants.GangIdAnnotation] = gangId
 		msg.GetObjectMeta().Labels = labels
 	}
 }

--- a/internal/server/submit/conversion/post_process_test.go
+++ b/internal/server/submit/conversion/post_process_test.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/pointer"
 
+	"github.com/armadaproject/armada/internal/common/constants"
 	"github.com/armadaproject/armada/internal/common/util"
 	"github.com/armadaproject/armada/internal/server/configuration"
 	"github.com/armadaproject/armada/pkg/armadaevents"
@@ -125,23 +126,23 @@ func TestDefaultGangNodeUniformity(t *testing.T) {
 				DefaultGangNodeUniformityLabel: "foo",
 			},
 			annotations: map[string]string{
-				configuration.GangIdAnnotation:          "bar",
-				configuration.GangCardinalityAnnotation: "1",
+				constants.GangIdAnnotation:          "bar",
+				constants.GangCardinalityAnnotation: "1",
 			},
 			expected: map[string]string{
-				configuration.GangIdAnnotation:          "bar",
-				configuration.GangCardinalityAnnotation: "1",
+				constants.GangIdAnnotation:          "bar",
+				constants.GangCardinalityAnnotation: "1",
 			},
 		},
 		"Empty default": {
 			annotations: map[string]string{
-				configuration.GangIdAnnotation:          "bar",
-				configuration.GangCardinalityAnnotation: "2",
+				constants.GangIdAnnotation:          "bar",
+				constants.GangCardinalityAnnotation: "2",
 			},
 			expected: map[string]string{
-				configuration.GangIdAnnotation:                  "bar",
-				configuration.GangCardinalityAnnotation:         "2",
-				configuration.GangNodeUniformityLabelAnnotation: "",
+				constants.GangIdAnnotation:                  "bar",
+				constants.GangCardinalityAnnotation:         "2",
+				constants.GangNodeUniformityLabelAnnotation: "",
 			},
 		},
 		"Add when missing": {
@@ -149,13 +150,13 @@ func TestDefaultGangNodeUniformity(t *testing.T) {
 				DefaultGangNodeUniformityLabel: "foo",
 			},
 			annotations: map[string]string{
-				configuration.GangIdAnnotation:          "bar",
-				configuration.GangCardinalityAnnotation: "2",
+				constants.GangIdAnnotation:          "bar",
+				constants.GangCardinalityAnnotation: "2",
 			},
 			expected: map[string]string{
-				configuration.GangIdAnnotation:                  "bar",
-				configuration.GangCardinalityAnnotation:         "2",
-				configuration.GangNodeUniformityLabelAnnotation: "foo",
+				constants.GangIdAnnotation:                  "bar",
+				constants.GangCardinalityAnnotation:         "2",
+				constants.GangNodeUniformityLabelAnnotation: "foo",
 			},
 		},
 	}
@@ -180,35 +181,35 @@ func TestDefaultGangFailFastFlag(t *testing.T) {
 		},
 		"No change for non-gang jobs with some gang annotations": {
 			annotations: map[string]string{
-				configuration.GangIdAnnotation:          "bar",
-				configuration.GangCardinalityAnnotation: "1",
+				constants.GangIdAnnotation:          "bar",
+				constants.GangCardinalityAnnotation: "1",
 			},
 			expected: map[string]string{
-				configuration.GangIdAnnotation:          "bar",
-				configuration.GangCardinalityAnnotation: "1",
+				constants.GangIdAnnotation:          "bar",
+				constants.GangCardinalityAnnotation: "1",
 			},
 		},
 		"Don't mutate existing": {
 			annotations: map[string]string{
-				configuration.GangIdAnnotation:          "bar",
-				configuration.GangCardinalityAnnotation: "2",
-				configuration.FailFastAnnotation:        "false",
+				constants.GangIdAnnotation:          "bar",
+				constants.GangCardinalityAnnotation: "2",
+				constants.FailFastAnnotation:        "false",
 			},
 			expected: map[string]string{
-				configuration.GangIdAnnotation:          "bar",
-				configuration.GangCardinalityAnnotation: "2",
-				configuration.FailFastAnnotation:        "false",
+				constants.GangIdAnnotation:          "bar",
+				constants.GangCardinalityAnnotation: "2",
+				constants.FailFastAnnotation:        "false",
 			},
 		},
 		"Add when missing": {
 			annotations: map[string]string{
-				configuration.GangIdAnnotation:          "bar",
-				configuration.GangCardinalityAnnotation: "2",
+				constants.GangIdAnnotation:          "bar",
+				constants.GangCardinalityAnnotation: "2",
 			},
 			expected: map[string]string{
-				configuration.GangIdAnnotation:          "bar",
-				configuration.GangCardinalityAnnotation: "2",
-				configuration.FailFastAnnotation:        "true",
+				constants.GangIdAnnotation:          "bar",
+				constants.GangCardinalityAnnotation: "2",
+				constants.FailFastAnnotation:        "true",
 			},
 		},
 	}
@@ -711,29 +712,29 @@ func TestAddGangIdLabel(t *testing.T) {
 		},
 		"Label added if gang id set": {
 			annotations: map[string]string{
-				configuration.GangIdAnnotation: "foo",
+				constants.GangIdAnnotation: "foo",
 			},
 			expectedLabels: map[string]string{
-				configuration.GangIdAnnotation: "foo",
+				constants.GangIdAnnotation: "foo",
 			},
 			enabled: true,
 		},
 		"Doesn't modify existing labels": {
 			annotations: map[string]string{
-				configuration.GangIdAnnotation: "foo",
+				constants.GangIdAnnotation: "foo",
 			},
 			initialLabels: map[string]string{
 				"fish": "chips",
 			},
 			expectedLabels: map[string]string{
-				"fish":                         "chips",
-				configuration.GangIdAnnotation: "foo",
+				"fish":                     "chips",
+				constants.GangIdAnnotation: "foo",
 			},
 			enabled: true,
 		},
 		"Unchanged if disabled": {
 			annotations: map[string]string{
-				configuration.GangIdAnnotation: "foo",
+				constants.GangIdAnnotation: "foo",
 			},
 			enabled: false,
 		},

--- a/internal/server/submit/validation/submit_request.go
+++ b/internal/server/submit/validation/submit_request.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/component-helpers/scheduling/corev1/nodeaffinity"
 
+	"github.com/armadaproject/armada/internal/common/constants"
 	armadaslices "github.com/armadaproject/armada/internal/common/slices"
 	"github.com/armadaproject/armada/internal/scheduler/jobdb"
 	"github.com/armadaproject/armada/internal/server/configuration"
@@ -213,7 +214,7 @@ func validateClientId(j *api.JobSubmitRequestItem, _ configuration.SubmissionCon
 }
 
 func validatePriceBand(j *api.JobSubmitRequestItem, _ configuration.SubmissionConfig) error {
-	priceBand, present := j.Annotations[configuration.JobPriceBand]
+	priceBand, present := j.Annotations[constants.JobPriceBand]
 	if present {
 		_, valid := bidstore.PriceBandFromShortName[strings.ToUpper(priceBand)]
 		if !valid {
@@ -349,11 +350,11 @@ func validateGangs(request *api.JobSubmitRequest, _ configuration.SubmissionConf
 			continue
 		}
 
-		failFastFlag, present := job.Annotations[configuration.FailFastAnnotation]
+		failFastFlag, present := job.Annotations[constants.FailFastAnnotation]
 		if present && failFastFlag != "true" {
 			return errors.Errorf(
 				"gang jobs may not set fail fast flag (annotation - %s) to anything but true",
-				configuration.FailFastAnnotation,
+				constants.FailFastAnnotation,
 			)
 		}
 

--- a/internal/server/submit/validation/submit_request_test.go
+++ b/internal/server/submit/validation/submit_request_test.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/pointer"
 
+	"github.com/armadaproject/armada/internal/common/constants"
 	protoutil "github.com/armadaproject/armada/internal/common/proto"
 	"github.com/armadaproject/armada/internal/server/configuration"
 	"github.com/armadaproject/armada/pkg/api"
@@ -134,8 +135,8 @@ func TestValidateGangs(t *testing.T) {
 			jobRequests: []*api.JobSubmitRequestItem{
 				{
 					Annotations: map[string]string{
-						configuration.GangIdAnnotation:          "foo",
-						configuration.GangCardinalityAnnotation: strconv.Itoa(1),
+						constants.GangIdAnnotation:          "foo",
+						constants.GangCardinalityAnnotation: strconv.Itoa(1),
 					},
 				},
 			},
@@ -145,8 +146,8 @@ func TestValidateGangs(t *testing.T) {
 			jobRequests: []*api.JobSubmitRequestItem{
 				{
 					Annotations: map[string]string{
-						configuration.GangIdAnnotation:          "",
-						configuration.GangCardinalityAnnotation: strconv.Itoa(1),
+						constants.GangIdAnnotation:          "",
+						constants.GangCardinalityAnnotation: strconv.Itoa(1),
 					},
 				},
 			},
@@ -156,9 +157,9 @@ func TestValidateGangs(t *testing.T) {
 			jobRequests: []*api.JobSubmitRequestItem{
 				{
 					Annotations: map[string]string{
-						configuration.GangIdAnnotation:          "foo",
-						configuration.GangCardinalityAnnotation: strconv.Itoa(2),
-						configuration.FailFastAnnotation:        "true",
+						constants.GangIdAnnotation:          "foo",
+						constants.GangCardinalityAnnotation: strconv.Itoa(2),
+						constants.FailFastAnnotation:        "true",
 					},
 				},
 			},
@@ -168,9 +169,9 @@ func TestValidateGangs(t *testing.T) {
 			jobRequests: []*api.JobSubmitRequestItem{
 				{
 					Annotations: map[string]string{
-						configuration.GangIdAnnotation:          "foo",
-						configuration.GangCardinalityAnnotation: strconv.Itoa(2),
-						configuration.FailFastAnnotation:        "false",
+						constants.GangIdAnnotation:          "foo",
+						constants.GangCardinalityAnnotation: strconv.Itoa(2),
+						constants.FailFastAnnotation:        "false",
 					},
 				},
 			},
@@ -180,20 +181,20 @@ func TestValidateGangs(t *testing.T) {
 			jobRequests: []*api.JobSubmitRequestItem{
 				{
 					Annotations: map[string]string{
-						configuration.GangIdAnnotation:          "foo",
-						configuration.GangCardinalityAnnotation: strconv.Itoa(3),
+						constants.GangIdAnnotation:          "foo",
+						constants.GangCardinalityAnnotation: strconv.Itoa(3),
 					},
 				},
 				{
 					Annotations: map[string]string{
-						configuration.GangIdAnnotation:          "foo",
-						configuration.GangCardinalityAnnotation: strconv.Itoa(3),
+						constants.GangIdAnnotation:          "foo",
+						constants.GangCardinalityAnnotation: strconv.Itoa(3),
 					},
 				},
 				{
 					Annotations: map[string]string{
-						configuration.GangIdAnnotation:          "foo",
-						configuration.GangCardinalityAnnotation: strconv.Itoa(3),
+						constants.GangIdAnnotation:          "foo",
+						constants.GangCardinalityAnnotation: strconv.Itoa(3),
 					},
 				},
 			},
@@ -203,32 +204,32 @@ func TestValidateGangs(t *testing.T) {
 			jobRequests: []*api.JobSubmitRequestItem{
 				{
 					Annotations: map[string]string{
-						configuration.GangIdAnnotation:          "bar",
-						configuration.GangCardinalityAnnotation: strconv.Itoa(2),
+						constants.GangIdAnnotation:          "bar",
+						constants.GangCardinalityAnnotation: strconv.Itoa(2),
 					},
 				},
 				{
 					Annotations: map[string]string{
-						configuration.GangIdAnnotation:          "foo",
-						configuration.GangCardinalityAnnotation: strconv.Itoa(3),
+						constants.GangIdAnnotation:          "foo",
+						constants.GangCardinalityAnnotation: strconv.Itoa(3),
 					},
 				},
 				{
 					Annotations: map[string]string{
-						configuration.GangIdAnnotation:          "foo",
-						configuration.GangCardinalityAnnotation: strconv.Itoa(3),
+						constants.GangIdAnnotation:          "foo",
+						constants.GangCardinalityAnnotation: strconv.Itoa(3),
 					},
 				},
 				{
 					Annotations: map[string]string{
-						configuration.GangIdAnnotation:          "foo",
-						configuration.GangCardinalityAnnotation: strconv.Itoa(3),
+						constants.GangIdAnnotation:          "foo",
+						constants.GangCardinalityAnnotation: strconv.Itoa(3),
 					},
 				},
 				{
 					Annotations: map[string]string{
-						configuration.GangIdAnnotation:          "bar",
-						configuration.GangCardinalityAnnotation: strconv.Itoa(2),
+						constants.GangIdAnnotation:          "bar",
+						constants.GangCardinalityAnnotation: strconv.Itoa(2),
 					},
 				},
 			},
@@ -238,26 +239,26 @@ func TestValidateGangs(t *testing.T) {
 			jobRequests: []*api.JobSubmitRequestItem{
 				{
 					Annotations: map[string]string{
-						configuration.GangIdAnnotation:          "bar",
-						configuration.GangCardinalityAnnotation: strconv.Itoa(2),
+						constants.GangIdAnnotation:          "bar",
+						constants.GangCardinalityAnnotation: strconv.Itoa(2),
 					},
 				},
 				{
 					Annotations: map[string]string{
-						configuration.GangIdAnnotation:          "foo",
-						configuration.GangCardinalityAnnotation: strconv.Itoa(3),
+						constants.GangIdAnnotation:          "foo",
+						constants.GangCardinalityAnnotation: strconv.Itoa(3),
 					},
 				},
 				{
 					Annotations: map[string]string{
-						configuration.GangIdAnnotation:          "foo",
-						configuration.GangCardinalityAnnotation: strconv.Itoa(3),
+						constants.GangIdAnnotation:          "foo",
+						constants.GangCardinalityAnnotation: strconv.Itoa(3),
 					},
 				},
 				{
 					Annotations: map[string]string{
-						configuration.GangIdAnnotation:          "bar",
-						configuration.GangCardinalityAnnotation: strconv.Itoa(2),
+						constants.GangIdAnnotation:          "bar",
+						constants.GangCardinalityAnnotation: strconv.Itoa(2),
 					},
 				},
 			},
@@ -267,13 +268,13 @@ func TestValidateGangs(t *testing.T) {
 			jobRequests: []*api.JobSubmitRequestItem{
 				{
 					Annotations: map[string]string{
-						configuration.GangIdAnnotation:          "bar",
-						configuration.GangCardinalityAnnotation: strconv.Itoa(2),
+						constants.GangIdAnnotation:          "bar",
+						constants.GangCardinalityAnnotation: strconv.Itoa(2),
 					},
 				},
 				{
 					Annotations: map[string]string{
-						configuration.GangIdAnnotation: "bar",
+						constants.GangIdAnnotation: "bar",
 					},
 				},
 			},
@@ -283,13 +284,13 @@ func TestValidateGangs(t *testing.T) {
 			jobRequests: []*api.JobSubmitRequestItem{
 				{
 					Annotations: map[string]string{
-						configuration.GangIdAnnotation:          "bar",
-						configuration.GangCardinalityAnnotation: "not an int",
+						constants.GangIdAnnotation:          "bar",
+						constants.GangCardinalityAnnotation: "not an int",
 					},
 				},
 				{
 					Annotations: map[string]string{
-						configuration.GangIdAnnotation: "not an int",
+						constants.GangIdAnnotation: "not an int",
 					},
 				},
 			},
@@ -299,8 +300,8 @@ func TestValidateGangs(t *testing.T) {
 			jobRequests: []*api.JobSubmitRequestItem{
 				{
 					Annotations: map[string]string{
-						configuration.GangIdAnnotation:          "bar",
-						configuration.GangCardinalityAnnotation: "0",
+						constants.GangIdAnnotation:          "bar",
+						constants.GangCardinalityAnnotation: "0",
 					},
 				},
 			},
@@ -310,8 +311,8 @@ func TestValidateGangs(t *testing.T) {
 			jobRequests: []*api.JobSubmitRequestItem{
 				{
 					Annotations: map[string]string{
-						configuration.GangIdAnnotation:          "bar",
-						configuration.GangCardinalityAnnotation: "-1",
+						constants.GangIdAnnotation:          "bar",
+						constants.GangCardinalityAnnotation: "-1",
 					},
 				},
 			},
@@ -321,32 +322,32 @@ func TestValidateGangs(t *testing.T) {
 			jobRequests: []*api.JobSubmitRequestItem{
 				{
 					Annotations: map[string]string{
-						configuration.GangIdAnnotation:          "bar",
-						configuration.GangCardinalityAnnotation: strconv.Itoa(2),
+						constants.GangIdAnnotation:          "bar",
+						constants.GangCardinalityAnnotation: strconv.Itoa(2),
 					},
 				},
 				{
 					Annotations: map[string]string{
-						configuration.GangIdAnnotation:          "foo",
-						configuration.GangCardinalityAnnotation: strconv.Itoa(3),
+						constants.GangIdAnnotation:          "foo",
+						constants.GangCardinalityAnnotation: strconv.Itoa(3),
 					},
 				},
 				{
 					Annotations: map[string]string{
-						configuration.GangIdAnnotation:          "foo",
-						configuration.GangCardinalityAnnotation: strconv.Itoa(3),
+						constants.GangIdAnnotation:          "foo",
+						constants.GangCardinalityAnnotation: strconv.Itoa(3),
 					},
 				},
 				{
 					Annotations: map[string]string{
-						configuration.GangIdAnnotation:          "bar",
-						configuration.GangCardinalityAnnotation: strconv.Itoa(2),
+						constants.GangIdAnnotation:          "bar",
+						constants.GangCardinalityAnnotation: strconv.Itoa(2),
 					},
 				},
 				{
 					Annotations: map[string]string{
-						configuration.GangIdAnnotation:          "foo",
-						configuration.GangCardinalityAnnotation: strconv.Itoa(2),
+						constants.GangIdAnnotation:          "foo",
+						constants.GangCardinalityAnnotation: strconv.Itoa(2),
 					},
 				},
 			},
@@ -356,8 +357,8 @@ func TestValidateGangs(t *testing.T) {
 			jobRequests: []*api.JobSubmitRequestItem{
 				{
 					Annotations: map[string]string{
-						configuration.GangIdAnnotation:          "bar",
-						configuration.GangCardinalityAnnotation: strconv.Itoa(2),
+						constants.GangIdAnnotation:          "bar",
+						constants.GangCardinalityAnnotation: strconv.Itoa(2),
 					},
 					PodSpec: &v1.PodSpec{
 						PriorityClassName: "baz",
@@ -365,8 +366,8 @@ func TestValidateGangs(t *testing.T) {
 				},
 				{
 					Annotations: map[string]string{
-						configuration.GangIdAnnotation:          "bar",
-						configuration.GangCardinalityAnnotation: strconv.Itoa(2),
+						constants.GangIdAnnotation:          "bar",
+						constants.GangCardinalityAnnotation: strconv.Itoa(2),
 					},
 					PodSpec: &v1.PodSpec{
 						PriorityClassName: "zab",
@@ -379,17 +380,17 @@ func TestValidateGangs(t *testing.T) {
 			jobRequests: []*api.JobSubmitRequestItem{
 				{
 					Annotations: map[string]string{
-						configuration.GangIdAnnotation:                  "bar",
-						configuration.GangCardinalityAnnotation:         strconv.Itoa(2),
-						configuration.GangNodeUniformityLabelAnnotation: "foo",
+						constants.GangIdAnnotation:                  "bar",
+						constants.GangCardinalityAnnotation:         strconv.Itoa(2),
+						constants.GangNodeUniformityLabelAnnotation: "foo",
 					},
 					PodSpec: &v1.PodSpec{},
 				},
 				{
 					Annotations: map[string]string{
-						configuration.GangIdAnnotation:                  "bar",
-						configuration.GangCardinalityAnnotation:         strconv.Itoa(2),
-						configuration.GangNodeUniformityLabelAnnotation: "bar",
+						constants.GangIdAnnotation:                  "bar",
+						constants.GangCardinalityAnnotation:         strconv.Itoa(2),
+						constants.GangNodeUniformityLabelAnnotation: "bar",
 					},
 					PodSpec: &v1.PodSpec{},
 				},
@@ -618,19 +619,19 @@ func TestValidatePriceBand(t *testing.T) {
 		},
 		"valid price band - lowercase": {
 			req: &api.JobSubmitRequestItem{
-				Annotations: map[string]string{configuration.JobPriceBand: "a"},
+				Annotations: map[string]string{constants.JobPriceBand: "a"},
 			},
 			expectSuccess: true,
 		},
 		"valid price band - uppercase": {
 			req: &api.JobSubmitRequestItem{
-				Annotations: map[string]string{configuration.JobPriceBand: "A"},
+				Annotations: map[string]string{constants.JobPriceBand: "A"},
 			},
 			expectSuccess: true,
 		},
 		"invalid price band": {
 			req: &api.JobSubmitRequestItem{
-				Annotations: map[string]string{configuration.JobPriceBand: "z"},
+				Annotations: map[string]string{constants.JobPriceBand: "z"},
 			},
 			expectSuccess: false,
 		},


### PR DESCRIPTION
The other files in configuration have a lot of dependencies that can cause circular dependency issues

Having a package appropriately named constants that'll contain simple constants, to avoid circular dependencies

