### PR TITLE
Add Model Context Protocol (MCP) endpoint to Lookout

### DIFF
--- a/config/lookout/config.yaml
+++ b/config/lookout/config.yaml
@@ -23,6 +23,12 @@ prunerConfig:
   deduplicationExpireAfter: 168h # 7 days
   timeout: 1h
   batchSize: 1000
+
+# Enable MCP (Model Context Protocol) endpoint for LLM integrations
+# When enabled, exposes /mcp endpoint for job queries via MCP protocol
+mcpEnabled: false
+lookoutUIBaseUrl: "http://localhost:10000"
+
 uiConfig:
   backend: "jsonb"
   armadaApiBaseUrl: "http://armada-server:8080"

--- a/internal/lookout/application.go
+++ b/internal/lookout/application.go
@@ -3,12 +3,20 @@
 package lookout
 
 import (
+	"encoding/json"
 	"fmt"
+	"html"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
 
 	"github.com/IBM/pgxpoolprometheus"
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/gogo/protobuf/jsonpb"
 	"github.com/jessevdk/go-flags"
+	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/armadaproject/armada/internal/common"
@@ -22,7 +30,10 @@ import (
 	"github.com/armadaproject/armada/internal/lookout/conversions"
 	"github.com/armadaproject/armada/internal/lookout/gen/restapi"
 	"github.com/armadaproject/armada/internal/lookout/gen/restapi/operations"
+	"github.com/armadaproject/armada/internal/lookout/model"
 	"github.com/armadaproject/armada/internal/lookout/repository"
+	"github.com/armadaproject/armada/internal/lookoutmcp/mcp"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 func Serve(configuration configuration.LookoutConfig) error {
@@ -184,10 +195,843 @@ func Serve(configuration configuration.LookoutConfig) error {
 
 	restapi.SetAuthService(auth.NewMultiAuthService(authServices))
 	restapi.SetCorsAllowedOrigins(configuration.CorsAllowedOrigins) // This needs to happen before ConfigureAPI
+
+	if configuration.MCPEnabled {
+		logger.Info("MCP endpoint enabled")
+		restapi.SetMCPHandler(mcpHandler(db, configuration, logger))
+	}
+
 	server.ConfigureAPI()
+
 	if err := server.Serve(); err != nil {
 		return err
 	}
 
 	return err
+}
+
+type mcpServerState struct {
+	config                configuration.LookoutConfig
+	getJobsRepo           *repository.SqlGetJobsRepository
+	getJobSpecRepo        repository.GetJobSpecRepository
+	getJobErrorRepo       repository.GetJobErrorRepository
+	getJobRunErrorRepo    repository.GetJobRunErrorRepository
+	getJobRunDebugMsgRepo repository.GetJobRunDebugMessageRepository
+	logger                *logging.Logger
+	marshaler             jsonpb.Marshaler
+}
+
+func mcpHandler(db *pgxpool.Pool, config configuration.LookoutConfig, logger *logging.Logger) http.HandlerFunc {
+	decompressor := compress.NewThreadSafeZlibDecompressor()
+	state := &mcpServerState{
+		config:                config,
+		getJobsRepo:           repository.NewSqlGetJobsRepository(db),
+		getJobSpecRepo:        repository.NewSqlGetJobSpecRepository(db, decompressor),
+		getJobErrorRepo:       repository.NewSqlGetJobErrorRepository(db, decompressor),
+		getJobRunErrorRepo:    repository.NewSqlGetJobRunErrorRepository(db, decompressor),
+		getJobRunDebugMsgRepo: repository.NewSqlGetJobRunDebugMessageRepository(db, decompressor),
+		logger:                logger,
+		marshaler: jsonpb.Marshaler{
+			OrigName:     true,
+			EmitDefaults: false,
+		},
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			logger.WithError(err).Error("error reading request body")
+			http.Error(w, "Bad request", http.StatusBadRequest)
+			return
+		}
+		defer r.Body.Close()
+
+		ctx := armadacontext.New(r.Context(), logger)
+		if err := state.handleMCPRequest(*ctx, body, w); err != nil {
+			logger.WithError(err).Error("error handling MCP request")
+		}
+	}
+}
+
+var jobIDPattern = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,128}$`)
+
+func validateJobID(jobID string) error {
+	if jobID == "" {
+		return errors.New("jobId is required")
+	}
+	if len(jobID) > 128 {
+		return errors.New("jobId must be at most 128 characters")
+	}
+	if !jobIDPattern.MatchString(jobID) {
+		return errors.New("jobId contains invalid characters (allowed: alphanumeric, underscore, hyphen)")
+	}
+	return nil
+}
+
+func extractJobID(args map[string]any) (string, error) {
+	jobID, ok := args["jobId"].(string)
+	if !ok {
+		return "", errors.New("jobId must be a string")
+	}
+	if err := validateJobID(jobID); err != nil {
+		return "", err
+	}
+	return jobID, nil
+}
+
+func (s *mcpServerState) handleMCPRequest(ctx armadacontext.Context, data []byte, w http.ResponseWriter) error {
+	var req mcp.Request
+	if err := json.Unmarshal(data, &req); err != nil {
+		s.logger.WithError(err).WithField("data", string(data)).Error("failed to parse MCP request")
+		s.sendMCPError(w, nil, mcp.ErrorCodeParseError, "parse error", err.Error())
+		return err
+	}
+
+	logger := s.logger.WithField("method", req.Method).WithField("requestId", req.ID)
+
+	switch req.Method {
+	case "initialize":
+		logger.Debug("handling initialize request")
+		return s.handleMCPInitialize(w, req)
+	case "tools/list":
+		logger.Debug("handling tools/list request")
+		return s.handleMCPListTools(w, req)
+	case "tools/call":
+		logger.Debug("handling tools/call request")
+		return s.handleMCPCallTool(ctx, w, req)
+	default:
+		logger.WithField("method", req.Method).Warn("unknown method")
+		s.sendMCPError(w, req.ID, mcp.ErrorCodeMethodNotFound, "method not found", nil)
+		return nil
+	}
+}
+
+func (s *mcpServerState) handleMCPInitialize(w http.ResponseWriter, req mcp.Request) error {
+	var params mcp.InitializeParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		s.sendMCPError(w, req.ID, mcp.ErrorCodeInvalidParams, "invalid params", err.Error())
+		return err
+	}
+
+	result := mcp.InitializeResult{
+		ProtocolVersion: mcp.ProtocolVersion,
+		Capabilities: mcp.ServerCapabilities{
+			Tools: &mcp.ToolsCapability{},
+		},
+		ServerInfo: mcp.Implementation{
+			Name:    "lookout-mcp-server",
+			Version: "1.0.0",
+		},
+	}
+
+	return s.sendMCPResult(w, req.ID, result)
+}
+
+func (s *mcpServerState) handleMCPListTools(w http.ResponseWriter, req mcp.Request) error {
+	tools := []mcp.Tool{
+		{
+			Name:        "search_jobs",
+			Description: "Search for jobs with flexible filters (queue, jobSet, owner, state, etc.)",
+			InputSchema: json.RawMessage(`{
+				"type": "object",
+				"properties": {
+					"filters": {
+						"type": "array",
+						"description": "List of filters to apply",
+						"items": {
+							"type": "object",
+							"properties": {
+								"field": {"type": "string", "description": "Field name (queue, jobSet, owner, state, etc.)"},
+								"match": {"type": "string", "description": "Match type (exact, contains, startsWith, etc.)"},
+								"value": {"description": "Value to match"}
+							},
+							"required": ["field", "match", "value"]
+						}
+					},
+					"skip": {
+						"type": "integer",
+						"description": "Number of results to skip for pagination",
+						"default": 0
+					},
+					"take": {
+						"type": "integer",
+						"description": "Number of results to return",
+						"default": 10,
+						"maximum": 100
+					}
+				}
+			}`),
+		},
+		{
+			Name:        "get_job_details",
+			Description: "Get detailed information about a job by its ID, including state, resources, runs, and metadata",
+			InputSchema: json.RawMessage(`{
+				"type": "object",
+				"properties": {
+					"jobId": {
+						"type": "string",
+						"description": "The unique identifier of the job"
+					}
+				},
+				"required": ["jobId"]
+			}`),
+		},
+		{
+			Name:        "get_job_spec",
+			Description: "Get the full job specification for a job by its ID",
+			InputSchema: json.RawMessage(`{
+				"type": "object",
+				"properties": {
+					"jobId": {
+						"type": "string",
+						"description": "The unique identifier of the job"
+					}
+				},
+				"required": ["jobId"]
+			}`),
+		},
+		{
+			Name:        "get_job_error",
+			Description: "Get the error message for a failed job",
+			InputSchema: json.RawMessage(`{
+				"type": "object",
+				"properties": {
+					"jobId": {
+						"type": "string",
+						"description": "The unique identifier of the job"
+					}
+				},
+				"required": ["jobId"]
+			}`),
+		},
+		{
+			Name:        "get_job_run_error",
+			Description: "Get the error message for a specific job run",
+			InputSchema: json.RawMessage(`{
+				"type": "object",
+				"properties": {
+					"runId": {
+						"type": "string",
+						"description": "The unique identifier of the job run"
+					}
+				},
+				"required": ["runId"]
+			}`),
+		},
+		{
+			Name:        "get_job_run_debug",
+			Description: "Get debug information for a specific job run",
+			InputSchema: json.RawMessage(`{
+				"type": "object",
+				"properties": {
+					"runId": {
+						"type": "string",
+						"description": "The unique identifier of the job run"
+					}
+				},
+				"required": ["runId"]
+			}`),
+		},
+		{
+			Name:        "get_job_commands",
+			Description: "Get the list of available commands for a job (e.g., kubectl logs, kubectl exec)",
+			InputSchema: json.RawMessage(`{
+				"type": "object",
+				"properties": {
+					"jobId": {
+						"type": "string",
+						"description": "The unique identifier of the job"
+					}
+				},
+				"required": ["jobId"]
+			}`),
+		},
+		{
+			Name:        "get_job_links",
+			Description: "Get the list of external links related to a job",
+			InputSchema: json.RawMessage(`{
+				"type": "object",
+				"properties": {
+					"jobId": {
+						"type": "string",
+						"description": "The unique identifier of the job"
+					}
+				},
+				"required": ["jobId"]
+			}`),
+		},
+		{
+			Name:        "get_lookout_ui_link",
+			Description: "Get the Lookout UI link for viewing a job",
+			InputSchema: json.RawMessage(`{
+				"type": "object",
+				"properties": {
+					"jobId": {
+						"type": "string",
+						"description": "The unique identifier of the job"
+					}
+				},
+				"required": ["jobId"]
+			}`),
+		},
+	}
+
+	result := mcp.ListToolsResult{
+		Tools: tools,
+	}
+
+	return s.sendMCPResult(w, req.ID, result)
+}
+
+func (s *mcpServerState) handleMCPCallTool(ctx armadacontext.Context, w http.ResponseWriter, req mcp.Request) error {
+	var params mcp.CallToolParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		s.sendMCPError(w, req.ID, mcp.ErrorCodeInvalidParams, "invalid params", err.Error())
+		return err
+	}
+
+	var result mcp.CallToolResult
+	var err error
+
+	switch params.Name {
+	case "search_jobs":
+		result, err = s.handleSearchJobs(ctx, params.Arguments)
+	case "get_job_details":
+		result, err = s.handleGetJobDetails(ctx, params.Arguments)
+	case "get_job_spec":
+		result, err = s.handleGetJobSpec(ctx, params.Arguments)
+	case "get_job_error":
+		result, err = s.handleGetJobError(ctx, params.Arguments)
+	case "get_job_run_error":
+		result, err = s.handleGetJobRunError(ctx, params.Arguments)
+	case "get_job_run_debug":
+		result, err = s.handleGetJobRunDebug(ctx, params.Arguments)
+	case "get_job_commands":
+		result, err = s.handleGetJobCommands(ctx, params.Arguments)
+	case "get_job_links":
+		result, err = s.handleGetJobLinks(ctx, params.Arguments)
+	case "get_lookout_ui_link":
+		result, err = s.handleGetLookoutUILink(params.Arguments)
+	default:
+		s.sendMCPError(w, req.ID, mcp.ErrorCodeInvalidParams, "unknown tool", params.Name)
+		return nil
+	}
+
+	if err != nil {
+		result = mcp.CallToolResult{
+			Content: []mcp.Content{
+				{
+					Type: "text",
+					Text: fmt.Sprintf("Error: %v", err),
+				},
+			},
+			IsError: true,
+		}
+	}
+
+	return s.sendMCPResult(w, req.ID, result)
+}
+
+func (s *mcpServerState) handleGetJobDetails(ctx armadacontext.Context, args map[string]any) (mcp.CallToolResult, error) {
+	jobID, err := extractJobID(args)
+	if err != nil {
+		return mcp.CallToolResult{}, err
+	}
+
+	logger := s.logger.WithField("jobId", jobID).WithField("tool", "get_job_details")
+	logger.Debug("getting job details")
+
+	filters := []*model.Filter{
+		{
+			Field: "jobId",
+			Match: model.MatchExact,
+			Value: jobID,
+		},
+	}
+
+	result, err := s.getJobsRepo.GetJobs(&ctx, filters, false, nil, 0, 1)
+	if err != nil {
+		logger.WithError(err).Error("failed to get job")
+		return mcp.CallToolResult{}, errors.Wrap(err, "failed to get job")
+	}
+
+	if len(result.Jobs) == 0 {
+		logger.Warn("job not found")
+		return mcp.CallToolResult{}, errors.Errorf("job with ID %s not found", jobID)
+	}
+
+	job := result.Jobs[0]
+
+	jsonData, err := json.MarshalIndent(job, "", "  ")
+	if err != nil {
+		return mcp.CallToolResult{}, errors.Wrap(err, "failed to marshal job to JSON")
+	}
+
+	return mcp.CallToolResult{
+		Content: []mcp.Content{
+			{
+				Type: "text",
+				Text: string(jsonData),
+			},
+		},
+	}, nil
+}
+
+func (s *mcpServerState) handleGetJobSpec(ctx armadacontext.Context, args map[string]any) (mcp.CallToolResult, error) {
+	jobID, err := extractJobID(args)
+	if err != nil {
+		return mcp.CallToolResult{}, err
+	}
+
+	logger := s.logger.WithField("jobId", jobID).WithField("tool", "get_job_spec")
+	logger.Debug("getting job spec")
+
+	jobSpec, err := s.getJobSpecRepo.GetJobSpec(&ctx, jobID)
+	if err != nil {
+		logger.WithError(err).Error("failed to get job spec")
+		return mcp.CallToolResult{}, errors.Wrap(err, "failed to get job spec")
+	}
+
+	jsonStr, err := s.marshaler.MarshalToString(jobSpec)
+	if err != nil {
+		return mcp.CallToolResult{}, errors.Wrap(err, "failed to marshal job spec to JSON")
+	}
+
+	var formatted map[string]any
+	if err := json.Unmarshal([]byte(jsonStr), &formatted); err != nil {
+		return mcp.CallToolResult{}, errors.Wrap(err, "failed to parse JSON for formatting")
+	}
+
+	jsonData, err := json.MarshalIndent(formatted, "", "  ")
+	if err != nil {
+		return mcp.CallToolResult{}, errors.Wrap(err, "failed to format JSON")
+	}
+
+	return mcp.CallToolResult{
+		Content: []mcp.Content{
+			{
+				Type: "text",
+				Text: string(jsonData),
+			},
+		},
+	}, nil
+}
+
+func (s *mcpServerState) handleGetJobCommands(ctx armadacontext.Context, args map[string]any) (mcp.CallToolResult, error) {
+	jobID, err := extractJobID(args)
+	if err != nil {
+		return mcp.CallToolResult{}, err
+	}
+
+	logger := s.logger.WithField("jobId", jobID).WithField("tool", "get_job_commands")
+	logger.Debug("getting job commands")
+
+	filters := []*model.Filter{
+		{
+			Field: "jobId",
+			Match: model.MatchExact,
+			Value: jobID,
+		},
+	}
+
+	result, err := s.getJobsRepo.GetJobs(&ctx, filters, false, nil, 0, 1)
+	if err != nil {
+		logger.WithError(err).Error("failed to get job")
+		return mcp.CallToolResult{}, errors.Wrap(err, "failed to get job")
+	}
+
+	if len(result.Jobs) == 0 {
+		logger.Warn("job not found")
+		return mcp.CallToolResult{}, errors.Errorf("job with ID %s not found", jobID)
+	}
+
+	job := result.Jobs[0]
+
+	commands := s.renderCommands(job)
+
+	jsonData, err := json.MarshalIndent(commands, "", "  ")
+	if err != nil {
+		return mcp.CallToolResult{}, errors.Wrap(err, "failed to marshal commands to JSON")
+	}
+
+	return mcp.CallToolResult{
+		Content: []mcp.Content{
+			{
+				Type: "text",
+				Text: string(jsonData),
+			},
+		},
+	}, nil
+}
+
+func (s *mcpServerState) handleGetJobLinks(ctx armadacontext.Context, args map[string]any) (mcp.CallToolResult, error) {
+	jobID, err := extractJobID(args)
+	if err != nil {
+		return mcp.CallToolResult{}, err
+	}
+
+	logger := s.logger.WithField("jobId", jobID).WithField("tool", "get_job_links")
+	logger.Debug("getting job links")
+
+	filters := []*model.Filter{
+		{
+			Field: "jobId",
+			Match: model.MatchExact,
+			Value: jobID,
+		},
+	}
+
+	result, err := s.getJobsRepo.GetJobs(&ctx, filters, false, nil, 0, 1)
+	if err != nil {
+		logger.WithError(err).Error("failed to get job")
+		return mcp.CallToolResult{}, errors.Wrap(err, "failed to get job")
+	}
+
+	if len(result.Jobs) == 0 {
+		logger.Warn("job not found")
+		return mcp.CallToolResult{}, errors.Errorf("job with ID %s not found", jobID)
+	}
+
+	job := result.Jobs[0]
+
+	links := s.renderLinks(job)
+
+	jsonData, err := json.MarshalIndent(links, "", "  ")
+	if err != nil {
+		return mcp.CallToolResult{}, errors.Wrap(err, "failed to marshal links to JSON")
+	}
+
+	return mcp.CallToolResult{
+		Content: []mcp.Content{
+			{
+				Type: "text",
+				Text: string(jsonData),
+			},
+		},
+	}, nil
+}
+
+func (s *mcpServerState) handleGetLookoutUILink(args map[string]any) (mcp.CallToolResult, error) {
+	jobID, err := extractJobID(args)
+	if err != nil {
+		return mcp.CallToolResult{}, err
+	}
+
+	logger := s.logger.WithField("jobId", jobID).WithField("tool", "get_lookout_ui_link")
+	logger.Debug("getting lookout UI link")
+
+	baseURL := strings.TrimSuffix(s.config.LookoutUIBaseUrl, "/")
+
+	link := fmt.Sprintf("%s/jobs/%s", baseURL, jobID)
+
+	type LinkResult struct {
+		URL string `json:"url"`
+	}
+
+	linkResult := LinkResult{URL: link}
+
+	jsonData, err := json.MarshalIndent(linkResult, "", "  ")
+	if err != nil {
+		return mcp.CallToolResult{}, errors.Wrap(err, "failed to marshal link to JSON")
+	}
+
+	return mcp.CallToolResult{
+		Content: []mcp.Content{
+			{
+				Type: "text",
+				Text: string(jsonData),
+			},
+		},
+	}, nil
+}
+
+func (s *mcpServerState) handleSearchJobs(ctx armadacontext.Context, args map[string]any) (mcp.CallToolResult, error) {
+	logger := s.logger.WithField("tool", "search_jobs")
+	logger.Debug("searching jobs")
+
+	var filters []*model.Filter
+	if filtersArg, ok := args["filters"].([]any); ok {
+		filters = make([]*model.Filter, 0, len(filtersArg))
+		for _, f := range filtersArg {
+			filterMap, ok := f.(map[string]any)
+			if !ok {
+				continue
+			}
+			field, _ := filterMap["field"].(string)
+			match, _ := filterMap["match"].(string)
+			value := filterMap["value"]
+
+			filters = append(filters, &model.Filter{
+				Field: field,
+				Match: match,
+				Value: value,
+			})
+		}
+	}
+
+	skip := 0
+	if s, ok := args["skip"].(float64); ok {
+		skip = int(s)
+	}
+
+	take := 10
+	if t, ok := args["take"].(float64); ok {
+		take = int(t)
+		if take > 100 {
+			take = 100
+		}
+	}
+
+	result, err := s.getJobsRepo.GetJobs(&ctx, filters, false, nil, skip, take)
+	if err != nil {
+		logger.WithError(err).Error("failed to search jobs")
+		return mcp.CallToolResult{}, errors.Wrap(err, "failed to search jobs")
+	}
+
+	jsonData, err := json.MarshalIndent(result.Jobs, "", "  ")
+	if err != nil {
+		return mcp.CallToolResult{}, errors.Wrap(err, "failed to marshal jobs to JSON")
+	}
+
+	return mcp.CallToolResult{
+		Content: []mcp.Content{
+			{
+				Type: "text",
+				Text: fmt.Sprintf("Found %d jobs:\n\n%s", len(result.Jobs), string(jsonData)),
+			},
+		},
+	}, nil
+}
+
+func (s *mcpServerState) handleGetJobError(ctx armadacontext.Context, args map[string]any) (mcp.CallToolResult, error) {
+	jobID, err := extractJobID(args)
+	if err != nil {
+		return mcp.CallToolResult{}, err
+	}
+
+	logger := s.logger.WithField("jobId", jobID).WithField("tool", "get_job_error")
+	logger.Debug("getting job error")
+
+	errorMsg, err := s.getJobErrorRepo.GetJobErrorMessage(&ctx, jobID)
+	if err != nil {
+		logger.WithError(err).Error("failed to get job error")
+		return mcp.CallToolResult{}, errors.Wrap(err, "failed to get job error")
+	}
+
+	return mcp.CallToolResult{
+		Content: []mcp.Content{
+			{
+				Type: "text",
+				Text: errorMsg,
+			},
+		},
+	}, nil
+}
+
+func validateRunID(runID string) error {
+	if runID == "" {
+		return errors.New("runId is required")
+	}
+	if len(runID) > 128 {
+		return errors.New("runId must be at most 128 characters")
+	}
+	return nil
+}
+
+func extractRunID(args map[string]any) (string, error) {
+	runID, ok := args["runId"].(string)
+	if !ok {
+		return "", errors.New("runId must be a string")
+	}
+	if err := validateRunID(runID); err != nil {
+		return "", err
+	}
+	return runID, nil
+}
+
+func (s *mcpServerState) handleGetJobRunError(ctx armadacontext.Context, args map[string]any) (mcp.CallToolResult, error) {
+	runID, err := extractRunID(args)
+	if err != nil {
+		return mcp.CallToolResult{}, err
+	}
+
+	logger := s.logger.WithField("runId", runID).WithField("tool", "get_job_run_error")
+	logger.Debug("getting job run error")
+
+	errorMsg, err := s.getJobRunErrorRepo.GetJobRunError(&ctx, runID)
+	if err != nil {
+		logger.WithError(err).Error("failed to get job run error")
+		return mcp.CallToolResult{}, errors.Wrap(err, "failed to get job run error")
+	}
+
+	return mcp.CallToolResult{
+		Content: []mcp.Content{
+			{
+				Type: "text",
+				Text: errorMsg,
+			},
+		},
+	}, nil
+}
+
+func (s *mcpServerState) handleGetJobRunDebug(ctx armadacontext.Context, args map[string]any) (mcp.CallToolResult, error) {
+	runID, err := extractRunID(args)
+	if err != nil {
+		return mcp.CallToolResult{}, err
+	}
+
+	logger := s.logger.WithField("runId", runID).WithField("tool", "get_job_run_debug")
+	logger.Debug("getting job run debug info")
+
+	debugMsg, err := s.getJobRunDebugMsgRepo.GetJobRunDebugMessage(&ctx, runID)
+	if err != nil {
+		logger.WithError(err).Error("failed to get job run debug message")
+		return mcp.CallToolResult{}, errors.Wrap(err, "failed to get job run debug message")
+	}
+
+	return mcp.CallToolResult{
+		Content: []mcp.Content{
+			{
+				Type: "text",
+				Text: debugMsg,
+			},
+		},
+	}, nil
+}
+
+func (s *mcpServerState) renderCommands(job *model.Job) []map[string]any {
+	commands := make([]map[string]any, 0, len(s.config.UIConfig.CommandSpecs))
+
+	for _, spec := range s.config.UIConfig.CommandSpecs {
+		rendered := s.renderTemplate(spec.Template, job)
+
+		cmd := map[string]any{
+			"name":     spec.Name,
+			"command":  rendered,
+			"template": spec.Template,
+		}
+
+		if spec.DescriptionMd != nil {
+			cmd["description"] = *spec.DescriptionMd
+		}
+
+		if spec.AlertMessageMd != nil {
+			cmd["alertMessage"] = *spec.AlertMessageMd
+			cmd["alertLevel"] = string(spec.AlertLevel)
+		}
+
+		commands = append(commands, cmd)
+	}
+
+	return commands
+}
+
+func (s *mcpServerState) renderLinks(job *model.Job) []map[string]any {
+	links := make([]map[string]any, 0, len(s.config.UIConfig.JobLinks))
+
+	for _, linkConfig := range s.config.UIConfig.JobLinks {
+		rendered := s.renderTemplate(linkConfig.LinkTemplate, job)
+
+		link := map[string]any{
+			"label": linkConfig.Label,
+			"url":   rendered,
+			"color": linkConfig.Colour,
+		}
+
+		links = append(links, link)
+	}
+
+	return links
+}
+
+func (s *mcpServerState) renderTemplate(templateStr string, job *model.Job) string {
+	result := templateStr
+
+	replacements := map[string]string{
+		"{{ jobId }}":  job.JobId,
+		"{{jobId}}":    job.JobId,
+		"{{ queue }}":  job.Queue,
+		"{{queue}}":    job.Queue,
+		"{{ jobSet }}": job.JobSet,
+		"{{jobSet}}":   job.JobSet,
+		"{{ owner }}":  job.Owner,
+		"{{owner}}":    job.Owner,
+	}
+
+	if job.Namespace != nil {
+		replacements["{{ namespace }}"] = *job.Namespace
+		replacements["{{namespace}}"] = *job.Namespace
+	}
+
+	if len(job.Runs) > 0 {
+		lastRun := job.Runs[len(job.Runs)-1]
+		replacements["{{ runs[runs.length - 1].cluster }}"] = lastRun.Cluster
+		replacements["{{runs[runs.length - 1].cluster}}"] = lastRun.Cluster
+		replacements["{{ runs[runs.length - 1].runId }}"] = lastRun.RunId
+		replacements["{{runs[runs.length - 1].runId}}"] = lastRun.RunId
+
+		if lastRun.Node != nil {
+			replacements["{{ runs[runs.length - 1].node }}"] = *lastRun.Node
+			replacements["{{runs[runs.length - 1].node}}"] = *lastRun.Node
+		}
+	}
+
+	for placeholder, value := range replacements {
+		escapedValue := html.EscapeString(value)
+		result = strings.ReplaceAll(result, placeholder, escapedValue)
+	}
+
+	for key, value := range job.Annotations {
+		placeholder := fmt.Sprintf(`{{ annotations["%s"] }}`, key)
+		escapedValue := html.EscapeString(value)
+		result = strings.ReplaceAll(result, placeholder, escapedValue)
+
+		placeholder = fmt.Sprintf(`{{annotations["%s"]}}`, key)
+		result = strings.ReplaceAll(result, placeholder, escapedValue)
+	}
+
+	return result
+}
+
+func (s *mcpServerState) sendMCPResult(w http.ResponseWriter, id any, result any) error {
+	response := mcp.Response{
+		JSONRPC: "2.0",
+		ID:      id,
+		Result:  result,
+	}
+
+	return s.sendMCPResponse(w, response)
+}
+
+func (s *mcpServerState) sendMCPError(w http.ResponseWriter, id any, code int, message string, data any) error {
+	response := mcp.Response{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error: &mcp.Error{
+			Code:    code,
+			Message: message,
+			Data:    data,
+		},
+	}
+
+	return s.sendMCPResponse(w, response)
+}
+
+func (s *mcpServerState) sendMCPResponse(w http.ResponseWriter, response mcp.Response) error {
+	data, err := json.Marshal(response)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal response")
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if _, err := w.Write(append(data, '\n')); err != nil {
+		return errors.Wrap(err, "failed to write response")
+	}
+
+	return nil
 }

--- a/internal/lookout/application_mcp_test.go
+++ b/internal/lookout/application_mcp_test.go
@@ -1,0 +1,275 @@
+package lookout
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/armadaproject/armada/internal/common/armadacontext"
+	"github.com/armadaproject/armada/internal/common/logging"
+	"github.com/armadaproject/armada/internal/lookout/configuration"
+	"github.com/armadaproject/armada/internal/lookoutmcp/mcp"
+)
+
+func testLogger() *logging.Logger {
+	zl := zerolog.New(io.Discard)
+	return logging.FromZerolog(zl)
+}
+
+func TestValidateJobID(t *testing.T) {
+	tests := []struct {
+		name    string
+		jobID   string
+		wantErr bool
+	}{
+		{"valid alphanumeric", "job123", false},
+		{"valid with dash", "job-123", false},
+		{"valid with underscore", "job_123", false},
+		{"empty", "", true},
+		{"too long", string(make([]byte, 129)), true},
+		{"invalid characters", "job@123", true},
+		{"valid ulid", "01f3j0g1md4qx7z5qb148qnh4d", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateJobID(tt.jobID)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestExtractJobID(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    map[string]any
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "valid job ID",
+			args:    map[string]any{"jobId": "test123"},
+			want:    "test123",
+			wantErr: false,
+		},
+		{
+			name:    "missing job ID",
+			args:    map[string]any{},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "non-string job ID",
+			args:    map[string]any{"jobId": 123},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "invalid job ID",
+			args:    map[string]any{"jobId": "job@123"},
+			want:    "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := extractJobID(tt.args)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestValidateRunID(t *testing.T) {
+	tests := []struct {
+		name    string
+		runID   string
+		wantErr bool
+	}{
+		{"valid", "run123", false},
+		{"empty", "", true},
+		{"too long", string(make([]byte, 129)), true},
+		{"valid uuid", "550e8400-e29b-41d4-a716-446655440000", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateRunID(tt.runID)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestMCPInitialize(t *testing.T) {
+	initRequest := mcp.Request{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "initialize",
+		Params: json.RawMessage(`{
+			"protocolVersion": "2024-11-05",
+			"capabilities": {},
+			"clientInfo": {"name": "test", "version": "1.0"}
+		}`),
+	}
+
+	reqBody, err := json.Marshal(initRequest)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewReader(append(reqBody, '\n')))
+	w := httptest.NewRecorder()
+
+	logger := testLogger()
+	state := &mcpServerState{
+		config: configuration.LookoutConfig{},
+		logger: logger,
+	}
+
+	ctx := req.Context()
+	err = state.handleMCPRequest(*armadacontext.New(ctx, logger), reqBody, w)
+	require.NoError(t, err)
+
+	var response mcp.Response
+	err = json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	assert.Equal(t, "2.0", response.JSONRPC)
+	assert.Nil(t, response.Error)
+	assert.NotNil(t, response.Result)
+}
+
+func TestMCPListTools(t *testing.T) {
+	listToolsRequest := mcp.Request{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "tools/list",
+	}
+
+	reqBody, err := json.Marshal(listToolsRequest)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewReader(append(reqBody, '\n')))
+	w := httptest.NewRecorder()
+
+	logger := testLogger()
+	state := &mcpServerState{
+		config: configuration.LookoutConfig{},
+		logger: logger,
+	}
+
+	ctx := req.Context()
+	err = state.handleMCPRequest(*armadacontext.New(ctx, logger), reqBody, w)
+	require.NoError(t, err)
+
+	var response mcp.Response
+	err = json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	assert.Equal(t, "2.0", response.JSONRPC)
+	assert.Nil(t, response.Error)
+	assert.NotNil(t, response.Result)
+
+	resultBytes, err := json.Marshal(response.Result)
+	require.NoError(t, err)
+
+	var listToolsResult mcp.ListToolsResult
+	err = json.Unmarshal(resultBytes, &listToolsResult)
+	require.NoError(t, err)
+
+	expectedTools := []string{
+		"search_jobs",
+		"get_job_details",
+		"get_job_spec",
+		"get_job_error",
+		"get_job_run_error",
+		"get_job_run_debug",
+		"get_job_commands",
+		"get_job_links",
+		"get_lookout_ui_link",
+	}
+
+	assert.Len(t, listToolsResult.Tools, len(expectedTools))
+
+	toolNames := make([]string, len(listToolsResult.Tools))
+	for i, tool := range listToolsResult.Tools {
+		toolNames[i] = tool.Name
+	}
+
+	for _, expectedTool := range expectedTools {
+		assert.Contains(t, toolNames, expectedTool, "Tool %s should be present", expectedTool)
+	}
+}
+
+func TestMCPInvalidMethod(t *testing.T) {
+	invalidRequest := mcp.Request{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "invalid/method",
+	}
+
+	reqBody, err := json.Marshal(invalidRequest)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewReader(append(reqBody, '\n')))
+	w := httptest.NewRecorder()
+
+	logger := testLogger()
+	state := &mcpServerState{
+		config: configuration.LookoutConfig{},
+		logger: logger,
+	}
+
+	ctx := req.Context()
+	err = state.handleMCPRequest(*armadacontext.New(ctx, logger), reqBody, w)
+	require.NoError(t, err)
+
+	var response mcp.Response
+	err = json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	assert.Equal(t, "2.0", response.JSONRPC)
+	assert.NotNil(t, response.Error)
+	assert.Equal(t, mcp.ErrorCodeMethodNotFound, response.Error.Code)
+}
+
+func TestMCPParseError(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewReader([]byte("invalid json")))
+	w := httptest.NewRecorder()
+
+	logger := testLogger()
+	state := &mcpServerState{
+		config: configuration.LookoutConfig{},
+		logger: logger,
+	}
+
+	ctx := req.Context()
+	err := state.handleMCPRequest(*armadacontext.New(ctx, logger), []byte("invalid json"), w)
+	assert.Error(t, err)
+
+	var response mcp.Response
+	err = json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	assert.Equal(t, "2.0", response.JSONRPC)
+	assert.NotNil(t, response.Error)
+	assert.Equal(t, mcp.ErrorCodeParseError, response.Error.Code)
+}

--- a/internal/lookout/configuration/types.go
+++ b/internal/lookout/configuration/types.go
@@ -23,6 +23,9 @@ type LookoutConfig struct {
 	PrunerConfig PrunerConfig
 
 	UIConfig
+
+	LookoutUIBaseUrl string
+	MCPEnabled       bool
 }
 
 type TlsConfig struct {

--- a/internal/lookout/doc.go
+++ b/internal/lookout/doc.go
@@ -1,0 +1,13 @@
+// Package lookout provides the Lookout UI backend service for viewing and querying Armada jobs.
+//
+// Lookout serves a REST API for job queries, group-by operations, and retrieving job details.
+// It also provides an optional MCP (Model Context Protocol) endpoint for LLM integrations,
+// which can be enabled via the MCPEnabled configuration flag.
+//
+// The MCP endpoint exposes tools for:
+//   - Getting job details
+//   - Retrieving job specifications
+//   - Listing available kubectl commands for jobs
+//   - Getting external links related to jobs
+//   - Generating Lookout UI links for jobs
+package lookout

--- a/internal/lookout/gen/restapi/configure_lookout.go
+++ b/internal/lookout/gen/restapi/configure_lookout.go
@@ -97,6 +97,12 @@ func setupMiddlewares(handler http.Handler) http.Handler {
 
 var UIConfig configuration.UIConfig
 
+var mcpHandlerFunc http.HandlerFunc
+
+func SetMCPHandler(handler http.HandlerFunc) {
+	mcpHandlerFunc = handler
+}
+
 // The middleware configuration happens before anything, this middleware also applies to serving the swagger.json document.
 // So this is a good place to plug in a panic handling middleware, logging and metrics.
 func setupGlobalMiddleware(apiHandler http.Handler) http.Handler {
@@ -152,6 +158,11 @@ func uiHandler(apiHandler http.Handler) http.Handler {
 
 	mux.Handle("/api/", apiHandler)
 	mux.Handle("/health", apiHandler)
+
+	// MCP endpoint (if configured)
+	if mcpHandlerFunc != nil {
+		mux.HandleFunc("/mcp", mcpHandlerFunc)
+	}
 
 	return mux
 }

--- a/internal/lookoutmcp/mcp/doc.go
+++ b/internal/lookoutmcp/mcp/doc.go
@@ -1,0 +1,56 @@
+// Package mcp provides core Model Context Protocol types and utilities.
+//
+// It implements the MCP wire protocol for communication between MCP servers
+// and clients over JSON-RPC 2.0.
+//
+// The Model Context Protocol (MCP) is a standardised protocol for integrating
+// LLM applications with external data sources and tools. This package provides
+// the fundamental types and structures needed to implement an MCP server.
+//
+// # Protocol Overview
+//
+// MCP uses JSON-RPC 2.0 as its transport layer. All communication follows the
+// request-response pattern where:
+//   - Requests have a method, optional params, and an ID for matching responses
+//   - Responses contain either a result or an error, with the same ID as the request
+//   - Notifications are one-way messages without an ID
+//
+// # Server Capabilities
+//
+// An MCP server can expose three types of capabilities:
+//   - Tools: Functions that can be invoked by the LLM
+//   - Prompts: Pre-defined prompt templates
+//   - Resources: Data sources that can be queried
+//
+// The Lookout MCP server currently implements Tools capability for querying
+// job information from the Armada Lookout database.
+//
+// # Available Tools
+//
+// The server provides the following tools:
+//   - search_jobs: Search for jobs with flexible filters
+//   - get_job_details: Get detailed information about a specific job
+//   - get_job_spec: Get the full job specification
+//   - get_job_error: Get error messages for failed jobs
+//   - get_job_run_error: Get error messages for specific job runs
+//   - get_job_run_debug: Get debug information for job runs
+//   - get_job_commands: Get kubectl commands for job management
+//   - get_job_links: Get external links related to jobs
+//   - get_lookout_ui_link: Get the Lookout UI link for a job
+//   - get_lookout_ui_link: Get the Lookout UI link for a job
+//
+// # Configuration
+//
+// To enable the MCP endpoint, set mcpEnabled: true in the Lookout configuration.
+// The server will expose an /mcp endpoint that accepts POST requests with
+// JSON-RPC 2.0 formatted messages.
+//
+// Example configuration:
+//
+//	mcpEnabled: true
+//	lookoutUIBaseUrl: "http://localhost:3000"
+//
+// # Protocol Version
+//
+// This implementation follows MCP protocol version 2024-11-05.
+package mcp

--- a/internal/lookoutmcp/mcp/types.go
+++ b/internal/lookoutmcp/mcp/types.go
@@ -1,0 +1,131 @@
+package mcp
+
+import (
+	"encoding/json"
+)
+
+// ProtocolVersion is the MCP protocol version implemented by this package.
+const ProtocolVersion = "2024-11-05"
+
+// Request represents a JSON-RPC 2.0 request message.
+type Request struct {
+	JSONRPC string          `json:"jsonrpc"` // Must be "2.0"
+	ID      any             `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+// Response represents a JSON-RPC 2.0 response message.
+type Response struct {
+	JSONRPC string `json:"jsonrpc"` // Must be "2.0"
+	ID      any    `json:"id,omitempty"`
+	Result  any    `json:"result,omitempty"`
+	Error   *Error `json:"error,omitempty"`
+}
+
+// Notification represents a JSON-RPC 2.0 notification message (one-way, no ID).
+type Notification struct {
+	JSONRPC string          `json:"jsonrpc"` // Must be "2.0"
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+// Error represents a JSON-RPC 2.0 error object.
+type Error struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    any    `json:"data,omitempty"`
+}
+
+// InitializeParams contains parameters for the initialize method.
+type InitializeParams struct {
+	ProtocolVersion string             `json:"protocolVersion"`
+	Capabilities    ClientCapabilities `json:"capabilities"`
+	ClientInfo      Implementation     `json:"clientInfo"`
+}
+
+// ClientCapabilities describes what features the client supports.
+type ClientCapabilities struct {
+	Experimental map[string]any `json:"experimental,omitempty"`
+	Sampling     map[string]any `json:"sampling,omitempty"`
+}
+
+// Implementation describes the name and version of an MCP client or server.
+type Implementation struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+// InitializeResult is returned from the initialize method.
+type InitializeResult struct {
+	ProtocolVersion string             `json:"protocolVersion"`
+	Capabilities    ServerCapabilities `json:"capabilities"`
+	ServerInfo      Implementation     `json:"serverInfo"`
+}
+
+// ServerCapabilities describes what features the server supports.
+type ServerCapabilities struct {
+	Tools        *ToolsCapability     `json:"tools,omitempty"`
+	Prompts      *PromptsCapability   `json:"prompts,omitempty"`
+	Resources    *ResourcesCapability `json:"resources,omitempty"`
+	Logging      map[string]any       `json:"logging,omitempty"`
+	Experimental map[string]any       `json:"experimental,omitempty"`
+}
+
+// ToolsCapability indicates that the server supports tools.
+type ToolsCapability struct {
+	ListChanged bool `json:"listChanged,omitempty"` // Whether the tool list can change
+}
+
+// PromptsCapability indicates that the server supports prompts.
+type PromptsCapability struct {
+	ListChanged bool `json:"listChanged,omitempty"` // Whether the prompt list can change
+}
+
+// ResourcesCapability indicates that the server supports resources.
+type ResourcesCapability struct {
+	Subscribe   bool `json:"subscribe,omitempty"`   // Whether clients can subscribe to resource updates
+	ListChanged bool `json:"listChanged,omitempty"` // Whether the resource list can change
+}
+
+// ListToolsResult is returned from the tools/list method.
+type ListToolsResult struct {
+	Tools []Tool `json:"tools"`
+}
+
+// Tool describes a function that can be invoked by the LLM.
+type Tool struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	InputSchema json.RawMessage `json:"inputSchema"` // JSON Schema for tool parameters
+}
+
+// CallToolParams contains parameters for the tools/call method.
+type CallToolParams struct {
+	Name      string         `json:"name"`
+	Arguments map[string]any `json:"arguments,omitempty"`
+}
+
+// CallToolResult is returned from the tools/call method.
+type CallToolResult struct {
+	Content []Content `json:"content,omitempty"`
+	IsError bool      `json:"isError,omitempty"`
+}
+
+// Content represents a piece of content returned by a tool.
+// It can be text, data, or other types depending on the MimeType.
+type Content struct {
+	Type     string `json:"type"`               // "text", "image", "resource", etc.
+	Text     string `json:"text,omitempty"`     // Text content
+	Data     string `json:"data,omitempty"`     // Base64-encoded data
+	MimeType string `json:"mimeType,omitempty"` // MIME type of the content
+}
+
+// Standard JSON-RPC 2.0 error codes.
+const (
+	ErrorCodeParseError     = -32700 // Invalid JSON received
+	ErrorCodeInvalidRequest = -32600 // JSON is not a valid request
+	ErrorCodeMethodNotFound = -32601 // Method does not exist
+	ErrorCodeInvalidParams  = -32602 // Invalid method parameters
+	ErrorCodeInternalError  = -32603 // Internal server error
+)


### PR DESCRIPTION
Implements an MCP server endpoint that enables LLM applications (like Claude) to query Armada job information directly from the Lookout database.

Features:
- New /mcp HTTP endpoint using JSON-RPC 2.0 protocol
- 9 tools for comprehensive job querying:
  * search_jobs: Search for jobs with flexible filters
  * get_job_details: Get detailed information about a specific job
  * get_job_spec: Get the full job specification
  * get_job_error: Get error messages for failed jobs
  * get_job_run_error: Get error messages for specific job runs
  * get_job_run_debug: Get debug information for job runs
  * get_job_commands: Get kubectl commands for job management
  * get_job_links: Get external links related to jobs
  * get_lookout_ui_link: Get the Lookout UI link for a job

Testing:
- Comprehensive unit tests for validation, tool listing, and error handling
- Test scripts for manual endpoint validation