### PR TITLE
update prometheus metric labels to constants

### DIFF
--- a/internal/common/metrics/scheduler_metrics.go
+++ b/internal/common/metrics/scheduler_metrics.go
@@ -154,7 +154,7 @@ var JobRunDurationDesc = prometheus.NewDesc(
 var QueueAllocatedDesc = prometheus.NewDesc(
 	MetricPrefix+"queue_resource_allocated",
 	"Resource allocated to running jobs of a queue",
-	[]string{"cluster", labelPool, labelPriorityClass, labelQueueName, labelQueue, labelPriceBand, labelResourceType, labelNodeType, labelReservation, labelPhysicalPool},
+	[]string{labelCluster, labelPool, labelPriorityClass, labelQueueName, labelQueue, labelPriceBand, labelResourceType, labelNodeType, labelReservation, labelPhysicalPool},
 	nil,
 )
 
@@ -182,14 +182,14 @@ var MedianQueueAllocatedDesc = prometheus.NewDesc(
 var QueueUsedDesc = prometheus.NewDesc(
 	MetricPrefix+"queue_resource_used",
 	"Resource actually being used by running jobs of a queue",
-	[]string{"cluster", labelPool, labelQueueName, labelQueue, labelResourceType, labelNodeType, labelReservation, labelPhysicalPool},
+	[]string{labelCluster, labelPool, labelQueueName, labelQueue, labelResourceType, labelNodeType, labelReservation, labelPhysicalPool},
 	nil,
 )
 
 var QueueLeasedPodCountDesc = prometheus.NewDesc(
 	MetricPrefix+"queue_leased_pod_count",
 	"Number of leased pods",
-	[]string{"cluster", labelPool, labelQueueName, labelQueue, labelPhase, labelNodeType, labelReservation},
+	[]string{labelCluster, labelPool, labelQueueName, labelQueue, labelPhase, labelNodeType, labelReservation},
 	nil,
 )
 


### PR DESCRIPTION
#### What type of PR is this?

#### What this PR does / why we need it

Updates prometheus labels to be constants instead of strings. This improves code quality and makes it less likely for future develops to mistakenly create new metrics in the future by introducing typos.

#### Which issue(s) this PR fixes

Fixes #4777 

#### Special notes for your reviewer
