### PR TITLE
Rework executor etcd monitoring metrics

### DIFF
--- a/internal/common/etcdhealth/etcdhealth.go
+++ b/internal/common/etcdhealth/etcdhealth.go
@@ -17,6 +17,7 @@ const (
 	etcdSizeBytesMetricName      string = "etcd_mvcc_db_total_size_in_bytes"
 	etcdCapacityBytesMetricName  string = "etcd_server_quota_backend_bytes"
 	etcdMemberUrl                string = "url"
+	etcdClusterName              string = "cluster_name"
 
 	EtcdReplicaSizeInUseExceededReason string = "etcdReplicaSizeInUseExceeded"
 	EtcdReplicaSizeExceededReason      string = "etcdReplicaSizeExceeded"
@@ -27,6 +28,8 @@ type EtcdReplicaHealthMonitor struct {
 	// Name of the replica being scraped, e.g., its url.
 	// Included in exported Prometheus metrics.
 	name string
+	// Name of the cluster this replica belongs to
+	clusterName string
 	// Exported Prometheus metrics are prefixed with this.
 	metricsPrefix string
 
@@ -75,6 +78,7 @@ type EtcdReplicaHealthMonitor struct {
 
 func NewEtcdReplicaHealthMonitor(
 	name string,
+	clusterName string,
 	fractionOfStorageInUseLimit float64,
 	fractionOfStorageLimit float64,
 	replicaTimeout time.Duration,
@@ -86,6 +90,7 @@ func NewEtcdReplicaHealthMonitor(
 ) *EtcdReplicaHealthMonitor {
 	srv := &EtcdReplicaHealthMonitor{
 		name:                                name,
+		clusterName:                         clusterName,
 		fractionOfStorageInUseLimit:         fractionOfStorageInUseLimit,
 		fractionOfStorageLimit:              fractionOfStorageLimit,
 		replicaTimeout:                      replicaTimeout,
@@ -111,37 +116,37 @@ func (srv *EtcdReplicaHealthMonitor) initialiseMetrics() {
 	srv.healthPrometheusDesc = prometheus.NewDesc(
 		srv.metricsPrefix+"etcd_replica_health",
 		"Shows the health of an etcd replica",
-		[]string{etcdMemberUrl},
+		[]string{etcdMemberUrl, etcdClusterName},
 		nil,
 	)
 	srv.timeOfMostRecentCollectionAttemptPrometheusDesc = prometheus.NewDesc(
 		srv.metricsPrefix+"etcd_replica_time_of_most_recent_metrics_collection_attempt",
 		"Time of most recent metrics collection attempt.",
-		[]string{etcdMemberUrl},
+		[]string{etcdMemberUrl, etcdClusterName},
 		nil,
 	)
 	srv.timeOfMostRecentSuccessfulCollectionAttemptPrometheusDesc = prometheus.NewDesc(
 		srv.metricsPrefix+"etcd_replica_time_of_most_recent_successful_metrics_collection",
 		"Time of most recent successful metrics collection.",
-		[]string{etcdMemberUrl},
+		[]string{etcdMemberUrl, etcdClusterName},
 		nil,
 	)
 	srv.sizeInUseFractionPrometheusDesc = prometheus.NewDesc(
 		srv.metricsPrefix+"etcd_replica_size_in_use_fraction",
 		"etcd_mvcc_db_total_size_in_use_in_bytes / etcd_server_quota_backend_bytes.",
-		[]string{etcdMemberUrl},
+		[]string{etcdMemberUrl, etcdClusterName},
 		nil,
 	)
 	srv.sizeFractionPrometheusDesc = prometheus.NewDesc(
 		srv.metricsPrefix+"etcd_replica_size_fraction",
 		"etcd_mvcc_db_total_size_in_bytes / etcd_server_quota_backend_bytes.",
-		[]string{etcdMemberUrl},
+		[]string{etcdMemberUrl, etcdClusterName},
 		nil,
 	)
 	srv.metricsCollectionDelayHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Name:        srv.metricsPrefix + "etcd_replica_metrics_collection_delay_seconds",
 		Help:        "Delay in seconds of collecting metrics from this etcd replica.",
-		ConstLabels: prometheus.Labels{etcdMemberUrl: srv.name},
+		ConstLabels: prometheus.Labels{etcdMemberUrl: srv.name, etcdClusterName: srv.clusterName},
 		Buckets: prometheus.ExponentialBuckets(
 			srv.metricsCollectionDelayBucketsStart,
 			srv.metricsCollectionDelayBucketsFactor,
@@ -309,18 +314,21 @@ func (srv *EtcdReplicaHealthMonitor) Collect(c chan<- prometheus.Metric) {
 		prometheus.GaugeValue,
 		resultOfMostRecentHealthCheck,
 		srv.name,
+		srv.clusterName,
 	)
 	c <- prometheus.MustNewConstMetric(
 		srv.timeOfMostRecentCollectionAttemptPrometheusDesc,
 		prometheus.CounterValue,
 		float64(timeOfMostRecentCollectionAttempt.Unix()),
 		srv.name,
+		srv.clusterName,
 	)
 	c <- prometheus.MustNewConstMetric(
 		srv.timeOfMostRecentSuccessfulCollectionAttemptPrometheusDesc,
 		prometheus.CounterValue,
 		float64(timeOfMostRecentSuccessfulCollectionAttempt.Unix()),
 		srv.name,
+		srv.clusterName,
 	)
 	if !srv.hasTimedOut() {
 		c <- prometheus.MustNewConstMetric(
@@ -328,12 +336,14 @@ func (srv *EtcdReplicaHealthMonitor) Collect(c chan<- prometheus.Metric) {
 			prometheus.GaugeValue,
 			sizeInUseFraction,
 			srv.name,
+			srv.clusterName,
 		)
 		c <- prometheus.MustNewConstMetric(
 			srv.sizeFractionPrometheusDesc,
 			prometheus.GaugeValue,
 			sizeFraction,
 			srv.name,
+			srv.clusterName,
 		)
 	}
 

--- a/internal/common/etcdhealth/etcdhealth_test.go
+++ b/internal/common/etcdhealth/etcdhealth_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestEtcdReplicaHealthMonitor(t *testing.T) {
 	mp := &metrics.ManualMetricsProvider{}
-	hm := NewEtcdReplicaHealthMonitor("foo", 0.2, 0.3, time.Second, time.Microsecond, 1e-3, 1.1, 10, mp)
+	hm := NewEtcdReplicaHealthMonitor("foo", "cluster", 0.2, 0.3, time.Second, time.Microsecond, 1e-3, 1.1, 10, mp)
 
 	// Initial call results in unavailable.
 	ok, reason, err := hm.IsHealthy()

--- a/internal/common/healthmonitor/multihealthmonitor.go
+++ b/internal/common/healthmonitor/multihealthmonitor.go
@@ -1,14 +1,14 @@
 package healthmonitor
 
 import (
-	"fmt"
-
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/exp/maps"
 
 	"github.com/armadaproject/armada/internal/common/armadacontext"
 )
+
+const nameLabel = "name"
 
 // MultiHealthMonitor wraps multiple HealthMonitors and itself implements the HealthMonitor interface.
 type MultiHealthMonitor struct {
@@ -24,9 +24,10 @@ type MultiHealthMonitor struct {
 	healthPrometheusDesc *prometheus.Desc
 }
 
-func NewMultiHealthMonitor(name string, healthMonitorsByName map[string]HealthMonitor) *MultiHealthMonitor {
+func NewMultiHealthMonitor(name string, metricsPrefix string, healthMonitorsByName map[string]HealthMonitor) *MultiHealthMonitor {
 	srv := &MultiHealthMonitor{
 		name:                     name,
+		metricsPrefix:            metricsPrefix,
 		minimumReplicasAvailable: len(healthMonitorsByName),
 		healthMonitorsByName:     maps.Clone(healthMonitorsByName),
 	}
@@ -39,23 +40,11 @@ func (srv *MultiHealthMonitor) WithMinimumReplicasAvailable(v int) *MultiHealthM
 	return srv
 }
 
-// WithMetricsPrefix adds a prefix to exported Prometheus metrics.
-// Must be called before Describe or Collect.
-func (srv *MultiHealthMonitor) WithMetricsPrefix(v string) *MultiHealthMonitor {
-	srv.metricsPrefix = v
-	srv.initialiseMetrics()
-	return srv
-}
-
 func (srv *MultiHealthMonitor) initialiseMetrics() {
-	metricsPrefix := srv.name
-	if srv.metricsPrefix != "" {
-		metricsPrefix = srv.metricsPrefix + srv.name
-	}
 	srv.healthPrometheusDesc = prometheus.NewDesc(
-		metricsPrefix+"_health",
-		fmt.Sprintf("Shows whether %s is healthy.", srv.name),
-		nil,
+		srv.metricsPrefix+"_health",
+		"Shows whether this group of etcds is healthy.",
+		[]string{nameLabel},
 		nil,
 	)
 }
@@ -114,6 +103,7 @@ func (srv *MultiHealthMonitor) Collect(c chan<- prometheus.Metric) {
 		srv.healthPrometheusDesc,
 		prometheus.GaugeValue,
 		resultOfMostRecentHealthCheck,
+		srv.name,
 	)
 
 	for _, healthMonitor := range srv.healthMonitorsByName {

--- a/internal/common/healthmonitor/multihealthmonitor_test.go
+++ b/internal/common/healthmonitor/multihealthmonitor_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestMultiHealthMonitor_OneChild(t *testing.T) {
 	hm := NewManualHealthMonitor()
-	mhm := NewMultiHealthMonitor("mhm", map[string]HealthMonitor{"hm": hm})
+	mhm := NewMultiHealthMonitor("mhm", "test_mhm_", map[string]HealthMonitor{"hm": hm})
 	ok, reason, err := mhm.IsHealthy()
 	require.False(t, ok)
 	require.NotEmpty(t, reason)
@@ -24,7 +24,7 @@ func TestMultiHealthMonitor_OneChild(t *testing.T) {
 func TestMultiHealthMonitor_TwoChildren(t *testing.T) {
 	hm1 := NewManualHealthMonitor()
 	hm2 := NewManualHealthMonitor()
-	mhm := NewMultiHealthMonitor("mhm", map[string]HealthMonitor{"hm1": hm1, "hm2": hm2})
+	mhm := NewMultiHealthMonitor("mhm", "test_mhm_", map[string]HealthMonitor{"hm1": hm1, "hm2": hm2})
 
 	ok, reason, err := mhm.IsHealthy()
 	require.False(t, ok)
@@ -55,7 +55,7 @@ func TestMultiHealthMonitor_TwoChildrenTimeouts(t *testing.T) {
 	hm1 := NewManualHealthMonitor()
 	hm1 = hm1.WithReason(UnavailableReason)
 	hm2 := NewManualHealthMonitor()
-	mhm := NewMultiHealthMonitor("mhm", map[string]HealthMonitor{"hm1": hm1, "hm2": hm2})
+	mhm := NewMultiHealthMonitor("mhm", "test_mhm_", map[string]HealthMonitor{"hm1": hm1, "hm2": hm2})
 	mhm = mhm.WithMinimumReplicasAvailable(1)
 
 	hm1.SetHealthStatus(false)

--- a/internal/executor/application.go
+++ b/internal/executor/application.go
@@ -67,6 +67,7 @@ func StartUp(ctx *armadacontext.Context, config configuration.ExecutorConfigurat
 		for _, metricsUrl := range etcdClusterHealthMonitoring.MetricUrls {
 			etcdReplicaHealthMonitorsByUrl[metricsUrl] = etcdhealth.NewEtcdReplicaHealthMonitor(
 				metricsUrl,
+				etcdClusterHealthMonitoring.Name,
 				etcdClusterHealthMonitoring.FractionOfStorageInUseLimit,
 				etcdClusterHealthMonitoring.FractionOfStorageLimit,
 				etcdClusterHealthMonitoring.ReplicaTimeout,
@@ -79,21 +80,19 @@ func StartUp(ctx *armadacontext.Context, config configuration.ExecutorConfigurat
 		}
 		etcdClusterHealthMonitoringByName[etcdClusterHealthMonitoring.Name] = healthmonitor.NewMultiHealthMonitor(
 			etcdClusterHealthMonitoring.Name,
+			metrics.ArmadaExecutorMetricsPrefix+"etcd_cluster",
 			etcdReplicaHealthMonitorsByUrl,
 		).WithMinimumReplicasAvailable(
 			etcdClusterHealthMonitoring.MinimumReplicasAvailable,
-		).WithMetricsPrefix(
-			metrics.ArmadaExecutorMetricsPrefix,
 		)
 	}
 	var etcdClustersHealthMonitoring healthmonitor.HealthMonitor
 	if len(etcdClusterHealthMonitoringByName) > 0 {
 		ctx.Info("etcd URLs provided; monitoring etcd health enabled")
 		etcdClustersHealthMonitoring = healthmonitor.NewMultiHealthMonitor(
-			"overall_etcd",
+			"overall",
+			metrics.ArmadaExecutorMetricsPrefix+"overall_etcd",
 			etcdClusterHealthMonitoringByName,
-		).WithMetricsPrefix(
-			metrics.ArmadaExecutorMetricsPrefix,
 		)
 		g.Go(func() error { return etcdClustersHealthMonitoring.Run(ctx) })
 		prometheus.MustRegister(etcdClustersHealthMonitoring)


### PR DESCRIPTION
When monitoring multiple etcd clusters the metrics we provide are a bit hard to use

I've reworked them very slightly to make it easier to cross-reference the metrics and be a bit more prometheus like

 - Added `cluster_name` to etcd replica metrics, so you can easily see which cluster this replica belongs to.
   - The cluster name comes from executor config
 - Stopped making creating a newly named metric for each etcd cluster we monitor
   - Now we use the same metric `armada_executor_etcd_cluster_health` and just publish them with different labels.
```
armada_executor_etcd_cluster_health{name="cluster-1"} 1
armada_executor_etcd_cluster_health{name="cluster-2"} 1
```
 - The overall metric remains the same called `armada_executor_overall_etcd_health`

