### PR TITLE
Use trusted publishing to publish Rust client

### DIFF
--- a/.github/workflows/rust-client-release-to-crates.yml
+++ b/.github/workflows/rust-client-release-to-crates.yml
@@ -7,6 +7,9 @@ jobs:
   publish:
     runs-on: ubuntu-22.04
     environment: crates-release
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -56,7 +59,11 @@ jobs:
       - name: Clippy
         run: ARMADA_GENERATE=1 cargo clippy --manifest-path client/rust/Cargo.toml --all-targets -- -D warnings
 
+      - name: Setup trusted publishing credentials
+        uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+
       - name: Publish to crates.io
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: cargo publish --manifest-path client/rust/Cargo.toml


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you: -->

#### What type of PR is this?

CI

#### What this PR does / why we need it

This PR configures the Rust client release workflow to use trusted publishing instead of a secret token.

See https://crates.io/docs/trusted-publishing for more details.

- [x] Trusted publishing has already been configured for the crate.
- [x] Once merged, the existing secret token can be revoked and deleted from the `crates-release` environment.

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

N/A

#### Special notes for your reviewer
