### PR TITLE
Validate category/subcategory length matches varchar(63) DB constraint

### DIFF
--- a/internal/executor/categorizer/classifier.go
+++ b/internal/executor/categorizer/classifier.go
@@ -9,6 +9,12 @@ import (
 	"github.com/armadaproject/armada/internal/common/errormatch"
 )
 
+// maxCategoryNameLen is the maximum length for category and subcategory strings.
+// Matches the varchar(63) constraint on the failure_category and failure_subcategory
+// columns in the lookout job_run table (migration 032). Validating at config load
+// time prevents the ingester from failing batch UPDATEs at runtime.
+const maxCategoryNameLen = 63
+
 type category struct {
 	name  string
 	rules []rule
@@ -40,11 +46,20 @@ type Classifier struct {
 // Returns an error if any regex is invalid, a condition is unknown,
 // or an exit code matcher has an invalid operator.
 func NewClassifier(config ErrorCategoriesConfig) (*Classifier, error) {
+	if len(config.DefaultCategory) > maxCategoryNameLen {
+		return nil, fmt.Errorf("defaultCategory %q exceeds maximum length %d", config.DefaultCategory, maxCategoryNameLen)
+	}
+	if len(config.DefaultSubcategory) > maxCategoryNameLen {
+		return nil, fmt.Errorf("defaultSubcategory %q exceeds maximum length %d", config.DefaultSubcategory, maxCategoryNameLen)
+	}
 	categories := make([]category, 0, len(config.Categories))
 	seen := make(map[string]bool, len(config.Categories))
 	for _, cfg := range config.Categories {
 		if cfg.Name == "" {
 			return nil, fmt.Errorf("category config must have a name")
+		}
+		if len(cfg.Name) > maxCategoryNameLen {
+			return nil, fmt.Errorf("category name %q exceeds maximum length %d", cfg.Name, maxCategoryNameLen)
 		}
 		if seen[cfg.Name] {
 			return nil, fmt.Errorf("duplicate category name %q", cfg.Name)
@@ -71,6 +86,9 @@ func NewClassifier(config ErrorCategoriesConfig) (*Classifier, error) {
 }
 
 func buildRule(cfg CategoryRule) (rule, error) {
+	if len(cfg.Subcategory) > maxCategoryNameLen {
+		return rule{}, fmt.Errorf("subcategory %q exceeds maximum length %d", cfg.Subcategory, maxCategoryNameLen)
+	}
 	matcherCount := 0
 	if len(cfg.OnConditions) > 0 {
 		matcherCount++

--- a/internal/executor/categorizer/classifier_test.go
+++ b/internal/executor/categorizer/classifier_test.go
@@ -1,6 +1,7 @@
 package categorizer
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -367,6 +368,34 @@ func TestNewClassifier_ValidationErrors(t *testing.T) {
 				}},
 			}},
 			errContains: "duplicate category name",
+		},
+		"category name too long": {
+			config: ErrorCategoriesConfig{Categories: []CategoryConfig{
+				{Name: strings.Repeat("a", maxCategoryNameLen+1), Rules: []CategoryRule{
+					{OnConditions: []string{errormatch.ConditionOOMKilled}},
+				}},
+			}},
+			errContains: "category name",
+		},
+		"subcategory too long": {
+			config: ErrorCategoriesConfig{Categories: []CategoryConfig{
+				{Name: "oom", Rules: []CategoryRule{
+					{OnConditions: []string{errormatch.ConditionOOMKilled}, Subcategory: strings.Repeat("b", maxCategoryNameLen+1)},
+				}},
+			}},
+			errContains: "subcategory",
+		},
+		"default category too long": {
+			config: ErrorCategoriesConfig{
+				DefaultCategory: strings.Repeat("c", maxCategoryNameLen+1),
+			},
+			errContains: "defaultCategory",
+		},
+		"default subcategory too long": {
+			config: ErrorCategoriesConfig{
+				DefaultSubcategory: strings.Repeat("d", maxCategoryNameLen+1),
+			},
+			errContains: "defaultSubcategory",
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you: -->

#### What type of PR is this?

bug-fix / follow-up

#### What this PR does / why we need it

Follow-up to #4863. PR #4863 added `failure_category varchar(63)` and `failure_subcategory varchar(63)` columns to `job_run` (migration 032), but `NewClassifier` accepted arbitrarily long values from config. An operator setting a category name longer than 63 chars would only discover the problem at the first failed pod, when the lookout ingester's batch UPDATE hit `value too long for type character varying(63)` and stalled the batch.

This PR adds length guards at config-load time so the executor refuses to start with bad config rather than silently failing hours later. New constant `maxCategoryNameLen = 63` documents the link to migration 032. `NewClassifier` validates `DefaultCategory`, `DefaultSubcategory`, every `cfg.Name`, and every rule's `Subcategory`.

#### Which issue(s) this PR fixes

Fixes #

#### Special notes for your reviewer

Addresses a review follow-up on #4863. A second follow-up from that review (handling rejected jobs for categorization purposes) is intentionally out of scope here - it's a design discussion rather than a mechanical change and belongs in a separate issue/PR.