### PR TITLE
Skip submit check on cordoned queues

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -22,6 +22,7 @@ import (
 	"github.com/armadaproject/armada/internal/scheduler/leader"
 	"github.com/armadaproject/armada/internal/scheduler/metrics"
 	"github.com/armadaproject/armada/internal/scheduler/pricing"
+	"github.com/armadaproject/armada/internal/scheduler/queue"
 	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
 	"github.com/armadaproject/armada/internal/scheduler/scheduling"
 	schedulercontext "github.com/armadaproject/armada/internal/scheduler/scheduling/context"
@@ -89,6 +90,8 @@ type Scheduler struct {
 	// A list of the pools that are market driven
 	// Used to know which jobs need update when updating job prices
 	marketDrivenPools []string
+	// Used to look up queue state (e.g., cordoned status)
+	queueCache queue.QueueCache
 }
 
 func NewScheduler(
@@ -109,6 +112,7 @@ func NewScheduler(
 	metrics *metrics.Metrics,
 	bidPriceProvider pricing.BidPriceProvider,
 	marketDrivenPools []string,
+	queueCache queue.QueueCache,
 ) (*Scheduler, error) {
 	return &Scheduler{
 		jobRepository:      jobRepository,
@@ -131,6 +135,7 @@ func NewScheduler(
 		runsSerial:         -1,
 		metrics:            metrics,
 		marketDrivenPools:  marketDrivenPools,
+		queueCache:         queueCache,
 	}, nil
 }
 
@@ -1106,11 +1111,23 @@ func (s *Scheduler) expireJobsIfNecessary(ctx *armadacontext.Context, txn *jobdb
 func (s *Scheduler) submitCheck(ctx *armadacontext.Context, txn *jobdb.Txn) ([]*armadaevents.EventSequence, error) {
 	jobsToCheck := make([]*jobdb.Job, 0)
 
+	queues, err := s.queueCache.GetAll(ctx)
+	if err != nil {
+		ctx.Warnf("Failed to fetch queues for cordon check, proceeding without: %v", err)
+	}
+
+	cordonedQueues := make(map[string]bool)
+	for _, q := range queues {
+		if q.Cordoned {
+			cordonedQueues[q.Name] = true
+		}
+	}
+
 	it := txn.UnvalidatedJobs()
 
 	for job, _ := it.Next(); job != nil; job, _ = it.Next() {
-		// Don't check jobs that are terminal
-		if job.InTerminalState() {
+		// Don't check jobs that are terminal or in cordoned queues
+		if job.InTerminalState() || cordonedQueues[job.Queue()] {
 			continue
 		}
 		jobsToCheck = append(jobsToCheck, job)

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -330,10 +330,9 @@ func (s *Scheduler) cycle(ctx *armadacontext.Context, updateAll bool, leaderToke
 	// Validate that any new jobs can be scheduled
 	validationEvents, err := s.submitCheck(ctx, txn)
 	if err != nil {
-		ctx.Warnf("Failed to validate jobs this cycle: %v", err)
-	} else {
-		events = append(events, validationEvents...)
+		return err
 	}
+	events = append(events, validationEvents...)
 
 	// Expire any jobs running on clusters that haven't heartbeated within the configured deadline.
 	ctx.Info("Looking for jobs to expire")

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -330,9 +330,10 @@ func (s *Scheduler) cycle(ctx *armadacontext.Context, updateAll bool, leaderToke
 	// Validate that any new jobs can be scheduled
 	validationEvents, err := s.submitCheck(ctx, txn)
 	if err != nil {
-		return err
+		ctx.Warnf("Failed to validate jobs this cycle: %v", err)
+	} else {
+		events = append(events, validationEvents...)
 	}
-	events = append(events, validationEvents...)
 
 	// Expire any jobs running on clusters that haven't heartbeated within the configured deadline.
 	ctx.Info("Looking for jobs to expire")
@@ -1113,10 +1114,10 @@ func (s *Scheduler) submitCheck(ctx *armadacontext.Context, txn *jobdb.Txn) ([]*
 
 	queues, err := s.queueCache.GetAll(ctx)
 	if err != nil {
-		ctx.Warnf("Failed to fetch queues for cordon check, proceeding without: %v", err)
+		return nil, err
 	}
 
-	cordonedQueues := make(map[string]bool)
+	cordonedQueues := make(map[string]bool, len(queues))
 	for _, q := range queues {
 		if q.Cordoned {
 			cordonedQueues[q.Name] = true

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -157,6 +157,21 @@ var queuedJob = testfixtures.NewJob(
 	true,
 )
 
+var queuedJobCordonedQueue = testfixtures.NewJob(
+	util.NewULID(),
+	"testJobset",
+	"cordonedQueue",
+	uint32(10),
+	toInternalSchedulingInfo(schedulingInfo),
+	true,
+	0,
+	false,
+	false,
+	false,
+	1,
+	true,
+)
+
 var queuedGangJob = testfixtures.NewJob(
 	util.NewULID(),
 	"testJobset",
@@ -383,6 +398,8 @@ func TestScheduler_TestCycle(t *testing.T) {
 		expectedNodeAntiAffinities         []string                       // list of nodes there is expected to be anti affinities for on job scheduling info
 		expectedJobSchedulingInfoVersion   int                            // expected scheduling info version of jobs at the end of the cycle
 		expectedQueuedVersion              int32                          // expected queued version of jobs at the end of the cycle
+		cordonedQueues                     []string                       // queues that are cordoned
+		queueCacheError                    bool                           // if true then the queue cache will throw an error
 	}{
 		"Lease a single job already in the db": {
 			initialJobs:           []*jobdb.Job{queuedJob},
@@ -392,6 +409,26 @@ func TestScheduler_TestCycle(t *testing.T) {
 		},
 		"Submit check a job": {
 			initialJobs:           []*jobdb.Job{queuedJob.WithValidated(false)},
+			expectedQueued:        []string{queuedJob.Id()},
+			expectedValidated:     []string{queuedJob.Id()},
+			expectedQueuedVersion: 0,
+		},
+		"Submit check skips cordoned queue": {
+			initialJobs:           []*jobdb.Job{queuedJobCordonedQueue.WithValidated(false)},
+			cordonedQueues:        []string{"cordonedQueue"},
+			expectedQueued:        []string{queuedJobCordonedQueue.Id()},
+			expectedQueuedVersion: 0,
+		},
+		"Submit check validates non-cordoned queue but skips cordoned queue": {
+			initialJobs:           []*jobdb.Job{queuedJob.WithValidated(false), queuedJobCordonedQueue.WithValidated(false)},
+			cordonedQueues:        []string{"cordonedQueue"},
+			expectedQueued:        []string{queuedJob.Id(), queuedJobCordonedQueue.Id()},
+			expectedValidated:     []string{queuedJob.Id()},
+			expectedQueuedVersion: 0,
+		},
+		"Submit check proceeds when queue cache errors": {
+			initialJobs:           []*jobdb.Job{queuedJob.WithValidated(false)},
+			queueCacheError:       true,
 			expectedQueued:        []string{queuedJob.Id()},
 			expectedValidated:     []string{queuedJob.Id()},
 			expectedQueuedVersion: 0,
@@ -935,6 +972,11 @@ func TestScheduler_TestCycle(t *testing.T) {
 			clusterRepo := &testExecutorRepository{
 				updateTimes: map[string]time.Time{"testExecutor": heartbeatTime},
 			}
+			var queues []*api.Queue
+			for _, name := range tc.cordonedQueues {
+				queues = append(queues, &api.Queue{Name: name, Cordoned: true})
+			}
+			queueCache := &testQueueCache{queues: queues, shouldError: tc.queueCacheError}
 			sched, err := NewScheduler(
 				testfixtures.NewJobDb(testfixtures.TestResourceListFactory),
 				jobRepo,
@@ -953,6 +995,7 @@ func TestScheduler_TestCycle(t *testing.T) {
 				schedulerMetrics,
 				pricing.NoopBidPriceProvider{},
 				[]string{},
+				queueCache,
 			)
 			require.NoError(t, err)
 			sched.EnableAssertions()
@@ -1145,6 +1188,7 @@ func TestRun(t *testing.T) {
 		schedulerMetrics,
 		pricing.NoopBidPriceProvider{},
 		[]string{},
+		&testQueueCache{},
 	)
 	require.NoError(t, err)
 	sched.EnableAssertions()
@@ -1336,6 +1380,7 @@ func TestJobPriceUpdates(t *testing.T) {
 				schedulerMetrics,
 				priceProvider,
 				tc.marketDrivenPools,
+				&testQueueCache{},
 			)
 			require.NoError(t, err)
 
@@ -1523,6 +1568,7 @@ func TestScheduler_TestSyncInitialState(t *testing.T) {
 				schedulerMetrics,
 				pricing.NoopBidPriceProvider{},
 				[]string{},
+				&testQueueCache{},
 			)
 			require.NoError(t, err)
 			sched.EnableAssertions()
@@ -1736,6 +1782,7 @@ func TestScheduler_TestSyncState(t *testing.T) {
 				schedulerMetrics,
 				pricing.NoopBidPriceProvider{},
 				[]string{},
+				&testQueueCache{},
 			)
 			require.NoError(t, err)
 			sched.EnableAssertions()
@@ -1797,6 +1844,18 @@ func (t *testSubmitChecker) Check(_ *armadacontext.Context, jobs []*jobdb.Job) (
 		}
 	}
 	return result, nil
+}
+
+type testQueueCache struct {
+	queues      []*api.Queue
+	shouldError bool
+}
+
+func (t *testQueueCache) GetAll(_ *armadacontext.Context) ([]*api.Queue, error) {
+	if t.shouldError {
+		return nil, fmt.Errorf("queue cache error")
+	}
+	return t.queues, nil
 }
 
 // Test implementations of the interfaces needed by the Scheduler
@@ -2983,6 +3042,7 @@ func TestCycleConsistency(t *testing.T) {
 					schedulerMetrics,
 					pricing.NoopBidPriceProvider{},
 					[]string{},
+					&testQueueCache{},
 				)
 				require.NoError(t, err)
 				scheduler.clock = testClock

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -426,11 +426,10 @@ func TestScheduler_TestCycle(t *testing.T) {
 			expectedValidated:     []string{queuedJob.Id()},
 			expectedQueuedVersion: 0,
 		},
-		"Submit check proceeds when queue cache errors": {
+		"Submit check skipped when queue cache errors": {
 			initialJobs:           []*jobdb.Job{queuedJob.WithValidated(false)},
 			queueCacheError:       true,
 			expectedQueued:        []string{queuedJob.Id()},
-			expectedValidated:     []string{queuedJob.Id()},
 			expectedQueuedVersion: 0,
 		},
 		"Lease a single job from an update": {

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -426,7 +426,7 @@ func TestScheduler_TestCycle(t *testing.T) {
 			expectedValidated:     []string{queuedJob.Id()},
 			expectedQueuedVersion: 0,
 		},
-		"Submit check skipped when queue cache errors": {
+		"Submit check fails fast when queue cache errors": {
 			initialJobs:           []*jobdb.Job{queuedJob.WithValidated(false)},
 			queueCacheError:       true,
 			expectedQueued:        []string{queuedJob.Id()},
@@ -1010,7 +1010,7 @@ func TestScheduler_TestCycle(t *testing.T) {
 			// run a scheduler cycle
 			ctx, cancel := armadacontext.WithTimeout(armadacontext.Background(), 5*time.Second)
 			err = sched.cycle(ctx, false, sched.leaderController.GetToken(), true, 1)
-			if tc.fetchError || tc.publishError || tc.scheduleError {
+			if tc.fetchError || tc.publishError || tc.scheduleError || tc.queueCacheError {
 				assert.Error(t, err)
 			} else {
 				require.NoError(t, err)

--- a/internal/scheduler/schedulerapp.go
+++ b/internal/scheduler/schedulerapp.go
@@ -397,6 +397,7 @@ func Run(config schedulerconfig.Configuration) error {
 		schedulerMetrics,
 		bidPriceProvider,
 		marketDrivenPools,
+		queueCache,
 	)
 	if err != nil {
 		return errors.WithMessage(err, "error creating scheduler")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you: -->

#### What type of PR is this?

Enhancement

#### What this PR does / why we need it

When a queue is cordoned, the scheduling algo already refuses to schedule jobs from it (`constraints.CheckJobConstraints` returns `QueueCordonedUnschedulableReason`). However, the submit check was still running for cordoned queue jobs. This wasted compute on jobs that could never be scheduled and marked them as "validated" with assigned pools, which is misleading.

This PR makes `submitCheck` skip jobs from cordoned queues entirely, leaving them unvalidated. If the queue is later uncordoned, the jobs will be picked up by `UnvalidatedJobs()` on the next scheduler cycle and validated normally. The filtering happens at the top of `scheduler.submitCheck()`, alongside the existing terminal-job filter, so cordoned queue jobs never enter the submit check pipeline.

If the queue cache is unavailable, the submit check fails fast and throws the error so this doesn't go undetected / silently fail.

#### Special notes for your reviewer

- The `Scheduler` struct gains a `queueCache` dependency. This is the same `QueueCache` already used by the `SubmitChecker` and other scheduler components.
- Cordoned queue jobs are **skipped** (left unvalidated), not rejected (terminal failure). I did this intentionally as cordoning is temporary, so jobs should survive it. Open to feedback on this approach, though.