### PR TITLE
Fix typos across docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ Armada uses GH Discussions for long form communication and design discussions. T
 
 Real-time interactions between Armada developers and users occurs primarily in CNCF Slack. To join us there:
 * If you already have an account on CNCF Slack, join #armada on [https://cloud-native.slack.com](https://cloud-native.slack.com).
-* If you need an inviation to CNCF Slack, you can get one at [https://slack.cncf.io](https://slack.cncf.io).
+* If you need an invitation to CNCF Slack, you can get one at [https://slack.cncf.io](https://slack.cncf.io).
 
 ## Finding Issues to Work On
 If you're new to the project and looking for a place to start, we recommend checking out the issues tagged with "good first issues". These issues are specifically curated for newcomers to the project, providing an opportunity to get familiar with the codebase and make meaningful contributions.

--- a/client/python/examples/README.md
+++ b/client/python/examples/README.md
@@ -10,13 +10,13 @@ Currently there are five examples:
 
 There is also a section on [Using Basic Auth](#using-basic-auth)
 
-## Preqrequisites
+## Prerequisites
 
 Please see the [python client docs](https://github.com/armadaproject/armada/blob/master/client/python/README.md) for getting the client setup.
 
 ### Running the examples
 
-> Each example has three enviromental variables for setup
+> Each example has three environmental variables for setup
 > ```bash
 > export ARMADA_SERVER=localhost
 > export ARMADA_PORT=443
@@ -44,7 +44,7 @@ then watch for the job to succeed or fail.
 > def create_dummy_job(client: ArmadaClient):
 > ```
 
-> If you are using a remote server, secure_channel should be used to ensure that all infomation is encrypted.
+> If you are using a remote server, secure_channel should be used to ensure that all information is encrypted.
 > ```py
 > if DISABLE_SSL:
 >     channel = grpc.insecure_channel(f"{HOST}:{PORT}")
@@ -175,7 +175,7 @@ the job-set id.
 > )
 > ```
 >
-> You can set `ilter_states` to either \[JobState.Queued] or [JobState.PENDING, JobState.RUNNING]
+> You can set `filter_states` to either \[JobState.Queued] or [JobState.PENDING, JobState.RUNNING]
 
 ### monitor.py
 

--- a/developer/env/README.md
+++ b/developer/env/README.md
@@ -1,5 +1,5 @@
 # Component Environmental variables
 
-This folder contains all the enviromental variables that are required to run.
+This folder contains all the environmental variables that are required to run.
 
-If a component is not listed as a file here, it does not require any enviromental variables to run.
+If a component is not listed as a file here, it does not require any environmental variables to run.


### PR DESCRIPTION
#### What type of PR is this?
Docs fix

#### What this PR does / why we need it
Fixes typos found across several docs:

- `CONTRIBUTING.md` line 101: `"inviation"` → `"invitation"`
- `client/python/examples/README.md`: `"Preqrequisites"` → `"Prerequisites"`, `"enviromental"` → `"environmental"`, `"infomation"` → `"information"`, `"ilter_states"` → `"filter_states"`
- `developer/env/README.md`: `"enviromental"` → `"environmental"` (2 instances)

#### Which issue(s) this PR fixes
N/A

#### Special notes for your reviewer
Docs-only change, no code affected.
