### PR TITLE
Add hot cold config flag and lookout pruner optimizations

### DIFF
--- a/cmd/lookout/main.go
+++ b/cmd/lookout/main.go
@@ -18,7 +18,8 @@ import (
 	"github.com/armadaproject/armada/internal/lookout/configuration"
 	"github.com/armadaproject/armada/internal/lookout/gen/restapi"
 	"github.com/armadaproject/armada/internal/lookout/pruner"
-	"github.com/armadaproject/armada/internal/lookout/schema"
+	lookoutschema "github.com/armadaproject/armada/internal/lookout/schema"
+	lookouthcschema "github.com/armadaproject/armada/internal/lookouthc/schema"
 	armada_config "github.com/armadaproject/armada/internal/server/configuration"
 )
 
@@ -61,12 +62,19 @@ func makeContext() (*armadacontext.Context, func()) {
 }
 
 func migrate(ctx *armadacontext.Context, config configuration.LookoutConfig) {
+	var err error
+	var migrations []database.Migration
+
 	db, err := database.OpenPgxPool(config.Postgres)
 	if err != nil {
 		panic(err)
 	}
 
-	migrations, err := schema.LookoutMigrations()
+	if config.HotColdSplit {
+		migrations, err = lookouthcschema.LookoutHCMigrations()
+	} else {
+		migrations, err = lookoutschema.LookoutMigrations()
+	}
 	if err != nil {
 		panic(err)
 	}
@@ -110,7 +118,9 @@ func prune(ctx *armadacontext.Context, config configuration.LookoutConfig) {
 		config.PrunerConfig.ExpireAfter,
 		config.PrunerConfig.DeduplicationExpireAfter,
 		config.PrunerConfig.BatchSize,
-		clock.RealClock{})
+		clock.RealClock{},
+		config.HotColdSplit,
+	)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/lookout/main.go
+++ b/cmd/lookout/main.go
@@ -70,7 +70,7 @@ func migrate(ctx *armadacontext.Context, config configuration.LookoutConfig) {
 		panic(err)
 	}
 
-	if config.HotColdSplit {
+	if config.ExperimentalHotColdSplit {
 		migrations, err = lookouthcschema.LookoutHCMigrations()
 	} else {
 		migrations, err = lookoutschema.LookoutMigrations()
@@ -119,7 +119,7 @@ func prune(ctx *armadacontext.Context, config configuration.LookoutConfig) {
 		config.PrunerConfig.DeduplicationExpireAfter,
 		config.PrunerConfig.BatchSize,
 		clock.RealClock{},
-		config.HotColdSplit,
+		config.ExperimentalHotColdSplit,
 	)
 	if err != nil {
 		panic(err)

--- a/internal/lookout/configuration/types.go
+++ b/internal/lookout/configuration/types.go
@@ -22,6 +22,8 @@ type LookoutConfig struct {
 
 	PrunerConfig PrunerConfig
 
+	HotColdSplit bool
+
 	UIConfig
 }
 

--- a/internal/lookout/configuration/types.go
+++ b/internal/lookout/configuration/types.go
@@ -22,7 +22,7 @@ type LookoutConfig struct {
 
 	PrunerConfig PrunerConfig
 
-	HotColdSplit bool
+	ExperimentalHotColdSplit bool
 
 	UIConfig
 }

--- a/internal/lookout/pruner/pruner.go
+++ b/internal/lookout/pruner/pruner.go
@@ -102,6 +102,7 @@ func createJobIdsToDeleteTempTable(ctx *armadacontext.Context, db *pgx.Conn, cut
 		table = "job_terminated"
 	}
 
+	// Using interpolation for table name as parameterized queries do not allow it. The table name is controlled by us and not user input, so this is safe.
 	query := fmt.Sprintf(`
 		CREATE TEMP TABLE job_ids_to_delete AS (
 			SELECT job_id FROM %s

--- a/internal/lookout/pruner/pruner.go
+++ b/internal/lookout/pruner/pruner.go
@@ -1,6 +1,7 @@
 package pruner
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -19,10 +20,11 @@ func PruneDb(
 	deduplicationLifetime time.Duration,
 	batchLimit int,
 	clock clock.Clock,
+	hotColdSplit bool,
 ) error {
 	var result *multierror.Error
 
-	if err := deleteJobs(ctx, db, jobLifetime, batchLimit, clock); err != nil {
+	if err := deleteJobs(ctx, db, jobLifetime, batchLimit, clock, hotColdSplit); err != nil {
 		result = multierror.Append(result, err)
 	}
 
@@ -44,10 +46,10 @@ func deleteDeduplications(ctx *armadacontext.Context, db *pgx.Conn, deduplicatio
 	return nil
 }
 
-func deleteJobs(ctx *armadacontext.Context, db *pgx.Conn, jobLifetime time.Duration, batchLimit int, clock clock.Clock) error {
+func deleteJobs(ctx *armadacontext.Context, db *pgx.Conn, jobLifetime time.Duration, batchLimit int, clock clock.Clock, hotColdSplit bool) error {
 	now := clock.Now()
 	cutOffTime := now.Add(-jobLifetime)
-	totalJobsToDelete, err := createJobIdsToDeleteTempTable(ctx, db, cutOffTime)
+	totalJobsToDelete, err := createJobIdsToDeleteTempTable(ctx, db, cutOffTime, hotColdSplit)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -94,10 +96,15 @@ func deleteJobs(ctx *armadacontext.Context, db *pgx.Conn, jobLifetime time.Durat
 }
 
 // Returns total number of jobs to delete
-func createJobIdsToDeleteTempTable(ctx *armadacontext.Context, db *pgx.Conn, cutOffTime time.Time) (int, error) {
-	_, err := db.Exec(ctx, `
+func createJobIdsToDeleteTempTable(ctx *armadacontext.Context, db *pgx.Conn, cutOffTime time.Time, hotColdSplit bool) (int, error) {
+	table := "job"
+	if hotColdSplit {
+		table = "job_terminated"
+	}
+
+	query := fmt.Sprintf(`
 		CREATE TEMP TABLE job_ids_to_delete AS (
-			SELECT job_id FROM job
+			SELECT job_id FROM %s
 			WHERE last_transition_time < $1
 			AND state in (
 				4, -- Succeeded
@@ -106,7 +113,9 @@ func createJobIdsToDeleteTempTable(ctx *armadacontext.Context, db *pgx.Conn, cut
 		   		7, -- Preempted
 		   		9  -- Rejected
 		    )
-		)`, cutOffTime)
+		)`, table)
+
+	_, err := db.Exec(ctx, query, cutOffTime)
 	if err != nil {
 		return -1, errors.WithStack(err)
 	}
@@ -135,6 +144,7 @@ func deleteBatch(ctx *armadacontext.Context, tx pgx.Tx, batchLimit int) (int, er
 		DELETE FROM job WHERE job_id in (SELECT job_id from batch);
 		DELETE FROM job_spec WHERE job_id in (SELECT job_id from batch);
 		DELETE FROM job_run WHERE job_id in (SELECT job_id from batch);
+		DELETE FROM job_error WHERE job_id in (SELECT job_id from batch);
 		DELETE FROM job_ids_to_delete WHERE job_id in (SELECT job_id from batch);
 		TRUNCATE TABLE batch;`)
 	if err != nil {

--- a/internal/lookout/pruner/pruner_test.go
+++ b/internal/lookout/pruner/pruner_test.go
@@ -31,10 +31,13 @@ type testJob struct {
 
 func TestPruneDb(t *testing.T) {
 	type testCase struct {
-		testName    string
-		expireAfter time.Duration
-		jobs        []testJob
-		jobIdsLeft  []string
+		testName             string
+		expireAfter          time.Duration
+		jobs                 []testJob
+		jobIdsLeft           []string
+		activeJobIdsLeft     []string // HC only: when non-nil, assert job_active contains exactly these
+		terminatedJobIdsLeft []string // HC only: when non-nil, assert job_terminated contains exactly these
+		jobErrorIdsLeft      []string // when non-nil, assert job_error contains exactly these
 	}
 
 	nIds := 100
@@ -129,6 +132,79 @@ func TestPruneDb(t *testing.T) {
 			),
 			jobIdsLeft: sampleJobIds[50:],
 		},
+		{
+			testName:    "delete from job_terminated when hot cold split enabled",
+			expireAfter: 10 * time.Hour,
+			jobs: []testJob{
+				{
+					jobId: sampleJobIds[0],
+					ts:    baseTime.Add(-(10*time.Hour + 1*time.Minute)),
+					state: lookout.JobSucceeded,
+				},
+			},
+			jobIdsLeft:           []string{},
+			terminatedJobIdsLeft: []string{},
+		},
+		{
+			testName:    "active jobs in job_active are never touched by the pruner",
+			expireAfter: 10 * time.Hour,
+			jobs: []testJob{
+				{
+					jobId: sampleJobIds[0],
+					ts:    baseTime.Add(-11 * time.Hour),
+					state: lookout.JobRunning, // active, old — must NOT be pruned
+				},
+				{
+					jobId: sampleJobIds[1],
+					ts:    baseTime.Add(-11 * time.Hour),
+					state: lookout.JobSucceeded, // terminal, old — must be pruned
+				},
+			},
+			jobIdsLeft:           []string{sampleJobIds[0]},
+			activeJobIdsLeft:     []string{sampleJobIds[0]},
+			terminatedJobIdsLeft: []string{},
+		},
+		{
+			testName:    "terminal jobs in job_terminated older than the cutoff are deleted",
+			expireAfter: 10 * time.Hour,
+			jobs: []testJob{
+				{
+					jobId: sampleJobIds[0],
+					ts:    baseTime.Add(-(10*time.Hour + 1*time.Minute)),
+					state: lookout.JobSucceeded,
+				},
+				{
+					jobId: sampleJobIds[1],
+					ts:    baseTime.Add(-(10*time.Hour + 1*time.Minute)),
+					state: lookout.JobFailed,
+				},
+				{
+					jobId: sampleJobIds[2],
+					ts:    baseTime.Add(-(10*time.Hour + 1*time.Minute)),
+					state: lookout.JobCancelled,
+				},
+				{
+					jobId: sampleJobIds[3],
+					ts:    baseTime.Add(-(10*time.Hour + 1*time.Minute)),
+					state: lookout.JobPreempted,
+				},
+			},
+			jobIdsLeft:           []string{},
+			terminatedJobIdsLeft: []string{},
+		},
+		{
+			testName:    "related job_run, job_spec, job_error rows are also deleted",
+			expireAfter: 10 * time.Hour,
+			jobs: []testJob{
+				{
+					jobId: sampleJobIds[0],
+					ts:    baseTime.Add(-(10*time.Hour + 1*time.Minute)),
+					state: lookout.JobRejected,
+				},
+			},
+			jobIdsLeft:      []string{},
+			jobErrorIdsLeft: []string{},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -145,7 +221,8 @@ func TestPruneDb(t *testing.T) {
 
 				dbConn, err := db.Acquire(ctx)
 				assert.NoError(t, err)
-				err = PruneDb(ctx, dbConn.Conn(), tc.expireAfter, 0, 10, clock.NewFakeClock(baseTime))
+				isHC := isHotColdSchema(ctx, db)
+				err = PruneDb(ctx, dbConn.Conn(), tc.expireAfter, 0, 10, clock.NewFakeClock(baseTime), isHC)
 				assert.NoError(t, err)
 
 				queriedJobIdsPerTable := []map[string]bool{
@@ -160,6 +237,19 @@ func TestPruneDb(t *testing.T) {
 						assert.True(t, ok)
 					}
 				}
+
+				if isHC {
+					if tc.activeJobIdsLeft != nil {
+						assertJobIds(t, db, "SELECT job_id FROM job_active", tc.activeJobIdsLeft)
+					}
+					if tc.terminatedJobIdsLeft != nil {
+						assertJobIds(t, db, "SELECT job_id FROM job_terminated", tc.terminatedJobIdsLeft)
+					}
+				}
+				if tc.jobErrorIdsLeft != nil {
+					assertJobIds(t, db, "SELECT job_id FROM job_error", tc.jobErrorIdsLeft)
+				}
+
 				return nil
 			})
 			assert.NoError(t, err)
@@ -202,12 +292,33 @@ func storeJob(job testJob, db *lookoutdb.LookoutDb, converter *instructions.Inst
 			Build()
 	case lookout.JobRejected:
 		simulator.
-			Rejected("invalid", job.ts)
+			Rejected("invalid", job.ts).
+			Build()
 	case lookout.JobRunning:
 		simulator.
 			Build()
 	default:
 		panic(fmt.Sprintf("job state %s not supported", job.state))
+	}
+}
+
+func isHotColdSchema(ctx *armadacontext.Context, db *pgxpool.Pool) bool {
+	var exists bool
+	err := db.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM information_schema.tables
+			WHERE table_name = 'job_active'
+		)`).Scan(&exists)
+	return err == nil && exists
+}
+
+func assertJobIds(t *testing.T, db *pgxpool.Pool, query string, expected []string) {
+	t.Helper()
+	got := selectStringSet(t, db, query)
+	assert.Equal(t, len(expected), len(got))
+	for _, id := range expected {
+		_, ok := got[id]
+		assert.True(t, ok)
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you: -->

#### What type of PR is this?

#### What this PR does / why we need it

Updating Lookout to include a hot/cold flag for utilizing the hot/cold partitioned jobs database, as well as updating the lookout pruner to only prune jobs from the `job_terminated` table when hot/cold is in use

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer
