### PR TITLE
Fix bug with checking if node is overallocated

### DIFF
--- a/internal/scheduler/scheduling/scheduling_algo.go
+++ b/internal/scheduler/scheduling/scheduling_algo.go
@@ -850,9 +850,8 @@ func populateNodeDb(nodeDb *nodedb.NodeDb, currentPoolJobs []*jobdb.Job, otherPo
 			continue
 		}
 
-		res := job.KubernetesResourceRequirements()
-		allocatedByNodeId[nodeId] = allocatedByNodeId[nodeId].Add(res)
-		allocatedToOtherPoolsByNodeId[nodeId] = allocatedToOtherPoolsByNodeId[nodeId].Add(res)
+		allocatedByNodeId[nodeId] = allocatedByNodeId[nodeId].Add(job.KubernetesResourceRequirements())
+		allocatedToOtherPoolsByNodeId[nodeId] = allocatedToOtherPoolsByNodeId[nodeId].Add(job.KubernetesResourceRequirements())
 	}
 
 	for _, node := range nodes {


### PR DESCRIPTION
A recent PR fixed MarkResourceUnallocatable
 - https://github.com/armadaproject/armada/pull/4714/changes#diff-1586be9e6d66471f316b4f536803e03351ba2b47132b9e34d0b6d4332101e5c2R859

However that inadvertently caused another bug where the resource is removed before we check if the node is overallocated

The upshot of this is we consider a node overallocated when it isn't. Due to marking resource unallocatable before comparing it to what is allocated
 - Resulting in allocated > allocatable and deeming it overallocated

Now we check if a node is overallocated before we mark any resource unallocatable - resulting in the expected behaviour
