### PR TITLE
docs: clarify Armada vs Kubernetes priority class configuration

### DIFF
--- a/internal/common/types/scheduling.go
+++ b/internal/common/types/scheduling.go
@@ -15,9 +15,16 @@ type AwayNodeType struct {
 	WellKnownNodeTypeName string `validate:"required"`
 }
 
+// PriorityClass represents an Armada-specific priority class used for scheduling and preemption.
+// This is separate from Kubernetes PriorityClass resources - Armada manages preemption
+// in its own scheduler before pods are ever submitted to Kubernetes.
 type PriorityClass struct {
+	// Priority controls scheduling order. Higher values get scheduled first and can
+	// preempt running jobs with lower priority values (urgency-based preemption).
 	Priority int32 `validate:"gte=0"`
-	// If true, Armada may preempt jobs of this class to improve fairness.
+	// Preemptible determines if jobs can be evicted to rebalance resources across queues.
+	// When false, jobs are protected from fair-share preemption but can still be preempted
+	// by higher-priority jobs.
 	Preemptible bool
 	// Limits resources assigned to jobs of this priority class.
 	// Specifically, jobs of this priority class are only scheduled if doing so does not exceed this limit.

--- a/internal/scheduler/configuration/configuration.go
+++ b/internal/scheduler/configuration/configuration.go
@@ -146,21 +146,46 @@ type SchedulingConfig struct {
 	// Set to true to enable larger job preferential ordering in the candidate gang iterator.
 	// This will result in larger jobs being ordered earlier in the job scheduling order
 	EnablePreferLargeJobOrdering bool
-	// Only queues allocated more than this fraction of their fair share are considered for preemption.
+	// ProtectedFractionOfFairShare sets the threshold for fair-share preemption.
+	// Queues at or below this fraction of their fair share are protected from preemption.
+	//
+	//   1.0 = Fair-share preemption disabled (default)
+	//   0.5 = Queues over 50% of fair share can have jobs preempted
+	//   0.1 = Aggressive - only queues under 10% of fair share are protected
+	//
+	// This only affects fair-share preemption, not priority-based preemption.
+	// Can be overridden per-pool via Pools[].ProtectedFractionOfFairShare.
 	ProtectedFractionOfFairShare float64 `validate:"gte=0"`
 	// Armada adds a node selector term to every scheduled pod using this label with the node name as value.
 	// This to force kube-scheduler to schedule pods on the node chosen by Armada.
 	// For example, if NodeIdLabel is "kubernetes.io/hostname" and armada schedules a pod on node "myNode",
 	// then Armada adds "kubernetes.io/hostname": "myNode" to the pod node selector before sending it to the executor.
 	NodeIdLabel string `validate:"required"`
-	// Map from priority class names to priority classes.
-	// Must be consistent with Kubernetes priority classes.
-	// I.e., priority classes defined here must be defined in all executor clusters and should map to the same priority.
+	// PriorityClasses defines Armada's own priority classes for scheduling and preemption.
+	// These are separate from Kubernetes PriorityClass resources. Armada handles all preemption
+	// in its scheduler before pods reach Kubernetes.
+	//
+	// Each class has two key fields:
+	//   - priority: Higher values are scheduled first and can preempt lower-priority jobs
+	//   - preemptible: If true, jobs can be evicted to rebalance resources across queues
+	//
+	// Example:
+	//   priorityClasses:
+	//     low:    { priority: 100,  preemptible: true }   # Can be preempted
+	//     medium: { priority: 500,  preemptible: true }   # Can be preempted, preempts "low"
+	//     high:   { priority: 1000, preemptible: false }  # Protected from fair-share preemption
 	PriorityClasses map[string]types.PriorityClass `validate:"dive"`
-	// Jobs with no priority class are assigned this priority class when ingested by the scheduler.
-	// Must be a key in the PriorityClasses map above.
+	// DefaultPriorityClassName is assigned to jobs submitted without a priority class.
+	// Must match a key in PriorityClasses.
 	DefaultPriorityClassName string
-	// If set, override the priority class name of pods with this value when sending to an executor.
+	// PriorityClassNameOverride sets the Kubernetes PriorityClass name on pods sent to executors.
+	// This controls what Kubernetes PriorityClass appears on the pod spec, not Armada's preemption behavior.
+	//
+	//   - "" (empty): Pods have no priorityClassName field
+	//   - Any other value: All pods use this Kubernetes PriorityClass
+	//
+	// This is only relevant for clusters that require pods to have a Kubernetes PriorityClass set.
+	// It does not affect how Armada schedules or preempts jobs.
 	PriorityClassNameOverride *string
 	// Number of jobs to load from the database at a time.
 	MaxQueueLookback uint


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you: -->

#### What type of PR is this?

Documentation

#### What this PR does / why we need it

Clarifies differences between Armada & Kubernetes Prirority Classes.

Armada handles preemption itself before pods reach Kubernetes. The Kubernetes PriorityClass on the pod is just for cluster admission policies, not for scheduling or preemption, as that is handled before the pod reaches the cluster, in the Armada Scheduler.

How it works:
1. User submits a job with a priority class
  ```
  # job.yaml
  queue: my-queue
  jobSetId: my-job-set
  jobs:
    - priority: 1
      podSpec:
        priorityClassName: high  # Armada priority class name
        containers:
          - name: app
            image: alpine:latest
  ```

2. Scheduler looks up high in its `priorityClasses` config
  ```
  # scheduler config
  scheduling:
    priorityClasses:
      low:
        priority: 100
        preemptible: true
      default:
        priority: 500
        preemptible: true
      high:
        priority: 1000
        preemptible: false   # Protected from fair-share preemption
    defaultPriorityClassName: default
    priorityClassNameOverride: some-k8s-priority-class
  ```

3. Scheduler assigns the job to a node
  - Jobs with high (priority 1000) are scheduled before low (priority 100)
  - Jobs with `preemptible: false` are protected from fair-share preemption
  - Higher priority jobs can still preempt lower priority jobs

4. Executor creates the pod with overridden priority class
  ```
  # What actually gets created in Kubernetes
  apiVersion: v1
  kind: Pod
  metadata:
    name: armada-job-xyz
  spec:
    priorityClassName: some-k8s-priority-class  # Overridden, not "high"
    ...
    containers:
      - name: app
        image: alpine:latest
  ```

#### Special notes for your reviewer
