### PR TITLE
Make each package use a unique redis db in tests

### DIFF
--- a/internal/eventingester/metrics/redis/collector_test.go
+++ b/internal/eventingester/metrics/redis/collector_test.go
@@ -957,7 +957,7 @@ func TestHistogramBuckets_AgeDistribution(t *testing.T) {
 }
 
 func withRedisClient(ctx *armadacontext.Context, action func(client redis.UniversalClient)) {
-	client := redis.NewClient(&redis.Options{Addr: "localhost:6379", DB: 12})
+	client := redis.NewClient(&redis.Options{Addr: "localhost:6379", DB: 7})
 	defer client.FlushDB(ctx)
 	defer client.Close()
 

--- a/internal/eventingester/repository/scanner_test.go
+++ b/internal/eventingester/repository/scanner_test.go
@@ -119,7 +119,7 @@ func TestScanAll_ContextCancelled(t *testing.T) {
 }
 
 func withRedisClient(ctx *armadacontext.Context, action func(client redis.UniversalClient)) {
-	client := redis.NewClient(&redis.Options{Addr: "localhost:6379", DB: 11})
+	client := redis.NewClient(&redis.Options{Addr: "localhost:6379", DB: 8})
 	defer client.FlushDB(ctx)
 	defer client.Close()
 

--- a/internal/eventingester/store/eventstore_test.go
+++ b/internal/eventingester/store/eventstore_test.go
@@ -47,11 +47,11 @@ func TestReportEvents(t *testing.T) {
 }
 
 func withRedisEventStore(ctx *armadacontext.Context, action func(es *RedisEventStore)) {
-	client := redis.NewClient(&redis.Options{Addr: "localhost:6379", DB: 10})
+	client := redis.NewClient(&redis.Options{Addr: "localhost:6379", DB: 5})
 	defer client.FlushDB(ctx)
 	defer client.Close()
 
-	client2 := redis.NewClient(&redis.Options{Addr: "localhost:6379", DB: 11})
+	client2 := redis.NewClient(&redis.Options{Addr: "localhost:6379", DB: 6})
 	defer client2.FlushDB(ctx)
 	defer client2.Close()
 


### PR DESCRIPTION
This is a bad bit a tech debt we should pay down

However for now, I've simply made sure all packages use unique db numbers, to avoid clashes + flakes

