### PR TITLE
Add new pool configuration - DisableHomeScheduling

### DIFF
--- a/internal/scheduler/configuration/configuration.go
+++ b/internal/scheduler/configuration/configuration.go
@@ -349,6 +349,7 @@ type PoolConfig struct {
 	ExperimentalSubmissionGroup   string
 	ExperimentalMarketScheduling  *MarketSchedulingConfig
 	ExperimentalRunReconciliation *RunReconciliationConfig
+	DisableHomeScheduling         bool
 	DisableAwayScheduling         bool
 	DisableGangAwayScheduling     bool
 }

--- a/internal/scheduler/scheduling/scheduling_algo.go
+++ b/internal/scheduler/scheduling/scheduling_algo.go
@@ -230,6 +230,10 @@ func (l *FairSchedulingAlgo) reconcileAndSchedulePool(
 		fsctx.nodeDb.DisableAwayScheduling()
 	}
 
+	if pool.DisableHomeScheduling {
+		fsctx.nodeDb.DisableHomeScheduling()
+	}
+
 	if pool.DisableGangAwayScheduling {
 		fsctx.nodeDb.DisableGangAwayScheduling()
 	}

--- a/internal/scheduler/scheduling/scheduling_algo_test.go
+++ b/internal/scheduler/scheduling/scheduling_algo_test.go
@@ -218,6 +218,17 @@ func TestSchedule(t *testing.T) {
 			expectedScheduledIndices: []int{0, 1, 2, 3},
 			expectedScheduledByPool:  map[string]int{testfixtures.TestPool: 4},
 		},
+		"scheduling - home scheduling disabled": {
+			schedulingConfig: testfixtures.WithHomeSchedulingDisabled(testfixtures.TestSchedulingConfig()),
+			executors: []*schedulerobjects.Executor{
+				test1Node32CoreExecutor("executor1"),
+				test1Node32CoreExecutor("executor2"),
+			},
+			queues:                   []*api.Queue{testfixtures.MakeTestQueue()},
+			queuedJobs:               testfixtures.N16Cpu128GiJobs(testfixtures.TestQueue, testfixtures.PriorityClass3, 10),
+			expectedScheduledIndices: []int{},
+			expectedScheduledByPool:  map[string]int{},
+		},
 		"scheduling - home away": {
 			schedulingConfig: testfixtures.TestSchedulingConfig(),
 			executors: []*schedulerobjects.Executor{

--- a/internal/scheduler/submitcheck.go
+++ b/internal/scheduler/submitcheck.go
@@ -304,6 +304,12 @@ poolStart:
 				ex.nodeDb.EnableAwayScheduling()
 			}
 
+			if pool.DisableHomeScheduling {
+				ex.nodeDb.DisableHomeScheduling()
+			} else {
+				ex.nodeDb.EnableHomeScheduling()
+			}
+
 			if pool.DisableGangAwayScheduling {
 				ex.nodeDb.DisableGangAwayScheduling()
 			} else {

--- a/internal/scheduler/testfixtures/testfixtures.go
+++ b/internal/scheduler/testfixtures/testfixtures.go
@@ -228,6 +228,14 @@ func WithReconcilerEnabled(config schedulerconfiguration.SchedulingConfig) sched
 	return config
 }
 
+func WithHomeSchedulingDisabled(config schedulerconfiguration.SchedulingConfig) schedulerconfiguration.SchedulingConfig {
+	for i, pool := range config.Pools {
+		pool.DisableHomeScheduling = true
+		config.Pools[i] = pool
+	}
+	return config
+}
+
 func WithAwaySchedulingDisabled(config schedulerconfiguration.SchedulingConfig) schedulerconfiguration.SchedulingConfig {
 	for i, pool := range config.Pools {
 		pool.DisableAwayScheduling = true


### PR DESCRIPTION
This feature allows disabling home scheduling on a pool
 - Making it possible to have a pool that only schedules jobs away
 - This is useful for away/synthetic pools where you only want jobs to be scheduled away
   - Without this they cannot be preempted by the main pools

