### PR TITLE
Refactor binoculars internal library to eliminate os.Exit usage

### DIFF
--- a/cmd/binoculars/main.go
+++ b/cmd/binoculars/main.go
@@ -71,7 +71,10 @@ func main() {
 	)
 	defer shutdownGateway()
 
-	shutdown, wg := binoculars.StartUp(&config)
+	shutdown, wg, err := binoculars.StartUp(&config)
+	if err != nil {
+		log.Fatalf("Failed to startup binoculars: %v", err)
+	}
 	go func() {
 		<-stopSignal
 		shutdown()

--- a/internal/binoculars/server.go
+++ b/internal/binoculars/server.go
@@ -1,7 +1,7 @@
 package binoculars
 
 import (
-	"os"
+	"fmt"
 	"sync"
 
 	"github.com/armadaproject/armada/internal/binoculars/configuration"
@@ -10,11 +10,10 @@ import (
 	"github.com/armadaproject/armada/internal/common/auth"
 	"github.com/armadaproject/armada/internal/common/cluster"
 	grpcCommon "github.com/armadaproject/armada/internal/common/grpc"
-	log "github.com/armadaproject/armada/internal/common/logging"
 	"github.com/armadaproject/armada/pkg/api/binoculars"
 )
 
-func StartUp(config *configuration.BinocularsConfig) (func(), *sync.WaitGroup) {
+func StartUp(config *configuration.BinocularsConfig) (func(), *sync.WaitGroup, error) {
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 
@@ -24,14 +23,12 @@ func StartUp(config *configuration.BinocularsConfig) (func(), *sync.WaitGroup) {
 		config.Kubernetes.Burst,
 	)
 	if err != nil {
-		log.Errorf("Failed to connect to kubernetes because %s", err)
-		os.Exit(-1)
+		return nil, nil, fmt.Errorf("failed to connect to kubernetes: %w", err)
 	}
 
 	authServices, err := auth.ConfigureAuth(config.Auth)
 	if err != nil {
-		log.Errorf("Failed to create auth services %s", err)
-		os.Exit(-1)
+		return nil, nil, fmt.Errorf("failed to create auth services: %w", err)
 	}
 
 	grpcServer := grpcCommon.CreateGrpcServer(config.Grpc.KeepaliveParams, config.Grpc.KeepaliveEnforcementPolicy, authServices, config.Grpc.Tls)
@@ -49,5 +46,5 @@ func StartUp(config *configuration.BinocularsConfig) (func(), *sync.WaitGroup) {
 
 	grpcCommon.Listen(config.GrpcPort, grpcServer, wg)
 
-	return grpcServer.GracefulStop, wg
+	return grpcServer.GracefulStop, wg, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you: -->

#### What type of PR is this?
Refactoring internal library - binoculars
#### What this PR does / why we need it
Refactored the binoculars internal library to remove process terminating os.Exit calls, replacing them with returns as mentioned in the issue.
By changing the code to return an error, we give control back to cmd/binoculars/main.go (the main entry point). The main function will handle fatal errors and exit gracefully.
#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4779

#### Special notes for your reviewer
Tested in local with these commands
```
go build ./cmd/binoculars/...
golangci-lint run ./internal/binoculars/... ./cmd/binoculars/...
```
**Screenshot:**
<img width="1081" height="191" alt="Screenshot from 2026-04-22 21-30-20" src="https://github.com/user-attachments/assets/eace3085-a9cd-47ee-8199-cefe1d6bec09" />
