### PR TITLE
More user friendly pod issue message

### DIFF
--- a/internal/executor/service/pod_issue_handler.go
+++ b/internal/executor/service/pod_issue_handler.go
@@ -233,7 +233,7 @@ func (p *PodIssueHandler) detectPodIssues(allManagedPods []*v1.Pod) {
 			// it is safer to produce failed event than retrying as the job might have run already
 			issue := &podIssue{
 				OriginalPodState: pod.DeepCopy(),
-				Message:          "pod stuck in terminating phase, this might be due to platform problems",
+				Message:          "job couldn't shut down cleanly as pod stuck in terminating phase, this indicates a node issue",
 				Retryable:        false,
 				Type:             StuckTerminating,
 			}


### PR DESCRIPTION
If a node is having problems you can often get a message of "pod stuck in terminating phase, this might be due to platform problems". Users have suggested that this isn't a very helpful error message. We can clarify what is going on.
