### PR TITLE
Remove reported done flow on executor

### DIFF
--- a/internal/executor/domain/pod_metadata.go
+++ b/internal/executor/domain/pod_metadata.go
@@ -13,6 +13,5 @@ const (
 	AssociatedServicesCount  = "associated_services_count"
 	IngressReported          = "ingress_reported"
 	MarkedForDeletion        = "deletion_requested"
-	JobDoneAnnotation        = "reported_done"
 	JobPreemptedAnnotation   = "reported_preempted"
 )

--- a/internal/executor/job/job_run_state_store_test.go
+++ b/internal/executor/job/job_run_state_store_test.go
@@ -42,7 +42,6 @@ func TestOnStartUp_ReconcilesWithKubernetes_ActivePod(t *testing.T) {
 func TestOnStartUp_ReconcilesWithKubernetes_IgnoresDonePods(t *testing.T) {
 	donePod := createPod()
 	donePod.Status.Phase = v1.PodSucceeded
-	donePod.Annotations[domain.JobDoneAnnotation] = "true"
 	donePod.Annotations[string(donePod.Status.Phase)] = fmt.Sprintf("%s", time.Now())
 
 	jobRunStateManager, _ := setup(t, []*v1.Pod{donePod})

--- a/internal/executor/util/pod_util.go
+++ b/internal/executor/util/pod_util.go
@@ -271,11 +271,6 @@ func IsMarkedForDeletion(pod *v1.Pod) bool {
 	return exists
 }
 
-func IsReportedDone(pod *v1.Pod) bool {
-	_, exists := pod.Annotations[domain.JobDoneAnnotation]
-	return exists
-}
-
 func IsReportedPreempted(pod *v1.Pod) bool {
 	_, exists := pod.Annotations[domain.JobPreemptedAnnotation]
 	return exists
@@ -294,7 +289,6 @@ func GetDeletionGracePeriodOrDefault(pod *v1.Pod) time.Duration {
 
 func IsPodFinishedAndReported(pod *v1.Pod) bool {
 	if !IsInTerminalState(pod) ||
-		!IsReportedDone(pod) ||
 		!HasCurrentStateBeenReported(pod) {
 		return false
 	}

--- a/internal/executor/util/pod_util_test.go
+++ b/internal/executor/util/pod_util_test.go
@@ -562,17 +562,6 @@ func TestLastStatusChange_ReportsTimeFromContainerStatus(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestIsReportedDone(t *testing.T) {
-	isNotReportedDone := &v1.Pod{}
-	isReportedDone := &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Annotations: map[string]string{domain.JobDoneAnnotation: time.Now().String()},
-		},
-	}
-	assert.False(t, IsReportedDone(isNotReportedDone))
-	assert.True(t, IsReportedDone(isReportedDone))
-}
-
 func TestIsMarkedForDeletion(t *testing.T) {
 	isNotMarkedForDeletion := &v1.Pod{}
 	isMarkedForDeletion := &v1.Pod{

--- a/internal/executor/utilisation/cluster_utilisation.go
+++ b/internal/executor/utilisation/cluster_utilisation.go
@@ -140,12 +140,11 @@ func (clusterUtilisationService *ClusterUtilisationService) getRunIdsByNode(node
 			nodeIdToNodeName[nodeId] = n.Name
 		}
 	}
-	noLongerNeedsReportingFunc := util.IsReportedDone
 
 	result := map[string]map[string]api.JobState{}
 	for _, pod := range pods {
 		// Skip pods that are not armada pods or "complete" from the servers point of view
-		if !util.IsManagedPod(pod) || noLongerNeedsReportingFunc(pod) {
+		if !util.IsManagedPod(pod) || util.IsPodFinishedAndReported(pod) {
 			continue
 		}
 		nodeIdNodeSelector, nodeSelectorPresent := pod.Spec.NodeSelector[clusterUtilisationService.nodeIdLabel]


### PR DESCRIPTION
This flow is from many years ago when the scheduler wasn't split out from the API.

Back then the executor "owned" the lease and the scheduler would do nothing with it until the executor reported it was done with the lease (or stopped renewing the lease for long enough).
 - Most of this flow was removed (the api call) however the labelling of pods to confirm it has been reported done still exists

Nowadays the scheduler ends the lease automatically when the job is done - making the entire reported done flow redundant.
 - It also has a race condition where the lease it ended, the pod deleted and then we try to report it done (and can't as the pod is missing) causing spurious errors
 
 This just removes the remnants of the reported done flow