### PR TITLE
Broadside improvements (#467)

### DIFF
--- a/internal/broadside/configuration/configuration.go
+++ b/internal/broadside/configuration/configuration.go
@@ -89,5 +89,6 @@ type QueryConfig struct {
 	GetJobsPageSize                     int `yaml:"getJobsPageSize"`
 	GetJobGroupsQueriesPerHour          int `yaml:"getJobGroupsQueriesPerHour"`
 	GetJobGroupsPageSize                int `yaml:"getJobGroupsPageSize"`
+	MaxConcurrentQueries                int `yaml:"maxConcurrentQueries,omitempty"`
 	MaxErrorsToCollect                  int `yaml:"maxErrorsToCollect,omitempty"`
 }

--- a/internal/broadside/configuration/validation.go
+++ b/internal/broadside/configuration/validation.go
@@ -356,6 +356,10 @@ func (q *QueryConfig) Validate() error {
 		}
 	}
 
+	if q.MaxConcurrentQueries < 0 {
+		return fmt.Errorf("maxConcurrentQueries must be non-negative, got %d", q.MaxConcurrentQueries)
+	}
+
 	if q.MaxErrorsToCollect < 0 {
 		return fmt.Errorf("maxErrorsToCollect must be non-negative, got %d", q.MaxErrorsToCollect)
 	}

--- a/internal/broadside/db/db.go
+++ b/internal/broadside/db/db.go
@@ -57,8 +57,6 @@ func JobIDFromQuery(q IngestionQuery) string {
 	switch v := q.(type) {
 	case InsertJob:
 		return v.Job.JobID
-	case InsertJobSpec:
-		return v.JobID
 	case UpdateJobPriority:
 		return v.JobID
 	case SetJobCancelled:
@@ -106,7 +104,8 @@ func jobIDFromRunID(runID string) string {
 }
 
 type InsertJob struct {
-	Job *NewJob
+	Job     *NewJob
+	JobSpec []byte
 }
 
 func (InsertJob) isIngestionQuery() {}
@@ -126,13 +125,6 @@ type NewJob struct {
 	Gpu              int64
 	Annotations      map[string]string
 }
-
-type InsertJobSpec struct {
-	JobID   string
-	JobSpec string
-}
-
-func (InsertJobSpec) isIngestionQuery() {}
 
 type UpdateJobPriority struct {
 	JobID    string

--- a/internal/broadside/db/doc.go
+++ b/internal/broadside/db/doc.go
@@ -52,8 +52,7 @@ parallel batch execution whilst maintaining per-job ordering).
 
 Supported ingestion query types:
 
-  - InsertJob: Insert a new job record
-  - InsertJobSpec: Insert job specification
+  - InsertJob: Insert a new job record (with optional job spec)
   - UpdateJobPriority: Update job priority
   - SetJobCancelled: Mark job as cancelled
   - SetJobSucceeded: Mark job as succeeded

--- a/internal/broadside/db/historical.go
+++ b/internal/broadside/db/historical.go
@@ -61,8 +61,7 @@ func buildHistoricalJobQueries(jobNum int, params HistoricalJobsParams) []Ingest
 	}
 
 	queries := []IngestionQuery{
-		InsertJob{Job: newJob},
-		InsertJobSpec{JobID: jobID, JobSpec: string(params.JobSpecBytes)},
+		InsertJob{Job: newJob, JobSpec: params.JobSpecBytes},
 		SetJobLeased{JobID: jobID, Time: leasedTime, RunID: runID},
 		InsertJobRun{JobRunID: runID, JobID: jobID, Cluster: cluster, Node: node, Pool: jobspec.GetPool(jobNum), Time: leasedTime},
 		SetJobPending{JobID: jobID, Time: pendingTime, RunID: runID},

--- a/internal/broadside/db/instruction_set.go
+++ b/internal/broadside/db/instruction_set.go
@@ -9,15 +9,10 @@ import (
 // queriesToInstructionSet converts a batch of IngestionQuery values into a
 // lookoutmodel.InstructionSet suitable for passing to the LookoutDb methods.
 //
-// InsertJob and InsertJobSpec are matched by JobID and merged into a single
-// CreateJobInstruction. If InsertJobSpec is absent for a job in this batch,
-// JobProto will be nil — callers must filter before passing to CreateJobSpecs.
-//
 // Multiple job or job-run updates for the same ID within a batch are conflated
 // (last write wins per field) to avoid undefined behaviour in the UPDATE … FROM
 // temp-table pattern when duplicate source rows are present.
 func queriesToInstructionSet(queries []IngestionQuery) (*lookoutmodel.InstructionSet, error) {
-	// Keyed by JobID so InsertJob and InsertJobSpec can be merged.
 	jobCreates := make(map[string]*lookoutmodel.CreateJobInstruction)
 
 	// Keyed by JobID / RunID for last-write-wins conflation.
@@ -29,20 +24,8 @@ func queriesToInstructionSet(queries []IngestionQuery) (*lookoutmodel.Instructio
 	for _, query := range queries {
 		switch q := query.(type) {
 		case InsertJob:
-			instr, ok := jobCreates[q.Job.JobID]
-			if !ok {
-				instr = jobToCreateInstruction(q.Job)
-				jobCreates[q.Job.JobID] = instr
-			}
-			_ = instr // spec bytes set by a later InsertJobSpec if present
-
-		case InsertJobSpec:
-			instr, ok := jobCreates[q.JobID]
-			if !ok {
-				instr = &lookoutmodel.CreateJobInstruction{JobId: q.JobID}
-				jobCreates[q.JobID] = instr
-			}
-			instr.JobProto = []byte(q.JobSpec)
+			instr := jobToCreateInstruction(q)
+			jobCreates[q.Job.JobID] = instr
 
 		case InsertJobRun:
 			set.JobRunsToCreate = append(set.JobRunsToCreate, jobRunToCreateInstruction(q))
@@ -207,20 +190,8 @@ func runUpdate(m map[string]*lookoutmodel.UpdateJobRunInstruction, runID string)
 	return u
 }
 
-// jobSpecInstructions returns only those instructions that have a non-nil
-// JobProto. This filters out jobs whose InsertJobSpec arrived in a different
-// batch from their InsertJob.
-func jobSpecInstructions(jobs []*lookoutmodel.CreateJobInstruction) []*lookoutmodel.CreateJobInstruction {
-	var result []*lookoutmodel.CreateJobInstruction
-	for _, j := range jobs {
-		if j.JobProto != nil {
-			result = append(result, j)
-		}
-	}
-	return result
-}
-
-func jobToCreateInstruction(job *NewJob) *lookoutmodel.CreateJobInstruction {
+func jobToCreateInstruction(q InsertJob) *lookoutmodel.CreateJobInstruction {
+	job := q.Job
 	var priorityClass *string
 	if job.PriorityClass != "" {
 		priorityClass = &job.PriorityClass
@@ -242,6 +213,7 @@ func jobToCreateInstruction(job *NewJob) *lookoutmodel.CreateJobInstruction {
 		LastTransitionTimeSeconds: job.Submitted.Unix(),
 		PriorityClass:             priorityClass,
 		Annotations:               job.Annotations,
+		JobProto:                  q.JobSpec,
 	}
 }
 

--- a/internal/broadside/db/instruction_set_test.go
+++ b/internal/broadside/db/instruction_set_test.go
@@ -8,18 +8,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestQueriesToInstructionSet_InsertJobAndSpecMerged(t *testing.T) {
+func TestQueriesToInstructionSet_InsertJobWithSpec(t *testing.T) {
 	now := time.Now()
-	job := &NewJob{
-		JobID:     "job001",
-		Queue:     "q1",
-		JobSet:    "js1",
-		Owner:     "owner",
-		Submitted: now,
-	}
 	queries := []IngestionQuery{
-		InsertJob{Job: job},
-		InsertJobSpec{JobID: "job001", JobSpec: "specbytes"},
+		InsertJob{
+			Job:     &NewJob{JobID: "job001", Queue: "q1", JobSet: "js1", Owner: "owner", Submitted: now},
+			JobSpec: []byte("specbytes"),
+		},
 	}
 
 	set, err := queriesToInstructionSet(queries)

--- a/internal/broadside/db/memory.go
+++ b/internal/broadside/db/memory.go
@@ -119,8 +119,6 @@ func (m *MemoryDatabase) executeQuery(query IngestionQuery) error {
 	switch q := query.(type) {
 	case InsertJob:
 		return m.insertJob(q)
-	case InsertJobSpec:
-		return m.insertJobSpec(q)
 	case UpdateJobPriority:
 		return m.updateJobPriority(q)
 	case SetJobCancelled:
@@ -221,18 +219,18 @@ func (m *MemoryDatabase) insertJob(q InsertJob) error {
 			}
 		}
 	}
-	return nil
-}
 
-func (m *MemoryDatabase) insertJobSpec(q InsertJobSpec) error {
-	var job api.Job
-	if err := proto.Unmarshal([]byte(q.JobSpec), &job); err != nil {
-		return fmt.Errorf("unmarshalling job spec for %s: %w", q.JobID, err)
+	if len(q.JobSpec) > 0 {
+		var apiJob api.Job
+		if err := proto.Unmarshal(q.JobSpec, &apiJob); err != nil {
+			return fmt.Errorf("unmarshalling job spec for %s: %w", job.JobID, err)
+		}
+		m.jobSpecs[job.JobID] = &jobSpecRecord{
+			JobID:   job.JobID,
+			JobSpec: &apiJob,
+		}
 	}
-	m.jobSpecs[q.JobID] = &jobSpecRecord{
-		JobID:   q.JobID,
-		JobSpec: &job,
-	}
+
 	return nil
 }
 

--- a/internal/broadside/db/postgres.go
+++ b/internal/broadside/db/postgres.go
@@ -139,7 +139,7 @@ func (p *PostgresDatabase) ExecuteIngestionQueryBatch(ctx context.Context, queri
 	// Phase 1: job rows must be committed before job_run FK references them.
 	var wg sync.WaitGroup
 	wg.Go(func() { p.lookoutDb.CreateJobs(armadaCtx, set.JobsToCreate) })
-	wg.Go(func() { p.lookoutDb.CreateJobSpecs(armadaCtx, jobSpecInstructions(set.JobsToCreate)) })
+	wg.Go(func() { p.lookoutDb.CreateJobSpecs(armadaCtx, set.JobsToCreate) })
 	wg.Wait()
 
 	// Phase 2: job runs, errors and job-state updates can proceed in parallel.

--- a/internal/broadside/ingester/ingester.go
+++ b/internal/broadside/ingester/ingester.go
@@ -397,18 +397,8 @@ func (i *Ingester) runBatchExecutor(
 }
 
 func (i *Ingester) executeBatch(ctx context.Context, batch []db.IngestionQuery) {
-	// Create a detached context with timeout for this batch operation
-	// This allows the batch to complete even if the parent context is cancelled,
-	// preventing partial writes and ensuring clean shutdown
-	batchTimeout := i.config.BatchTimeout
-	if batchTimeout == 0 {
-		batchTimeout = 30 * time.Second
-	}
-	batchCtx, cancel := context.WithTimeout(context.Background(), batchTimeout)
-	defer cancel()
-
 	start := time.Now()
-	err := i.database.ExecuteIngestionQueryBatch(batchCtx, batch)
+	err := i.database.ExecuteIngestionQueryBatch(ctx, batch)
 	duration := time.Since(start)
 
 	i.metrics.RecordBatchExecution(len(batch), duration, err)
@@ -452,15 +442,8 @@ func (i *Ingester) submitJob(
 
 	i.routerSend(router, timestampedQuery{
 		query: db.InsertJob{
-			Job: newJob,
-		},
-		enqueuedAt: now,
-	}, ctx)
-
-	i.routerSend(router, timestampedQuery{
-		query: db.InsertJobSpec{
-			JobID:   newJob.JobID,
-			JobSpec: defaultJobSpec,
+			Job:     newJob,
+			JobSpec: []byte(defaultJobSpec),
 		},
 		enqueuedAt: now,
 	}, ctx)

--- a/internal/broadside/querier/querier.go
+++ b/internal/broadside/querier/querier.go
@@ -53,6 +53,7 @@ type Querier struct {
 	testStart    time.Time
 	testDuration time.Duration
 	queryWg      sync.WaitGroup // Tracks in-flight queries
+	querySem     chan struct{}  // Limits concurrent database queries; nil means unlimited
 }
 
 // NewQuerier creates a new Querier with the given configuration.
@@ -64,6 +65,10 @@ func NewQuerier(
 	testStart time.Time,
 	testDuration time.Duration,
 ) *Querier {
+	var sem chan struct{}
+	if queryConfig.MaxConcurrentQueries > 0 {
+		sem = make(chan struct{}, queryConfig.MaxConcurrentQueries)
+	}
 	return &Querier{
 		queryConfig:  queryConfig,
 		queueConfigs: queueConfigs,
@@ -71,6 +76,7 @@ func NewQuerier(
 		metrics:      metrics,
 		testStart:    testStart,
 		testDuration: testDuration,
+		querySem:     sem,
 	}
 }
 
@@ -139,7 +145,30 @@ func (q *Querier) Metrics() *metrics.QuerierMetrics {
 	return q.metrics
 }
 
+func (q *Querier) acquireSem(ctx context.Context) bool {
+	if q.querySem == nil {
+		return true
+	}
+	select {
+	case q.querySem <- struct{}{}:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func (q *Querier) releaseSem() {
+	if q.querySem != nil {
+		<-q.querySem
+	}
+}
+
 func (q *Querier) executeGetJobsQuery(ctx context.Context, queryIndex int) {
+	if !q.acquireSem(ctx) {
+		return
+	}
+	defer q.releaseSem()
+
 	filters, filterCombo := q.buildFilters(queryIndex)
 	order := q.buildOrder(queryIndex)
 
@@ -149,7 +178,7 @@ func (q *Querier) executeGetJobsQuery(ctx context.Context, queryIndex int) {
 	}
 
 	start := time.Now()
-	jobs, err := q.database.GetJobs(&ctx, filters, true, order, 0, pageSize)
+	jobs, err := q.database.GetJobs(&ctx, filters, false, order, 0, pageSize)
 	duration := time.Since(start)
 
 	if errors.Is(err, context.Canceled) {
@@ -386,6 +415,11 @@ func (q *Querier) selectQueueAndJobSet(queryIndex int) (int, string) {
 }
 
 func (q *Querier) executeGetJobGroupsQuery(ctx context.Context, queryIndex int) {
+	if !q.acquireSem(ctx) {
+		return
+	}
+	defer q.releaseSem()
+
 	groupedField := q.buildGroupedField(queryIndex)
 	aggregates := q.buildAggregates(queryIndex, groupedField)
 	filters, filterCombo := q.buildFilters(queryIndex)
@@ -601,6 +635,11 @@ func (q *Querier) executeFollowUpQueriesForAllJobs(ctx context.Context, jobs []*
 }
 
 func (q *Querier) executeGetJobRunDebugMessage(ctx context.Context, runID string) {
+	if !q.acquireSem(ctx) {
+		return
+	}
+	defer q.releaseSem()
+
 	start := time.Now()
 	_, err := q.database.GetJobRunDebugMessage(ctx, runID)
 	duration := time.Since(start)
@@ -617,6 +656,11 @@ func (q *Querier) executeGetJobRunDebugMessage(ctx context.Context, runID string
 }
 
 func (q *Querier) executeGetJobRunError(ctx context.Context, runID string) {
+	if !q.acquireSem(ctx) {
+		return
+	}
+	defer q.releaseSem()
+
 	start := time.Now()
 	_, err := q.database.GetJobRunError(ctx, runID)
 	duration := time.Since(start)
@@ -633,6 +677,11 @@ func (q *Querier) executeGetJobRunError(ctx context.Context, runID string) {
 }
 
 func (q *Querier) executeGetJobSpec(ctx context.Context, jobID string) {
+	if !q.acquireSem(ctx) {
+		return
+	}
+	defer q.releaseSem()
+
 	start := time.Now()
 	_, err := q.database.GetJobSpec(ctx, jobID)
 	duration := time.Since(start)


### PR DESCRIPTION
- Merge `InsertJob` and `InsertJobSpec` into a single `InsertJob` query type carrying an optional `JobSpec []byte` field, eliminating the possibility of the two straddling a batch boundary. This fixes the `job_annotations_not_null` constraint violation that occurred when an orphaned `InsertJobSpec` created a bare job row with nil annotations.
- Removed the `context.WithTimeout(context.Background(), 30s)` in the broadside ingester's `executeBatch`, passing the parent context directly instead. The 30-second timeout was shared across all three sequential phases, starving Phase 3 under load.
- Added `MaxConcurrentQueries` field to `QueryConfig` in `configuration.go` with corresponding validation in `validation.go`.
- Added a buffered-channel semaphore to the `Querier` struct, initialised from `MaxConcurrentQueries` in `NewQuerier`. All five database-hitting query methods (`executeGetJobsQuery`, `executeGetJobGroupsQuery`, `executeGetJobRunDebugMessage`, `executeGetJobRunError`, `executeGetJobSpec`) acquire a slot before issuing a database call and release it on return, with clean exit on context cancellation. This prevents the querier's unbounded goroutine spawning from exhausting the shared connection pool.