### PR TITLE
fix: free disk space in release workflow to prevent Docker build failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,13 @@ jobs:
           # Checkout the tag that triggered the workflow.
           ref: ${{ github.event.workflow_run.head_branch }}
 
+      # Free disk space to prevent "no space left on device" during Docker builds.
+      # This runs on every build since GitHub runners are ephemeral.
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false
+
       - name: Fetch Git tags
         run: git fetch --force --tags
 

--- a/magefiles/main.go
+++ b/magefiles/main.go
@@ -151,6 +151,7 @@ func KindTeardown() {
 
 // Generate scheduler SQL.
 func Sql() error {
+	mg.Deps(BootstrapTools)
 	mg.Deps(sqlcCheck)
 
 	if err := sqlcRun("generate", "-f", "internal/scheduler/database/sql.yaml"); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you: -->

#### What type of PR is this?

Fix

#### What this PR does / why we need it

Adds disk space cleanup step to the release workflow to fix "no space left on device" errors during Docker image builds.

Fix issue with `mage sql` not downloading dependencies.

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer
