### PR TITLE
Add job_failure_category_total counter metric to executor

### DIFF
--- a/internal/executor/metrics/metrics.go
+++ b/internal/executor/metrics/metrics.go
@@ -1,3 +1,36 @@
 package metrics
 
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
 const ArmadaExecutorMetricsPrefix = "armada_executor_"
+
+const (
+	failureCategoryLabel    = "failure_category"
+	failureSubcategoryLabel = "failure_subcategory"
+)
+
+var jobFailureCategoryTotal = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: ArmadaExecutorMetricsPrefix + "job_failure_category_total",
+		Help: "Total number of job failures by failure category and subcategory",
+	},
+	[]string{failureCategoryLabel, failureSubcategoryLabel},
+)
+
+// RecordJobFailure increments the per-category failure counter. Should be
+// called from paths that commit to emitting a JobFailedEvent — retryable
+// pod issues that emit a ReturnLease instead must not call this.
+//
+// An empty category indicates no classification happened (e.g. the feature
+// flag is off or the classifier is nil); in that case no metric is emitted.
+// An empty subcategory is allowed and indicates a matched rule with no
+// subcategory set; it produces an empty-string label value.
+func RecordJobFailure(category, subcategory string) {
+	if category == "" {
+		return
+	}
+	jobFailureCategoryTotal.WithLabelValues(category, subcategory).Inc()
+}

--- a/internal/executor/metrics/metrics_test.go
+++ b/internal/executor/metrics/metrics_test.go
@@ -1,0 +1,40 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRecordJobFailure(t *testing.T) {
+	tests := map[string]struct {
+		category      string
+		subcategory   string
+		expectedDelta float64
+	}{
+		"increments counter for category and subcategory": {
+			category:      "metrics-test-cat",
+			subcategory:   "metrics-test-sub",
+			expectedDelta: 1,
+		},
+		"accepts empty subcategory": {
+			category:      "metrics-test-empty-sub",
+			subcategory:   "",
+			expectedDelta: 1,
+		},
+		"empty category is a no-op": {
+			category:      "",
+			subcategory:   "metrics-test-empty-cat",
+			expectedDelta: 0,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			before := testutil.ToFloat64(jobFailureCategoryTotal.WithLabelValues(tc.category, tc.subcategory))
+			RecordJobFailure(tc.category, tc.subcategory)
+			after := testutil.ToFloat64(jobFailureCategoryTotal.WithLabelValues(tc.category, tc.subcategory))
+			assert.Equal(t, tc.expectedDelta, after-before)
+		})
+	}
+}

--- a/internal/executor/reporter/event.go
+++ b/internal/executor/reporter/event.go
@@ -15,7 +15,9 @@ import (
 	"github.com/armadaproject/armada/pkg/armadaevents"
 )
 
-func CreateEventForCurrentState(pod *v1.Pod, clusterId string, classifier *categorizer.Classifier) (*armadaevents.EventSequence, error) {
+// CreateEventForCurrentState builds the armada event for pod's current phase.
+// For failed pods the caller supplies the classification result to attach to the event.
+func CreateEventForCurrentState(pod *v1.Pod, clusterId string, classifyResult categorizer.ClassifyResult) (*armadaevents.EventSequence, error) {
 	phase := pod.Status.Phase
 	sequence := createEmptySequence(pod)
 	jobId, runId, err := extractIds(pod)
@@ -81,7 +83,6 @@ func CreateEventForCurrentState(pod *v1.Pod, clusterId string, classifier *categ
 		})
 		return sequence, nil
 	case v1.PodFailed:
-		result := classifier.Classify(pod)
 		return CreateJobFailedEvent(
 			pod,
 			util.ExtractPodFailedReason(pod),
@@ -89,8 +90,8 @@ func CreateEventForCurrentState(pod *v1.Pod, clusterId string, classifier *categ
 			"",
 			util.ExtractFailedPodContainerStatuses(pod, clusterId),
 			clusterId,
-			result.Category,
-			result.Subcategory)
+			classifyResult.Category,
+			classifyResult.Subcategory)
 	case v1.PodSucceeded:
 		sequence.Events = append(sequence.Events, &armadaevents.EventSequence_Event{
 			Created: now,

--- a/internal/executor/reporter/event_sender_test.go
+++ b/internal/executor/reporter/event_sender_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/armadaproject/armada/internal/common/constants"
 	"github.com/armadaproject/armada/internal/common/util"
+	"github.com/armadaproject/armada/internal/executor/categorizer"
 	"github.com/armadaproject/armada/internal/executor/domain"
 	"github.com/armadaproject/armada/pkg/executorapi"
 )
@@ -48,7 +49,7 @@ func generateEventMessages(t *testing.T, count int) []EventMessage {
 
 	for i := 0; i < count; i++ {
 		pod := makeTestPod(v1.PodRunning)
-		event, err := CreateEventForCurrentState(pod, "cluster-1", nil)
+		event, err := CreateEventForCurrentState(pod, "cluster-1", categorizer.ClassifyResult{})
 		require.NoError(t, err)
 		result = append(result, EventMessage{Event: event, JobRunId: uuid.New().String()})
 	}

--- a/internal/executor/reporter/event_test.go
+++ b/internal/executor/reporter/event_test.go
@@ -16,7 +16,7 @@ import (
 func TestCreateEventForCurrentState_WhenPodPending(t *testing.T) {
 	pod := makeTestPod(v1.PodPending)
 
-	result, err := CreateEventForCurrentState(pod, "cluster1", nil)
+	result, err := CreateEventForCurrentState(pod, "cluster1", categorizer.ClassifyResult{})
 	assert.Nil(t, err)
 
 	assert.Len(t, result.Events, 1)
@@ -28,7 +28,7 @@ func TestCreateEventForCurrentState_WhenPodPending(t *testing.T) {
 func TestCreateEventForCurrentState_WhenPodRunning(t *testing.T) {
 	pod := makeTestPod(v1.PodRunning)
 
-	result, err := CreateEventForCurrentState(pod, "cluster1", nil)
+	result, err := CreateEventForCurrentState(pod, "cluster1", categorizer.ClassifyResult{})
 	assert.Nil(t, err)
 
 	assert.Len(t, result.Events, 1)
@@ -40,7 +40,7 @@ func TestCreateEventForCurrentState_WhenPodRunning(t *testing.T) {
 func TestCreateEventForCurrentState_WhenPodFailed(t *testing.T) {
 	pod := makeTestPod(v1.PodFailed)
 
-	result, err := CreateEventForCurrentState(pod, "cluster1", nil)
+	result, err := CreateEventForCurrentState(pod, "cluster1", categorizer.ClassifyResult{})
 	assert.Nil(t, err)
 
 	assert.Len(t, result.Events, 1)
@@ -81,7 +81,7 @@ func TestCreateEventForCurrentState_WhenPodFailed_WithClassifier(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	result, err := CreateEventForCurrentState(pod, "cluster1", classifier)
+	result, err := CreateEventForCurrentState(pod, "cluster1", classifier.Classify(pod))
 	assert.NoError(t, err)
 
 	assert.Len(t, result.Events, 1)
@@ -107,7 +107,7 @@ func TestCreateEventForCurrentState_WhenPodFailed_NilClassifier(t *testing.T) {
 		},
 	}
 
-	result, err := CreateEventForCurrentState(pod, "cluster1", nil)
+	result, err := CreateEventForCurrentState(pod, "cluster1", categorizer.ClassifyResult{})
 	assert.NoError(t, err)
 	require.Len(t, result.Events, 1)
 
@@ -122,7 +122,7 @@ func TestCreateEventForCurrentState_WhenPodFailed_NilClassifier(t *testing.T) {
 func TestCreateEventForCurrentState_WhenPodSucceeded(t *testing.T) {
 	pod := makeTestPod(v1.PodSucceeded)
 
-	result, err := CreateEventForCurrentState(pod, "cluster1", nil)
+	result, err := CreateEventForCurrentState(pod, "cluster1", categorizer.ClassifyResult{})
 	assert.Nil(t, err)
 
 	assert.Len(t, result.Events, 1)
@@ -133,7 +133,7 @@ func TestCreateEventForCurrentState_WhenPodSucceeded(t *testing.T) {
 func TestCreateEventForCurrentState_ShouldError_WhenPodPhaseUnknown(t *testing.T) {
 	pod := makeTestPod(v1.PodUnknown)
 
-	_, err := CreateEventForCurrentState(pod, "cluster1", nil)
+	_, err := CreateEventForCurrentState(pod, "cluster1", categorizer.ClassifyResult{})
 	assert.Error(t, err)
 }
 

--- a/internal/executor/service/job_state_reporter.go
+++ b/internal/executor/service/job_state_reporter.go
@@ -10,6 +10,7 @@ import (
 	"github.com/armadaproject/armada/internal/executor/categorizer"
 	clusterContext "github.com/armadaproject/armada/internal/executor/context"
 	domain2 "github.com/armadaproject/armada/internal/executor/domain"
+	"github.com/armadaproject/armada/internal/executor/metrics"
 	"github.com/armadaproject/armada/internal/executor/reporter"
 	"github.com/armadaproject/armada/internal/executor/util"
 )
@@ -90,7 +91,12 @@ func (stateReporter *JobStateReporter) reportCurrentStatus(pod *v1.Pod) {
 		return
 	}
 
-	event, err := reporter.CreateEventForCurrentState(pod, stateReporter.clusterContext.GetClusterId(), stateReporter.classifier)
+	var classifyResult categorizer.ClassifyResult
+	if pod.Status.Phase == v1.PodFailed {
+		classifyResult = stateReporter.classifier.Classify(pod)
+	}
+
+	event, err := reporter.CreateEventForCurrentState(pod, stateReporter.clusterContext.GetClusterId(), classifyResult)
 	if err != nil {
 		log.Errorf("Failed to report event: %v", err)
 		return
@@ -118,6 +124,9 @@ func (stateReporter *JobStateReporter) reportCurrentStatus(pod *v1.Pod) {
 			log.Errorf("Failed to report event: %s", err)
 			return
 		}
+		// Increment only after successful emission so failed sends do not inflate the counter.
+		// RecordJobFailure is a no-op for non-failure phases and for nil classifiers (empty category).
+		metrics.RecordJobFailure(classifyResult.Category, classifyResult.Subcategory)
 
 		if util.IsReportingPhaseRequired(pod.Status.Phase) {
 			err = stateReporter.addAnnotationToMarkStateReported(pod)

--- a/internal/executor/service/job_state_reporter_test.go
+++ b/internal/executor/service/job_state_reporter_test.go
@@ -11,6 +11,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/armadaproject/armada/internal/common/errormatch"
+	"github.com/armadaproject/armada/internal/executor/categorizer"
 	fakecontext "github.com/armadaproject/armada/internal/executor/context/fake"
 	"github.com/armadaproject/armada/internal/executor/domain"
 	"github.com/armadaproject/armada/internal/executor/reporter"
@@ -167,12 +169,127 @@ func TestJobStateReporter_HandlesFailedPod_WithRetryableError(t *testing.T) {
 }
 
 func setUpJobStateReporterTest(t *testing.T) (*JobStateReporter, *stubIssueHandler, *mocks.FakeEventReporter, *fakecontext.SyncFakeClusterContext) {
+	return setUpJobStateReporterTestWithClassifier(t, nil, &stubIssueHandler{})
+}
+
+func setUpJobStateReporterTestWithClassifier(
+	t *testing.T,
+	classifier *categorizer.Classifier,
+	issueHandler *stubIssueHandler,
+) (*JobStateReporter, *stubIssueHandler, *mocks.FakeEventReporter, *fakecontext.SyncFakeClusterContext) {
 	fakeClusterContext := fakecontext.NewSyncFakeClusterContext()
 	eventReporter := mocks.NewFakeEventReporter()
-	issueHandler := &stubIssueHandler{detectAndRegisterFailedPodIssueResult: false, detectAndRegisterFailedPodIssueError: nil}
-	jobStateReporter, err := NewJobStateReporter(fakeClusterContext, eventReporter, issueHandler, nil)
+	jobStateReporter, err := NewJobStateReporter(fakeClusterContext, eventReporter, issueHandler, classifier)
 	require.NoError(t, err)
 	return jobStateReporter, issueHandler, eventReporter, fakeClusterContext
+}
+
+func makeFailedPodWithExitCode(t *testing.T, exitCode int32) *v1.Pod {
+	t.Helper()
+	pod := makeTestPod(v1.PodStatus{
+		Phase: v1.PodFailed,
+		ContainerStatuses: []v1.ContainerStatus{
+			{
+				Name: "main",
+				State: v1.ContainerState{
+					Terminated: &v1.ContainerStateTerminated{ExitCode: exitCode, Reason: "Error"},
+				},
+			},
+		},
+	})
+	return pod
+}
+
+func classifierForExitCode(t *testing.T, category, subcategory string, exitCode int32) *categorizer.Classifier {
+	t.Helper()
+	c, err := categorizer.NewClassifier(categorizer.ErrorCategoriesConfig{
+		Categories: []categorizer.CategoryConfig{
+			{
+				Name: category,
+				Rules: []categorizer.CategoryRule{
+					{
+						OnExitCodes: &errormatch.ExitCodeMatcher{
+							Operator: errormatch.ExitCodeOperatorIn,
+							Values:   []int32{exitCode},
+						},
+						Subcategory: subcategory,
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	return c
+}
+
+// The metric counter itself is tested in the metrics package.
+// These tests cover the emission gating that governs when the counter is
+// advanced: a JobFailedEvent must be emitted (not a ReturnLease or a no-op).
+
+func TestJobStateReporter_PodFailed_EmitsJobFailedEventWhenClassifierMatches(t *testing.T) {
+	classifier := classifierForExitCode(t, "jsr-emit-cat", "jsr-emit-sub", 42)
+	_, _, eventReporter, fakeClusterContext := setUpJobStateReporterTestWithClassifier(t, classifier, &stubIssueHandler{})
+
+	pod := makeFailedPodWithExitCode(t, 42)
+	addPod(t, fakeClusterContext, pod)
+	fakeClusterContext.SimulatePodAddEvent(pod)
+	time.Sleep(time.Millisecond * 100)
+
+	assert.Len(t, eventReporter.ReceivedEvents, 1)
+}
+
+func TestJobStateReporter_PodFailed_SuppressesEmissionWhenRetryableIssueRegistered(t *testing.T) {
+	classifier := classifierForExitCode(t, "jsr-retryable-cat", "jsr-retryable-sub", 42)
+	_, _, eventReporter, fakeClusterContext := setUpJobStateReporterTestWithClassifier(
+		t, classifier,
+		&stubIssueHandler{detectAndRegisterFailedPodIssueResult: true},
+	)
+
+	pod := makeFailedPodWithExitCode(t, 42)
+	addPod(t, fakeClusterContext, pod)
+	fakeClusterContext.SimulatePodAddEvent(pod)
+	time.Sleep(time.Millisecond * 100)
+
+	assert.Len(t, eventReporter.ReceivedEvents, 0, "retryable issue path emits ReturnLease, not JobFailed")
+}
+
+func TestJobStateReporter_PodFailed_SuppressesEmissionWhenIssueAlreadyExists(t *testing.T) {
+	classifier := classifierForExitCode(t, "jsr-existing-cat", "jsr-existing-sub", 42)
+	pod := makeFailedPodWithExitCode(t, 42)
+	_, _, eventReporter, fakeClusterContext := setUpJobStateReporterTestWithClassifier(
+		t, classifier,
+		&stubIssueHandler{runIdsWithIssues: map[string]bool{util.ExtractJobRunId(pod): true}},
+	)
+
+	addPod(t, fakeClusterContext, pod)
+	fakeClusterContext.SimulatePodAddEvent(pod)
+	time.Sleep(time.Millisecond * 100)
+
+	assert.Len(t, eventReporter.ReceivedEvents, 0, "run already owned by issue handler - no direct emission from this path")
+}
+
+func TestJobStateReporter_PodFailed_DropsEventWhenReporterErrors(t *testing.T) {
+	classifier := classifierForExitCode(t, "jsr-report-error-cat", "jsr-report-error-sub", 42)
+	_, _, eventReporter, fakeClusterContext := setUpJobStateReporterTestWithClassifier(t, classifier, &stubIssueHandler{})
+	eventReporter.ErrorOnReport = true
+
+	pod := makeFailedPodWithExitCode(t, 42)
+	addPod(t, fakeClusterContext, pod)
+	fakeClusterContext.SimulatePodAddEvent(pod)
+	time.Sleep(time.Millisecond * 100)
+
+	assert.Len(t, eventReporter.ReceivedEvents, 0, "event is dropped when reporter errors - counter increment is gated behind successful emission")
+}
+
+func TestJobStateReporter_PodFailed_EmitsEventWithEmptyCategoryWhenClassifierIsNil(t *testing.T) {
+	_, _, eventReporter, fakeClusterContext := setUpJobStateReporterTestWithClassifier(t, nil, &stubIssueHandler{})
+
+	pod := makeFailedPodWithExitCode(t, 42)
+	addPod(t, fakeClusterContext, pod)
+	fakeClusterContext.SimulatePodAddEvent(pod)
+	time.Sleep(time.Millisecond * 100)
+
+	assert.Len(t, eventReporter.ReceivedEvents, 1, "event still emitted with empty category/subcategory when classification is disabled")
 }
 
 func assertExpectedEvents(t *testing.T, pod *v1.Pod, messages []reporter.EventMessage, expectedType reflect.Type) {

--- a/internal/executor/service/pod_issue_handler.go
+++ b/internal/executor/service/pod_issue_handler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/armadaproject/armada/internal/executor/configuration"
 	executorContext "github.com/armadaproject/armada/internal/executor/context"
 	"github.com/armadaproject/armada/internal/executor/job"
+	"github.com/armadaproject/armada/internal/executor/metrics"
 	"github.com/armadaproject/armada/internal/executor/podchecks"
 	"github.com/armadaproject/armada/internal/executor/podchecks/failedpodchecks"
 	"github.com/armadaproject/armada/internal/executor/reporter"
@@ -445,6 +446,9 @@ func (p *PodIssueHandler) handleNonRetryableJobIssue(issue *issue) {
 			log.Errorf("Failed to report failed event for job %s because %s", issue.RunIssue.JobId, err)
 			return
 		}
+		// Increment only after successful Report so failed sends do not inflate the counter.
+		// RecordJobFailure is a no-op when classification didn't run (empty category).
+		metrics.RecordJobFailure(result.Category, result.Subcategory)
 		p.markIssueReported(issue.RunIssue)
 	}
 

--- a/internal/executor/service/pod_issue_handler_test.go
+++ b/internal/executor/service/pod_issue_handler_test.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	clock "k8s.io/utils/clock/testing"
 
+	"github.com/armadaproject/armada/internal/common/errormatch"
 	commonutil "github.com/armadaproject/armada/internal/common/util"
 	"github.com/armadaproject/armada/internal/executor/categorizer"
 	"github.com/armadaproject/armada/internal/executor/configuration"
@@ -507,6 +508,10 @@ func TestPodIssueService_DoesNothing_IfSubmittedPodAppears(t *testing.T) {
 }
 
 func setupTestComponents(initialRunState []*job.RunState) (*PodIssueHandler, *job.JobRunStateStore, *fakecontext.SyncFakeClusterContext, *mocks.FakeEventReporter, error) {
+	return setupTestComponentsWithClassifier(initialRunState, nil)
+}
+
+func setupTestComponentsWithClassifier(initialRunState []*job.RunState, classifier *categorizer.Classifier) (*PodIssueHandler, *job.JobRunStateStore, *fakecontext.SyncFakeClusterContext, *mocks.FakeEventReporter, error) {
 	fakeClusterContext := fakecontext.NewSyncFakeClusterContext()
 	eventReporter := mocks.NewFakeEventReporter()
 	pendingPodChecker := makePendingPodChecker()
@@ -525,10 +530,78 @@ func setupTestComponents(initialRunState []*job.RunState) (*PodIssueHandler, *jo
 		pendingPodChecker,
 		failedPodChecker,
 		time.Minute*3,
-		nil,
+		classifier,
 	)
 
 	return podIssueHandler, runStateStore, fakeClusterContext, eventReporter, err
+}
+
+func conditionClassifier(t *testing.T, category, subcategory, condition string) *categorizer.Classifier {
+	t.Helper()
+	c, err := categorizer.NewClassifier(categorizer.ErrorCategoriesConfig{
+		Categories: []categorizer.CategoryConfig{
+			{
+				Name: category,
+				Rules: []categorizer.CategoryRule{
+					{OnConditions: []string{condition}, Subcategory: subcategory},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	return c
+}
+
+// The metric counter itself is tested in the metrics package. These tests
+// cover the emission gating for the non-retryable issue path: only a
+// successful Report call should have led to a counter increment.
+
+func TestPodIssueService_EmitsFailedEventWhenClassifierMatches(t *testing.T) {
+	classifier := conditionClassifier(t, "pih-success-cat", "pih-success-sub", errormatch.ConditionOOMKilled)
+	podIssueService, _, fakeClusterContext, eventReporter, err := setupTestComponentsWithClassifier([]*job.RunState{}, classifier)
+	require.NoError(t, err)
+
+	pod := makeTerminatingPod()
+	pod.Status.ContainerStatuses = []v1.ContainerStatus{
+		{Name: "main", State: v1.ContainerState{Terminated: &v1.ContainerStateTerminated{ExitCode: 137, Reason: errormatch.ConditionOOMKilled}}},
+	}
+	addPod(t, fakeClusterContext, pod)
+
+	podIssueService.HandlePodIssues()
+
+	assert.Len(t, eventReporter.ReceivedEvents, 1)
+}
+
+func TestPodIssueService_SuppressesEmissionWhenReportFails(t *testing.T) {
+	classifier := conditionClassifier(t, "pih-report-error-cat", "pih-report-error-sub", errormatch.ConditionOOMKilled)
+	podIssueService, _, fakeClusterContext, eventReporter, err := setupTestComponentsWithClassifier([]*job.RunState{}, classifier)
+	require.NoError(t, err)
+	eventReporter.ErrorOnReport = true
+
+	pod := makeTerminatingPod()
+	pod.Status.ContainerStatuses = []v1.ContainerStatus{
+		{Name: "main", State: v1.ContainerState{Terminated: &v1.ContainerStateTerminated{ExitCode: 137, Reason: errormatch.ConditionOOMKilled}}},
+	}
+	addPod(t, fakeClusterContext, pod)
+
+	podIssueService.HandlePodIssues()
+
+	assert.Len(t, eventReporter.ReceivedEvents, 0, "Report errored - event must not be recorded as delivered")
+}
+
+func TestPodIssueService_EmitsEventWithEmptyCategoryWhenClassifierIsNil(t *testing.T) {
+	podIssueService, _, fakeClusterContext, eventReporter, err := setupTestComponentsWithClassifier([]*job.RunState{}, nil)
+	require.NoError(t, err)
+
+	pod := makeTerminatingPod()
+	pod.Status.ContainerStatuses = []v1.ContainerStatus{
+		{Name: "main", State: v1.ContainerState{Terminated: &v1.ContainerStateTerminated{ExitCode: 137, Reason: errormatch.ConditionOOMKilled}}},
+	}
+	addPod(t, fakeClusterContext, pod)
+
+	podIssueService.HandlePodIssues()
+
+	assert.Len(t, eventReporter.ReceivedEvents, 1, "event still emitted with empty category/subcategory when classification is disabled")
 }
 
 func createRunState(jobId string, runId string, phase job.RunPhase) *job.RunState {


### PR DESCRIPTION
Adds Prometheus counter `armada_executor_job_failure_category_total` labelled by failure_category and failure_subcategory. One increment per emitted JobFailedEvent.

Gating matters here. A PodFailed pod that the issue handler flags as retryable gets a ReturnLease emitted instead of a JobFailedEvent, and that path must not feed this counter. Same for runs the issue handler already owns, and same for `handleNonRetryableJobIssue` when Report returns an error. Both `reportCurrentStatus` and `handleNonRetryableJobIssue` increment only after they have committed to emitting the JobFailedEvent.

`CreateEventForCurrentState` now takes a precomputed ClassifyResult instead of `*Classifier`. Keeps the function pure and moves classification plus metric accounting to the caller, where the emission decision lives.

When `enableJobErrorCategorization` is false the classifier is nil, Classify returns an empty result, and the counter is never touched.

## Validation

Ran locally on a k3d cluster with `enableJobErrorCategorization: true` and a multi-category executor config (infrastructure, user_error, gpu_error, default uncategorized/unknown). Submitted 6 jobs targeting each distinct category/subcategory once, verified the counter emitted with the expected label pairs:

```
# HELP armada_executor_job_failure_category_total Total number of job failures by failure category and subcategory
# TYPE armada_executor_job_failure_category_total counter
armada_executor_job_failure_category_total{failure_category="gpu_error",failure_subcategory="cuda"} 1
armada_executor_job_failure_category_total{failure_category="infrastructure",failure_subcategory="oom"} 1
armada_executor_job_failure_category_total{failure_category="uncategorized",failure_subcategory="unknown"} 1
armada_executor_job_failure_category_total{failure_category="user_error",failure_subcategory="command_not_found"} 1
armada_executor_job_failure_category_total{failure_category="user_error",failure_subcategory="generic_failure"} 1
armada_executor_job_failure_category_total{failure_category="user_error",failure_subcategory="signal_killed"} 1
```
