### PR TITLE
Lookout UI: implement realistic fake data for service hooks

### DIFF
--- a/internal/lookoutui/src/common/fakeJobsUtils.ts
+++ b/internal/lookoutui/src/common/fakeJobsUtils.ts
@@ -246,6 +246,37 @@ export function makeManyTestJobs(numJobs: number, numFinishedJobs: number): Job[
   return jobs
 }
 
+export function makeFakeJobSpec(jobId: string): Record<string, any> {
+  return {
+    id: jobId,
+    // eslint-disable-next-line @cspell/spellchecker
+    clientId: "01gvgjbr0jrzvschp2f8jhk6n5",
+    jobSetId: "demo-project-0",
+    queue: "demo",
+    namespace: "default",
+    owner: "anonymous",
+    podSpec: {
+      containers: [
+        {
+          name: "cpu-burner",
+          image: "alpine-stress:latest",
+          command: ["sh"],
+          args: ["-c", "echo STARTED && sleep 60"],
+          resources: {
+            limits: { cpu: "200m", "ephemeral-storage": "8Gi", memory: "128Mi", "nvidia.com/gpu": "8" },
+            requests: { cpu: "200m", "ephemeral-storage": "8Gi", memory: "128Mi", "nvidia.com/gpu": "8" },
+          },
+          imagePullPolicy: "IfNotPresent",
+        },
+      ],
+      restartPolicy: "Never",
+      terminationGracePeriodSeconds: 1,
+      priorityClassName: "armada-default",
+    },
+    created: "2023-03-14T17:23:21.29874Z",
+  }
+}
+
 export function getActiveJobSets(jobs: Job[]): Record<string, string[]> {
   const result: Record<string, string[]> = {}
   for (const job of jobs) {

--- a/internal/lookoutui/src/pages/jobs/components/JobsTableContainer.test.tsx
+++ b/internal/lookoutui/src/pages/jobs/components/JobsTableContainer.test.tsx
@@ -94,7 +94,7 @@ describe("JobsTableContainer", () => {
     vi.unstubAllGlobals()
   })
 
-  const renderComponent = (_fakeJobs: Job[] = [], search?: string) => {
+  const renderComponent = (search?: string) => {
     // Create a fresh query client for each test to avoid cache pollution
     const testQueryClient = new QueryClient({
       defaultOptions: {
@@ -145,7 +145,7 @@ describe("JobsTableContainer", () => {
   it("should render a spinner while loading initially", async () => {
     // Mock the jobs endpoint to never resolve to test loading state
     mockServer.setPostJobsResponse([])
-    const { findAllByRole } = renderComponent([])
+    const { findAllByRole } = renderComponent()
     await findAllByRole("progressbar")
   })
 
@@ -163,7 +163,7 @@ describe("JobsTableContainer", () => {
 
     mockServer.setPostJobsResponse(jobs)
 
-    const { findByText } = renderComponent(jobs, `?page=0&sort[id]=jobId&sort[desc]=false`)
+    const { findByText } = renderComponent(`?page=0&sort[id]=jobId&sort[desc]=false`)
     await waitForFinishedLoading()
     await findByText("1–50 of more than 50")
   })
@@ -173,7 +173,7 @@ describe("JobsTableContainer", () => {
 
     mockServer.setPostJobsResponse(jobs)
 
-    const { findByText } = renderComponent(jobs, `?page=1&sort[id]=jobId&sort[desc]=false`)
+    const { findByText } = renderComponent(`?page=1&sort[id]=jobId&sort[desc]=false`)
     await waitForFinishedLoading()
     await findByText("51–60 of 60")
   })
@@ -193,7 +193,7 @@ describe("JobsTableContainer", () => {
 
       mockServer.setPostJobsResponse(jobs)
 
-      renderComponent(jobs)
+      renderComponent()
       await waitForFinishedLoading()
 
       await groupByColumn(displayString)
@@ -220,7 +220,7 @@ describe("JobsTableContainer", () => {
 
       mockServer.setPostJobsResponse(jobs)
 
-      renderComponent(jobs)
+      renderComponent()
 
       // Group to 3 levels
       await groupByColumn("Queue")
@@ -252,7 +252,7 @@ describe("JobsTableContainer", () => {
 
       mockServer.setPostJobsResponse(jobs)
 
-      const { getByRole, queryAllByRole } = renderComponent(jobs)
+      const { getByRole, queryAllByRole } = renderComponent()
       await waitForFinishedLoading()
 
       await groupByColumn("Queue")
@@ -285,7 +285,7 @@ describe("JobsTableContainer", () => {
 
       mockServer.setPostJobsResponse(jobs)
 
-      const { findByRole } = renderComponent(jobs)
+      const { findByRole } = renderComponent()
       await waitForFinishedLoading()
       await groupByColumn("Queue")
 
@@ -320,7 +320,7 @@ describe("JobsTableContainer", () => {
 
       mockServer.setPostJobsResponse(jobs)
 
-      const { findByRole } = renderComponent(jobs)
+      const { findByRole } = renderComponent()
       await waitForFinishedLoading()
 
       await toggleSelectedRow("jobId", jobs[0].jobId)
@@ -338,7 +338,7 @@ describe("JobsTableContainer", () => {
 
       mockServer.setPostJobsResponse(jobs)
 
-      const { findByRole } = renderComponent(jobs)
+      const { findByRole } = renderComponent()
       await waitForFinishedLoading()
       await groupByColumn("Queue")
 
@@ -368,7 +368,7 @@ describe("JobsTableContainer", () => {
       mockServer.setGetQueuesResponse(["queue-1", "queue-2"])
       mockServer.setPostJobsResponse(jobs)
 
-      const { baseElement } = renderComponent(jobs)
+      const { baseElement } = renderComponent()
       await waitForFinishedLoading()
       await assertNumDataRowsShown(30)
 
@@ -388,7 +388,7 @@ describe("JobsTableContainer", () => {
       ]
 
       mockServer.setPostJobsResponse(jobs)
-      renderComponent(jobs)
+      renderComponent()
       await clearAllGroupings()
       await waitForFinishedLoading()
 
@@ -408,7 +408,7 @@ describe("JobsTableContainer", () => {
         ...makeTestJobs(5, "queue-3", "job-set-2", JobState.Cancelled),
       ]
       mockServer.setPostJobsResponse(jobs)
-      renderComponent(jobs)
+      renderComponent()
       await clearAllGroupings()
       await waitForFinishedLoading()
 
@@ -432,7 +432,7 @@ describe("JobsTableContainer", () => {
 
       mockServer.setPostJobsResponse(jobs)
 
-      const { findAllByRole } = renderComponent(jobs)
+      const { findAllByRole } = renderComponent()
       await clearAllGroupings()
       await waitForFinishedLoading()
 
@@ -463,7 +463,7 @@ describe("JobsTableContainer", () => {
 
       mockServer.setPostJobsResponse(jobs)
 
-      const { getAllByRole } = renderComponent(jobs)
+      const { getAllByRole } = renderComponent()
       await waitForFinishedLoading()
 
       await toggleSorting("Job ID")
@@ -494,7 +494,7 @@ describe("JobsTableContainer", () => {
 
       mockServer.setPostJobsResponse(jobs)
 
-      const { findByRole } = renderComponent(jobs)
+      const { findByRole } = renderComponent()
       await waitForFinishedLoading()
       await assertNumDataRowsShown(30)
 
@@ -524,7 +524,7 @@ describe("JobsTableContainer", () => {
       mockServer.setGetQueuesResponse(["queue-1", "queue-2", "queue-3"])
       mockServer.setPostJobsResponse(jobs)
 
-      const { findByText, baseElement } = renderComponent(jobs)
+      const { findByText, baseElement } = renderComponent()
       await waitForFinishedLoading()
 
       // Applying grouping and filtering
@@ -555,7 +555,7 @@ describe("JobsTableContainer", () => {
 
       mockServer.setPostJobsResponse(jobs)
 
-      const { getByRole } = renderComponent(jobs)
+      const { getByRole } = renderComponent()
       await waitForFinishedLoading()
 
       const firstJob = jobs[0]
@@ -575,7 +575,7 @@ describe("JobsTableContainer", () => {
 
       mockServer.setPostJobsResponse(jobs)
 
-      const { findByRole, queryByRole } = renderComponent(jobs)
+      const { findByRole, queryByRole } = renderComponent()
       await waitForFinishedLoading()
 
       await groupByColumn("Queue")
@@ -610,7 +610,7 @@ describe("JobsTableContainer", () => {
 
       mockServer.setPostJobsResponse(jobs)
 
-      const { router, baseElement, findByText } = renderComponent(jobs)
+      const { router, baseElement, findByText } = renderComponent()
       await waitForFinishedLoading()
 
       await findByText(targetJobId, undefined, { timeout: 3_000 })
@@ -655,7 +655,6 @@ describe("JobsTableContainer", () => {
       mockServer.setPostJobsResponse(jobs)
 
       renderComponent(
-        jobs,
         // eslint-disable-next-line @cspell/spellchecker
         `?page=0&g[0]=jobSet&sort[id]=jobId&sort[desc]=true&pS=50&f[0][id]=jobSet&f[0][value]=job-set-1&f[0][match]=startsWith&e[0]=jobSet%3Ajob-set-1`,
       )
@@ -674,7 +673,7 @@ describe("JobsTableContainer", () => {
 
       mockServer.setPostJobsResponse(jobs)
 
-      const { getAllByRole } = renderComponent(jobs, `?page=1&sort[id]=jobId&sort[desc]=false`)
+      const { getAllByRole } = renderComponent(`?page=1&sort[id]=jobId&sort[desc]=false`)
       await waitForFinishedLoading()
       await waitFor(() => {
         const rows = getAllByRole("row")

--- a/internal/lookoutui/src/services/lookout/useCancelJobSets.ts
+++ b/internal/lookoutui/src/services/lookout/useCancelJobSets.ts
@@ -1,6 +1,7 @@
 import { useMutation } from "@tanstack/react-query"
 
 import { getErrorMessage } from "../../common/utils"
+import { getConfig } from "../../config"
 import { JobSet } from "../../models/lookoutModels"
 import { ApiJobState } from "../../openapi/armada"
 
@@ -22,10 +23,19 @@ export interface CancelJobSetsVariables {
 }
 
 export const useCancelJobSets = () => {
+  const config = getConfig()
   const { submitApi } = useApiClients()
 
   return useMutation<CancelJobSetsResponse, string, CancelJobSetsVariables>({
     mutationFn: async ({ queue, jobSets, states, reason }) => {
+      if (config.fakeDataEnabled) {
+        await new Promise((r) => setTimeout(r, 1_000))
+        return {
+          cancelledJobSets: jobSets,
+          failedJobSetCancellations: [],
+        }
+      }
+
       const response: CancelJobSetsResponse = {
         cancelledJobSets: [],
         failedJobSetCancellations: [],

--- a/internal/lookoutui/src/services/lookout/useGetJobSpec.ts
+++ b/internal/lookoutui/src/services/lookout/useGetJobSpec.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query"
 
+import { makeFakeJobSpec } from "../../common/fakeJobsUtils"
 import { getErrorMessage } from "../../common/utils"
 import { getConfig } from "../../config"
 import { useAuthenticatedFetch } from "../../oidcAuth"
@@ -13,7 +14,7 @@ export const useGetJobSpec = (jobId: string, enabled = true) => {
     queryFn: async ({ signal }) => {
       try {
         if (config.fakeDataEnabled) {
-          return {}
+          return makeFakeJobSpec(jobId)
         }
 
         const response = await authenticatedFetch("/api/v1/jobSpec", {

--- a/internal/lookoutui/src/services/lookout/useGetJobs.ts
+++ b/internal/lookoutui/src/services/lookout/useGetJobs.ts
@@ -2,9 +2,10 @@ import { useMemo } from "react"
 
 import { QueryFunction, QueryKey, useQuery } from "@tanstack/react-query"
 
+import { compareValues, makeRandomJobs, mergeFilters } from "../../common/fakeJobsUtils"
 import { getErrorMessage } from "../../common/utils"
 import { getConfig } from "../../config"
-import { Job, JobFilter, JobOrder } from "../../models/lookoutModels"
+import { Job, JobFilter, JobKey, JobOrder } from "../../models/lookoutModels"
 import { useAuthenticatedFetch } from "../../oidcAuth"
 
 export interface GetJobsParams {
@@ -19,6 +20,15 @@ export interface GetJobsResponse {
   jobs: Job[]
 }
 
+let fakeJobsCache: Job[] | undefined
+
+function getFakeJobs(): Job[] {
+  if (fakeJobsCache === undefined) {
+    fakeJobsCache = makeRandomJobs(10_000, 42)
+  }
+  return fakeJobsCache
+}
+
 const getQueryFn =
   (
     params: GetJobsParams,
@@ -29,7 +39,15 @@ const getQueryFn =
   async ({ signal }) => {
     try {
       if (fakeDataEnabled) {
-        return { jobs: [] }
+        const filtered = getFakeJobs().filter(mergeFilters(params.filters))
+        const sorted = [...filtered].sort((a, b) =>
+          compareValues(
+            (a as Record<string, unknown>)[params.order.field as JobKey],
+            (b as Record<string, unknown>)[params.order.field as JobKey],
+            params.order.direction,
+          ),
+        )
+        return { jobs: sorted.slice(params.skip, params.skip + params.take) }
       }
 
       let path = "/api/v1/jobs"

--- a/internal/lookoutui/src/services/lookout/useGroupJobs.ts
+++ b/internal/lookoutui/src/services/lookout/useGroupJobs.ts
@@ -1,8 +1,9 @@
-import { useCallback } from "react"
+import { useCallback, useMemo } from "react"
 
+import { makeRandomJobs, mergeFilters } from "../../common/fakeJobsUtils"
 import { getErrorMessage } from "../../common/utils"
 import { getConfig } from "../../config"
-import { AggregateType, JobFilter, JobGroup, JobOrder } from "../../models/lookoutModels"
+import { AggregateType, Job, JobFilter, JobGroup, JobOrder, JobState } from "../../models/lookoutModels"
 import { useAuthenticatedFetch } from "../../oidcAuth"
 
 export type GroupedField = {
@@ -15,9 +16,57 @@ export type GroupJobsResponse = {
   groups: JobGroup[]
 }
 
+let fakeJobsCache: Job[] | undefined
+
+function getFakeJobs(): Job[] {
+  if (fakeJobsCache === undefined) {
+    fakeJobsCache = makeRandomJobs(10_000, 42)
+  }
+  return fakeJobsCache
+}
+
+function groupFakeJobs(
+  jobs: Job[],
+  filters: JobFilter[],
+  activeJobSets: boolean,
+  groupedField: GroupedField,
+  skip: number,
+  take: number,
+): JobGroup[] {
+  let filtered = jobs.filter(mergeFilters(filters))
+  if (activeJobSets) {
+    const activeStates = new Set([JobState.Queued, JobState.Leased, JobState.Pending, JobState.Running])
+    filtered = filtered.filter((j) => activeStates.has(j.state))
+  }
+
+  const grouped = new Map<string, Job[]>()
+  for (const job of filtered) {
+    const key = groupedField.isAnnotation
+      ? (job.annotations[groupedField.field] ?? "")
+      : String((job as Record<string, unknown>)[groupedField.field] ?? "")
+    if (!grouped.has(key)) {
+      grouped.set(key, [])
+    }
+    grouped.get(key)!.push(job)
+  }
+
+  return [...grouped.entries()].slice(skip, skip + take).map(([name, groupJobs]) => {
+    const stateCounts: Record<string, number> = {}
+    for (const j of groupJobs) {
+      stateCounts[j.state] = (stateCounts[j.state] ?? 0) + 1
+    }
+    return {
+      name,
+      count: groupJobs.length,
+      aggregates: { state: stateCounts },
+    }
+  })
+}
+
 export const useGroupJobs = () => {
   const authenticatedFetch = useAuthenticatedFetch()
   const config = getConfig()
+  const fakeJobs = useMemo(() => (config.fakeDataEnabled ? getFakeJobs() : []), [config.fakeDataEnabled])
 
   return useCallback(
     async (
@@ -31,7 +80,7 @@ export const useGroupJobs = () => {
       abortSignal?: AbortSignal,
     ): Promise<GroupJobsResponse> => {
       if (config.fakeDataEnabled) {
-        return { groups: [] }
+        return { groups: groupFakeJobs(fakeJobs, filters, activeJobSets, groupedField, skip, take) }
       }
 
       try {
@@ -63,6 +112,6 @@ export const useGroupJobs = () => {
         throw await getErrorMessage(e)
       }
     },
-    [authenticatedFetch, config.backend, config.fakeDataEnabled],
+    [authenticatedFetch, config.backend, config.fakeDataEnabled, fakeJobs],
   )
 }

--- a/internal/lookoutui/src/services/lookout/useReprioritizeJobSets.ts
+++ b/internal/lookoutui/src/services/lookout/useReprioritizeJobSets.ts
@@ -1,6 +1,7 @@
 import { useMutation } from "@tanstack/react-query"
 
 import { getErrorMessage } from "../../common/utils"
+import { getConfig } from "../../config"
 import { JobSet } from "../../models/lookoutModels"
 
 import { useApiClients } from "../apiClients"
@@ -20,10 +21,19 @@ export interface ReprioritizeJobSetsVariables {
 }
 
 export const useReprioritizeJobSets = () => {
+  const config = getConfig()
   const { submitApi } = useApiClients()
 
   return useMutation<ReprioritizeJobSetsResponse, string, ReprioritizeJobSetsVariables>({
     mutationFn: async ({ queue, jobSets, newPriority }) => {
+      if (config.fakeDataEnabled) {
+        await new Promise((r) => setTimeout(r, 1_000))
+        return {
+          reprioritizedJobSets: jobSets,
+          failedJobSetReprioritizations: [],
+        }
+      }
+
       const response: ReprioritizeJobSetsResponse = {
         reprioritizedJobSets: [],
         failedJobSetReprioritizations: [],


### PR DESCRIPTION
Replace empty stub responses in useGetJobs, useGroupJobs, useGetJobSpec, useCancelJobSets, and useReprioritizeJobSets with realistic fake data when fakeDataEnabled is set. Remove unused parameter from test helper.

Addresses comments in #4848.