### PR TITLE
Re-enable away scheduling for gang jobs

### DIFF
--- a/internal/scheduler/configuration/configuration.go
+++ b/internal/scheduler/configuration/configuration.go
@@ -327,6 +327,7 @@ type PoolConfig struct {
 	ExperimentalMarketScheduling  *MarketSchedulingConfig
 	ExperimentalRunReconciliation *RunReconciliationConfig
 	DisableAwayScheduling         bool
+	DisableGangAwayScheduling     bool
 }
 
 func (p PoolConfig) GetSubmissionGroup() string {

--- a/internal/scheduler/scheduling/scheduling_algo.go
+++ b/internal/scheduler/scheduling/scheduling_algo.go
@@ -188,6 +188,10 @@ func (l *FairSchedulingAlgo) Schedule(
 			fsctx.nodeDb.DisableAwayScheduling()
 		}
 
+		if pool.DisableGangAwayScheduling {
+			fsctx.nodeDb.DisableGangAwayScheduling()
+		}
+
 		start := time.Now()
 		resourceUnit, ok := resourceUnits[pool.Name]
 		if !ok {

--- a/internal/scheduler/scheduling/scheduling_algo_test.go
+++ b/internal/scheduler/scheduling/scheduling_algo_test.go
@@ -513,6 +513,26 @@ func TestSchedule(t *testing.T) {
 			queuedJobs:               testfixtures.WithGangAnnotationsJobs(testfixtures.N16Cpu128GiJobs("A", testfixtures.PriorityClass0, 2)),
 			expectedScheduledIndices: []int{0, 1},
 		},
+		"gang scheduling successful - away scheduling": {
+			schedulingConfig: testfixtures.TestSchedulingConfig(),
+			executors: []*schedulerobjects.Executor{
+				makeTestExecutorWithNodes("executor-1",
+					withLargeNodeTaint(testNodeWithPool(testfixtures.TestPool))),
+			},
+			queues:                   []*api.Queue{{Name: "A", PriorityFactor: 0.01}},
+			queuedJobs:               testfixtures.WithGangAnnotationsJobs(testfixtures.N16Cpu128GiJobs("A", testfixtures.PriorityClass4PreemptibleAway, 2)),
+			expectedScheduledIndices: []int{0, 1},
+		},
+		"not scheduling gang away - gang away scheduling disabled": {
+			schedulingConfig: testfixtures.WithGangAwaySchedulingDisabled(testfixtures.TestSchedulingConfig()),
+			executors: []*schedulerobjects.Executor{
+				makeTestExecutorWithNodes("executor-1",
+					withLargeNodeTaint(testNodeWithPool(testfixtures.TestPool))),
+			},
+			queues:                   []*api.Queue{{Name: "A", PriorityFactor: 0.01}},
+			queuedJobs:               testfixtures.WithGangAnnotationsJobs(testfixtures.N16Cpu128GiJobs("A", testfixtures.PriorityClass0, 2)),
+			expectedScheduledIndices: []int{},
+		},
 		"gang scheduling successful - mixed pool clusters": {
 			schedulingConfig: testfixtures.TestSchedulingConfigWithPools([]configuration.PoolConfig{{Name: "pool-1"}, {Name: "pool-2"}}),
 			executors: []*schedulerobjects.Executor{

--- a/internal/scheduler/submitcheck.go
+++ b/internal/scheduler/submitcheck.go
@@ -304,6 +304,12 @@ poolStart:
 				ex.nodeDb.EnableAwayScheduling()
 			}
 
+			if pool.DisableGangAwayScheduling {
+				ex.nodeDb.DisableGangAwayScheduling()
+			} else {
+				ex.nodeDb.EnableGangAwayScheduling()
+			}
+
 			txn := ex.nodeDb.Txn(true)
 			ok, err := ex.nodeDb.ScheduleManyWithTxn(txn, gctx)
 			txn.Abort()

--- a/internal/scheduler/testfixtures/testfixtures.go
+++ b/internal/scheduler/testfixtures/testfixtures.go
@@ -236,6 +236,14 @@ func WithAwaySchedulingDisabled(config schedulerconfiguration.SchedulingConfig) 
 	return config
 }
 
+func WithGangAwaySchedulingDisabled(config schedulerconfiguration.SchedulingConfig) schedulerconfiguration.SchedulingConfig {
+	for i, pool := range config.Pools {
+		pool.DisableGangAwayScheduling = true
+		config.Pools[i] = pool
+	}
+	return config
+}
+
 func WithMarketBasedSchedulingEnabled(config schedulerconfiguration.SchedulingConfig) schedulerconfiguration.SchedulingConfig {
 	for i, pool := range config.Pools {
 		pool.ExperimentalMarketScheduling = &schedulerconfiguration.MarketSchedulingConfig{


### PR DESCRIPTION
This was originally disabled due to a bug that caused gangs to get partially scheduled

Since that change we have largely rewritten how gang jobs are modelled internally in the scheduler so we believe this bug is now fixed
 - I've added several unit tests around this around, targeting what we believe was cause of the bug (scheduled and preempted in the same round)

I have added `DisableGangAwayScheduling` as:
 - If the bug is still there, it allows us to disable the feature again with a config change
 - Some configurations, it wouldn't be suitable for gang jobs to be scheduled away as these are typically more volatile (inclined to be preempted) and this isn't always suitable for gangs


