### PR TITLE
Lookout: reject groupBy order by state when used as aggregate

### DIFF
--- a/internal/broadside/querier/querier.go
+++ b/internal/broadside/querier/querier.go
@@ -514,7 +514,14 @@ func (q *Querier) buildAggregates(queryIndex int, groupedField *model.GroupedFie
 
 func (q *Querier) buildGroupOrder(queryIndex int, groupedField *model.GroupedField, aggregates []string) *model.Order {
 	validOrderFields := []string{"count"}
-	validOrderFields = append(validOrderFields, aggregates...)
+	for _, aggregate := range aggregates {
+		// State aggregates produce multiple output columns (one per state), so there is no
+		// single column to order by unless state is also the grouped field.
+		if aggregate == "state" && groupedField.Field != "state" {
+			continue
+		}
+		validOrderFields = append(validOrderFields, aggregate)
+	}
 	if !containsString(validOrderFields, groupedField.Field) && !groupedField.IsAnnotation {
 		validOrderFields = append(validOrderFields, groupedField.Field)
 	}

--- a/internal/lookout/repository/querybuilder.go
+++ b/internal/lookout/repository/querybuilder.go
@@ -211,7 +211,7 @@ func (qb *QueryBuilder) GroupBy(
 	if err != nil {
 		return nil, errors.Wrap(err, "filters are invalid")
 	}
-	err = qb.validateGroupOrder(order)
+	err = qb.validateGroupOrder(order, groupedField)
 	if err != nil {
 		return nil, errors.Wrap(err, "group order is invalid")
 	}
@@ -801,7 +801,7 @@ func orderIsNull(order *model.Order) bool {
 	return order == nil || (order.Direction == "" && order.Field == "")
 }
 
-func (qb *QueryBuilder) validateGroupOrder(order *model.Order) error {
+func (qb *QueryBuilder) validateGroupOrder(order *model.Order, groupedField *model.GroupedField) error {
 	if order == nil {
 		return nil
 	}
@@ -813,9 +813,18 @@ func (qb *QueryBuilder) validateGroupOrder(order *model.Order) error {
 		return errors.Errorf("unsupported field for order: %s", order.Field)
 	}
 
-	_, err = qb.lookoutTables.GroupAggregateForCol(col)
+	aggregateType, aggErr := qb.lookoutTables.GroupAggregateForCol(col)
+	// StateCounts produces multiple output columns with no single alias, so ordering
+	// by it is only valid when it is the grouped field itself (selected directly).
+	if aggErr == nil && aggregateType == StateCounts {
+		groupedCol, gErr := qb.lookoutTables.ColumnFromField(groupedField.Field)
+		if gErr != nil || groupedCol != col {
+			return errors.Errorf("unsupported field for order: %s", order.Field)
+		}
+	}
+
 	// If it is not an aggregate and not groupable, it can't be ordered by
-	if err != nil && !qb.lookoutTables.IsGroupable(col) {
+	if aggErr != nil && !qb.lookoutTables.IsGroupable(col) {
 		return errors.Errorf("unsupported field for order: %s, cannot sort by column %s", order.Field, col)
 	}
 	return nil


### PR DESCRIPTION
Ordering by "state" in a GroupBy query generates "ORDER BY state", but state aggregates produce multiple output columns (state_queued, etc.) with no alias matching "state". PostgreSQL resolves the bare column name to j.state from the FROM clause and rejects the query with a GROUP BY error.

validateGroupOrder now rejects this combination upfront. Broadside's buildGroupOrder is also fixed to not generate the invalid combination.