### PR TITLE
Sanitize jsonb column from unicode null character, hide jobFailureInfo jsonb map behind enableJobRunFailureInfoMap (disabled by default)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,5 @@ tmp/
 tmp.*
 *.tmp.*
 .aider*
+
+.claude/

--- a/internal/lookout/pruner/pruner_test.go
+++ b/internal/lookout/pruner/pruner_test.go
@@ -134,7 +134,7 @@ func TestPruneDb(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.testName, func(t *testing.T) {
 			err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-				converter := instructions.NewInstructionConverter(metrics.Get().Metrics, "armadaproject.io/", []string{}, &compress.NoOpCompressor{})
+				converter := instructions.NewInstructionConverter(metrics.Get().Metrics, "armadaproject.io/", []string{}, &compress.NoOpCompressor{}, false)
 				store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10, 10)
 
 				ctx, cancel := armadacontext.WithTimeout(armadacontext.Background(), 5*time.Minute)

--- a/internal/lookout/repository/getjoberror_test.go
+++ b/internal/lookout/repository/getjoberror_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestGetJobError(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		converter := instructions.NewInstructionConverter(metrics.Get().Metrics, userAnnotationPrefix, []string{}, &compress.NoOpCompressor{})
+		converter := instructions.NewInstructionConverter(metrics.Get().Metrics, userAnnotationPrefix, []string{}, &compress.NoOpCompressor{}, false)
 		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10, 10)
 		errMsg := "some bad error happened!"
 		_ = NewJobSimulator(converter, store).

--- a/internal/lookout/repository/getjobrundebugmessage_test.go
+++ b/internal/lookout/repository/getjobrundebugmessage_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestGetJobRunDebugMessage(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		converter := instructions.NewInstructionConverter(metrics.Get().Metrics, userAnnotationPrefix, []string{}, &compress.NoOpCompressor{})
+		converter := instructions.NewInstructionConverter(metrics.Get().Metrics, userAnnotationPrefix, []string{}, &compress.NoOpCompressor{}, false)
 		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10, 10)
 
 		debugMessageStrings := []string{

--- a/internal/lookout/repository/getjobrunerror_test.go
+++ b/internal/lookout/repository/getjobrunerror_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestGetJobRunError(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		converter := instructions.NewInstructionConverter(metrics.Get().Metrics, userAnnotationPrefix, []string{}, &compress.NoOpCompressor{})
+		converter := instructions.NewInstructionConverter(metrics.Get().Metrics, userAnnotationPrefix, []string{}, &compress.NoOpCompressor{}, false)
 		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10, 10)
 
 		errorStrings := []string{

--- a/internal/lookout/repository/getjobs_test.go
+++ b/internal/lookout/repository/getjobs_test.go
@@ -59,7 +59,7 @@ var (
 func withGetJobsSetup(f func(*instructions.InstructionConverter, *lookoutdb.LookoutDb, *SqlGetJobsRepository, *clock.FakeClock) error) error {
 	testClock := clock.NewFakeClock(time.Now())
 	return lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		converter := instructions.NewInstructionConverter(metrics.Get().Metrics, userAnnotationPrefix, []string{}, &compress.NoOpCompressor{})
+		converter := instructions.NewInstructionConverter(metrics.Get().Metrics, userAnnotationPrefix, []string{}, &compress.NoOpCompressor{}, false)
 		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10, 10)
 		repo := NewSqlGetJobsRepository(db)
 		repo.clock = testClock

--- a/internal/lookout/repository/getjobspec_test.go
+++ b/internal/lookout/repository/getjobspec_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestGetJobSpec(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		converter := instructions.NewInstructionConverter(metrics.Get().Metrics, userAnnotationPrefix, []string{}, &compress.NoOpCompressor{})
+		converter := instructions.NewInstructionConverter(metrics.Get().Metrics, userAnnotationPrefix, []string{}, &compress.NoOpCompressor{}, false)
 		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10, 10)
 
 		job := NewJobSimulator(converter, store).
@@ -54,7 +54,7 @@ func TestGetJobSpec(t *testing.T) {
 func TestMIGRATEDGetJobSpec(t *testing.T) {
 	var migratedResult *api.Job
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		converter := instructions.NewInstructionConverter(metrics.Get().Metrics, userAnnotationPrefix, []string{}, &compress.NoOpCompressor{})
+		converter := instructions.NewInstructionConverter(metrics.Get().Metrics, userAnnotationPrefix, []string{}, &compress.NoOpCompressor{}, false)
 		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10, 10)
 
 		_ = NewJobSimulator(converter, store).

--- a/internal/lookout/repository/groupjobs_test.go
+++ b/internal/lookout/repository/groupjobs_test.go
@@ -22,7 +22,7 @@ import (
 
 func withGroupJobsSetup(f func(*instructions.InstructionConverter, *lookoutdb.LookoutDb, *SqlGroupJobsRepository) error) error {
 	return lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		converter := instructions.NewInstructionConverter(metrics.Get().Metrics, userAnnotationPrefix, []string{}, &compress.NoOpCompressor{})
+		converter := instructions.NewInstructionConverter(metrics.Get().Metrics, userAnnotationPrefix, []string{}, &compress.NoOpCompressor{}, false)
 		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10, 10)
 		repo := NewSqlGroupJobsRepository(db)
 		return f(converter, store, repo)

--- a/internal/lookoutingester/configuration/types.go
+++ b/internal/lookoutingester/configuration/types.go
@@ -49,6 +49,9 @@ type LookoutIngesterConfiguration struct {
 	Profiling *profilingconfig.ProfilingConfig
 	// List of Regexes which will identify fatal errors when inserting into postgres
 	FatalInsertionErrors []string
+	// When true, populate FailureInfo on terminal job run errors from the proto FailureInfo field.
+	// When false, set FailureInfo to an empty map for terminal errors.
+	EnableJobRunFailureInfoMap bool
 }
 
 func (c *LookoutIngesterConfiguration) GetUserAnnotationPrefix() string {

--- a/internal/lookoutingester/dbloadtester/simulator.go
+++ b/internal/lookoutingester/dbloadtester/simulator.go
@@ -79,7 +79,7 @@ func Setup(lookoutIngesterConfig configuration.LookoutIngesterConfiguration, tes
 		panic(errors.WithMessage(err, "Error creating compressor"))
 	}
 
-	converter := instructions.NewInstructionConverter(m.Metrics, lookoutIngesterConfig.UserAnnotationPrefix, []string{}, compressor)
+	converter := instructions.NewInstructionConverter(m.Metrics, lookoutIngesterConfig.UserAnnotationPrefix, []string{}, compressor, lookoutIngesterConfig.EnableJobRunFailureInfoMap)
 
 	submitJobTemplate := &v1.PodSpec{}
 	err = clientUtil.BindJsonOrYaml(testConfig.JobTemplateFile, submitJobTemplate)

--- a/internal/lookoutingester/ingester.go
+++ b/internal/lookoutingester/ingester.go
@@ -65,6 +65,7 @@ func Run(config *configuration.LookoutIngesterConfiguration) {
 		config.GetUserAnnotationPrefix(),
 		config.Annotations.BlocklistAnnotations,
 		compressor,
+		config.EnableJobRunFailureInfoMap,
 	)
 
 	ingester := ingest.NewIngestionPipeline[*model.InstructionSet, *armadaevents.EventSequence](

--- a/internal/lookoutingester/instructions/instructions.go
+++ b/internal/lookoutingester/instructions/instructions.go
@@ -40,10 +40,11 @@ type HasNodeName interface {
 }
 
 type InstructionConverter struct {
-	metrics              *metrics.Metrics
-	userAnnotationPrefix string
-	blocklistAnnotations map[string]struct{}
-	compressor           compress.Compressor
+	metrics                    *metrics.Metrics
+	userAnnotationPrefix       string
+	blocklistAnnotations       map[string]struct{}
+	compressor                 compress.Compressor
+	enableJobRunFailureInfoMap bool
 }
 
 type jobResources struct {
@@ -53,16 +54,17 @@ type jobResources struct {
 	Gpu              int64
 }
 
-func NewInstructionConverter(m *metrics.Metrics, userAnnotationPrefix string, blocklistAnnotations []string, compressor compress.Compressor) *InstructionConverter {
+func NewInstructionConverter(m *metrics.Metrics, userAnnotationPrefix string, blocklistAnnotations []string, compressor compress.Compressor, enableJobRunFailureInfoMap bool) *InstructionConverter {
 	blocked := make(map[string]struct{}, len(blocklistAnnotations))
 	for _, b := range blocklistAnnotations {
 		blocked[strings.ToLower(b)] = struct{}{}
 	}
 	return &InstructionConverter{
-		metrics:              m,
-		userAnnotationPrefix: userAnnotationPrefix,
-		blocklistAnnotations: blocked,
-		compressor:           compressor,
+		metrics:                    m,
+		userAnnotationPrefix:       userAnnotationPrefix,
+		blocklistAnnotations:       blocked,
+		compressor:                 compressor,
+		enableJobRunFailureInfoMap: enableJobRunFailureInfoMap,
 	}
 }
 
@@ -176,7 +178,7 @@ func (c *InstructionConverter) handleSubmitJob(
 	}
 
 	annotations := event.GetObjectMeta().GetAnnotations()
-	userAnnotations := extractUserAnnotations(c.userAnnotationPrefix, c.blocklistAnnotations, annotations)
+	userAnnotations := extractUserAnnotations(event.JobId, c.userAnnotationPrefix, c.blocklistAnnotations, annotations)
 	// Prefer the proto field; fall back to annotation for events produced before the field existed.
 	externalJobUri := event.ExternalJobUri
 	if externalJobUri == "" {
@@ -215,7 +217,7 @@ filters out any keys in blocklistAnnotations (case-insensitive),
 and truncates keys and values to their maximal lengths as specified by
 maxAnnotationKeyLen and maxAnnotationValLen.
 */
-func extractUserAnnotations(userAnnotationPrefix string, blocklistAnnotations map[string]struct{}, jobAnnotations map[string]string) map[string]string {
+func extractUserAnnotations(jobId string, userAnnotationPrefix string, blocklistAnnotations map[string]struct{}, jobAnnotations map[string]string) map[string]string {
 	result := make(map[string]string, len(jobAnnotations))
 	n := len(userAnnotationPrefix)
 	for k, v := range jobAnnotations {
@@ -225,11 +227,22 @@ func extractUserAnnotations(userAnnotationPrefix string, blocklistAnnotations ma
 		if strings.HasPrefix(k, userAnnotationPrefix) {
 			k = k[n:]
 		}
-		key := util.Truncate(k, maxAnnotationKeyLen)
-		val := util.Truncate(v, maxAnnotationValLen)
+		key := sanitizeForJsonb(k)
+		val := sanitizeForJsonb(v)
+		if key != k || val != v {
+			log.Warnf("Sanitized annotation for job %s: key %q (was %q), value %q (was %q)", jobId, key, k, val, v)
+		}
+		key = util.Truncate(key, maxAnnotationKeyLen)
+		val = util.Truncate(val, maxAnnotationValLen)
 		result[key] = val
 	}
 	return result
+}
+
+// sanitizeForJsonb removes null bytes (\x00) from s.
+// PostgreSQL jsonb rejects strings containing \u0000 with SQLSTATE 22P05.
+func sanitizeForJsonb(s string) string {
+	return strings.ReplaceAll(s, "\x00", "")
 }
 
 func (c *InstructionConverter) handleReprioritiseJob(_ time.Time, event *armadaevents.ReprioritisedJob, update *model.InstructionSet) error {
@@ -454,7 +467,11 @@ func (c *InstructionConverter) handleJobRunErrors(ts time.Time, event *armadaeve
 		// may be retried and the final FailureInfo is the one that matters.
 		if e.Terminal {
 			if fi := e.GetFailureInfo(); fi != nil {
-				jobRunUpdate.FailureInfo = failureInfoToMap(fi)
+				if c.enableJobRunFailureInfoMap {
+					jobRunUpdate.FailureInfo = failureInfoToMap(event.JobId, fi)
+				} else {
+					jobRunUpdate.FailureInfo = map[string]any{}
+				}
 			}
 		}
 		update.JobRunsToUpdate = append(update.JobRunsToUpdate, jobRunUpdate)
@@ -486,13 +503,18 @@ func (c *InstructionConverter) handleStandaloneIngressInfo(event *armadaevents.S
 // failureInfoToMap converts a FailureInfo proto to a JSON-friendly map for JSONB storage.
 // Only non-zero fields are included. After a JSON round-trip through PostgreSQL,
 // numeric fields arrive as float64 - see failureInfoToSwagger for the read side.
-func failureInfoToMap(fi *armadaevents.FailureInfo) map[string]any {
+func failureInfoToMap(jobId string, fi *armadaevents.FailureInfo) map[string]any {
 	m := make(map[string]any, 4)
 	if fi.GetExitCode() != 0 {
 		m["exitCode"] = fi.GetExitCode()
 	}
 	if fi.GetTerminationMessage() != "" {
-		m["terminationMessage"] = util.Truncate(fi.GetTerminationMessage(), maxTerminationMessageLen)
+		terminationMessage := util.Truncate(fi.GetTerminationMessage(), maxTerminationMessageLen)
+		sanitizedTerminationMessage := sanitizeForJsonb(terminationMessage)
+		if sanitizedTerminationMessage != terminationMessage {
+			log.Warnf("Sanitized termination message for job %s: %q (was %q)", jobId, sanitizedTerminationMessage, terminationMessage)
+		}
+		m["terminationMessage"] = sanitizedTerminationMessage
 	}
 	if len(fi.GetCategories()) > 0 {
 		m["categories"] = fi.GetCategories()

--- a/internal/lookoutingester/instructions/instructions_test.go
+++ b/internal/lookoutingester/instructions/instructions_test.go
@@ -507,7 +507,7 @@ func TestConvert(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			converter := NewInstructionConverter(metrics.Get().Metrics, userAnnotationPrefix, []string{}, &compress.NoOpCompressor{})
+			converter := NewInstructionConverter(metrics.Get().Metrics, userAnnotationPrefix, []string{}, &compress.NoOpCompressor{}, true)
 			decompressor := &compress.NoOpDecompressor{}
 			instructionSet := converter.Convert(armadacontext.TODO(), tc.events)
 			require.Equal(t, len(tc.expected.JobsToCreate), len(instructionSet.JobsToCreate))
@@ -580,7 +580,7 @@ func TestExternalJobUriProtoFieldPreferred(t *testing.T) {
 				MessageIds: []pulsar.MessageID{pulsarutils.NewMessageId(1)},
 			}
 
-			converter := NewInstructionConverter(metrics.Get().Metrics, userAnnotationPrefix, []string{}, &compress.NoOpCompressor{})
+			converter := NewInstructionConverter(metrics.Get().Metrics, userAnnotationPrefix, []string{}, &compress.NoOpCompressor{}, true)
 			instructionSet := converter.Convert(armadacontext.TODO(), events)
 			require.Len(t, instructionSet.JobsToCreate, 1)
 			assert.Equal(t, tc.expected, instructionSet.JobsToCreate[0].ExternalJobUri)
@@ -627,7 +627,7 @@ func TestTruncatesStringsThatAreTooLong(t *testing.T) {
 		MessageIds: []pulsar.MessageID{pulsarutils.NewMessageId(1)},
 	}
 
-	converter := NewInstructionConverter(metrics.Get().Metrics, userAnnotationPrefix, []string{}, &compress.NoOpCompressor{})
+	converter := NewInstructionConverter(metrics.Get().Metrics, userAnnotationPrefix, []string{}, &compress.NoOpCompressor{}, true)
 	actual := converter.Convert(armadacontext.TODO(), events)
 
 	// String lengths obtained from database schema
@@ -650,26 +650,146 @@ func TestExtractNodeName(t *testing.T) {
 
 func TestExtractUserAnnotations_NoPrefixNoBlocklist_SomeAnnotations(t *testing.T) {
 	annotations := map[string]string{"a": "1", "b": "2"}
-	result := extractUserAnnotations("", map[string]struct{}{}, annotations)
+	result := extractUserAnnotations("test-job", "", map[string]struct{}{}, annotations)
 	assert.Equal(t, annotations, result)
 }
 
 func TestExtractUserAnnotations_NoPrefixNoBlocklist_EmptyAnnotations(t *testing.T) {
-	result := extractUserAnnotations("", map[string]struct{}{}, map[string]string{})
+	result := extractUserAnnotations("test-job", "", map[string]struct{}{}, map[string]string{})
 	assert.Empty(t, result)
 }
 
 func TestExtractUserAnnotations_PrefixTrimming(t *testing.T) {
 	annotations := map[string]string{"prefix/key": "value", "other": "v2"}
 	expected := map[string]string{"key": "value", "other": "v2"}
-	result := extractUserAnnotations("prefix/", map[string]struct{}{}, annotations)
+	result := extractUserAnnotations("test-job", "prefix/", map[string]struct{}{}, annotations)
 	assert.Equal(t, expected, result)
 }
 
 func TestExtractUserAnnotations_Blocklist(t *testing.T) {
 	annotations := map[string]string{"Block": "v1", "block": "v2", "keep": "v3"}
 	blocklist := map[string]struct{}{"block": {}}
-	result := extractUserAnnotations("", blocklist, annotations)
+	result := extractUserAnnotations("test-job", "", blocklist, annotations)
 	expected := map[string]string{"keep": "v3"}
 	assert.Equal(t, expected, result)
+}
+
+func TestExtractUserAnnotations_SanitizesNullBytes(t *testing.T) {
+	annotations := map[string]string{
+		"clean":            "no nulls here",
+		"dirty\x00key":     "value",
+		"key":              "dirty\x00value",
+		"both\x00k":        "both\x00v",
+		"\x00\x00multiple": "\x00",
+	}
+	result := extractUserAnnotations("test-job", "", map[string]struct{}{}, annotations)
+	expected := map[string]string{
+		"clean":    "no nulls here",
+		"dirtykey": "value",
+		"key":      "dirtyvalue",
+		"bothk":    "bothv",
+		"multiple": "",
+	}
+	assert.Equal(t, expected, result)
+}
+
+func TestSanitizeForJsonb(t *testing.T) {
+	assert.Equal(t, "hello", sanitizeForJsonb("hello"))
+	assert.Equal(t, "ab", sanitizeForJsonb("a\x00b"))
+	assert.Equal(t, "", sanitizeForJsonb("\x00"))
+	assert.Equal(t, "", sanitizeForJsonb(""))
+}
+
+func TestFailureInfoToMap(t *testing.T) {
+	tests := map[string]struct {
+		fi       *armadaevents.FailureInfo
+		expected map[string]any
+	}{
+		"all fields populated": {
+			fi: &armadaevents.FailureInfo{
+				ExitCode:           137,
+				TerminationMessage: "OOM killed",
+				Categories:         []string{"RESOURCE_LIMIT"},
+				ContainerName:      "main",
+			},
+			expected: map[string]any{
+				"exitCode":           int32(137),
+				"terminationMessage": "OOM killed",
+				"categories":         []string{"RESOURCE_LIMIT"},
+				"containerName":      "main",
+			},
+		},
+		"only exit code": {
+			fi: &armadaevents.FailureInfo{
+				ExitCode: 1,
+			},
+			expected: map[string]any{
+				"exitCode": int32(1),
+			},
+		},
+		"zero exit code omitted": {
+			fi: &armadaevents.FailureInfo{
+				TerminationMessage: "something went wrong",
+			},
+			expected: map[string]any{
+				"terminationMessage": "something went wrong",
+			},
+		},
+		"all fields zero returns nil": {
+			fi:       &armadaevents.FailureInfo{},
+			expected: nil,
+		},
+		"termination message truncated": {
+			fi: &armadaevents.FailureInfo{
+				TerminationMessage: strings.Repeat("x", maxTerminationMessageLen+100),
+			},
+			expected: map[string]any{
+				"terminationMessage": strings.Repeat("x", maxTerminationMessageLen),
+			},
+		},
+		"termination message sanitized of null bytes": {
+			fi: &armadaevents.FailureInfo{
+				TerminationMessage: "OOM\x00killed",
+			},
+			expected: map[string]any{
+				"terminationMessage": "OOMkilled",
+			},
+		},
+		"multiple categories": {
+			fi: &armadaevents.FailureInfo{
+				Categories: []string{"RESOURCE_LIMIT", "MEMORY"},
+			},
+			expected: map[string]any{
+				"categories": []string{"RESOURCE_LIMIT", "MEMORY"},
+			},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := failureInfoToMap("test-job", tc.fi)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestJobRunFailedTerminalNilFailureInfoWhenFlagDisabled(t *testing.T) {
+	converter := NewInstructionConverter(metrics.Get().Metrics, userAnnotationPrefix, []string{}, &compress.NoOpCompressor{}, false)
+	events := &utils.EventsWithIds[*armadaevents.EventSequence]{
+		Events:     []*armadaevents.EventSequence{testfixtures.NewEventSequence(testfixtures.JobRunFailed)},
+		MessageIds: []pulsar.MessageID{pulsarutils.NewMessageId(1)},
+	}
+	instructionSet := converter.Convert(armadacontext.TODO(), events)
+	require.Len(t, instructionSet.JobRunsToUpdate, 1)
+	assert.Nil(t, instructionSet.JobRunsToUpdate[0].FailureInfo)
+}
+
+func TestJobRunFailedWithFailureInfoIgnoredWhenFlagDisabled(t *testing.T) {
+	converter := NewInstructionConverter(metrics.Get().Metrics, userAnnotationPrefix, []string{}, &compress.NoOpCompressor{}, false)
+	events := &utils.EventsWithIds[*armadaevents.EventSequence]{
+		Events:     []*armadaevents.EventSequence{testfixtures.NewEventSequence(testfixtures.JobRunFailedWithFailureInfo)},
+		MessageIds: []pulsar.MessageID{pulsarutils.NewMessageId(1)},
+	}
+	instructionSet := converter.Convert(armadacontext.TODO(), events)
+	require.Len(t, instructionSet.JobRunsToUpdate, 1)
+	assert.Equal(t, map[string]any{}, instructionSet.JobRunsToUpdate[0].FailureInfo)
 }


### PR DESCRIPTION
* Unicode null termination characters in /dev/termination-log will no longer break lookout ingester.
* We're gating the error categorisation error map behind feature flag (as we're likely to change field shape due to load on the DB).