### PR TITLE
Add composite (last_transition_time, job_id) index on lookout.job

### DIFF
--- a/internal/lookout/schema/migrations/027_create_job_ltt_jobid_idx.sql
+++ b/internal/lookout/schema/migrations/027_create_job_ltt_jobid_idx.sql
@@ -1,0 +1,2 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_job_ltt_jobid ON job (last_transition_time, job_id)
+WITH (fillfactor = '80');


### PR DESCRIPTION
When we run analytical queries we pull data by last transition time and job id.

Without an index, this requires a full sequential scan plus a parallel sort. 

