### PR TITLE
Run all existing Lookout database tests on Lookout HC

### DIFF
--- a/internal/common/database/lookout/util.go
+++ b/internal/common/database/lookout/util.go
@@ -4,13 +4,22 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/armadaproject/armada/internal/common/database"
-	"github.com/armadaproject/armada/internal/lookout/schema"
+	lookoutschema "github.com/armadaproject/armada/internal/lookout/schema"
+	lookouthcschema "github.com/armadaproject/armada/internal/lookouthc/schema"
 )
 
 func WithLookoutDb(action func(db *pgxpool.Pool) error) error {
-	migrations, err := schema.LookoutMigrations()
+	lookoutMigrations, err := lookoutschema.LookoutMigrations()
 	if err != nil {
 		return err
 	}
-	return database.WithTestDb(migrations, action)
+	if err := database.WithTestDb(lookoutMigrations, action); err != nil {
+		return err
+	}
+
+	lookoutHCMigrations, err := lookouthcschema.LookoutHCMigrations()
+	if err != nil {
+		return err
+	}
+	return database.WithTestDb(lookoutHCMigrations, action)
 }

--- a/internal/common/database/upsert_partitioned.go
+++ b/internal/common/database/upsert_partitioned.go
@@ -1,0 +1,139 @@
+package database
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/pkg/errors"
+
+	"github.com/armadaproject/armada/internal/common/armadacontext"
+)
+
+// UpsertPartitionedWithTransaction is the partition-safe sibling of
+// UpsertWithTransaction. It stages records via COPY, then performs
+// DELETE-by-conflict-key followed by plain INSERT, in a single transaction.
+//
+// Unlike UpsertWithTransaction, which relies on INSERT ... ON CONFLICT DO UPDATE,
+// this variant correctly handles rows that move between partitions (e.g. a row
+// whose partition-key column changes between calls). It is intended for tables
+// partitioned by a column that forms part of the primary key, where ON CONFLICT
+// on the non-partition-key alone is not possible.
+//
+// conflictKey names the column(s) that identify "the same row" across upserts
+// — typically the logical primary key (e.g. ["job_id"]) even when the physical
+// primary key is composite (e.g. (job_id, state)). Duplicate conflict-key values
+// within a single batch are not deduplicated; callers must dedupe.
+func UpsertPartitionedWithTransaction[T any](
+	ctx *armadacontext.Context,
+	db *pgxpool.Pool,
+	tableName string,
+	conflictKey []string,
+	records []T,
+	options ...UpsertOption,
+) error {
+	if len(records) == 0 {
+		return nil
+	}
+	return pgx.BeginTxFunc(ctx, db, pgx.TxOptions{
+		IsoLevel:       pgx.ReadCommitted,
+		AccessMode:     pgx.ReadWrite,
+		DeferrableMode: pgx.Deferrable,
+	}, func(tx pgx.Tx) error {
+		return UpsertPartitioned(ctx, tx, tableName, conflictKey, records, options...)
+	})
+}
+
+// UpsertPartitioned is the in-transaction form of UpsertPartitionedWithTransaction.
+// See that function for semantics.
+func UpsertPartitioned[T any](
+	ctx *armadacontext.Context,
+	tx pgx.Tx,
+	tableName string,
+	conflictKey []string,
+	records []T,
+	options ...UpsertOption,
+) error {
+	if len(records) == 0 {
+		return nil
+	}
+	if len(conflictKey) == 0 {
+		return errors.New("UpsertPartitioned: conflictKey must contain at least one column")
+	}
+
+	opts := &upsertOptions{
+		excludeColumns: make(map[string]bool),
+	}
+	for _, opt := range options {
+		opt(opts)
+	}
+
+	allNames, _ := NamesValuesFromRecord(records[0])
+	writableIndices := make([]int, 0, len(allNames))
+	writableNames := make([]string, 0, len(allNames))
+	for i, name := range allNames {
+		if !opts.excludeColumns[name] {
+			writableIndices = append(writableIndices, i)
+			writableNames = append(writableNames, name)
+		}
+	}
+	if len(writableNames) < 2 {
+		return errors.Errorf("NamesValuesFromRecord must return at least 2 writable columns, got %v", writableNames)
+	}
+
+	writableSet := make(map[string]bool, len(writableNames))
+	for _, n := range writableNames {
+		writableSet[n] = true
+	}
+	for _, k := range conflictKey {
+		if !writableSet[k] {
+			return errors.Errorf("UpsertPartitioned: conflict key column %q is not a writable column (present=%v, excluded=%v)", k, allNames, opts.excludeColumns)
+		}
+	}
+
+	tempTableName := uniqueTableName(tableName)
+	_, err := tx.Exec(ctx, fmt.Sprintf(
+		"CREATE TEMPORARY TABLE %s ON COMMIT DROP AS SELECT * FROM %s LIMIT 0;",
+		tempTableName, tableName))
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	n, err := tx.CopyFrom(ctx,
+		pgx.Identifier{tempTableName},
+		writableNames,
+		pgx.CopyFromSlice(len(records), func(i int) ([]interface{}, error) {
+			_, allValues := NamesValuesFromRecord(records[i])
+			values := make([]interface{}, len(writableIndices))
+			for j, idx := range writableIndices {
+				values[j] = allValues[idx]
+			}
+			return values, nil
+		}),
+	)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	if n != int64(len(records)) {
+		return errors.Errorf("only %d out of %d rows were inserted", n, len(records))
+	}
+
+	keyList := strings.Join(conflictKey, ",")
+	deleteSQL := fmt.Sprintf(
+		"DELETE FROM %s WHERE (%s) IN (SELECT %s FROM %s);",
+		tableName, keyList, keyList, tempTableName)
+	if _, err := tx.Exec(ctx, deleteSQL); err != nil {
+		return errors.WithStack(err)
+	}
+
+	columnList := strings.Join(writableNames, ",")
+	insertSQL := fmt.Sprintf(
+		"INSERT INTO %s (%s) SELECT %s FROM %s;",
+		tableName, columnList, columnList, tempTableName)
+	if _, err := tx.Exec(ctx, insertSQL); err != nil {
+		return errors.WithStack(err)
+	}
+
+	return nil
+}

--- a/internal/common/database/upsert_partitioned_test.go
+++ b/internal/common/database/upsert_partitioned_test.go
@@ -1,0 +1,256 @@
+package database
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/armadaproject/armada/internal/common/armadacontext"
+)
+
+type PartitionedRecord struct {
+	Id    uuid.UUID `db:"id"`
+	State int       `db:"state"`
+	Msg   string    `db:"msg"`
+}
+
+const partitionedTableName = "partitioned_records"
+
+const partitionedSchema = `
+CREATE TABLE partitioned_records (
+    id    uuid NOT NULL,
+    state int  NOT NULL,
+    msg   text NOT NULL,
+    PRIMARY KEY (id, state)
+) PARTITION BY LIST (state);
+CREATE TABLE partitioned_records_p0 PARTITION OF partitioned_records FOR VALUES IN (0);
+CREATE TABLE partitioned_records_p1 PARTITION OF partitioned_records FOR VALUES IN (1);
+`
+
+func withPartitionedDb(action func(db *pgxpool.Pool) error) error {
+	return WithTestDb([]Migration{
+		NewMigration(1, "init", partitionedSchema),
+	}, action)
+}
+
+func selectPartitionedRecords(ctx *armadacontext.Context, db *pgxpool.Pool, table string) ([]PartitionedRecord, error) {
+	rows, err := db.Query(ctx, fmt.Sprintf("SELECT id, state, msg FROM %s ORDER BY msg", table))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []PartitionedRecord
+	for rows.Next() {
+		var r PartitionedRecord
+		if err := rows.Scan(&r.Id, &r.State, &r.Msg); err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, nil
+}
+
+func TestUpsertPartitioned_InitialInsert(t *testing.T) {
+	ctx, cancel := armadacontext.WithTimeout(armadacontext.Background(), 30*time.Second)
+	defer cancel()
+
+	err := withPartitionedDb(func(db *pgxpool.Pool) error {
+		records := []PartitionedRecord{
+			{Id: uuid.New(), State: 0, Msg: "a"},
+			{Id: uuid.New(), State: 1, Msg: "b"},
+			{Id: uuid.New(), State: 0, Msg: "c"},
+		}
+		err := UpsertPartitionedWithTransaction(ctx, db, partitionedTableName, []string{"id"}, records)
+		require.NoError(t, err)
+
+		actual, err := selectPartitionedRecords(ctx, db, partitionedTableName)
+		require.NoError(t, err)
+		assert.Len(t, actual, 3)
+
+		p0, err := selectPartitionedRecords(ctx, db, "partitioned_records_p0")
+		require.NoError(t, err)
+		assert.Len(t, p0, 2)
+
+		p1, err := selectPartitionedRecords(ctx, db, "partitioned_records_p1")
+		require.NoError(t, err)
+		assert.Len(t, p1, 1)
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+func TestUpsertPartitioned_CrossPartitionMove(t *testing.T) {
+	ctx, cancel := armadacontext.WithTimeout(armadacontext.Background(), 30*time.Second)
+	defer cancel()
+
+	err := withPartitionedDb(func(db *pgxpool.Pool) error {
+		id := uuid.New()
+		initial := []PartitionedRecord{{Id: id, State: 0, Msg: "before"}}
+		require.NoError(t, UpsertPartitionedWithTransaction(
+			ctx, db, partitionedTableName, []string{"id"}, initial))
+
+		p0, err := selectPartitionedRecords(ctx, db, "partitioned_records_p0")
+		require.NoError(t, err)
+		require.Len(t, p0, 1)
+
+		updated := []PartitionedRecord{{Id: id, State: 1, Msg: "after"}}
+		require.NoError(t, UpsertPartitionedWithTransaction(
+			ctx, db, partitionedTableName, []string{"id"}, updated))
+
+		p0, err = selectPartitionedRecords(ctx, db, "partitioned_records_p0")
+		require.NoError(t, err)
+		assert.Empty(t, p0)
+
+		p1, err := selectPartitionedRecords(ctx, db, "partitioned_records_p1")
+		require.NoError(t, err)
+		require.Len(t, p1, 1)
+		assert.Equal(t, id, p1[0].Id)
+		assert.Equal(t, 1, p1[0].State)
+		assert.Equal(t, "after", p1[0].Msg)
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+func TestUpsertPartitioned_BatchMixed(t *testing.T) {
+	ctx, cancel := armadacontext.WithTimeout(armadacontext.Background(), 30*time.Second)
+	defer cancel()
+
+	err := withPartitionedDb(func(db *pgxpool.Pool) error {
+		movingId := uuid.New()
+		stableId := uuid.New()
+		newId := uuid.New()
+
+		initial := []PartitionedRecord{
+			{Id: movingId, State: 0, Msg: "moving-before"},
+			{Id: stableId, State: 1, Msg: "stable"},
+		}
+		require.NoError(t, UpsertPartitionedWithTransaction(
+			ctx, db, partitionedTableName, []string{"id"}, initial))
+
+		batch := []PartitionedRecord{
+			{Id: movingId, State: 1, Msg: "moving-after"},
+			{Id: newId, State: 0, Msg: "new"},
+		}
+		require.NoError(t, UpsertPartitionedWithTransaction(
+			ctx, db, partitionedTableName, []string{"id"}, batch))
+
+		all, err := selectPartitionedRecords(ctx, db, partitionedTableName)
+		require.NoError(t, err)
+		assert.Len(t, all, 3)
+
+		byId := map[uuid.UUID]PartitionedRecord{}
+		for _, r := range all {
+			byId[r.Id] = r
+		}
+		assert.Equal(t, PartitionedRecord{Id: movingId, State: 1, Msg: "moving-after"}, byId[movingId])
+		assert.Equal(t, PartitionedRecord{Id: stableId, State: 1, Msg: "stable"}, byId[stableId])
+		assert.Equal(t, PartitionedRecord{Id: newId, State: 0, Msg: "new"}, byId[newId])
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+type partitionedRecordWithGenerated struct {
+	Id       uuid.UUID `db:"id"`
+	State    int       `db:"state"`
+	Msg      string    `db:"msg"`
+	MsgUpper string    `db:"msg_upper"`
+}
+
+const partitionedSchemaWithGenerated = `
+CREATE TABLE partitioned_records (
+    id        uuid NOT NULL,
+    state     int  NOT NULL,
+    msg       text NOT NULL,
+    msg_upper text GENERATED ALWAYS AS (upper(msg)) STORED,
+    PRIMARY KEY (id, state)
+) PARTITION BY LIST (state);
+CREATE TABLE partitioned_records_p0 PARTITION OF partitioned_records FOR VALUES IN (0);
+CREATE TABLE partitioned_records_p1 PARTITION OF partitioned_records FOR VALUES IN (1);
+`
+
+func TestUpsertPartitioned_ExcludeColumns(t *testing.T) {
+	ctx, cancel := armadacontext.WithTimeout(armadacontext.Background(), 30*time.Second)
+	defer cancel()
+
+	err := WithTestDb([]Migration{NewMigration(1, "init", partitionedSchemaWithGenerated)},
+		func(db *pgxpool.Pool) error {
+			records := []partitionedRecordWithGenerated{
+				{Id: uuid.New(), State: 0, Msg: "hello"},
+			}
+			require.NoError(t, UpsertPartitionedWithTransaction(
+				ctx, db, partitionedTableName, []string{"id"}, records,
+				WithExcludeColumns("msg_upper")))
+
+			rows, err := db.Query(ctx,
+				`SELECT msg, msg_upper FROM partitioned_records`)
+			require.NoError(t, err)
+			defer rows.Close()
+			require.True(t, rows.Next())
+			var msg, upper string
+			require.NoError(t, rows.Scan(&msg, &upper))
+			assert.Equal(t, "hello", msg)
+			assert.Equal(t, "HELLO", upper)
+			return nil
+		})
+	require.NoError(t, err)
+}
+
+func TestUpsertPartitioned_EmptyBatch(t *testing.T) {
+	ctx, cancel := armadacontext.WithTimeout(armadacontext.Background(), 30*time.Second)
+	defer cancel()
+
+	err := withPartitionedDb(func(db *pgxpool.Pool) error {
+		err := UpsertPartitionedWithTransaction[PartitionedRecord](
+			ctx, db, partitionedTableName, []string{"id"}, nil)
+		assert.NoError(t, err)
+
+		err = UpsertPartitionedWithTransaction(
+			ctx, db, partitionedTableName, []string{"id"}, []PartitionedRecord{})
+		assert.NoError(t, err)
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+func TestUpsertPartitioned_EmptyConflictKey(t *testing.T) {
+	ctx, cancel := armadacontext.WithTimeout(armadacontext.Background(), 30*time.Second)
+	defer cancel()
+
+	err := withPartitionedDb(func(db *pgxpool.Pool) error {
+		records := []PartitionedRecord{{Id: uuid.New(), State: 0, Msg: "x"}}
+		err := UpsertPartitionedWithTransaction(
+			ctx, db, partitionedTableName, nil, records)
+		assert.Error(t, err)
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+func TestUpsertPartitioned_ConflictKeyNotWritable(t *testing.T) {
+	ctx, cancel := armadacontext.WithTimeout(armadacontext.Background(), 30*time.Second)
+	defer cancel()
+
+	err := WithTestDb([]Migration{NewMigration(1, "init", partitionedSchemaWithGenerated)},
+		func(db *pgxpool.Pool) error {
+			records := []partitionedRecordWithGenerated{
+				{Id: uuid.New(), State: 0, Msg: "hello"},
+			}
+			err := UpsertPartitionedWithTransaction(
+				ctx, db, partitionedTableName, []string{"msg_upper"}, records,
+				WithExcludeColumns("msg_upper"))
+			assert.Error(t, err)
+
+			err = UpsertPartitionedWithTransaction(
+				ctx, db, partitionedTableName, []string{"nonexistent"}, records)
+			assert.Error(t, err)
+			return nil
+		})
+	require.NoError(t, err)
+}

--- a/internal/common/database/upsert_partitioned_test.go
+++ b/internal/common/database/upsert_partitioned_test.go
@@ -52,6 +52,9 @@ func selectPartitionedRecords(ctx *armadacontext.Context, db *pgxpool.Pool, tabl
 		}
 		out = append(out, r)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return out, nil
 }
 

--- a/internal/lookouthc/schema/migrations/001_initial_schema.sql
+++ b/internal/lookouthc/schema/migrations/001_initial_schema.sql
@@ -103,21 +103,23 @@ CREATE INDEX idx_job_active_queue_jobset
 
 -- Job run table (unpartitioned).
 CREATE TABLE job_run (
-    run_id            varchar(36)  NOT NULL PRIMARY KEY,
-    job_id            varchar(32)  NOT NULL,
-    cluster           varchar(512) NOT NULL,
-    node              varchar(512) NULL,
-    pending           timestamp    NULL,
-    started           timestamp    NULL,
-    finished          timestamp    NULL,
-    job_run_state     smallint     NOT NULL,
-    error             bytea        NULL,
-    exit_code         int          NULL,
-    leased            timestamp    NULL,
-    debug             bytea        NULL,
-    pool              text         NULL,
-    ingress_addresses jsonb        NULL,
-    failure_info      jsonb        NULL
+    run_id              varchar(36)  NOT NULL PRIMARY KEY,
+    job_id              varchar(32)  NOT NULL,
+    cluster             varchar(512) NOT NULL,
+    node                varchar(512) NULL,
+    pending             timestamp    NULL,
+    started             timestamp    NULL,
+    finished            timestamp    NULL,
+    job_run_state       smallint     NOT NULL,
+    error               bytea        NULL,
+    exit_code           int          NULL,
+    leased              timestamp    NULL,
+    debug               bytea        NULL,
+    pool                text         NULL,
+    ingress_addresses   jsonb        NULL,
+    failure_info        jsonb        NULL,
+    failure_category    varchar(63)  NULL,
+    failure_subcategory varchar(63)  NULL
 ) WITH (fillfactor = 70);
 ALTER TABLE job_run ALTER COLUMN error SET STORAGE EXTERNAL;
 

--- a/internal/server/queryapi/query_api_test.go
+++ b/internal/server/queryapi/query_api_test.go
@@ -122,9 +122,9 @@ func TestGetJobDetails(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-				err := dbcommon.UpsertWithTransaction(ctx, db, "job", testJobs)
+				err := dbcommon.UpsertPartitionedWithTransaction(ctx, db, "job", []string{"job_id"}, testJobs)
 				require.NoError(t, err)
-				err = dbcommon.UpsertWithTransaction(ctx, db, "job_run", testJobRuns)
+				err = dbcommon.UpsertPartitionedWithTransaction(ctx, db, "job_run", []string{"run_id"}, testJobRuns)
 				require.NoError(t, err)
 				queryApi := New(db, defaultMaxQueryItems, testDecompressor)
 				resp, err := queryApi.GetJobDetails(ctx, tc.request)
@@ -196,9 +196,9 @@ func TestGetJobRunDetails(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-				err := dbcommon.UpsertWithTransaction(ctx, db, "job", testJobs)
+				err := dbcommon.UpsertPartitionedWithTransaction(ctx, db, "job", []string{"job_id"}, testJobs)
 				require.NoError(t, err)
-				err = dbcommon.UpsertWithTransaction(ctx, db, "job_run", testJobRuns)
+				err = dbcommon.UpsertPartitionedWithTransaction(ctx, db, "job_run", []string{"run_id"}, testJobRuns)
 				require.NoError(t, err)
 				queryApi := New(db, defaultMaxQueryItems, testDecompressor)
 				resp, err := queryApi.GetJobRunDetails(ctx, tc.request)
@@ -276,7 +276,7 @@ func TestGetJobStatus(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-				err := dbcommon.UpsertWithTransaction(ctx, db, "job", testdata)
+				err := dbcommon.UpsertPartitionedWithTransaction(ctx, db, "job", []string{"job_id"}, testdata)
 				require.NoError(t, err)
 				queryApi := New(db, defaultMaxQueryItems, testDecompressor)
 				resp, err := queryApi.GetJobStatus(ctx, &api.JobStatusRequest{JobIds: tc.jobIds})
@@ -319,7 +319,7 @@ func TestGetJobStatusUsingExternalJobUri(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-				err := dbcommon.UpsertWithTransaction(ctx, db, "job", testdata)
+				err := dbcommon.UpsertPartitionedWithTransaction(ctx, db, "job", []string{"job_id"}, testdata)
 				require.NoError(t, err)
 				queryApi := New(db, defaultMaxQueryItems, testDecompressor)
 				resp, err := queryApi.GetJobStatusUsingExternalJobUri(ctx, &api.JobStatusUsingExternalJobUriRequest{
@@ -395,11 +395,11 @@ func TestGetJobErrors(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-				err := dbcommon.UpsertWithTransaction(ctx, db, "job", testJobs)
+				err := dbcommon.UpsertPartitionedWithTransaction(ctx, db, "job", []string{"job_id"}, testJobs)
 				require.NoError(t, err)
-				err = dbcommon.UpsertWithTransaction(ctx, db, "job_run", testJobRuns)
+				err = dbcommon.UpsertPartitionedWithTransaction(ctx, db, "job_run", []string{"run_id"}, testJobRuns)
 				require.NoError(t, err)
-				err = dbcommon.UpsertWithTransaction(ctx, db, "job_error", testJobErrors)
+				err = dbcommon.UpsertPartitionedWithTransaction(ctx, db, "job_error", []string{"job_id"}, testJobErrors)
 				require.NoError(t, err)
 				queryApi := New(db, defaultMaxQueryItems, testDecompressor)
 				resp, err := queryApi.GetJobErrors(ctx, tc.request)


### PR DESCRIPTION
Extend WithLookoutDb to also run against the lookout HC schema, and update queryapi tests to use UpsertPartitionedWithTransaction. No changes to application request-handling code.