### PR TITLE
Broadside: tuning SQL

### DIFF
--- a/cmd/broadside/configs/examples/test-postgres.yaml
+++ b/cmd/broadside/configs/examples/test-postgres.yaml
@@ -9,6 +9,14 @@ databaseConfig:
     user: broadside
     password: broadside
     sslmode: disable
+  # Optional: Postgres tuning SQL statements applied after schema migrations.
+  postgresTuningSQL:
+    - "ALTER TABLE job SET (autovacuum_vacuum_scale_factor = 0.01, autovacuum_analyze_scale_factor = 0.005, autovacuum_vacuum_threshold = 1000, autovacuum_analyze_threshold = 500)"
+    - "ALTER TABLE job_run SET (autovacuum_vacuum_scale_factor = 0.02, autovacuum_analyze_scale_factor = 0.01)"
+  # Optional: Postgres revert SQL statements executed at the start of TearDown.
+  postgresTuningRevertSQL:
+    - "ALTER TABLE job RESET (autovacuum_vacuum_scale_factor, autovacuum_analyze_scale_factor, autovacuum_vacuum_threshold, autovacuum_analyze_threshold)"
+    - "ALTER TABLE job_run RESET (autovacuum_vacuum_scale_factor, autovacuum_analyze_scale_factor)"
 
 queueConfig:
   - name: queue-1

--- a/cmd/broadside/visualise.html
+++ b/cmd/broadside/visualise.html
@@ -595,6 +595,14 @@
       ::-webkit-scrollbar-thumb {
         background: var(--border-mid);
       }
+      .tuning-sql-pre {
+        margin: 0.5rem 0 0;
+        white-space: pre-wrap;
+        word-break: break-all;
+        font-size: 0.75rem;
+        max-height: 20rem;
+        overflow-y: auto;
+      }
     </style>
   </head>
   <body>
@@ -1431,6 +1439,28 @@
             get: (d) => d.configuration.databaseConfig.type,
           },
           {
+            label: "Tuning SQL",
+            html: true,
+            get: (d) => {
+              const stmts = d.configuration.databaseConfig.tuningSql;
+              if (!stmts || stmts.length === 0) return "\u2014";
+              const preview = `${stmts.length} statement${stmts.length !== 1 ? "s" : ""}`;
+              const escaped = stmts.map((s) => esc(s)).join("\n");
+              return `<details><summary>${esc(preview)}</summary><pre class="tuning-sql-pre">${escaped}</pre></details>`;
+            },
+          },
+          {
+            label: "Tuning revert SQL",
+            html: true,
+            get: (d) => {
+              const stmts = d.configuration.databaseConfig.tuningRevertSql;
+              if (!stmts || stmts.length === 0) return "\u2014";
+              const preview = `${stmts.length} statement${stmts.length !== 1 ? "s" : ""}`;
+              const escaped = stmts.map((s) => esc(s)).join("\n");
+              return `<details><summary>${esc(preview)}</summary><pre class="tuning-sql-pre">${escaped}</pre></details>`;
+            },
+          },
+          {
             label: "Submissions / hr",
             get: (d) =>
               d.configuration.ingestionConfig.submissionsPerHour.toLocaleString(),
@@ -1686,7 +1716,7 @@
                 else if (row.hi && nums[i] === minN) cls += " worst";
               }
               if (display === "\u2014") cls += " na";
-              tr.innerHTML += `<td class="${cls}">${esc(String(display))}</td>`;
+              tr.innerHTML += `<td class="${cls}">${row.html ? display : esc(String(display))}</td>`;
             });
           }
           tbody.appendChild(tr);

--- a/internal/broadside/configuration/configuration.go
+++ b/internal/broadside/configuration/configuration.go
@@ -14,9 +14,11 @@ type TestConfig struct {
 }
 
 type DatabaseConfig struct {
-	Postgres   map[string]string `yaml:"postgres,omitempty"`
-	ClickHouse map[string]string `yaml:"clickHouse,omitempty"`
-	InMemory   bool              `yaml:"inMemory,omitempty"`
+	Postgres                map[string]string `yaml:"postgres,omitempty"`
+	ClickHouse              map[string]string `yaml:"clickHouse,omitempty"`
+	InMemory                bool              `yaml:"inMemory,omitempty"`
+	PostgresTuningSQL       []string          `yaml:"postgresTuningSQL,omitempty"`
+	PostgresTuningRevertSQL []string          `yaml:"postgresTuningRevertSQL,omitempty"`
 }
 
 type IngestionConfig struct {

--- a/internal/broadside/configuration/doc.go
+++ b/internal/broadside/configuration/doc.go
@@ -11,7 +11,7 @@ job submissions, state transitions, and query patterns.
 The main configuration type is TestConfig, which defines:
 
   - Test duration and warmup period
-  - Database configuration (Postgres or ClickHouse connection parameters)
+  - Database configuration (Postgres or ClickHouse connection parameters, optional Postgres tuning and revert SQL)
   - Queue configuration (queue/jobset distribution and historical job setup)
   - Ingestion configuration (job submission rates and state transitions)
   - Query configuration (rates for different query types)
@@ -26,6 +26,10 @@ The main configuration type is TestConfig, which defines:
 	    host: localhost
 	    port: "5432"
 	    database: lookout
+	  # postgresTuningSQL:
+	  #   - "ALTER TABLE job SET (autovacuum_vacuum_scale_factor = 0.01)"
+	  # postgresTuningRevertSQL:
+	  #   - "ALTER TABLE job RESET (autovacuum_vacuum_scale_factor)"
 	queueConfig:
 	  - name: queue-a
 	    proportion: 0.7

--- a/internal/broadside/db/doc.go
+++ b/internal/broadside/db/doc.go
@@ -76,7 +76,11 @@ Supported ingestion query types:
 
 Three implementations are provided:
 
-  - PostgresDatabase: PostgreSQL adapter (placeholder implementation)
+  - PostgresDatabase: PostgreSQL adapter using the production Lookout schema and
+    query infrastructure. After applying schema migrations, InitialiseSchema
+    executes any Postgres tuning SQL statements supplied via configuration. TearDown
+    reverts tuning settings by executing any Postgres tuning revert SQL statements,
+    then truncates all tables.
   - ClickHouseDatabase: ClickHouse adapter (placeholder implementation)
   - MemoryDatabase: In-memory adapter for smoke-testing Broadside
 
@@ -119,7 +123,7 @@ Create a database instance using the appropriate constructor:
 	    "host":     "localhost",
 	    "port":     "5432",
 	    "database": "lookout",
-	})
+	}, nil, nil)
 
 	// For ClickHouse
 	db := db.NewClickHouseDatabase(map[string]string{

--- a/internal/broadside/db/postgres.go
+++ b/internal/broadside/db/postgres.go
@@ -28,14 +28,16 @@ import (
 // It reuses the Lookout schema and query infrastructure to ensure
 // realistic testing of production query patterns.
 type PostgresDatabase struct {
-	config                map[string]string
-	pool                  *pgxpool.Pool
-	lookoutDb             *lookoutdb.LookoutDb
-	jobsRepository        *repository.SqlGetJobsRepository
-	groupRepository       *repository.SqlGroupJobsRepository
-	jobSpecRepository     *repository.SqlGetJobSpecRepository
-	jobRunErrorRepository *repository.SqlGetJobRunErrorRepository
-	jobRunDebugRepository *repository.SqlGetJobRunDebugMessageRepository
+	config                    map[string]string
+	tuningSQLStatements       []string
+	tuningRevertSQLStatements []string
+	pool                      *pgxpool.Pool
+	lookoutDb                 *lookoutdb.LookoutDb
+	jobsRepository            *repository.SqlGetJobsRepository
+	groupRepository           *repository.SqlGroupJobsRepository
+	jobSpecRepository         *repository.SqlGetJobSpecRepository
+	jobRunErrorRepository     *repository.SqlGetJobRunErrorRepository
+	jobRunDebugRepository     *repository.SqlGetJobRunDebugMessageRepository
 }
 
 // NewPostgresDatabase creates a new PostgresDatabase instance.
@@ -46,12 +48,17 @@ type PostgresDatabase struct {
 //   - password: database password
 //   - dbname: database name (e.g., "broadside_test")
 //   - sslmode: SSL mode (e.g., "disable")
-func NewPostgresDatabase(config map[string]string) *PostgresDatabase {
-	return &PostgresDatabase{config: config}
+func NewPostgresDatabase(config map[string]string, tuningSQLStatements []string, tuningRevertSQLStatements []string) *PostgresDatabase {
+	return &PostgresDatabase{
+		config:                    config,
+		tuningSQLStatements:       tuningSQLStatements,
+		tuningRevertSQLStatements: tuningRevertSQLStatements,
+	}
 }
 
 // InitialiseSchema opens the connection pool, applies the Lookout database
-// migrations, and initialises the query repository.
+// migrations, applies per-table autovacuum tuning SQL, and initialises the
+// query repository.
 func (p *PostgresDatabase) InitialiseSchema(ctx context.Context) error {
 	pgConfig := configuration.PostgresConfig{
 		Connection: p.config,
@@ -75,6 +82,11 @@ func (p *PostgresDatabase) InitialiseSchema(ctx context.Context) error {
 		return fmt.Errorf("applying migrations: %w", err)
 	}
 
+	if err := p.applyTuningSQL(ctx); err != nil {
+		pool.Close()
+		return fmt.Errorf("applying tuning SQL: %w", err)
+	}
+
 	decompressor := &compress.NoOpDecompressor{}
 	p.lookoutDb = lookoutdb.NewLookoutDb(p.pool, nil, nil, 16, 12)
 	p.jobsRepository = repository.NewSqlGetJobsRepository(p.pool)
@@ -83,6 +95,26 @@ func (p *PostgresDatabase) InitialiseSchema(ctx context.Context) error {
 	p.jobRunErrorRepository = repository.NewSqlGetJobRunErrorRepository(p.pool, decompressor)
 	p.jobRunDebugRepository = repository.NewSqlGetJobRunDebugMessageRepository(p.pool, decompressor)
 
+	return nil
+}
+
+func (p *PostgresDatabase) applyTuningSQL(ctx context.Context) error {
+	for i, stmt := range p.tuningSQLStatements {
+		if _, err := p.pool.Exec(ctx, stmt); err != nil {
+			return fmt.Errorf("executing tuning SQL statement %d: %w", i+1, err)
+		}
+		logging.Infof("Applied tuning SQL statement %d", i+1)
+	}
+	return nil
+}
+
+func (p *PostgresDatabase) revertTuningSQL(ctx context.Context) error {
+	for i, stmt := range p.tuningRevertSQLStatements {
+		if _, err := p.pool.Exec(ctx, stmt); err != nil {
+			return fmt.Errorf("executing tuning revert SQL statement %d: %w", i+1, err)
+		}
+		logging.Infof("Executed tuning revert SQL statement %d", i+1)
+	}
 	return nil
 }
 
@@ -219,6 +251,10 @@ func (p *PostgresDatabase) GetJobGroups(ctx *context.Context, filters []*model.F
 // This is faster than dropping and recreating the database, and
 // allows multiple test runs against the same database instance.
 func (p *PostgresDatabase) TearDown(ctx context.Context) error {
+	if err := p.revertTuningSQL(ctx); err != nil {
+		return fmt.Errorf("reverting tuning SQL: %w", err)
+	}
+
 	tables := []string{
 		"job_run",
 		"job_spec",

--- a/internal/broadside/db/postgres_historical_test.go
+++ b/internal/broadside/db/postgres_historical_test.go
@@ -29,7 +29,7 @@ func postgresConfig(t *testing.T) map[string]string {
 
 func TestPostgresDatabase_PopulateHistoricalJobs_JobCount(t *testing.T) {
 	cfg := postgresConfig(t)
-	pg := db.NewPostgresDatabase(cfg)
+	pg := db.NewPostgresDatabase(cfg, nil, nil)
 	ctx := context.Background()
 	require.NoError(t, pg.InitialiseSchema(ctx))
 	defer func() { _ = pg.TearDown(ctx) }()
@@ -60,7 +60,7 @@ func TestPostgresDatabase_PopulateHistoricalJobs_JobCount(t *testing.T) {
 
 func TestPostgresDatabase_PopulateHistoricalJobs_StateDistribution(t *testing.T) {
 	cfg := postgresConfig(t)
-	pg := db.NewPostgresDatabase(cfg)
+	pg := db.NewPostgresDatabase(cfg, nil, nil)
 	ctx := context.Background()
 	require.NoError(t, pg.InitialiseSchema(ctx))
 	defer func() { _ = pg.TearDown(ctx) }()
@@ -100,7 +100,7 @@ func TestPostgresDatabase_PopulateHistoricalJobs_StateDistribution(t *testing.T)
 
 func TestPostgresDatabase_PopulateHistoricalJobs_Chunked(t *testing.T) {
 	cfg := postgresConfig(t)
-	pg := db.NewPostgresDatabase(cfg)
+	pg := db.NewPostgresDatabase(cfg, nil, nil)
 	ctx := context.Background()
 	require.NoError(t, pg.InitialiseSchema(ctx))
 	defer func() { _ = pg.TearDown(ctx) }()
@@ -139,7 +139,7 @@ func TestPostgresDatabase_PopulateHistoricalJobs_Chunked(t *testing.T) {
 
 func TestPostgresDatabase_PopulateHistoricalJobs_Resume(t *testing.T) {
 	cfg := postgresConfig(t)
-	pg := db.NewPostgresDatabase(cfg)
+	pg := db.NewPostgresDatabase(cfg, nil, nil)
 	ctx := context.Background()
 	require.NoError(t, pg.InitialiseSchema(ctx))
 	defer func() { _ = pg.TearDown(ctx) }()
@@ -176,4 +176,34 @@ func TestPostgresDatabase_PopulateHistoricalJobs_Resume(t *testing.T) {
 	jobs, err = pg.GetJobs(&ctx, nil, false, nil, 0, 2000)
 	require.NoError(t, err)
 	assert.Len(t, jobs, 1000, "re-running should not create duplicates")
+}
+
+func TestPostgresDatabase_InitialiseSchema_ExecutesTuningSQLWithoutError(t *testing.T) {
+	cfg := postgresConfig(t)
+	tuningSQLStatements := []string{
+		"ALTER TABLE job SET (autovacuum_vacuum_scale_factor = 0.01)",
+	}
+	pg := db.NewPostgresDatabase(cfg, tuningSQLStatements, nil)
+	ctx := context.Background()
+	require.NoError(t, pg.InitialiseSchema(ctx))
+	defer func() { _ = pg.TearDown(ctx) }()
+	defer pg.Close()
+
+	// Once tuningSQLStatements is populated, InitialiseSchema applies
+	// each statement without error.
+}
+
+func TestPostgresDatabase_TearDown_ExecutesTuningRevertSQLWithoutError(t *testing.T) {
+	cfg := postgresConfig(t)
+	revertSQLStatements := []string{
+		"ALTER TABLE job RESET (autovacuum_vacuum_scale_factor)",
+	}
+	pg := db.NewPostgresDatabase(cfg, nil, revertSQLStatements)
+	ctx := context.Background()
+	require.NoError(t, pg.InitialiseSchema(ctx))
+	defer pg.Close()
+
+	require.NoError(t, pg.TearDown(ctx))
+	// TearDown should have executed the revert SQL statement without error
+	// and truncated all tables.
 }

--- a/internal/broadside/metrics/doc.go
+++ b/internal/broadside/metrics/doc.go
@@ -57,7 +57,7 @@ The TestResult structure includes:
 
   - Metadata: timestamp, schema version, and actual test duration
   - Configuration snapshot: complete test configuration including database
-    settings, queue configuration, ingestion and query parameters
+    settings, tuning SQL and revert SQL, queue configuration, ingestion and query parameters
   - Results: ingester and querier metrics in JSON-serialisable format
 
 JSON output files are written with timestamps in their filenames

--- a/internal/broadside/metrics/generate_schema.go
+++ b/internal/broadside/metrics/generate_schema.go
@@ -33,8 +33,10 @@ type ConfigurationSnapshot struct {
 }
 
 type DatabaseConfigSnapshot struct {
-	Type             string `json:"type" jsonschema:"enum=postgres,enum=clickhouse,enum=inmemory" jsonschema_description:"Database backend type used for the test"`
-	ConnectionString string `json:"connectionString,omitempty" jsonschema_description:"Database connection details (sensitive data should be redacted)"`
+	Type             string   `json:"type" jsonschema:"enum=postgres,enum=clickhouse,enum=inmemory" jsonschema_description:"Database backend type used for the test"`
+	ConnectionString string   `json:"connectionString,omitempty" jsonschema_description:"Database connection details (sensitive data should be redacted)"`
+	TuningSQL        []string `json:"tuningSql,omitempty" jsonschema_description:"Postgres tuning SQL statements applied after migrations"`
+	TuningRevertSQL  []string `json:"tuningRevertSql,omitempty" jsonschema_description:"Postgres revert SQL statements executed at the start of teardown"`
 }
 
 type QueueConfigSnapshot struct {

--- a/internal/broadside/metrics/output.go
+++ b/internal/broadside/metrics/output.go
@@ -35,8 +35,10 @@ type ConfigurationSnapshot struct {
 }
 
 type DatabaseConfigSnapshot struct {
-	Type             string `json:"type"`
-	ConnectionString string `json:"connectionString,omitempty"`
+	Type             string   `json:"type"`
+	ConnectionString string   `json:"connectionString,omitempty"`
+	TuningSQL        []string `json:"tuningSql,omitempty"`
+	TuningRevertSQL  []string `json:"tuningRevertSql,omitempty"`
 }
 
 type QueueConfigSnapshot struct {
@@ -207,6 +209,14 @@ func convertDatabaseConfig(config configuration.DatabaseConfig) DatabaseConfigSn
 		}
 	} else if config.InMemory {
 		snapshot.Type = "inmemory"
+	}
+
+	if len(config.PostgresTuningSQL) > 0 {
+		snapshot.TuningSQL = config.PostgresTuningSQL
+	}
+
+	if len(config.PostgresTuningRevertSQL) > 0 {
+		snapshot.TuningRevertSQL = config.PostgresTuningRevertSQL
 	}
 
 	return snapshot

--- a/internal/broadside/metrics/schema.json
+++ b/internal/broadside/metrics/schema.json
@@ -49,6 +49,20 @@
             "connectionString": {
               "type": "string",
               "description": "Database connection details (sensitive data should be redacted)"
+            },
+            "tuningSql": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "description": "Postgres tuning SQL statements applied after migrations"
+            },
+            "tuningRevertSql": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "description": "Postgres revert SQL statements executed at the start of teardown"
             }
           },
           "additionalProperties": false,

--- a/internal/broadside/orchestrator/runner.go
+++ b/internal/broadside/orchestrator/runner.go
@@ -252,7 +252,11 @@ func (r *Runner) newDatabase() (db.Database, error) {
 func NewDatabase(config configuration.TestConfig) (db.Database, error) {
 	switch {
 	case len(config.DatabaseConfig.Postgres) > 0:
-		return db.NewPostgresDatabase(config.DatabaseConfig.Postgres), nil
+		return db.NewPostgresDatabase(
+			config.DatabaseConfig.Postgres,
+			config.DatabaseConfig.PostgresTuningSQL,
+			config.DatabaseConfig.PostgresTuningRevertSQL,
+		), nil
 	case len(config.DatabaseConfig.ClickHouse) > 0:
 		return db.NewClickHouseDatabase(config.DatabaseConfig.ClickHouse), nil
 	case config.DatabaseConfig.InMemory:


### PR DESCRIPTION
Add support for running SQL statements before the start of tests. Can be used for things like modifying indexes and autovacuum parameters.