### PR TITLE
Fix eventingester leadership config - plumb podname through

### DIFF
--- a/config/eventingester/config.yaml
+++ b/config/eventingester/config.yaml
@@ -44,4 +44,5 @@ metrics:
       leaseLockNamespace: "armada" # This must be set so viper allows env vars to overwrite it
       leaseDuration: 15s
       renewDeadline: 10s
+      podName: "" # This must be set so viper allows env vars to overwrite it
       retryPeriod: 2s

--- a/deployment/event-ingester/templates/deployment.yaml
+++ b/deployment/event-ingester/templates/deployment.yaml
@@ -39,6 +39,10 @@ spec:
             - --config
             - /config/application_config.yaml
           env:
+            - name: ARMADA_METRICS_REDIS_LEADER_PODNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: ARMADA_METRICS_REDIS_LEADER_LEASELOCKNAMESPACE
               valueFrom:
                 fieldRef:

--- a/internal/eventingester/configuration/types.go
+++ b/internal/eventingester/configuration/types.go
@@ -67,6 +67,7 @@ type LeaderConfig struct {
 	LeaseDuration      time.Duration
 	RenewDeadline      time.Duration
 	RetryPeriod        time.Duration
+	PodName            string
 }
 
 // TODO: unpack this into just EventExpirtation

--- a/internal/eventingester/ingester.go
+++ b/internal/eventingester/ingester.go
@@ -173,6 +173,7 @@ func createLeaderController(ctx *armadacontext.Context, config configuration.Lea
 			LeaseDuration:      config.LeaseDuration,
 			RenewDeadline:      config.RenewDeadline,
 			RetryPeriod:        config.RetryPeriod,
+			PodName:            config.PodName,
 		}
 
 		leaderController := leader.NewKubernetesLeaderController(schedulerLeaderConfig, clientSet.CoordinationV1())


### PR DESCRIPTION
The eventingester leadership configuration did not include podname which it uses for the lease identity

This causes the application to panic if it tries to get a lease (as it doesn't provide a lead id)

I've now plumbed PodName through the config + made the k8s chart set this to the current pod name by default

