### PR TITLE
feat(scheduler): isolate pool scheduling failures to prevent cascade abort

### DIFF
--- a/internal/scheduler/scheduling/scheduling_algo.go
+++ b/internal/scheduler/scheduling/scheduling_algo.go
@@ -174,9 +174,10 @@ func (l *FairSchedulingAlgo) Schedule(
 		// If we use a different copy of nodes (possibly more to date copy) it may no longer align with the jobs/runs
 		fsctx, err := l.newFairSchedulingAlgoContext(ctx, txn, executors, pool)
 		if err != nil {
+			ctx.Errorf("failed to create scheduling context for pool %s: %v", pool.Name, err)
 			overallSchedulerResult.PoolSchedulingOutcomes = append(overallSchedulerResult.PoolSchedulingOutcomes,
 				PoolSchedulingOutcome{Pool: pool.Name, Success: false, TerminationReason: PoolSchedulingTerminationReasonError})
-			return overallSchedulerResult, err
+			continue
 		}
 
 		if fsctx.nodeDb.NumNodes() <= 0 {
@@ -208,9 +209,10 @@ func (l *FairSchedulingAlgo) Schedule(
 			ctx.Info("stopped scheduling early as we have hit the maximum scheduling duration")
 			break
 		} else if err != nil {
+			ctx.Errorf("failed to schedule pool %s: %v", pool.Name, err)
 			overallSchedulerResult.PoolSchedulingOutcomes = append(overallSchedulerResult.PoolSchedulingOutcomes,
 				PoolSchedulingOutcome{Pool: pool.Name, Success: false, TerminationReason: PoolSchedulingTerminationReasonError})
-			return overallSchedulerResult, err
+			continue
 		}
 		if l.schedulingContextRepository != nil {
 			l.schedulingContextRepository.StoreSchedulingContext(sctx)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you: -->

#### What type of PR is this?

Enhancement

#### What this PR does / why we need it

* Pool context creation or scheduling errors now log and continue to next pool instead of aborting the entire scheduling cycle
* Failed pools still report outcomes via `PoolSchedulingOutcome` for metrics/alerting

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer
