### PR TITLE
Drop failure_info column from job_run table

### DIFF
--- a/internal/lookout/schema/migrations/033_drop_failure_info_from_job_run.sql
+++ b/internal/lookout/schema/migrations/033_drop_failure_info_from_job_run.sql
@@ -1,0 +1,1 @@
+ALTER TABLE job_run DROP COLUMN IF EXISTS failure_info;

--- a/internal/lookouthc/schema/migrations/001_initial_schema.sql
+++ b/internal/lookouthc/schema/migrations/001_initial_schema.sql
@@ -117,7 +117,6 @@ CREATE TABLE job_run (
     debug               bytea        NULL,
     pool                text         NULL,
     ingress_addresses   jsonb        NULL,
-    failure_info        jsonb        NULL,
     failure_category    varchar(63)  NULL,
     failure_subcategory varchar(63)  NULL
 ) WITH (fillfactor = 70);

--- a/internal/server/queryapi/database/models.go
+++ b/internal/server/queryapi/database/models.go
@@ -60,7 +60,6 @@ type JobRun struct {
 	Debug              []byte           `db:"debug"`
 	Pool               *string          `db:"pool"`
 	IngressAddresses   []byte           `db:"ingress_addresses"`
-	FailureInfo        []byte           `db:"failure_info"`
 	FailureCategory    *string          `db:"failure_category"`
 	FailureSubcategory *string          `db:"failure_subcategory"`
 }

--- a/internal/server/queryapi/database/query.sql.go
+++ b/internal/server/queryapi/database/query.sql.go
@@ -126,7 +126,7 @@ func (q *Queries) GetJobErrorsByJobIds(ctx context.Context, jobIds []string) ([]
 }
 
 const getJobRunsByJobIds = `-- name: GetJobRunsByJobIds :many
-SELECT run_id, job_id, cluster, node, pending, started, finished, job_run_state, error, exit_code, leased, debug, pool, ingress_addresses, failure_info, failure_category, failure_subcategory FROM job_run WHERE job_id = ANY($1::text[]) order by leased  desc
+SELECT run_id, job_id, cluster, node, pending, started, finished, job_run_state, error, exit_code, leased, debug, pool, ingress_addresses, failure_category, failure_subcategory FROM job_run WHERE job_id = ANY($1::text[]) order by leased  desc
 `
 
 func (q *Queries) GetJobRunsByJobIds(ctx context.Context, jobIds []string) ([]JobRun, error) {
@@ -153,7 +153,6 @@ func (q *Queries) GetJobRunsByJobIds(ctx context.Context, jobIds []string) ([]Jo
 			&i.Debug,
 			&i.Pool,
 			&i.IngressAddresses,
-			&i.FailureInfo,
 			&i.FailureCategory,
 			&i.FailureSubcategory,
 		); err != nil {
@@ -168,7 +167,7 @@ func (q *Queries) GetJobRunsByJobIds(ctx context.Context, jobIds []string) ([]Jo
 }
 
 const getJobRunsByRunIds = `-- name: GetJobRunsByRunIds :many
-SELECT run_id, job_id, cluster, node, pending, started, finished, job_run_state, error, exit_code, leased, debug, pool, ingress_addresses, failure_info, failure_category, failure_subcategory FROM job_run WHERE run_id = ANY($1::text[])
+SELECT run_id, job_id, cluster, node, pending, started, finished, job_run_state, error, exit_code, leased, debug, pool, ingress_addresses, failure_category, failure_subcategory FROM job_run WHERE run_id = ANY($1::text[])
 `
 
 func (q *Queries) GetJobRunsByRunIds(ctx context.Context, runIds []string) ([]JobRun, error) {
@@ -195,7 +194,6 @@ func (q *Queries) GetJobRunsByRunIds(ctx context.Context, runIds []string) ([]Jo
 			&i.Debug,
 			&i.Pool,
 			&i.IngressAddresses,
-			&i.FailureInfo,
 			&i.FailureCategory,
 			&i.FailureSubcategory,
 		); err != nil {


### PR DESCRIPTION
Drops the failure_info jsonb column from job_run. Nothing writes or reads it after #4843 and #4853, and the column was never populated in production outside the opt-in flag path anyway.

Also drops the unused FailureInfo field from the queryapi sqlc model.

Only merge after #4843 and #4853 have been deployed long enough that we are sure no consumer still depends on the column.