### PR TITLE
Add e2e test cases for error categorization

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -130,6 +130,7 @@ services:
       - 4001:4000
     volumes:
       - "./.kube/internal:/.kube"
+      - "./e2e/config/executor_config.yaml:/config/executor_config.yaml"
       - "go-cache:/root/.cache/go-build:rw"
       - "gomod-cache:/go/pkg/mod:rw"
     environment:
@@ -137,7 +138,7 @@ services:
     env_file:
       - developer/env/docker/executor.env
     working_dir: /app
-    command: ./executor
+    command: ./executor --config /config/executor_config.yaml
 
   binoculars:
     container_name: binoculars

--- a/e2e/config/executor_config.yaml
+++ b/e2e/config/executor_config.yaml
@@ -1,0 +1,10 @@
+application:
+  errorCategories:
+    - name: oom
+      rules:
+        - onConditions: ["OOMKilled"]
+    - name: user_error
+      rules:
+        - onExitCodes:
+            operator: In
+            values: [1, 2, 126, 127]

--- a/internal/testsuite/app.go
+++ b/internal/testsuite/app.go
@@ -88,11 +88,19 @@ func (a *App) TestPattern(ctx context.Context, pattern string) (*TestSuiteReport
 }
 
 func TestSpecsFromPattern(pattern string) ([]*api.TestSpec, error) {
-	filePaths, err := zglob.Glob(pattern)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to glob test specs with pattern %s", pattern)
+	var allPaths []string
+	for _, p := range strings.Split(pattern, ",") {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		paths, err := zglob.Glob(p)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to glob test specs with pattern %s", p)
+		}
+		allPaths = append(allPaths, paths...)
 	}
-	return TestSpecsFromFilePaths(filePaths)
+	return TestSpecsFromFilePaths(allPaths)
 }
 
 func TestSpecsFromFilePaths(filePaths []string) ([]*api.TestSpec, error) {
@@ -231,7 +239,7 @@ func (r *TestCaseReport) Collect(c chan<- prometheus.Metric) {
 	// Test failures always contain either "unexpected event for job" or "error asserting failure reason".
 	// TODO(albin): Improve this.
 	testFailure := 0.0
-	if strings.Contains(r.FailureReason, "unexpected event for job") || strings.Contains(r.FailureReason, "error asserting failure reason") {
+	if strings.Contains(r.FailureReason, "unexpected event for job") || strings.Contains(r.FailureReason, "error asserting failure reason") || strings.Contains(r.FailureReason, "expected categories") {
 		testFailure = 1.0
 	}
 	c <- prometheus.MustNewConstMetric(

--- a/internal/testsuite/eventwatcher/validators.go
+++ b/internal/testsuite/eventwatcher/validators.go
@@ -2,6 +2,8 @@ package eventwatcher
 
 import (
 	"regexp"
+	"slices"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -19,23 +21,42 @@ func assertEvent(expected *api.EventMessage, actual *api.EventMessage) error {
 }
 
 func assertEventFailed(expected *api.EventMessage_Failed, actual *api.EventMessage_Failed) error {
-	if expected.Failed.GetReason() == "" {
-		return nil
-	}
 	if actual == nil {
 		return errors.Errorf("unexpected nil event 'actual'")
 	}
 
-	re, err := regexp.Compile(expected.Failed.GetReason())
-	if err != nil {
-		return errors.Errorf("failed to compile regex %q: %v", expected.Failed.GetReason(), err)
+	if reason := expected.Failed.GetReason(); reason != "" {
+		re, err := regexp.Compile(reason)
+		if err != nil {
+			return errors.Errorf("failed to compile regex %q: %v", reason, err)
+		}
+		if !re.MatchString(actual.Failed.GetReason()) {
+			return errors.Errorf(
+				"error asserting failure reason: expected %s, got %s",
+				reason, actual.Failed.GetReason(),
+			)
+		}
 	}
 
-	if re.MatchString(actual.Failed.GetReason()) {
-		return errors.Errorf(
-			"error asserting failure reason: expected %s, got %s",
-			expected.Failed.GetReason(), actual.Failed.GetReason(),
-		)
+	if len(expected.Failed.GetCategories()) > 0 {
+		if err := assertCategories(expected.Failed.GetCategories(), actual.Failed.GetCategories()); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func assertCategories(expected, actual []string) error {
+	exp := slices.Clone(expected)
+	slices.Sort(exp)
+
+	act := slices.Clone(actual)
+	slices.Sort(act)
+
+	if !slices.Equal(exp, act) {
+		return errors.Errorf("expected categories [%s] but got [%s]",
+			strings.Join(exp, ", "), strings.Join(act, ", "))
 	}
 	return nil
 }

--- a/magefiles/ci.go
+++ b/magefiles/ci.go
@@ -36,7 +36,7 @@ func TestSuite() error {
 
 	timeTaken := time.Now()
 	out, err2 := goOutput("run", "cmd/testsuite/main.go", "test",
-		"--tests", "testsuite/testcases/basic/*",
+		"--tests", "testsuite/testcases/basic/*,testsuite/testcases/categorization/*",
 		"--junit", "junit.xml",
 		"--config", "e2e/config/armadactl_config.yaml",
 	)

--- a/testsuite/testcases/categorization/oom.yaml
+++ b/testsuite/testcases/categorization/oom.yaml
@@ -1,0 +1,28 @@
+numBatches: 1
+batchSize: 1
+queue: e2e-test-queue
+jobs:
+  - priority: 0
+    namespace: default
+    podSpec:
+      terminationGracePeriodSeconds: 0
+      restartPolicy: Never
+      containers:
+        - name: oom
+          imagePullPolicy: IfNotPresent
+          image: alpine:3.20.0
+          command: ["sh", "-c", "dd if=/dev/zero of=/dev/shm/fill bs=1M count=256"]
+          resources:
+            limits:
+              memory: 25Mi
+              cpu: 100m
+            requests:
+              memory: 25Mi
+              cpu: 100m
+---
+timeout: "300s"
+expectedEvents:
+  - submitted:
+  - failed:
+      categories:
+        - "oom"

--- a/testsuite/testcases/categorization/user_error.yaml
+++ b/testsuite/testcases/categorization/user_error.yaml
@@ -1,0 +1,28 @@
+numBatches: 1
+batchSize: 1
+queue: e2e-test-queue
+jobs:
+  - priority: 0
+    namespace: default
+    podSpec:
+      terminationGracePeriodSeconds: 0
+      restartPolicy: Never
+      containers:
+        - name: fail
+          imagePullPolicy: IfNotPresent
+          image: alpine:3.20.0
+          command: ["sh", "-c", "exit 1"]
+          resources:
+            limits:
+              memory: 25Mi
+              cpu: 100m
+            requests:
+              memory: 25Mi
+              cpu: 100m
+---
+timeout: "300s"
+expectedEvents:
+  - submitted:
+  - failed:
+      categories:
+        - "user_error"


### PR DESCRIPTION
## What type of PR is this?

Feature (PR 4 of 4)

## What this PR does / why we need it

Adds end-to-end test cases that verify error categories flow through the full Armada pipeline, asserting directly from the public event stream.

- Extends `assertEventFailed` in the testsuite event watcher to compare expected vs actual categories on `JobFailedEvent` (sorted exact match)
- Adds 2 categorization test cases: OOM kill (`dd` fills tmpfs to trigger OOMKilled) and user_error (exit code 1)
- Test YAML declares expected categories inline on the `failed` event:
  ```yaml
  expectedEvents:
    - submitted:
    - failed:
        categories: ["oom"]
  ```

## Which issue(s) this PR fixes

Part of #4713 (Error Categorization)

## Special notes for your reviewer

- This is PR 4 of 4: Proto + classifier (#4741) -> Wire into executor (#4745) -> Store in lookout DB + UI + public event (#4755) -> e2e tests (this)
- Depends on #4755 (which added `categories` field to `JobFailedEvent`)
- Categories are asserted from the event stream, not from the Lookout API - no HTTP polling or additional infrastructure needed
- CI executor config needs `errorCategories` rules added separately (included in `e2e/config/executor_config.yaml`)
- Both tests validated locally against a full local dev stack