### PR TITLE
Replace os.Exit in binoculars StartUp with error return

### DIFF
--- a/cmd/binoculars/main.go
+++ b/cmd/binoculars/main.go
@@ -71,7 +71,13 @@ func main() {
 	)
 	defer shutdownGateway()
 
-	shutdown, wg := binoculars.StartUp(&config)
+	shutdown, wg, err := binoculars.StartUp(&config)
+	if err != nil {
+		log.Errorf("Binoculars startup failed: %v", err)
+		shutdownGateway()
+		shutdownMetricServer()
+		os.Exit(1)
+	}
 	go func() {
 		<-stopSignal
 		shutdown()

--- a/internal/binoculars/server.go
+++ b/internal/binoculars/server.go
@@ -1,7 +1,7 @@
 package binoculars
 
 import (
-	"os"
+	"fmt"
 	"sync"
 
 	"github.com/armadaproject/armada/internal/binoculars/configuration"
@@ -10,28 +10,22 @@ import (
 	"github.com/armadaproject/armada/internal/common/auth"
 	"github.com/armadaproject/armada/internal/common/cluster"
 	grpcCommon "github.com/armadaproject/armada/internal/common/grpc"
-	log "github.com/armadaproject/armada/internal/common/logging"
 	"github.com/armadaproject/armada/pkg/api/binoculars"
 )
 
-func StartUp(config *configuration.BinocularsConfig) (func(), *sync.WaitGroup) {
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
-
+func StartUp(config *configuration.BinocularsConfig) (func(), *sync.WaitGroup, error) {
 	kubernetesClientProvider, err := cluster.NewKubernetesClientProvider(
 		config.ImpersonateUsers,
 		config.Kubernetes.QPS,
 		config.Kubernetes.Burst,
 	)
 	if err != nil {
-		log.Errorf("Failed to connect to kubernetes because %s", err)
-		os.Exit(-1)
+		return nil, nil, fmt.Errorf("failed to connect to kubernetes: %w", err)
 	}
 
 	authServices, err := auth.ConfigureAuth(config.Auth)
 	if err != nil {
-		log.Errorf("Failed to create auth services %s", err)
-		os.Exit(-1)
+		return nil, nil, fmt.Errorf("failed to create auth services: %w", err)
 	}
 
 	grpcServer := grpcCommon.CreateGrpcServer(config.Grpc.KeepaliveParams, config.Grpc.KeepaliveEnforcementPolicy, authServices, config.Grpc.Tls)
@@ -47,7 +41,9 @@ func StartUp(config *configuration.BinocularsConfig) (func(), *sync.WaitGroup) {
 	binocularsServer := server.NewBinocularsServer(logService, cordonService)
 	binoculars.RegisterBinocularsServer(grpcServer, binocularsServer)
 
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
 	grpcCommon.Listen(config.GrpcPort, grpcServer, wg)
 
-	return grpcServer.GracefulStop, wg
+	return grpcServer.GracefulStop, wg, nil
 }


### PR DESCRIPTION
Fixes #4779

`StartUp()` in `internal/binoculars/server.go` was calling `os.Exit(-1)` on init errors, which makes the function impossible to test and prevents the caller from doing any cleanup.

Changed the function to return an error instead, and updated the caller in `cmd/binoculars/main.go` to handle it with `log.Fatalf`. The end result is the same (process exits on failure), but now the logic is testable and the caller is in control.

Changes:
- `StartUp` signature: `(func(), *sync.WaitGroup)` → `(func(), *sync.WaitGroup, error)`
- Two `os.Exit(-1)` calls replaced with `fmt.Errorf` + `%w` wrapping
- Removed unused `os` and `log` imports from server.go
- Caller in main.go updated to check the returned error