### PR TITLE
Rust client: allow protos to be vendored with crate

### DIFF
--- a/.github/workflows/rust-client-release-to-crates.yml
+++ b/.github/workflows/rust-client-release-to-crates.yml
@@ -56,4 +56,4 @@ jobs:
       - name: Publish to crates.io
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish --manifest-path client/rust/Cargo.toml
+        run: cargo publish --manifest-path client/rust/Cargo.toml --allow-dirty


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you: -->

#### What type of PR is this?
Update Rust client publish workflow to allow protos to be vendored with crate.

#### What this PR does / why we need it
Right now publish workflow fails because protos are not vendored with crate.

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer
