### PR TITLE
fix: scheduler database schema sync - regenerate sqlc after terminated column migration

### DIFF
--- a/internal/common/database/upsert.go
+++ b/internal/common/database/upsert.go
@@ -13,7 +13,26 @@ import (
 	"github.com/armadaproject/armada/internal/common/armadacontext"
 )
 
-func UpsertWithTransaction[T any](ctx *armadacontext.Context, db *pgxpool.Pool, tableName string, records []T) error {
+type UpsertOption func(*upsertOptions)
+
+type upsertOptions struct {
+	excludeColumns map[string]bool
+}
+
+// WithExcludeColumns returns an option that excludes specific columns from upsert.
+// This is useful for PostgreSQL GENERATED ALWAYS columns which cannot be explicitly inserted.
+func WithExcludeColumns(columns ...string) UpsertOption {
+	return func(opts *upsertOptions) {
+		if opts.excludeColumns == nil {
+			opts.excludeColumns = make(map[string]bool)
+		}
+		for _, col := range columns {
+			opts.excludeColumns[col] = true
+		}
+	}
+}
+
+func UpsertWithTransaction[T any](ctx *armadacontext.Context, db *pgxpool.Pool, tableName string, records []T, options ...UpsertOption) error {
 	if len(records) == 0 {
 		return nil
 	}
@@ -22,7 +41,7 @@ func UpsertWithTransaction[T any](ctx *armadacontext.Context, db *pgxpool.Pool, 
 		AccessMode:     pgx.ReadWrite,
 		DeferrableMode: pgx.Deferrable,
 	}, func(tx pgx.Tx) error {
-		return Upsert(ctx, tx, tableName, records)
+		return Upsert(ctx, tx, tableName, records, options...)
 	})
 }
 
@@ -40,9 +59,18 @@ func UpsertWithTransaction[T any](ctx *armadacontext.Context, db *pgxpool.Pool, 
 // The records to write should be structs with fields marked with "db" tags.
 // Field names and values are extracted using the NamesValuesFromRecord function;
 // see its definition for details. The first field is used as the primary key in SQL.
-func Upsert[T any](ctx *armadacontext.Context, tx pgx.Tx, tableName string, records []T) error {
+//
+// Options can be provided to customize upsert behavior, such as excluding specific columns.
+func Upsert[T any](ctx *armadacontext.Context, tx pgx.Tx, tableName string, records []T, options ...UpsertOption) error {
 	if len(records) < 1 {
 		return nil
+	}
+
+	opts := &upsertOptions{
+		excludeColumns: make(map[string]bool),
+	}
+	for _, opt := range options {
+		opt(opts)
 	}
 
 	// Write records into postgres.
@@ -60,16 +88,35 @@ func Upsert[T any](ctx *armadacontext.Context, tx pgx.Tx, tableName string, reco
 	// https://pkg.go.dev/github.com/jackc/pgx/v5#hdr-Copy_Protocol
 	//
 	// We're guaranteed there is at least one record.
-	names, _ := NamesValuesFromRecord(records[0])
-	if len(names) < 2 {
-		return errors.Errorf("Names() must return at least 2 elements, but got %v", names)
+	allNames, _ := NamesValuesFromRecord(records[0])
+
+	// Filter out excluded columns (e.g., PostgreSQL GENERATED ALWAYS columns which cannot be explicitly inserted).
+	// We maintain both a list of writable column names and their original indices because:
+	// 1. Column names are needed for the SQL INSERT statement
+	// 2. Original indices are needed to extract corresponding values from each record
+	writableIndices := make([]int, 0, len(allNames))
+	writableNames := make([]string, 0, len(allNames))
+	for i, name := range allNames {
+		if !opts.excludeColumns[name] {
+			writableIndices = append(writableIndices, i)
+			writableNames = append(writableNames, name)
+		}
+	}
+
+	if len(writableNames) < 2 {
+		return errors.Errorf("Names() must return at least 2 elements, but got %v", writableNames)
 	}
 	n, err := tx.CopyFrom(ctx,
 		pgx.Identifier{tempTableName},
-		names,
+		writableNames,
 		pgx.CopyFromSlice(len(records), func(i int) ([]interface{}, error) {
 			// TODO: Are we guaranteed that values always come in the order listed in the record? Otherwise we need to control the order.
-			_, values := NamesValuesFromRecord(records[i])
+			_, allValues := NamesValuesFromRecord(records[i])
+			// Filter values to match filtered names
+			values := make([]interface{}, len(writableIndices))
+			for j, idx := range writableIndices {
+				values[j] = allValues[idx]
+			}
 			return values, nil
 		}),
 	)
@@ -83,11 +130,11 @@ func Upsert[T any](ctx *armadacontext.Context, tx pgx.Tx, tableName string, reco
 	// Move those rows into the main table, using ON CONFLICT rules to over-write existing rows.
 	var b strings.Builder
 
-	fmt.Fprintf(&b, "INSERT INTO %s SELECT %s from %s ", tableName, strings.Join(names, ","), tempTableName)
-	fmt.Fprintf(&b, "ON CONFLICT (%s) DO UPDATE SET ", names[0])
-	for i, name := range names {
+	fmt.Fprintf(&b, "INSERT INTO %s SELECT %s from %s ", tableName, strings.Join(writableNames, ","), tempTableName)
+	fmt.Fprintf(&b, "ON CONFLICT (%s) DO UPDATE SET ", writableNames[0])
+	for i, name := range writableNames {
 		fmt.Fprintf(&b, "%s = EXCLUDED.%s", name, name)
-		if i != len(names)-1 {
+		if i != len(writableNames)-1 {
 			fmt.Fprintf(&b, ", ")
 		}
 	}

--- a/internal/scheduler/database/db_pruner_test.go
+++ b/internal/scheduler/database/db_pruner_test.go
@@ -117,7 +117,7 @@ func TestPruneDb_RemoveJobs(t *testing.T) {
 				jobsToInsert := armadaslices.Map(tc.jobs, populateRequiredJobFields)
 				err := removeTriggers(ctx, db)
 				require.NoError(t, err)
-				err = database.UpsertWithTransaction(ctx, db, "jobs", jobsToInsert)
+				err = database.UpsertWithTransaction(ctx, db, "jobs", jobsToInsert, database.WithExcludeColumns("terminated"))
 				require.NoError(t, err)
 				err = database.UpsertWithTransaction(ctx, db, "runs", tc.runs)
 				require.NoError(t, err)

--- a/internal/scheduler/database/job_repository_test.go
+++ b/internal/scheduler/database/job_repository_test.go
@@ -187,7 +187,7 @@ func TestFetchInitialJobs(t *testing.T) {
 				ctx, cancel := armadacontext.WithTimeout(armadacontext.Background(), 5*time.Second)
 
 				// Set up db
-				err := database.UpsertWithTransaction(ctx, repo.db, "jobs", tc.dbJobs)
+				err := database.UpsertWithTransaction(ctx, repo.db, "jobs", tc.dbJobs, database.WithExcludeColumns("terminated"))
 				require.NoError(t, err)
 				err = database.UpsertWithTransaction(ctx, repo.db, "runs", tc.dbRuns)
 				require.NoError(t, err)
@@ -290,7 +290,7 @@ func TestFetchJobUpdates(t *testing.T) {
 				ctx, cancel := armadacontext.WithTimeout(armadacontext.Background(), 5*time.Second)
 
 				// Set up db
-				err := database.UpsertWithTransaction(ctx, repo.db, "jobs", tc.dbJobs)
+				err := database.UpsertWithTransaction(ctx, repo.db, "jobs", tc.dbJobs, database.WithExcludeColumns("terminated"))
 				require.NoError(t, err)
 				err = database.UpsertWithTransaction(ctx, repo.db, "runs", tc.dbRuns)
 				require.NoError(t, err)
@@ -723,7 +723,7 @@ func TestFetchJobRunLeases(t *testing.T) {
 				ctx, cancel := armadacontext.WithTimeout(armadacontext.Background(), 5*time.Second)
 
 				// Set up db
-				err := database.UpsertWithTransaction(ctx, repo.db, "jobs", tc.dbJobs)
+				err := database.UpsertWithTransaction(ctx, repo.db, "jobs", tc.dbJobs, database.WithExcludeColumns("terminated"))
 				require.NoError(t, err)
 				err = database.UpsertWithTransaction(ctx, repo.db, "runs", tc.dbRuns)
 				require.NoError(t, err)

--- a/internal/scheduler/database/models.go
+++ b/internal/scheduler/database/models.go
@@ -49,6 +49,7 @@ type Job struct {
 	BidPrice                float64   `db:"bid_price"`
 	CancelUser              *string   `db:"cancel_user"`
 	PriceBand               int32     `db:"price_band"`
+	Terminated              *bool     `db:"terminated"`
 }
 
 type JobRunError struct {

--- a/internal/scheduler/database/query.sql.go
+++ b/internal/scheduler/database/query.sql.go
@@ -142,7 +142,7 @@ func (q *Queries) MarkJobRunsSucceededById(ctx context.Context, runIds []string)
 }
 
 const markJobsCancelRequestedById = `-- name: MarkJobsCancelRequestedById :exec
-UPDATE jobs SET cancel_requested = true, cancel_user = $1 WHERE queue = $2 and job_set = $3 and job_id = ANY($4::text[]) and cancelled = false and succeeded = false and failed = false
+UPDATE jobs SET cancel_requested = true, cancel_user = $1 WHERE queue = $2 and job_set = $3 and job_id = ANY($4::text[]) and terminated = false
 `
 
 type MarkJobsCancelRequestedByIdParams struct {
@@ -163,7 +163,7 @@ func (q *Queries) MarkJobsCancelRequestedById(ctx context.Context, arg MarkJobsC
 }
 
 const markJobsCancelRequestedBySet = `-- name: MarkJobsCancelRequestedBySet :exec
-UPDATE jobs SET cancel_by_jobset_requested = true, cancel_user = $1 WHERE job_set = $2 and queue = $3 and cancelled = false and succeeded = false and failed = false
+UPDATE jobs SET cancel_by_jobset_requested = true, cancel_user = $1 WHERE job_set = $2 and queue = $3 and terminated = false
 `
 
 type MarkJobsCancelRequestedBySetParams struct {
@@ -178,7 +178,7 @@ func (q *Queries) MarkJobsCancelRequestedBySet(ctx context.Context, arg MarkJobs
 }
 
 const markJobsCancelRequestedBySetAndQueuedState = `-- name: MarkJobsCancelRequestedBySetAndQueuedState :exec
-UPDATE jobs SET cancel_by_jobset_requested = true, cancel_user = $1 WHERE job_set = $2 and queue = $3 and queued = ANY($4::bool[]) and cancelled = false and succeeded = false and failed = false
+UPDATE jobs SET cancel_by_jobset_requested = true, cancel_user = $1 WHERE job_set = $2 and queue = $3 and queued = ANY($4::bool[]) and terminated = false
 `
 
 type MarkJobsCancelRequestedBySetAndQueuedStateParams struct {
@@ -414,7 +414,7 @@ func (q *Queries) SelectExecutorUpdateTimes(ctx context.Context) ([]SelectExecut
 }
 
 const selectInitialJobs = `-- name: SelectInitialJobs :many
-SELECT job_id, job_set, queue, priority, submitted, queued, queued_version, validated, cancel_requested, cancel_user, cancel_by_jobset_requested, cancelled, succeeded, failed, scheduling_info, scheduling_info_version, pools, price_band, serial FROM jobs WHERE serial > $1 AND cancelled = 'false' AND succeeded = 'false' and failed = 'false' ORDER BY serial LIMIT $2
+SELECT job_id, job_set, queue, priority, submitted, queued, queued_version, validated, cancel_requested, cancel_user, cancel_by_jobset_requested, cancelled, succeeded, failed, scheduling_info, scheduling_info_version, pools, price_band, serial FROM jobs WHERE serial > $1 AND terminated = false ORDER BY serial LIMIT $2
 `
 
 type SelectInitialJobsParams struct {
@@ -542,7 +542,7 @@ func (q *Queries) SelectInitialRuns(ctx context.Context, arg SelectInitialRunsPa
 }
 
 const selectJobsByExecutorAndQueues = `-- name: SelectJobsByExecutorAndQueues :many
-SELECT j.job_id, j.job_set, j.queue, j.user_id, j.submitted, j.groups, j.priority, j.queued, j.queued_version, j.cancel_requested, j.cancelled, j.cancel_by_jobset_requested, j.succeeded, j.failed, j.submit_message, j.scheduling_info, j.scheduling_info_version, j.serial, j.last_modified, j.validated, j.pools, j.bid_price, j.cancel_user, j.price_band
+SELECT j.job_id, j.job_set, j.queue, j.user_id, j.submitted, j.groups, j.priority, j.queued, j.queued_version, j.cancel_requested, j.cancelled, j.cancel_by_jobset_requested, j.succeeded, j.failed, j.submit_message, j.scheduling_info, j.scheduling_info_version, j.serial, j.last_modified, j.validated, j.pools, j.bid_price, j.cancel_user, j.price_band, j.terminated
 FROM runs jr
        JOIN jobs j
             ON jr.job_id = j.job_id
@@ -590,6 +590,7 @@ func (q *Queries) SelectJobsByExecutorAndQueues(ctx context.Context, arg SelectJ
 			&i.BidPrice,
 			&i.CancelUser,
 			&i.PriceBand,
+			&i.Terminated,
 		); err != nil {
 			return nil, err
 		}
@@ -675,7 +676,7 @@ func (q *Queries) SelectLatestJobSerial(ctx context.Context) (int64, error) {
 }
 
 const selectLeasedJobsByQueue = `-- name: SelectLeasedJobsByQueue :many
-SELECT j.job_id, j.job_set, j.queue, j.user_id, j.submitted, j.groups, j.priority, j.queued, j.queued_version, j.cancel_requested, j.cancelled, j.cancel_by_jobset_requested, j.succeeded, j.failed, j.submit_message, j.scheduling_info, j.scheduling_info_version, j.serial, j.last_modified, j.validated, j.pools, j.bid_price, j.cancel_user, j.price_band
+SELECT j.job_id, j.job_set, j.queue, j.user_id, j.submitted, j.groups, j.priority, j.queued, j.queued_version, j.cancel_requested, j.cancelled, j.cancel_by_jobset_requested, j.succeeded, j.failed, j.submit_message, j.scheduling_info, j.scheduling_info_version, j.serial, j.last_modified, j.validated, j.pools, j.bid_price, j.cancel_user, j.price_band, j.terminated
 FROM runs jr
        JOIN jobs j
             ON jr.job_id = j.job_id
@@ -722,6 +723,7 @@ func (q *Queries) SelectLeasedJobsByQueue(ctx context.Context, queue []string) (
 			&i.BidPrice,
 			&i.CancelUser,
 			&i.PriceBand,
+			&i.Terminated,
 		); err != nil {
 			return nil, err
 		}
@@ -756,7 +758,7 @@ func (q *Queries) SelectMaxRunSerial(ctx context.Context) (int64, error) {
 }
 
 const selectNewJobs = `-- name: SelectNewJobs :many
-SELECT job_id, job_set, queue, user_id, submitted, groups, priority, queued, queued_version, cancel_requested, cancelled, cancel_by_jobset_requested, succeeded, failed, submit_message, scheduling_info, scheduling_info_version, serial, last_modified, validated, pools, bid_price, cancel_user, price_band FROM jobs WHERE serial > $1 ORDER BY serial LIMIT $2
+SELECT job_id, job_set, queue, user_id, submitted, groups, priority, queued, queued_version, cancel_requested, cancelled, cancel_by_jobset_requested, succeeded, failed, submit_message, scheduling_info, scheduling_info_version, serial, last_modified, validated, pools, bid_price, cancel_user, price_band, terminated FROM jobs WHERE serial > $1 ORDER BY serial LIMIT $2
 `
 
 type SelectNewJobsParams struct {
@@ -798,6 +800,7 @@ func (q *Queries) SelectNewJobs(ctx context.Context, arg SelectNewJobsParams) ([
 			&i.BidPrice,
 			&i.CancelUser,
 			&i.PriceBand,
+			&i.Terminated,
 		); err != nil {
 			return nil, err
 		}
@@ -922,7 +925,7 @@ func (q *Queries) SelectNewRunsForJobs(ctx context.Context, arg SelectNewRunsFor
 }
 
 const selectPendingJobsByQueue = `-- name: SelectPendingJobsByQueue :many
-SELECT j.job_id, j.job_set, j.queue, j.user_id, j.submitted, j.groups, j.priority, j.queued, j.queued_version, j.cancel_requested, j.cancelled, j.cancel_by_jobset_requested, j.succeeded, j.failed, j.submit_message, j.scheduling_info, j.scheduling_info_version, j.serial, j.last_modified, j.validated, j.pools, j.bid_price, j.cancel_user, j.price_band
+SELECT j.job_id, j.job_set, j.queue, j.user_id, j.submitted, j.groups, j.priority, j.queued, j.queued_version, j.cancel_requested, j.cancelled, j.cancel_by_jobset_requested, j.succeeded, j.failed, j.submit_message, j.scheduling_info, j.scheduling_info_version, j.serial, j.last_modified, j.validated, j.pools, j.bid_price, j.cancel_user, j.price_band, j.terminated
 FROM runs jr
        JOIN jobs j
             ON jr.job_id = j.job_id
@@ -969,6 +972,7 @@ func (q *Queries) SelectPendingJobsByQueue(ctx context.Context, queue []string) 
 			&i.BidPrice,
 			&i.CancelUser,
 			&i.PriceBand,
+			&i.Terminated,
 		); err != nil {
 			return nil, err
 		}
@@ -981,7 +985,7 @@ func (q *Queries) SelectPendingJobsByQueue(ctx context.Context, queue []string) 
 }
 
 const selectQueuedJobsByQueue = `-- name: SelectQueuedJobsByQueue :many
-SELECT j.job_id, j.job_set, j.queue, j.user_id, j.submitted, j.groups, j.priority, j.queued, j.queued_version, j.cancel_requested, j.cancelled, j.cancel_by_jobset_requested, j.succeeded, j.failed, j.submit_message, j.scheduling_info, j.scheduling_info_version, j.serial, j.last_modified, j.validated, j.pools, j.bid_price, j.cancel_user, j.price_band
+SELECT j.job_id, j.job_set, j.queue, j.user_id, j.submitted, j.groups, j.priority, j.queued, j.queued_version, j.cancel_requested, j.cancelled, j.cancel_by_jobset_requested, j.succeeded, j.failed, j.submit_message, j.scheduling_info, j.scheduling_info_version, j.serial, j.last_modified, j.validated, j.pools, j.bid_price, j.cancel_user, j.price_band, j.terminated
 FROM jobs j
 WHERE j.queue = ANY($1::text[])
   AND j.queued = true
@@ -1021,6 +1025,7 @@ func (q *Queries) SelectQueuedJobsByQueue(ctx context.Context, queue []string) (
 			&i.BidPrice,
 			&i.CancelUser,
 			&i.PriceBand,
+			&i.Terminated,
 		); err != nil {
 			return nil, err
 		}
@@ -1058,7 +1063,7 @@ func (q *Queries) SelectRunErrorsById(ctx context.Context, runIds []string) ([]J
 }
 
 const selectRunningJobsByQueue = `-- name: SelectRunningJobsByQueue :many
-SELECT j.job_id, j.job_set, j.queue, j.user_id, j.submitted, j.groups, j.priority, j.queued, j.queued_version, j.cancel_requested, j.cancelled, j.cancel_by_jobset_requested, j.succeeded, j.failed, j.submit_message, j.scheduling_info, j.scheduling_info_version, j.serial, j.last_modified, j.validated, j.pools, j.bid_price, j.cancel_user, j.price_band
+SELECT j.job_id, j.job_set, j.queue, j.user_id, j.submitted, j.groups, j.priority, j.queued, j.queued_version, j.cancel_requested, j.cancelled, j.cancel_by_jobset_requested, j.succeeded, j.failed, j.submit_message, j.scheduling_info, j.scheduling_info_version, j.serial, j.last_modified, j.validated, j.pools, j.bid_price, j.cancel_user, j.price_band, j.terminated
 FROM runs jr
        JOIN jobs j
             ON jr.job_id = j.job_id
@@ -1105,6 +1110,7 @@ func (q *Queries) SelectRunningJobsByQueue(ctx context.Context, queue []string) 
 			&i.BidPrice,
 			&i.CancelUser,
 			&i.PriceBand,
+			&i.Terminated,
 		); err != nil {
 			return nil, err
 		}
@@ -1244,7 +1250,7 @@ func (q *Queries) SetTerminatedTime(ctx context.Context, arg SetTerminatedTimePa
 }
 
 const updateJobPriorityById = `-- name: UpdateJobPriorityById :exec
-UPDATE jobs SET priority = $1 WHERE queue = $2 and job_set = $3 and job_id = ANY($4::text[]) and cancelled = false and succeeded = false and failed = false
+UPDATE jobs SET priority = $1 WHERE queue = $2 and job_set = $3 and job_id = ANY($4::text[]) and terminated = false
 `
 
 type UpdateJobPriorityByIdParams struct {
@@ -1265,7 +1271,7 @@ func (q *Queries) UpdateJobPriorityById(ctx context.Context, arg UpdateJobPriori
 }
 
 const updateJobPriorityByJobSet = `-- name: UpdateJobPriorityByJobSet :exec
-UPDATE jobs SET priority = $1 WHERE job_set = $2 and queue = $3 and cancelled = false and succeeded = false and failed = false
+UPDATE jobs SET priority = $1 WHERE job_set = $2 and queue = $3 and terminated = false
 `
 
 type UpdateJobPriorityByJobSetParams struct {

--- a/internal/scheduleringester/schedulerdb.go
+++ b/internal/scheduleringester/schedulerdb.go
@@ -106,7 +106,7 @@ func (s *SchedulerDb) WriteDbOp(ctx *armadacontext.Context, tx pgx.Tx, op DbOper
 			records[i] = *v
 			i++
 		}
-		err := database.Upsert(ctx, tx, "jobs", records)
+		err := database.Upsert(ctx, tx, "jobs", records, database.WithExcludeColumns("terminated"))
 		if err != nil {
 			return err
 		}

--- a/internal/scheduleringester/schedulerdb_test.go
+++ b/internal/scheduleringester/schedulerdb_test.go
@@ -591,6 +591,9 @@ func assertOpSuccess(t *testing.T, schedulerDb *SchedulerDb, serials map[string]
 			}
 		}
 		for k, v := range expected {
+			// Compute Terminated field to match database GENERATED column: terminated = cancelled OR succeeded OR failed
+			terminated := v.Cancelled || v.Succeeded || v.Failed
+			v.Terminated = &terminated
 			assert.Equal(t, v, actual[k])
 		}
 	case InsertRuns:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you: -->

#### What type of PR is this?

Bug fix.

#### What this PR does / why we need it

Migration 027 added the `terminated` GENERATED column to the jobs table, but sqlc was never regenerated after the migration. This created schema-code drift where the Job model struct was missing the `Terminated` field and generated query code was stale.

The `terminated` column is a PostgreSQL GENERATED column (`terminated = cancelled OR succeeded OR failed`). It's computed automatically and provides query optimization - checking `terminated = false` instead of `cancelled = false AND succeeded = false AND failed = false`. All individual status fields (`cancelled`, `succeeded`, `failed`) remain in the schema and code.

There were issues with the upsert logic where it was updating the `terminated` column and causing issues. The fix was to add option support to the function, and an option implementation to exclude certain columns.

#### Special notes for your reviewer
