### PR TITLE
Pin apache-airflow<3.0.0 to fix CI breakage

### DIFF
--- a/third_party/airflow/pyproject.toml
+++ b/third_party/airflow/pyproject.toml
@@ -11,7 +11,7 @@ authors = [{name = "Armada-GROSS", email = "armada@armadaproject.io"}]
 license = { text = "Apache Software License" }
 dependencies=[
     'armada-client>=0.4.8',
-    'apache-airflow>=2.6.3',
+    'apache-airflow>=2.6.3,<3.0.0',
     'types-protobuf==4.24.0.1',
     'kubernetes>=23.6.0',
     'kubernetes_asyncio>=24.2.3',


### PR DESCRIPTION
## Summary
- Pin `apache-airflow>=2.6.3,<3.0.0` in `third_party/airflow/pyproject.toml`

Airflow 3.2.0 was recently released and moved `airflow.serialization.serde` to `airflow.sdk.serde`, breaking the Armada airflow operator CI. Since `pyproject.toml` had no upper bound (`>=2.6.3`), CI pulled in Airflow 3.x automatically.

Airflow 3.0 is a major version with breaking changes beyond just this import path. The operator needs a dedicated migration effort for Airflow 3.x compatibility, so pin to `<3.0.0` for now to unblock all PRs that touch `pkg/api/*.proto`.