### PR TITLE
Broadside: add skipTearDown config option

### DIFF
--- a/internal/broadside/configuration/configuration.go
+++ b/internal/broadside/configuration/configuration.go
@@ -5,6 +5,7 @@ import "time"
 type TestConfig struct {
 	TestDuration    time.Duration   `yaml:"testDuration"`
 	WarmupDuration  time.Duration   `yaml:"warmupDuration"`
+	SkipTearDown    bool            `yaml:"skipTearDown,omitempty"`
 	DatabaseConfig  DatabaseConfig  `yaml:"databaseConfig"`
 	QueueConfig     []QueueConfig   `yaml:"queueConfig"`
 	IngestionConfig IngestionConfig `yaml:"ingestionConfig"`

--- a/internal/broadside/orchestrator/runner.go
+++ b/internal/broadside/orchestrator/runner.go
@@ -233,13 +233,17 @@ func (r *Runner) logProgress(ctx context.Context, ingesterMetrics *metrics.Inges
 }
 
 func (r *Runner) tearDown(database db.Database) {
-	logging.Info("Tearing down database")
-	tearDownCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
-	if err := database.TearDown(tearDownCtx); err != nil {
-		logging.WithError(err).Warn("Failed to tear down database")
+	if r.config.SkipTearDown {
+		logging.Info("Skipping database teardown (skipTearDown is enabled)")
 	} else {
-		logging.Info("Database torn down successfully")
+		logging.Info("Tearing down database")
+		tearDownCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+		if err := database.TearDown(tearDownCtx); err != nil {
+			logging.WithError(err).Warn("Failed to tear down database")
+		} else {
+			logging.Info("Database torn down successfully")
+		}
 	}
 	database.Close()
 }


### PR DESCRIPTION
This allows us to re-use the data generated in the database.