### PR TITLE
Refactor executor classifier to first-match-wins with subcategory

### DIFF
--- a/e2e/config/executor_config.yaml
+++ b/e2e/config/executor_config.yaml
@@ -1,10 +1,13 @@
 application:
+  enableJobErrorCategorization: true
   errorCategories:
-    - name: oom
-      rules:
-        - onConditions: ["OOMKilled"]
-    - name: user_error
-      rules:
-        - onExitCodes:
-            operator: In
-            values: [1, 2, 126, 127]
+    defaultCategory: "uncategorized"
+    categories:
+      - name: oom
+        rules:
+          - onConditions: ["OOMKilled"]
+      - name: user_error
+        rules:
+          - onExitCodes:
+              operator: In
+              values: [1, 2, 126, 127]

--- a/internal/executor/application.go
+++ b/internal/executor/application.go
@@ -203,9 +203,12 @@ func setupExecutorApiComponents(
 		ctx.Fatalf("Config error in failed pod checks: %s", err)
 	}
 
-	classifier, err := categorizer.NewClassifier(config.Application.ErrorCategories)
-	if err != nil {
-		ctx.Fatalf("Config error in error categories: %s", err)
+	var classifier *categorizer.Classifier
+	if config.Application.EnableJobErrorCategorization {
+		classifier, err = categorizer.NewClassifier(config.Application.ErrorCategories)
+		if err != nil {
+			ctx.Fatalf("Config error in error categories: %s", err)
+		}
 	}
 
 	eventReporter, stopReporter := reporter.NewJobEventReporter(eventSender, clock.RealClock{}, 200)

--- a/internal/executor/categorizer/classifier.go
+++ b/internal/executor/categorizer/classifier.go
@@ -9,6 +9,10 @@ import (
 	"github.com/armadaproject/armada/internal/common/errormatch"
 )
 
+// DefaultCategoryName is the category assigned when no classifier rule matches
+// and no custom defaultCategory is configured.
+const DefaultCategoryName = "uncategorized"
+
 type category struct {
 	name  string
 	rules []rule
@@ -19,21 +23,34 @@ type rule struct {
 	onExitCodes          *errormatch.ExitCodeMatcher
 	onTerminationMessage *regexp.Regexp
 	onConditions         []string
+	subcategory          string
+}
+
+// ClassifyResult holds the classification output for a failed pod.
+type ClassifyResult struct {
+	Category    string
+	Subcategory string
 }
 
 // Classifier evaluates pods against a set of category rules and returns
-// the names of all matching categories.
+// the first matching category and subcategory.
 type Classifier struct {
-	categories []category
+	defaultCategory string
+	categories      []category
 }
 
 // NewClassifier validates config and compiles regex patterns.
 // Returns an error if any regex is invalid, a condition is unknown,
 // or an exit code matcher has an invalid operator.
-func NewClassifier(configs []CategoryConfig) (*Classifier, error) {
-	categories := make([]category, 0, len(configs))
-	seen := make(map[string]bool, len(configs))
-	for _, cfg := range configs {
+func NewClassifier(config ErrorCategoriesConfig) (*Classifier, error) {
+	defaultCat := config.DefaultCategory
+	if defaultCat == "" {
+		defaultCat = DefaultCategoryName
+	}
+
+	categories := make([]category, 0, len(config.Categories))
+	seen := make(map[string]bool, len(config.Categories))
+	for _, cfg := range config.Categories {
 		if cfg.Name == "" {
 			return nil, fmt.Errorf("category config must have a name")
 		}
@@ -45,16 +62,16 @@ func NewClassifier(configs []CategoryConfig) (*Classifier, error) {
 			return nil, fmt.Errorf("category %q must have at least one rule", cfg.Name)
 		}
 		cat := category{name: cfg.Name}
-		for i, rule := range cfg.Rules {
-			r, err := buildRule(rule)
+		for i, r := range cfg.Rules {
+			built, err := buildRule(r)
 			if err != nil {
 				return nil, fmt.Errorf("category %q rule %d: %w", cfg.Name, i, err)
 			}
-			cat.rules = append(cat.rules, r)
+			cat.rules = append(cat.rules, built)
 		}
 		categories = append(categories, cat)
 	}
-	return &Classifier{categories: categories}, nil
+	return &Classifier{defaultCategory: defaultCat, categories: categories}, nil
 }
 
 func buildRule(cfg CategoryRule) (rule, error) {
@@ -109,34 +126,29 @@ func buildRule(cfg CategoryRule) (rule, error) {
 		onExitCodes:          cfg.OnExitCodes,
 		onConditions:         cfg.OnConditions,
 		onTerminationMessage: compiledRegex,
+		subcategory:          cfg.Subcategory,
 	}, nil
 }
 
-// Classify returns the names of all categories that match the given pod.
-// Returns nil if the receiver is nil, the pod is nil, or no categories match.
-func (c *Classifier) Classify(pod *v1.Pod) []string {
+// Classify returns the category and subcategory for the given pod.
+// Rules are evaluated in config order; the first matching rule wins.
+// Returns empty result if the receiver is nil or the pod is nil.
+// Returns (defaultCategory, "") if no rules match.
+func (c *Classifier) Classify(pod *v1.Pod) ClassifyResult {
 	if c == nil || pod == nil {
-		return nil
+		return ClassifyResult{}
 	}
 	containers := failedContainers(pod)
 	podReason := pod.Status.Reason
 
-	var matched []string
 	for _, cat := range c.categories {
-		if categoryMatches(cat, containers, podReason) {
-			matched = append(matched, cat.name)
+		for _, r := range cat.rules {
+			if ruleMatches(r, containers, podReason) {
+				return ClassifyResult{Category: cat.name, Subcategory: r.subcategory}
+			}
 		}
 	}
-	return matched
-}
-
-func categoryMatches(cat category, containers []containerInfo, podReason string) bool {
-	for _, rule := range cat.rules {
-		if ruleMatches(rule, containers, podReason) {
-			return true
-		}
-	}
-	return false
+	return ClassifyResult{Category: c.defaultCategory}
 }
 
 // ruleMatches evaluates a single rule. When containerName is set, only that
@@ -173,14 +185,12 @@ func matchesCondition(conditions []string, containers []containerInfo, podReason
 	for _, cond := range conditions {
 		switch cond {
 		case errormatch.ConditionOOMKilled:
-			// Container-level: check the terminated reason on each failed container.
 			for _, c := range containers {
 				if c.reason == cond {
 					return true
 				}
 			}
 		case errormatch.ConditionEvicted, errormatch.ConditionDeadlineExceeded:
-			// Pod-level: these conditions appear on pod.Status.Reason, not on containers.
 			if podReason == cond {
 				return true
 			}

--- a/internal/executor/categorizer/classifier_test.go
+++ b/internal/executor/categorizer/classifier_test.go
@@ -12,82 +12,96 @@ import (
 
 func TestClassify(t *testing.T) {
 	tests := map[string]struct {
-		configs    []CategoryConfig
-		pod        *v1.Pod
-		categories []string
+		config              ErrorCategoriesConfig
+		pod                 *v1.Pod
+		expectedCategory    string
+		expectedSubcategory string
 	}{
 		"OOM condition matches": {
-			configs: []CategoryConfig{
+			config: ErrorCategoriesConfig{Categories: []CategoryConfig{
 				{Name: "oom", Rules: []CategoryRule{
-					{OnConditions: []string{errormatch.ConditionOOMKilled}},
+					{OnConditions: []string{errormatch.ConditionOOMKilled}, Subcategory: "kernel"},
 				}},
-			},
-			pod:        podWithTerminatedContainer(137, errormatch.ConditionOOMKilled, ""),
-			categories: []string{"oom"},
+			}},
+			pod:                 podWithTerminatedContainer(137, errormatch.ConditionOOMKilled, ""),
+			expectedCategory:    "oom",
+			expectedSubcategory: "kernel",
 		},
 		"exit code In matches": {
-			configs: []CategoryConfig{
+			config: ErrorCategoriesConfig{Categories: []CategoryConfig{
 				{Name: "cuda_error", Rules: []CategoryRule{
 					{OnExitCodes: &errormatch.ExitCodeMatcher{Operator: errormatch.ExitCodeOperatorIn, Values: []int32{74, 75}}},
 				}},
-			},
-			pod:        podWithTerminatedContainer(74, "Error", ""),
-			categories: []string{"cuda_error"},
+			}},
+			pod:              podWithTerminatedContainer(74, "Error", ""),
+			expectedCategory: "cuda_error",
 		},
 		"exit code NotIn matches": {
-			configs: []CategoryConfig{
+			config: ErrorCategoriesConfig{Categories: []CategoryConfig{
 				{Name: "unexpected", Rules: []CategoryRule{
 					{OnExitCodes: &errormatch.ExitCodeMatcher{Operator: errormatch.ExitCodeOperatorNotIn, Values: []int32{1, 2}}},
 				}},
-			},
-			pod:        podWithTerminatedContainer(42, "Error", ""),
-			categories: []string{"unexpected"},
+			}},
+			pod:              podWithTerminatedContainer(42, "Error", ""),
+			expectedCategory: "unexpected",
 		},
 		"termination message regex matches": {
-			configs: []CategoryConfig{
+			config: ErrorCategoriesConfig{Categories: []CategoryConfig{
 				{Name: "gpu_error", Rules: []CategoryRule{
-					{OnTerminationMessage: &errormatch.RegexMatcher{Pattern: "(?i)cuda.*error"}},
+					{OnTerminationMessage: &errormatch.RegexMatcher{Pattern: "(?i)cuda.*error"}, Subcategory: "cuda"},
 				}},
-			},
-			pod:        podWithTerminatedContainer(1, "Error", "CUDA memory error on device 0"),
-			categories: []string{"gpu_error"},
+			}},
+			pod:                 podWithTerminatedContainer(1, "Error", "CUDA memory error on device 0"),
+			expectedCategory:    "gpu_error",
+			expectedSubcategory: "cuda",
 		},
-		"multiple categories can match": {
-			configs: []CategoryConfig{
+		"first match wins across categories": {
+			config: ErrorCategoriesConfig{Categories: []CategoryConfig{
 				{Name: "oom", Rules: []CategoryRule{
 					{OnConditions: []string{errormatch.ConditionOOMKilled}},
 				}},
 				{Name: "high_exit", Rules: []CategoryRule{
 					{OnExitCodes: &errormatch.ExitCodeMatcher{Operator: errormatch.ExitCodeOperatorIn, Values: []int32{137}}},
 				}},
-			},
-			pod:        podWithTerminatedContainer(137, errormatch.ConditionOOMKilled, ""),
-			categories: []string{"oom", "high_exit"},
+			}},
+			pod:              podWithTerminatedContainer(137, errormatch.ConditionOOMKilled, ""),
+			expectedCategory: "oom", // first match wins, not both
 		},
-		"no match returns nil": {
-			configs: []CategoryConfig{
+		"no match returns default category": {
+			config: ErrorCategoriesConfig{Categories: []CategoryConfig{
 				{Name: "oom", Rules: []CategoryRule{
 					{OnConditions: []string{errormatch.ConditionOOMKilled}},
 				}},
-			},
-			pod:        podWithTerminatedContainer(1, "Error", "normal failure"),
-			categories: nil,
+			}},
+			pod:              podWithTerminatedContainer(1, "Error", "normal failure"),
+			expectedCategory: DefaultCategoryName,
 		},
-		"nil pod returns nil": {
-			configs: []CategoryConfig{
+		"custom default category": {
+			config: ErrorCategoriesConfig{
+				DefaultCategory: "other",
+				Categories: []CategoryConfig{
+					{Name: "oom", Rules: []CategoryRule{
+						{OnConditions: []string{errormatch.ConditionOOMKilled}},
+					}},
+				},
+			},
+			pod:              podWithTerminatedContainer(1, "Error", "normal failure"),
+			expectedCategory: "other",
+		},
+		"nil pod returns empty": {
+			config: ErrorCategoriesConfig{Categories: []CategoryConfig{
 				{Name: "oom", Rules: []CategoryRule{
 					{OnConditions: []string{errormatch.ConditionOOMKilled}},
 				}},
-			},
-			pod:        nil,
-			categories: nil,
+			}},
+			pod: nil,
 		},
 		"init container is checked": {
-			configs: []CategoryConfig{
+			config: ErrorCategoriesConfig{Categories: []CategoryConfig{
 				{Name: "init_fail", Rules: []CategoryRule{
 					{OnExitCodes: &errormatch.ExitCodeMatcher{Operator: errormatch.ExitCodeOperatorIn, Values: []int32{1}}},
 				}},
-			},
+			}},
 			pod: &v1.Pod{
 				Status: v1.PodStatus{
 					Phase: v1.PodFailed,
@@ -101,52 +115,52 @@ func TestClassify(t *testing.T) {
 					},
 				},
 			},
-			categories: []string{"init_fail"},
+			expectedCategory: "init_fail",
 		},
 		"evicted condition matches": {
-			configs: []CategoryConfig{
+			config: ErrorCategoriesConfig{Categories: []CategoryConfig{
 				{Name: "evicted", Rules: []CategoryRule{
 					{OnConditions: []string{errormatch.ConditionEvicted}},
 				}},
-			},
+			}},
 			pod: &v1.Pod{
 				Status: v1.PodStatus{
 					Phase:  v1.PodFailed,
 					Reason: errormatch.ConditionEvicted,
 				},
 			},
-			categories: []string{"evicted"},
+			expectedCategory: "evicted",
 		},
 		"deadline exceeded condition matches": {
-			configs: []CategoryConfig{
+			config: ErrorCategoriesConfig{Categories: []CategoryConfig{
 				{Name: "timeout", Rules: []CategoryRule{
 					{OnConditions: []string{errormatch.ConditionDeadlineExceeded}},
 				}},
-			},
+			}},
 			pod: &v1.Pod{
 				Status: v1.PodStatus{
 					Phase:  v1.PodFailed,
 					Reason: errormatch.ConditionDeadlineExceeded,
 				},
 			},
-			categories: []string{"timeout"},
+			expectedCategory: "timeout",
 		},
 		"rules within category are ORed": {
-			configs: []CategoryConfig{
+			config: ErrorCategoriesConfig{Categories: []CategoryConfig{
 				{Name: "infra", Rules: []CategoryRule{
 					{OnConditions: []string{errormatch.ConditionOOMKilled}},
 					{OnExitCodes: &errormatch.ExitCodeMatcher{Operator: errormatch.ExitCodeOperatorIn, Values: []int32{137}}},
 				}},
-			},
-			pod:        podWithTerminatedContainer(137, "Error", ""),
-			categories: []string{"infra"},
+			}},
+			pod:              podWithTerminatedContainer(137, "Error", ""),
+			expectedCategory: "infra",
 		},
 		"exit code 0 container is skipped": {
-			configs: []CategoryConfig{
+			config: ErrorCategoriesConfig{Categories: []CategoryConfig{
 				{Name: "msg_match", Rules: []CategoryRule{
 					{OnTerminationMessage: &errormatch.RegexMatcher{Pattern: "success"}},
 				}},
-			},
+			}},
 			pod: &v1.Pod{
 				Status: v1.PodStatus{
 					Phase: v1.PodFailed,
@@ -174,14 +188,14 @@ func TestClassify(t *testing.T) {
 					},
 				},
 			},
-			categories: nil,
+			expectedCategory: DefaultCategoryName,
 		},
 		"containerName targets specific container": {
-			configs: []CategoryConfig{
+			config: ErrorCategoriesConfig{Categories: []CategoryConfig{
 				{Name: "main_oom", Rules: []CategoryRule{
 					{ContainerName: "main", OnConditions: []string{errormatch.ConditionOOMKilled}},
 				}},
-			},
+			}},
 			pod: &v1.Pod{
 				Status: v1.PodStatus{
 					Phase: v1.PodFailed,
@@ -195,14 +209,14 @@ func TestClassify(t *testing.T) {
 					},
 				},
 			},
-			categories: nil, // sidecar OOMs but main does not, rule targets main only
+			expectedCategory: DefaultCategoryName, // sidecar OOMs but main does not, rule targets main only
 		},
 		"containerName matches when container matches": {
-			configs: []CategoryConfig{
+			config: ErrorCategoriesConfig{Categories: []CategoryConfig{
 				{Name: "main_error", Rules: []CategoryRule{
 					{ContainerName: "main", OnExitCodes: &errormatch.ExitCodeMatcher{Operator: errormatch.ExitCodeOperatorIn, Values: []int32{42}}},
 				}},
-			},
+			}},
 			pod: &v1.Pod{
 				Status: v1.PodStatus{
 					Phase: v1.PodFailed,
@@ -213,14 +227,14 @@ func TestClassify(t *testing.T) {
 					},
 				},
 			},
-			categories: []string{"main_error"},
+			expectedCategory: "main_error",
 		},
 		"no containerName matches any container": {
-			configs: []CategoryConfig{
+			config: ErrorCategoriesConfig{Categories: []CategoryConfig{
 				{Name: "any_oom", Rules: []CategoryRule{
 					{OnConditions: []string{errormatch.ConditionOOMKilled}},
 				}},
-			},
+			}},
 			pod: &v1.Pod{
 				Status: v1.PodStatus{
 					Phase: v1.PodFailed,
@@ -231,105 +245,106 @@ func TestClassify(t *testing.T) {
 					},
 				},
 			},
-			categories: []string{"any_oom"}, // no containerName, matches sidecar
+			expectedCategory: "any_oom",
 		},
-		"empty config returns nil": {
-			configs:    nil,
-			pod:        podWithTerminatedContainer(1, "Error", ""),
-			categories: nil,
+		"empty config returns default": {
+			config:           ErrorCategoriesConfig{},
+			pod:              podWithTerminatedContainer(1, "Error", ""),
+			expectedCategory: DefaultCategoryName,
 		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			classifier, err := NewClassifier(tc.configs)
+			classifier, err := NewClassifier(tc.config)
 			require.NoError(t, err)
 			result := classifier.Classify(tc.pod)
-			assert.Equal(t, tc.categories, result)
+			assert.Equal(t, tc.expectedCategory, result.Category)
+			assert.Equal(t, tc.expectedSubcategory, result.Subcategory)
 		})
 	}
 }
 
 func TestNewClassifier_ValidationErrors(t *testing.T) {
 	tests := map[string]struct {
-		configs     []CategoryConfig
+		config      ErrorCategoriesConfig
 		errContains string
 	}{
 		"empty name": {
-			configs: []CategoryConfig{
+			config: ErrorCategoriesConfig{Categories: []CategoryConfig{
 				{Name: "", Rules: []CategoryRule{
 					{OnConditions: []string{errormatch.ConditionOOMKilled}},
 				}},
-			},
+			}},
 			errContains: "must have a name",
 		},
 		"empty rule": {
-			configs:     []CategoryConfig{{Name: "bad", Rules: []CategoryRule{{}}}},
+			config:      ErrorCategoriesConfig{Categories: []CategoryConfig{{Name: "bad", Rules: []CategoryRule{{}}}}},
 			errContains: "must specify one of",
 		},
 		"multiple matchers in rule": {
-			configs: []CategoryConfig{
+			config: ErrorCategoriesConfig{Categories: []CategoryConfig{
 				{Name: "bad", Rules: []CategoryRule{
 					{
 						OnConditions: []string{errormatch.ConditionOOMKilled},
 						OnExitCodes:  &errormatch.ExitCodeMatcher{Operator: errormatch.ExitCodeOperatorIn, Values: []int32{137}},
 					},
 				}},
-			},
+			}},
 			errContains: "must specify only one of",
 		},
 		"unknown condition": {
-			configs: []CategoryConfig{
+			config: ErrorCategoriesConfig{Categories: []CategoryConfig{
 				{Name: "bad", Rules: []CategoryRule{
 					{OnConditions: []string{"NotARealCondition"}},
 				}},
-			},
+			}},
 			errContains: "unknown condition",
 		},
 		"invalid exit code operator": {
-			configs: []CategoryConfig{
+			config: ErrorCategoriesConfig{Categories: []CategoryConfig{
 				{Name: "bad", Rules: []CategoryRule{
 					{OnExitCodes: &errormatch.ExitCodeMatcher{Operator: "Equals", Values: []int32{1}}},
 				}},
-			},
+			}},
 			errContains: "invalid exit code operator",
 		},
 		"empty exit code values": {
-			configs: []CategoryConfig{
+			config: ErrorCategoriesConfig{Categories: []CategoryConfig{
 				{Name: "bad", Rules: []CategoryRule{
 					{OnExitCodes: &errormatch.ExitCodeMatcher{Operator: errormatch.ExitCodeOperatorIn, Values: nil}},
 				}},
-			},
+			}},
 			errContains: "requires at least one value",
 		},
 		"invalid regex": {
-			configs: []CategoryConfig{
+			config: ErrorCategoriesConfig{Categories: []CategoryConfig{
 				{Name: "bad", Rules: []CategoryRule{
 					{OnTerminationMessage: &errormatch.RegexMatcher{Pattern: "[invalid"}},
 				}},
-			},
+			}},
 			errContains: "invalid regex",
 		},
 		"empty rules": {
-			configs:     []CategoryConfig{{Name: "empty", Rules: nil}},
+			config:      ErrorCategoriesConfig{Categories: []CategoryConfig{{Name: "empty", Rules: nil}}},
 			errContains: "must have at least one rule",
 		},
 		"duplicate category name": {
-			configs: []CategoryConfig{
+			config: ErrorCategoriesConfig{Categories: []CategoryConfig{
 				{Name: "oom", Rules: []CategoryRule{
 					{OnConditions: []string{errormatch.ConditionOOMKilled}},
 				}},
 				{Name: "oom", Rules: []CategoryRule{
 					{OnExitCodes: &errormatch.ExitCodeMatcher{Operator: errormatch.ExitCodeOperatorIn, Values: []int32{137}}},
 				}},
-			},
+			}},
 			errContains: "duplicate category name",
 		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			_, err := NewClassifier(tc.configs)
+			_, err := NewClassifier(tc.config)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tc.errContains)
 		})

--- a/internal/executor/categorizer/doc.go
+++ b/internal/executor/categorizer/doc.go
@@ -1,14 +1,14 @@
-// Package categorizer classifies pod failures into named categories based
-// on configurable rules. It runs at the executor, where full Kubernetes pod
-// status is available. The resulting category names are included in the
-// FailureInfo proto attached to error events.
+// Package categorizer classifies pod failures into a single named category
+// with an optional subcategory, based on configurable rules. It runs at the
+// executor, where full Kubernetes pod status is available. The resulting
+// category and subcategory are set on the Error proto attached to events.
 //
 // # Configuration
 //
 // Categories are defined in the executor config under application.errorCategories.
-// Each category has a name and one or more rules. Rules within a category are
-// OR'd: if any rule matches, the category is included. A pod can match multiple
-// categories.
+// Each category has a name and one or more rules. Rules are evaluated in config
+// order across all categories; the first matching rule wins, setting both the
+// category name and the rule's optional subcategory.
 //
 // Each rule uses exactly one matcher:
 //   - OnConditions: matches Kubernetes failure signals (OOMKilled, Evicted, DeadlineExceeded, AppError)
@@ -21,22 +21,23 @@
 //
 //	application:
 //	  errorCategories:
-//	    - name: oom
-//	      rules:
-//	        - onConditions: ["OOMKilled"]
-//	    - name: cuda_error
-//	      rules:
-//	        - onExitCodes:
-//	            operator: In
-//	            values: [74, 75]
-//	        - onTerminationMessage:
-//	            pattern: "(?i)cuda.*error"
-//	    - name: transient_infra
-//	      rules:
-//	        - onConditions: ["Evicted"]
-//	        - onExitCodes:
-//	            operator: In
-//	            values: [137]
+//	    defaultCategory: "uncategorized"
+//	    categories:
+//	      - name: infrastructure
+//	        rules:
+//	          - onConditions: ["OOMKilled"]
+//	            subcategory: "oom"
+//	          - onConditions: ["Evicted"]
+//	            subcategory: "eviction"
+//	      - name: user_code
+//	        rules:
+//	          - onExitCodes:
+//	              operator: In
+//	              values: [74, 75]
+//	            subcategory: "cuda"
+//	          - onTerminationMessage:
+//	              pattern: "(?i)cuda.*error"
+//	            subcategory: "cuda"
 //
 // # Validation
 //
@@ -50,5 +51,5 @@
 //	if err != nil {
 //	    // handle invalid config
 //	}
-//	categories := classifier.Classify(pod) // returns []string{"oom", "cuda_error"} or nil
+//	result := classifier.Classify(pod) // result.Category = "infrastructure", result.Subcategory = "oom"
 package categorizer

--- a/internal/executor/categorizer/types.go
+++ b/internal/executor/categorizer/types.go
@@ -2,9 +2,17 @@ package categorizer
 
 import "github.com/armadaproject/armada/internal/common/errormatch"
 
+// ErrorCategoriesConfig is the top-level config for failure classification.
+type ErrorCategoriesConfig struct {
+	// DefaultCategory is the category assigned when no rule matches.
+	// Defaults to "uncategorized" if empty.
+	DefaultCategory string           `yaml:"defaultCategory"`
+	Categories      []CategoryConfig `yaml:"categories"`
+}
+
 // CategoryConfig defines a named error category with rules that match against
-// pod failure signals. When any rule matches, the category name is included
-// in the FailureInfo.categories field of the error event.
+// pod failure signals. The first matching rule (across all categories, in config order)
+// wins - setting both the category name and the rule's optional subcategory.
 type CategoryConfig struct {
 	Name  string         `yaml:"name"`
 	Rules []CategoryRule `yaml:"rules"`
@@ -19,4 +27,5 @@ type CategoryRule struct {
 	OnExitCodes          *errormatch.ExitCodeMatcher `yaml:"onExitCodes,omitempty"`
 	OnTerminationMessage *errormatch.RegexMatcher    `yaml:"onTerminationMessage,omitempty"`
 	OnConditions         []string                    `yaml:"onConditions,omitempty"`
+	Subcategory          string                      `yaml:"subcategory,omitempty"`
 }

--- a/internal/executor/configuration/types.go
+++ b/internal/executor/configuration/types.go
@@ -27,10 +27,12 @@ type ApplicationConfiguration struct {
 	// MaxLeasedJobs is the maximum jobs the executor should have in Leased state ay any one time (i.e jobs not submitted to kubernetes)
 	// It is largely used to calculate how many new jobs to request from the scheduler
 	MaxLeasedJobs int
+	// EnableJobErrorCategorization enables failure classification on pod errors.
+	// When false, no failure_category or failure_subcategory is set on error events.
+	EnableJobErrorCategorization bool `yaml:"enableJobErrorCategorization"`
 	// ErrorCategories defines category rules for classifying pod failures.
-	// Each category has a name and rules that match against exit codes,
-	// termination messages, or failure conditions. Empty means no categorization.
-	ErrorCategories []categorizer.CategoryConfig `yaml:"errorCategories"`
+	// Only used when EnableJobErrorCategorization is true.
+	ErrorCategories categorizer.ErrorCategoriesConfig `yaml:"errorCategories"`
 }
 
 type PodDefaults struct {

--- a/internal/executor/reporter/event_test.go
+++ b/internal/executor/reporter/event_test.go
@@ -66,11 +66,13 @@ func TestCreateEventForCurrentState_WhenPodFailed_WithClassifier(t *testing.T) {
 		},
 	}
 
-	classifier, err := categorizer.NewClassifier([]categorizer.CategoryConfig{
-		{
-			Name: "custom-error",
-			Rules: []categorizer.CategoryRule{
-				{OnExitCodes: &errormatch.ExitCodeMatcher{Operator: errormatch.ExitCodeOperatorIn, Values: []int32{74}}},
+	classifier, err := categorizer.NewClassifier(categorizer.ErrorCategoriesConfig{
+		Categories: []categorizer.CategoryConfig{
+			{
+				Name: "custom-error",
+				Rules: []categorizer.CategoryRule{
+					{OnExitCodes: &errormatch.ExitCodeMatcher{Operator: errormatch.ExitCodeOperatorIn, Values: []int32{74}}},
+				},
 			},
 		},
 	})

--- a/internal/executor/service/pod_issue_handler_test.go
+++ b/internal/executor/service/pod_issue_handler_test.go
@@ -97,11 +97,13 @@ func TestPodIssueService_DeletesPodAndReportsFailed_IfStuckAndUnretryable(t *tes
 }
 
 func TestPodIssueService_FailureInfoIncludesCategories_WhenClassifierConfigured(t *testing.T) {
-	classifier, err := categorizer.NewClassifier([]categorizer.CategoryConfig{
-		{
-			Name: "oom-failure",
-			Rules: []categorizer.CategoryRule{
-				{OnConditions: []string{"OOMKilled"}},
+	classifier, err := categorizer.NewClassifier(categorizer.ErrorCategoriesConfig{
+		Categories: []categorizer.CategoryConfig{
+			{
+				Name: "oom-failure",
+				Rules: []categorizer.CategoryRule{
+					{OnConditions: []string{"OOMKilled"}},
+				},
 			},
 		},
 	})

--- a/internal/executor/util/pod_status.go
+++ b/internal/executor/util/pod_status.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/armadaproject/armada/internal/common/errormatch"
 	"github.com/armadaproject/armada/internal/common/util"
+	"github.com/armadaproject/armada/internal/executor/categorizer"
 	"github.com/armadaproject/armada/pkg/armadaevents"
 )
 
@@ -109,9 +110,19 @@ func ExtractFailedPodContainerStatuses(pod *v1.Pod, clusterId string) []*armadae
 	return returnStatuses
 }
 
-// ExtractFailureInfo builds a FailureInfo proto from pod status and category labels.
-// It extracts the exit code and termination message from the first failed container.
-func ExtractFailureInfo(pod *v1.Pod, categories []string) *armadaevents.FailureInfo {
+// ExtractFailureInfo builds a FailureInfo proto from pod status and a classifier result.
+// The category and subcategory are packed into Categories (category first) so downstream
+// readers that already consume the Categories list see the first-match-wins classification.
+// Empty values are filtered out, preserving the prior no-category-found behavior.
+// It also extracts the exit code and termination message from the first failed container.
+func ExtractFailureInfo(pod *v1.Pod, result categorizer.ClassifyResult) *armadaevents.FailureInfo {
+	var categories []string
+	if result.Category != "" {
+		categories = append(categories, result.Category)
+	}
+	if result.Subcategory != "" {
+		categories = append(categories, result.Subcategory)
+	}
 	info := &armadaevents.FailureInfo{
 		Categories: categories,
 	}

--- a/internal/executor/util/pod_status_test.go
+++ b/internal/executor/util/pod_status_test.go
@@ -9,6 +9,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/armadaproject/armada/internal/executor/categorizer"
 	"github.com/armadaproject/armada/pkg/armadaevents"
 )
 
@@ -149,15 +150,32 @@ func TestExtractFailedPodContainerStatuses(t *testing.T) {
 func TestExtractFailureInfo(t *testing.T) {
 	tests := map[string]struct {
 		pod                   *v1.Pod
-		categories            []string
+		result                categorizer.ClassifyResult
 		expectedExitCode      int32
+		expectedCategories    []string
 		expectedTermMsg       string
 		expectedContainerName string
 	}{
-		"OOM pod": {
+		"OOM pod with category only": {
 			pod:                   oomPod,
-			categories:            []string{"oom"},
+			result:                categorizer.ClassifyResult{Category: "oom"},
 			expectedExitCode:      137,
+			expectedCategories:    []string{"oom"},
+			expectedContainerName: "custom-error",
+		},
+		"OOM pod with category and subcategory": {
+			pod:                   oomPod,
+			result:                categorizer.ClassifyResult{Category: "infrastructure", Subcategory: "oom"},
+			expectedExitCode:      137,
+			expectedCategories:    []string{"infrastructure", "oom"},
+			expectedContainerName: "custom-error",
+		},
+		"subcategory without category is still included": {
+			pod:                   customErrorPod,
+			result:                categorizer.ClassifyResult{Subcategory: "orphan"},
+			expectedExitCode:      1,
+			expectedCategories:    []string{"orphan"},
+			expectedTermMsg:       "Custom error",
 			expectedContainerName: "custom-error",
 		},
 		"evicted pod": {
@@ -182,9 +200,9 @@ func TestExtractFailureInfo(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			info := ExtractFailureInfo(tc.pod, tc.categories)
+			info := ExtractFailureInfo(tc.pod, tc.result)
 			assert.Equal(t, tc.expectedExitCode, info.ExitCode)
-			assert.Equal(t, tc.categories, info.Categories)
+			assert.Equal(t, tc.expectedCategories, info.Categories)
 			if tc.expectedTermMsg != "" {
 				assert.Equal(t, tc.expectedTermMsg, info.TerminationMessage)
 			}


### PR DESCRIPTION
## What type of PR is this?

Refactor (1 of 2 splitting #4843 into smaller reviews)

## What this PR does / why we need it

Rewrites the executor error classifier from returning all matching categories to a single (category, subcategory) pair with first-match-wins semantics. Gated behind a new executor flag (off by default) so existing deployments are untouched until they opt in.

**Wire format is preserved.** `ExtractFailureInfo` now takes `ClassifyResult` and packs non-empty category + subcategory into the existing `FailureInfo.Categories` list. No proto change, no migration in this PR. A follow-up PR will flatten `FailureInfo` into scalar `Error.failure_category` / `failure_subcategory` fields on the event proto and update the Lookout ingester.

Split from #4843 at the request of reviewers who asked for smaller PRs. This PR contains only the classifier logic change; the wire-format swap ships separately.

## Classifier changes

- `NewClassifier` now takes `ErrorCategoriesConfig` (which adds an optional `defaultCategory`) instead of `[]CategoryConfig`
- `Classify` returns `ClassifyResult{Category, Subcategory}` instead of `[]string`
- First-match-wins: rules within a category are evaluated in config order and the first matching rule (carrying its optional subcategory) wins
- When no rule matches, the configured `defaultCategory` (or the built-in `uncategorized`) is returned
- Nil-receiver / nil-pod safety preserved

## Feature flag

`enableJobErrorCategorization` (default `false`) in executor `ApplicationConfiguration`. When off, the classifier is never constructed; `Classify` on a nil receiver returns an empty `ClassifyResult` and `ExtractFailureInfo` writes an empty `Categories` list - identical behavior to the pre-PR executor.

## Special notes for your reviewer

- Focus review on `internal/executor/categorizer/*` (classifier semantics) and `internal/executor/util/pod_status.go` (the `ExtractFailureInfo` adapter that preserves the `FailureInfo.Categories` wire shape)
- Callers in `internal/executor/reporter/event.go` and `internal/executor/service/pod_issue_handler.go` type-check unchanged because `classifier.Classify()` and `ExtractFailureInfo()` types shifted in lockstep
- No proto, migration, or ingester changes in this PR - they live in the follow-up

## Part of

Split from #4843. Follow-up PR will flatten the wire format and update the Lookout ingester.