### PR TITLE
fix: move BasicAuth credentials to public package for external client use

### DIFF
--- a/internal/common/auth/basic_test.go
+++ b/internal/common/auth/basic_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/metadata"
 
-	"github.com/armadaproject/armada/internal/common"
 	"github.com/armadaproject/armada/internal/common/armadaerrors"
 	"github.com/armadaproject/armada/internal/common/auth/configuration"
+	"github.com/armadaproject/armada/pkg/client/auth/basic"
 )
 
 func TestBasicAuthService(t *testing.T) {
@@ -38,7 +38,7 @@ func TestBasicAuthService(t *testing.T) {
 }
 
 func basicPassword(user, password string) map[string][]string {
-	data, _ := (&common.LoginCredentials{
+	data, _ := (&basic.LoginCredentials{
 		Username: user,
 		Password: password,
 	}).GetRequestMetadata(context.Background())

--- a/pkg/client/auth/basic/credentials.go
+++ b/pkg/client/auth/basic/credentials.go
@@ -1,4 +1,4 @@
-package common
+package basic
 
 import (
 	"context"

--- a/pkg/client/connection.go
+++ b/pkg/client/connection.go
@@ -14,7 +14,7 @@ import (
 	"google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/grpc/keepalive"
 
-	"github.com/armadaproject/armada/internal/common"
+	"github.com/armadaproject/armada/pkg/client/auth/basic"
 	"github.com/armadaproject/armada/pkg/client/auth/exec"
 	"github.com/armadaproject/armada/pkg/client/auth/kubernetes"
 	"github.com/armadaproject/armada/pkg/client/auth/oidc"
@@ -36,7 +36,7 @@ type ApiConnectionDetails struct {
 	// closed.
 	GrpcKeepAliveTimeout time.Duration
 	// Authentication options.
-	BasicAuth                   common.LoginCredentials
+	BasicAuth                   basic.LoginCredentials
 	KubernetesNativeAuth        kubernetes.NativeAuthDetails
 	OpenIdAuth                  oidc.PKCEDetails
 	OpenIdDeviceAuth            oidc.DeviceDetails


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you: -->

#### What type of PR is this?

Bug fix

#### What this PR does / why we need it

Moves `LoginCredentials` from `internal/common` to `pkg/client/auth/basic` so external Go packages can use BasicAuth with the Armada client.

Previously, `ApiConnectionDetails.BasicAuth` referenced an internal type that external consumers couldn't import due to Go's visibility rules.

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer
