### PR TITLE
Set eventingester lease namespace by default in helm chart

### DIFF
--- a/config/eventingester/config.yaml
+++ b/config/eventingester/config.yaml
@@ -40,7 +40,7 @@ metrics:
     leader:
       mode: "kubernetes"
       leaseLockName: "armada-redis-metrics-leader"
-      leaseLockNamespace: "armada"
+      leaseLockNamespace: "armada" # This must be set so viper allows env vars to overwrite it
       leaseDuration: 15s
       renewDeadline: 10s
       retryPeriod: 2s

--- a/deployment/event-ingester/templates/deployment.yaml
+++ b/deployment/event-ingester/templates/deployment.yaml
@@ -38,8 +38,12 @@ spec:
           args:
             - --config
             - /config/application_config.yaml
-          {{- if .Values.env }}
           env:
+            - name: ARMADA_METRICS_REDIS_LEADER_LEASELOCKNAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          {{- if .Values.env }}
             {{- toYaml .Values.env | nindent 12 -}}
           {{- end }}
           resources:


### PR DESCRIPTION
This will set the lease namespace to match the current namespace in helm, so deployments into k8s will always use the current namespace creating the lease