### PR TITLE
Scala Client v0.3.0 post-release version bump

### DIFF
--- a/client/scala/armada-scala-client/pom.xml
+++ b/client/scala/armada-scala-client/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.armadaproject</groupId>
   <artifactId>armada-scala-client_2.13</artifactId>
-  <version>0.3.0</version>
+  <version>0.4.0-SNAPSHOT</version>
   <name>Armada Scala Client</name>
   <description>A Scala client for Armada.</description>
   <inceptionYear>2025</inceptionYear>


### PR DESCRIPTION
Mark that work has begun on v0.4.0-SNAPSHOT.