### PR TITLE
Broadside: generate historical jobs server-side via PostgreSQL

### DIFF
--- a/internal/broadside/db/clickhouse.go
+++ b/internal/broadside/db/clickhouse.go
@@ -43,6 +43,10 @@ func (c *ClickHouseDatabase) GetJobGroups(ctx *context.Context, filters []*model
 	panic("not implemented")
 }
 
+func (c *ClickHouseDatabase) PopulateHistoricalJobs(_ context.Context, _ HistoricalJobsParams) error {
+	panic("not implemented")
+}
+
 func (c *ClickHouseDatabase) TearDown(ctx context.Context) error {
 	panic("not implemented")
 }

--- a/internal/broadside/db/doc.go
+++ b/internal/broadside/db/doc.go
@@ -12,9 +12,21 @@ The Database interface provides methods for:
 
   - Schema initialisation (InitialiseSchema)
   - Batch ingestion query execution (ExecuteIngestionQueryBatch)
+  - Historical job population (PopulateHistoricalJobs)
   - Individual record retrieval (GetJobRunDebugMessage, GetJobRunError, GetJobSpec)
   - Multiple record retrieval (GetJobs, GetJobGroups)
   - Resource cleanup (TearDown, Close)
+
+# Historical Job Population
+
+PopulateHistoricalJobs inserts a batch of pre-completed historical jobs for a
+single (queue, job set) pair. It accepts a HistoricalJobsParams struct that
+specifies the queue and job set identifiers, the number of jobs to create, and
+threshold values used to divide jobs into terminal states (succeeded, errored,
+cancelled, preempted) via modular arithmetic on the job number. Implementations
+may perform the insertion using server-side SQL generation (e.g. PostgreSQL
+INSERT...SELECT FROM generate_series) to avoid round-trip overhead, or using
+in-memory Go loops for the MemoryDatabase.
 
 # Ingestion Queries
 

--- a/internal/broadside/db/historical.go
+++ b/internal/broadside/db/historical.go
@@ -1,0 +1,99 @@
+package db
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/armadaproject/armada/internal/broadside/jobspec"
+)
+
+const (
+	historicalJobAge           = 24 * time.Hour
+	historicalLeasedOffset     = time.Second
+	historicalPendingOffset    = 2 * time.Second
+	historicalRunningOffset    = 3 * time.Second
+	historicalTerminatedOffset = 10 * time.Second
+)
+
+func historicalJobID(queueIdx, jobSetIdx, jobNum int) string {
+	return fmt.Sprintf("%04d%04d%010d", queueIdx, jobSetIdx, jobNum)
+}
+
+func historicalState(jobNum int, p HistoricalJobsParams) jobspec.JobState {
+	pos := jobNum % 1000
+	switch {
+	case pos < p.SucceededThreshold:
+		return jobspec.StateSucceeded
+	case pos < p.ErroredThreshold:
+		return jobspec.StateErrored
+	case pos < p.CancelledThreshold:
+		return jobspec.StateCancelled
+	default:
+		return jobspec.StatePreempted
+	}
+}
+
+func buildHistoricalJobQueries(jobNum int, params HistoricalJobsParams) []IngestionQuery {
+	baseTime := time.Now().Add(-historicalJobAge)
+	jobID := historicalJobID(params.QueueIdx, params.JobSetIdx, jobNum)
+	runID := jobspec.EncodeRunID(jobID, 0)
+	cluster, node := jobspec.GetClusterNodeForJobNumber(jobNum)
+
+	leasedTime := baseTime.Add(historicalLeasedOffset)
+	pendingTime := baseTime.Add(historicalPendingOffset)
+	runningTime := baseTime.Add(historicalRunningOffset)
+	terminalTime := baseTime.Add(historicalTerminatedOffset)
+
+	newJob := &NewJob{
+		JobID:            jobID,
+		Queue:            params.QueueName,
+		JobSet:           params.JobSetName,
+		Owner:            params.QueueName,
+		Namespace:        jobspec.GetNamespace(jobNum),
+		Priority:         int64((jobNum % jobspec.PriorityValues) + 1),
+		PriorityClass:    jobspec.GetPriorityClass(jobNum),
+		Submitted:        baseTime,
+		Cpu:              jobspec.GetCpu(jobNum),
+		Memory:           jobspec.GetMemory(jobNum),
+		EphemeralStorage: jobspec.GetEphemeralStorage(jobNum),
+		Gpu:              jobspec.GetGpu(jobNum),
+		Annotations:      jobspec.GenerateAnnotationsForJob(jobNum),
+	}
+
+	queries := []IngestionQuery{
+		InsertJob{Job: newJob},
+		InsertJobSpec{JobID: jobID, JobSpec: string(params.JobSpecBytes)},
+		SetJobLeased{JobID: jobID, Time: leasedTime, RunID: runID},
+		InsertJobRun{JobRunID: runID, JobID: jobID, Cluster: cluster, Node: node, Pool: jobspec.GetPool(jobNum), Time: leasedTime},
+		SetJobPending{JobID: jobID, Time: pendingTime, RunID: runID},
+		SetJobRunPending{JobRunID: runID, Time: pendingTime},
+		SetJobRunning{JobID: jobID, Time: runningTime, LatestRunID: runID},
+		SetJobRunStarted{JobRunID: runID, Time: runningTime, Node: node},
+	}
+
+	switch historicalState(jobNum, params) {
+	case jobspec.StateSucceeded:
+		queries = append(queries,
+			SetJobSucceeded{JobID: jobID, Time: terminalTime},
+			SetJobRunSucceeded{JobRunID: runID, Time: terminalTime},
+		)
+	case jobspec.StateErrored:
+		queries = append(queries,
+			SetJobErrored{JobID: jobID, Time: terminalTime},
+			SetJobRunFailed{JobRunID: runID, Time: terminalTime, Error: params.ErrorBytes, Debug: params.DebugBytes},
+			InsertJobError{JobID: jobID, Error: params.ErrorBytes},
+		)
+	case jobspec.StateCancelled:
+		queries = append(queries,
+			SetJobCancelled{JobID: jobID, Time: terminalTime, CancelReason: "user requested", CancelUser: params.QueueName},
+			SetJobRunCancelled{JobRunID: runID, Time: terminalTime},
+		)
+	case jobspec.StatePreempted:
+		queries = append(queries,
+			SetJobPreempted{JobID: jobID, Time: terminalTime},
+			SetJobRunPreempted{JobRunID: runID, Time: terminalTime, Error: params.PreemptionBytes},
+		)
+	}
+
+	return queries
+}

--- a/internal/broadside/db/memory.go
+++ b/internal/broadside/db/memory.go
@@ -1125,6 +1125,19 @@ func paginateGroups(groups []*model.JobGroup, skip, take int) []*model.JobGroup 
 	return groups
 }
 
+func (m *MemoryDatabase) PopulateHistoricalJobs(ctx context.Context, params HistoricalJobsParams) error {
+	queries := make([]IngestionQuery, 0, params.NJobs*10)
+	for jobNum := 0; jobNum < params.NJobs; jobNum++ {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		queries = append(queries, buildHistoricalJobQueries(jobNum, params)...)
+	}
+	return m.ExecuteIngestionQueryBatch(ctx, queries)
+}
+
 func (m *MemoryDatabase) TearDown(_ context.Context) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/broadside/db/memory_historical_test.go
+++ b/internal/broadside/db/memory_historical_test.go
@@ -1,0 +1,126 @@
+package db_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/armadaproject/armada/internal/broadside/db"
+	"github.com/armadaproject/armada/pkg/api"
+)
+
+func validJobSpecBytes(t *testing.T) []byte {
+	t.Helper()
+	job := &api.Job{
+		PodSpecs: []*v1.PodSpec{
+			{Containers: []v1.Container{{Name: "test", Image: "alpine:latest"}}},
+		},
+	}
+	b, err := proto.Marshal(job)
+	require.NoError(t, err)
+	return b
+}
+
+func TestMemoryDatabase_PopulateHistoricalJobs_JobCount(t *testing.T) {
+	m := db.NewMemoryDatabase()
+	require.NoError(t, m.InitialiseSchema(context.Background()))
+
+	params := db.HistoricalJobsParams{
+		QueueIdx:           0,
+		JobSetIdx:          0,
+		QueueName:          "test-queue",
+		JobSetName:         "test-jobset",
+		NJobs:              100,
+		SucceededThreshold: 800,
+		ErroredThreshold:   900,
+		CancelledThreshold: 950,
+		JobSpecBytes:       validJobSpecBytes(t),
+		ErrorBytes:         []byte("simulated error"),
+		DebugBytes:         []byte("debug msg"),
+		PreemptionBytes:    []byte("preempted"),
+	}
+
+	err := m.PopulateHistoricalJobs(context.Background(), params)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	jobs, err := m.GetJobs(&ctx, nil, false, nil, 0, 1000)
+	require.NoError(t, err)
+	assert.Len(t, jobs, 100, "should have inserted exactly 100 jobs")
+}
+
+func TestMemoryDatabase_PopulateHistoricalJobs_StateDistribution(t *testing.T) {
+	m := db.NewMemoryDatabase()
+	require.NoError(t, m.InitialiseSchema(context.Background()))
+
+	// 70% succeeded, 10% errored, 10% cancelled, 10% preempted
+	params := db.HistoricalJobsParams{
+		QueueIdx:           0,
+		JobSetIdx:          0,
+		QueueName:          "test-queue",
+		JobSetName:         "test-jobset",
+		NJobs:              1000,
+		SucceededThreshold: 700,
+		ErroredThreshold:   800,
+		CancelledThreshold: 900,
+		JobSpecBytes:       validJobSpecBytes(t),
+		ErrorBytes:         []byte("simulated error"),
+		DebugBytes:         []byte("debug msg"),
+		PreemptionBytes:    []byte("preempted"),
+	}
+
+	err := m.PopulateHistoricalJobs(context.Background(), params)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	jobs, err := m.GetJobs(&ctx, nil, false, nil, 0, 2000)
+	require.NoError(t, err)
+
+	states := make(map[string]int)
+	for _, j := range jobs {
+		states[j.State]++
+	}
+
+	assert.Equal(t, 700, states["SUCCEEDED"])
+	assert.Equal(t, 100, states["FAILED"])
+	assert.Equal(t, 100, states["CANCELLED"])
+	assert.Equal(t, 100, states["PREEMPTED"])
+}
+
+func TestMemoryDatabase_PopulateHistoricalJobs_UniqueJobIDs(t *testing.T) {
+	m := db.NewMemoryDatabase()
+	require.NoError(t, m.InitialiseSchema(context.Background()))
+
+	params := db.HistoricalJobsParams{
+		QueueIdx:           1,
+		JobSetIdx:          2,
+		QueueName:          "queue-a",
+		JobSetName:         "jobset-b",
+		NJobs:              500,
+		SucceededThreshold: 1000,
+		ErroredThreshold:   1000,
+		CancelledThreshold: 1000,
+		JobSpecBytes:       validJobSpecBytes(t),
+		ErrorBytes:         []byte("err"),
+		DebugBytes:         []byte("dbg"),
+		PreemptionBytes:    []byte("pre"),
+	}
+
+	err := m.PopulateHistoricalJobs(context.Background(), params)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	jobs, err := m.GetJobs(&ctx, nil, false, nil, 0, 1000)
+	require.NoError(t, err)
+
+	seen := make(map[string]struct{})
+	for _, j := range jobs {
+		_, dup := seen[j.JobId]
+		assert.False(t, dup, "duplicate job ID: %s", j.JobId)
+		seen[j.JobId] = struct{}{}
+	}
+}

--- a/internal/broadside/db/postgres_historical_test.go
+++ b/internal/broadside/db/postgres_historical_test.go
@@ -1,0 +1,99 @@
+package db_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/armadaproject/armada/internal/broadside/db"
+)
+
+func postgresConfig(t *testing.T) map[string]string {
+	t.Helper()
+	host := os.Getenv("BROADSIDE_TEST_DB_HOST")
+	if host == "" {
+		t.Skip("BROADSIDE_TEST_DB_HOST not set; skipping PostgreSQL integration test")
+	}
+	return map[string]string{
+		"host":     host,
+		"port":     "5432",
+		"user":     "postgres",
+		"password": "psw",
+		"dbname":   "broadside_test",
+		"sslmode":  "disable",
+	}
+}
+
+func TestPostgresDatabase_PopulateHistoricalJobs_JobCount(t *testing.T) {
+	cfg := postgresConfig(t)
+	pg := db.NewPostgresDatabase(cfg)
+	ctx := context.Background()
+	require.NoError(t, pg.InitialiseSchema(ctx))
+	defer func() { _ = pg.TearDown(ctx) }()
+	defer pg.Close()
+
+	params := db.HistoricalJobsParams{
+		QueueIdx:           0,
+		JobSetIdx:          0,
+		QueueName:          "test-queue",
+		JobSetName:         "test-jobset",
+		NJobs:              1000,
+		SucceededThreshold: 800,
+		ErroredThreshold:   900,
+		CancelledThreshold: 950,
+		JobSpecBytes:       []byte("fakejobspec"),
+		ErrorBytes:         []byte("simulated error"),
+		DebugBytes:         []byte("debug"),
+		PreemptionBytes:    []byte("preempted"),
+	}
+
+	err := pg.PopulateHistoricalJobs(ctx, params)
+	require.NoError(t, err)
+
+	jobs, err := pg.GetJobs(&ctx, nil, false, nil, 0, 2000)
+	require.NoError(t, err)
+	assert.Len(t, jobs, 1000)
+}
+
+func TestPostgresDatabase_PopulateHistoricalJobs_StateDistribution(t *testing.T) {
+	cfg := postgresConfig(t)
+	pg := db.NewPostgresDatabase(cfg)
+	ctx := context.Background()
+	require.NoError(t, pg.InitialiseSchema(ctx))
+	defer func() { _ = pg.TearDown(ctx) }()
+	defer pg.Close()
+
+	params := db.HistoricalJobsParams{
+		QueueIdx:           0,
+		JobSetIdx:          0,
+		QueueName:          "test-queue",
+		JobSetName:         "test-jobset",
+		NJobs:              1000,
+		SucceededThreshold: 700,
+		ErroredThreshold:   800,
+		CancelledThreshold: 900,
+		JobSpecBytes:       []byte("fakejobspec"),
+		ErrorBytes:         []byte("simulated error"),
+		DebugBytes:         []byte("debug"),
+		PreemptionBytes:    []byte("preempted"),
+	}
+
+	err := pg.PopulateHistoricalJobs(ctx, params)
+	require.NoError(t, err)
+
+	jobs, err := pg.GetJobs(&ctx, nil, false, nil, 0, 2000)
+	require.NoError(t, err)
+
+	states := make(map[string]int)
+	for _, j := range jobs {
+		states[j.State]++
+	}
+
+	assert.Equal(t, 700, states["SUCCEEDED"])
+	assert.Equal(t, 100, states["FAILED"])
+	assert.Equal(t, 100, states["CANCELLED"])
+	assert.Equal(t, 100, states["PREEMPTED"])
+}

--- a/internal/broadside/ingester/doc.go
+++ b/internal/broadside/ingester/doc.go
@@ -4,7 +4,10 @@ Package ingester simulates job ingestion events for the Broadside load tester.
 The ingester has two main phases:
 
  1. Setup Phase (Setup method) - Blocking initialisation that populates the
-    database with historical jobs according to the configured proportions.
+    database with historical jobs according to the configured proportions. For
+    each (queue, job set) pair it calls database.PopulateHistoricalJobs once,
+    delegating the actual insertion to the database layer rather than issuing
+    per-job queries from Go.
 
  2. Run Phase (Run method) - Non-blocking simulation that submits new jobs at
     the configured rate and processes state transitions through the job

--- a/internal/broadside/ingester/ingester_setup_test.go
+++ b/internal/broadside/ingester/ingester_setup_test.go
@@ -1,0 +1,79 @@
+package ingester_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/armadaproject/armada/internal/broadside/configuration"
+	"github.com/armadaproject/armada/internal/broadside/db"
+	"github.com/armadaproject/armada/internal/broadside/ingester"
+	"github.com/armadaproject/armada/internal/broadside/metrics"
+)
+
+func TestIngester_Setup_PopulatesExpectedJobCount(t *testing.T) {
+	mem := db.NewMemoryDatabase()
+	require.NoError(t, mem.InitialiseSchema(context.Background()))
+
+	queueCfgs := []configuration.QueueConfig{
+		{
+			Name:       "q1",
+			Proportion: 0.6,
+			JobSetConfig: []configuration.JobSetConfig{
+				{
+					Name:       "js1",
+					Proportion: 0.5,
+					HistoricalJobsConfig: configuration.HistoricalJobsConfig{
+						NumberOfJobs:        50,
+						ProportionSucceeded: 0.8,
+						ProportionErrored:   0.1,
+						ProportionCancelled: 0.05,
+						ProportionPreempted: 0.05,
+					},
+				},
+				{
+					Name:       "js2",
+					Proportion: 0.5,
+					HistoricalJobsConfig: configuration.HistoricalJobsConfig{
+						NumberOfJobs:        30,
+						ProportionSucceeded: 1.0,
+					},
+				},
+			},
+		},
+		{
+			Name:       "q2",
+			Proportion: 0.4,
+			JobSetConfig: []configuration.JobSetConfig{
+				{
+					Name:       "js3",
+					Proportion: 1.0,
+					HistoricalJobsConfig: configuration.HistoricalJobsConfig{
+						NumberOfJobs:        20,
+						ProportionSucceeded: 0.5,
+						ProportionErrored:   0.5,
+					},
+				},
+			},
+		},
+	}
+
+	cfg := configuration.IngestionConfig{
+		BatchSize:  100,
+		NumWorkers: 1,
+	}
+
+	ing, err := ingester.NewIngester(cfg, queueCfgs, mem, metrics.NewIngesterMetrics())
+	require.NoError(t, err)
+
+	err = ing.Setup(context.Background())
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	jobs, err := mem.GetJobs(&ctx, nil, false, nil, 0, 1000)
+	require.NoError(t, err)
+	// Total: 50 + 30 + 20 = 100
+	assert.Len(t, jobs, 100)
+}

--- a/internal/broadside/jobspec/constants.go
+++ b/internal/broadside/jobspec/constants.go
@@ -18,28 +18,28 @@ var (
 		"research-green",
 		"research-yellow",
 	}
-	priorityClassOptions = []string{
+	PriorityClassOptions = []string{
 		"armada-default",
 		"armada-resilient",
 		"armada-high",
 		"armada-custom",
 	}
-	cpuOptions    = []int64{1, 2, 4, 8, 16, 32}
-	memoryOptions = []int64{
+	CpuOptions    = []int64{1, 2, 4, 8, 16, 32}
+	MemoryOptions = []int64{
 		1024 * 1024 * 1024,
 		4 * 1024 * 1024 * 1024,
 		64 * 1024 * 1024 * 1024,
 		1024 * 1024 * 1024 * 1024,
 	}
-	ephemeralStorageOptions = []int64{
+	EphemeralStorageOptions = []int64{
 		512 * 1024 * 1024,
 		2 * 1024 * 1024 * 1024,
 		10 * 1024 * 1024 * 1024,
 		1024 * 1024 * 1024 * 1024,
 		30 * 1024 * 1024 * 1024 * 1024,
 	}
-	gpuOptions  = []int64{0, 0, 0, 1, 0, 0, 0, 8}
-	poolOptions = []string{
+	GpuOptions  = []int64{0, 0, 0, 1, 0, 0, 0, 8}
+	PoolOptions = []string{
 		"general-purpose",
 		"high-memory",
 		"high-cpu",
@@ -106,25 +106,25 @@ func GetNamespace(jobNumber int) string {
 }
 
 func GetPriorityClass(jobNumber int) string {
-	return priorityClassOptions[jobNumber%len(priorityClassOptions)]
+	return PriorityClassOptions[jobNumber%len(PriorityClassOptions)]
 }
 
 func GetCpu(jobNumber int) int64 {
-	return cpuOptions[jobNumber%len(cpuOptions)]
+	return CpuOptions[jobNumber%len(CpuOptions)]
 }
 
 func GetMemory(jobNumber int) int64 {
-	return memoryOptions[jobNumber%len(memoryOptions)]
+	return MemoryOptions[jobNumber%len(MemoryOptions)]
 }
 
 func GetEphemeralStorage(jobNumber int) int64 {
-	return ephemeralStorageOptions[jobNumber%len(ephemeralStorageOptions)]
+	return EphemeralStorageOptions[jobNumber%len(EphemeralStorageOptions)]
 }
 
 func GetGpu(jobNumber int) int64 {
-	return gpuOptions[jobNumber%len(gpuOptions)]
+	return GpuOptions[jobNumber%len(GpuOptions)]
 }
 
 func GetPool(jobNumber int) string {
-	return poolOptions[jobNumber%len(poolOptions)]
+	return PoolOptions[jobNumber%len(PoolOptions)]
 }

--- a/internal/broadside/jobspec/doc.go
+++ b/internal/broadside/jobspec/doc.go
@@ -37,9 +37,12 @@ runs whilst avoiding the overhead of random number generation.
 
 # Job Properties
 
-Constants and helper functions define the range of job properties (CPU, memory,
-annotations, etc.) used in synthetic job generation. These properties are
-selected deterministically based on job number to create realistic variation
-whilst maintaining reproducibility.
+Exported variable slices (NamespaceOptions, PriorityClassOptions, CpuOptions,
+MemoryOptions, EphemeralStorageOptions, GpuOptions, PoolOptions,
+AnnotationConfigs) and helper functions define the range of job properties used
+in synthetic job generation. These are selected deterministically based on job
+number to create realistic variation whilst maintaining reproducibility. The
+slices are exported so that database implementations can reference them directly
+for server-side SQL generation.
 */
 package jobspec


### PR DESCRIPTION
Replaces Go-side historical job generation (which looped in Go, built rows, and sent them over the network in small batches) with four server-side INSERT ... SELECT FROM generate_series statements. All data generation now happens inside PostgreSQL, eliminating network transfer of per-row data during setup.

For large historical datasets (e.g. 300M jobs) this reduces setup time from many hours to tens of minutes, with the remaining bottleneck being PostgreSQL I/O and index maintenance.

Also fixes two runtime bugs found against a real PostgreSQL instance (per-statement parameter binding; explicit ::bytea casts for CASE WHEN expressions), and a shutdown hang caused by pgxpool.Close blocking on internal health-check goroutines after the schema has been torn down.