### PR TITLE
Add duration & count metrics to submitcheck

### DIFF
--- a/deployment/armada/templates/prometheusrule.yaml
+++ b/deployment/armada/templates/prometheusrule.yaml
@@ -17,7 +17,7 @@ spec:
         - record: armada:queue:size
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: max(sum(armada_queue_size{namespace="{{ .Release.Namespace }}"}) by (queueName, instance)) by (queueName) > 0
+          expr: max(sum(armada_queue_size{namespace="{{ .Release.Namespace }}"}) by (queueName, state, instance)) by (queueName, state) > 0
 
         - record: armada:queue:priority
           labels:

--- a/internal/common/metrics/scheduler_metrics.go
+++ b/internal/common/metrics/scheduler_metrics.go
@@ -20,6 +20,9 @@ const (
 
 	AccountingRolePrimary   = "primary"
 	AccountingRoleSecondary = "secondary"
+
+	QueueStateValidated   = "validated"
+	QueueStateUnvalidated = "unvalidated"
 )
 
 var PoolInfoDesc = prometheus.NewDesc(
@@ -32,7 +35,7 @@ var PoolInfoDesc = prometheus.NewDesc(
 var QueueSizeDesc = prometheus.NewDesc(
 	MetricPrefix+"queue_size",
 	"Number of jobs in a queue",
-	[]string{"queueName", "queue"},
+	[]string{"queueName", "queue", "state"},
 	nil,
 )
 
@@ -350,14 +353,20 @@ func Describe(out chan<- *prometheus.Desc) {
 	}
 }
 
-func CollectQueueMetrics(pools []configuration.PoolConfig, queueCounts map[string]int, bidPriceSnapshot pricing.BidPriceSnapshot, queueDistinctSchedulingKeyCounts map[string]int, metricsProvider QueueMetricProvider) []prometheus.Metric {
+type QueueSizeCounts struct {
+	Validated   int
+	Unvalidated int
+}
+
+func CollectQueueMetrics(pools []configuration.PoolConfig, queueCounts map[string]QueueSizeCounts, bidPriceSnapshot pricing.BidPriceSnapshot, queueDistinctSchedulingKeyCounts map[string]int, metricsProvider QueueMetricProvider) []prometheus.Metric {
 	metrics := make([]prometheus.Metric, 0, len(AllDescs))
 	poolNames := armadaslices.Map(pools, func(pool configuration.PoolConfig) string {
 		return pool.Name
 	})
 
-	for q, count := range queueCounts {
-		metrics = append(metrics, NewQueueSizeMetric(count, q))
+	for q, counts := range queueCounts {
+		metrics = append(metrics, NewQueueSizeMetric(counts.Validated, q, QueueStateValidated))
+		metrics = append(metrics, NewQueueSizeMetric(counts.Unvalidated, q, QueueStateUnvalidated))
 		metrics = append(metrics, NewQueueDistinctSchedulingKeyMetric(queueDistinctSchedulingKeyCounts[q], q))
 		queuedJobMetrics := metricsProvider.GetQueuedJobMetrics(q)
 		runningJobMetrics := metricsProvider.GetRunningJobMetrics(q)
@@ -457,8 +466,8 @@ func NewPoolInfoMetric(pool string) prometheus.Metric {
 	return prometheus.MustNewConstMetric(PoolInfoDesc, prometheus.GaugeValue, float64(1), pool)
 }
 
-func NewQueueSizeMetric(value int, queue string) prometheus.Metric {
-	return prometheus.MustNewConstMetric(QueueSizeDesc, prometheus.GaugeValue, float64(value), queue, queue)
+func NewQueueSizeMetric(value int, queue string, state string) prometheus.Metric {
+	return prometheus.MustNewConstMetric(QueueSizeDesc, prometheus.GaugeValue, float64(value), queue, queue, state)
 }
 
 func NewQueueDistinctSchedulingKeyMetric(value int, queue string) prometheus.Metric {

--- a/internal/scheduler/metrics.go
+++ b/internal/scheduler/metrics.go
@@ -177,7 +177,7 @@ func (c *MetricsCollector) updateQueueMetrics(ctx *armadacontext.Context) ([]pro
 	}
 
 	provider := metricProvider{queueStates: make(map[string]*queueState, len(queues))}
-	queuedJobsCount := make(map[string]int, len(queues))
+	queuedJobsCount := make(map[string]commonmetrics.QueueSizeCounts, len(queues))
 	schedulingKeysByQueue := make(map[string]map[internaltypes.SchedulingKey]bool, len(queues))
 
 	for _, queue := range queues {
@@ -186,7 +186,7 @@ func (c *MetricsCollector) updateQueueMetrics(ctx *armadacontext.Context) ([]pro
 			runningJobRecorder: commonmetrics.NewJobMetricsRecorder(),
 			queue:              queue,
 		}
-		queuedJobsCount[queue.Name] = 0
+		queuedJobsCount[queue.Name] = commonmetrics.QueueSizeCounts{}
 		schedulingKeysByQueue[queue.Name] = map[internaltypes.SchedulingKey]bool{}
 	}
 
@@ -230,7 +230,13 @@ func (c *MetricsCollector) updateQueueMetrics(ctx *armadacontext.Context) ([]pro
 				}
 			}
 			timeInState = currentTime.Sub(queuedTime)
-			queuedJobsCount[job.Queue()]++
+			counts := queuedJobsCount[job.Queue()]
+			if job.Validated() {
+				counts.Validated++
+			} else {
+				counts.Unvalidated++
+			}
+			queuedJobsCount[job.Queue()] = counts
 			schedulingKeysByQueue[job.Queue()][job.SchedulingKey()] = true
 		} else {
 			run := job.LatestRun()

--- a/internal/scheduler/metrics/cycle_metrics.go
+++ b/internal/scheduler/metrics/cycle_metrics.go
@@ -461,7 +461,7 @@ func newCycleMetrics(publisher pulsarutils.Publisher[*metricevents.Event], scala
 		prometheus.HistogramOpts{
 			Name:    ArmadaSchedulerMetricsPrefix + "submit_check_times",
 			Help:    "Time spent in submit check per queue per scheduling cycle, in milliseconds.",
-			Buckets: prometheus.ExponentialBuckets(10.0, 1.1, 110),
+			Buckets: prometheus.ExponentialBuckets(0.5, 1.5, 25),
 		},
 		[]string{queueLabel},
 	)

--- a/internal/scheduler/metrics/cycle_metrics.go
+++ b/internal/scheduler/metrics/cycle_metrics.go
@@ -386,6 +386,7 @@ type cycleMetrics struct {
 	scheduleCycleOutcome    *prometheus.CounterVec
 	scheduleCycleTime       prometheus.Histogram
 	reconciliationCycleTime prometheus.Histogram
+	submitCheckDuration     *prometheus.GaugeVec
 	latestCycleMetrics      atomic.Pointer[perCycleMetrics]
 	metricsPublisher        pulsarutils.Publisher[*metricevents.Event]
 }
@@ -456,6 +457,14 @@ func newCycleMetrics(publisher pulsarutils.Publisher[*metricevents.Event], scala
 		poolLabels,
 	)
 
+	submitCheckDuration := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: ArmadaSchedulerMetricsPrefix + "per_queue_submit_check_times",
+			Help: "Time spent in submit check per queue per scheduling cycle, in milliseconds.",
+		},
+		[]string{queueLabel},
+	)
+
 	cycleMetrics := &cycleMetrics{
 		leaderMetricsEnabled:    true,
 		scalableUnitLabelKey:    scalableUnitLabelKey,
@@ -467,6 +476,7 @@ func newCycleMetrics(publisher pulsarutils.Publisher[*metricevents.Event], scala
 		scheduleCycleTime:       scheduleCycleTime,
 		scheduleCycleOutcome:    scheduleCycleOutcome,
 		reconciliationCycleTime: reconciliationCycleTime,
+		submitCheckDuration:     submitCheckDuration,
 		latestCycleMetrics:      atomic.Pointer[perCycleMetrics]{},
 		metricsPublisher:        publisher,
 	}
@@ -488,6 +498,7 @@ func (m *cycleMetrics) resetLeaderMetrics() {
 	m.scheduledJobs.Reset()
 	m.failedJobs.Reset()
 	m.poolSchedulingOutcome.Reset()
+	m.submitCheckDuration.Reset()
 	m.latestCycleMetrics.Store(newPerCycleMetrics())
 }
 
@@ -525,6 +536,14 @@ func (m *cycleMetrics) ReportPoolSchedulingOutcome(pool string, outcome scheduli
 
 func (m *cycleMetrics) ReportPoolSchedulingCycleTime(pool string, cycleTime time.Duration) {
 	m.poolSchedulingCycleTime.WithLabelValues(pool).Observe(float64(cycleTime.Milliseconds()))
+}
+
+func (m *cycleMetrics) ReportSubmitCheckDuration(queue string, duration time.Duration) {
+	m.submitCheckDuration.WithLabelValues(queue).Set(float64(duration) / float64(time.Millisecond))
+}
+
+func (m *cycleMetrics) ResetSubmitCheckDurations() {
+	m.submitCheckDuration.Reset()
 }
 
 func (m *cycleMetrics) ReportSchedulerResult(ctx *armadacontext.Context, result scheduling.SchedulerResult) {
@@ -696,6 +715,7 @@ func (m *cycleMetrics) describe(ch chan<- *prometheus.Desc) {
 		m.poolSchedulingCycleTime.Describe(ch)
 		m.scheduleCycleTime.Describe(ch)
 		m.scheduleCycleOutcome.Describe(ch)
+		m.submitCheckDuration.Describe(ch)
 
 		cycleMetrics := newPerCycleMetrics()
 		cycleMetrics.consideredJobs.Describe(ch)
@@ -745,6 +765,7 @@ func (m *cycleMetrics) collect(ch chan<- prometheus.Metric) {
 		m.poolSchedulingCycleTime.Collect(ch)
 		m.scheduleCycleTime.Collect(ch)
 		m.scheduleCycleOutcome.Collect(ch)
+		m.submitCheckDuration.Collect(ch)
 
 		currentCycle := m.latestCycleMetrics.Load()
 		currentCycle.consideredJobs.Collect(ch)

--- a/internal/scheduler/metrics/cycle_metrics.go
+++ b/internal/scheduler/metrics/cycle_metrics.go
@@ -386,7 +386,7 @@ type cycleMetrics struct {
 	scheduleCycleOutcome    *prometheus.CounterVec
 	scheduleCycleTime       prometheus.Histogram
 	reconciliationCycleTime prometheus.Histogram
-	submitCheckDuration     *prometheus.GaugeVec
+	submitCheckDuration     *prometheus.HistogramVec
 	latestCycleMetrics      atomic.Pointer[perCycleMetrics]
 	metricsPublisher        pulsarutils.Publisher[*metricevents.Event]
 }
@@ -457,10 +457,11 @@ func newCycleMetrics(publisher pulsarutils.Publisher[*metricevents.Event], scala
 		poolLabels,
 	)
 
-	submitCheckDuration := prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: ArmadaSchedulerMetricsPrefix + "per_queue_submit_check_times",
-			Help: "Time spent in submit check per queue per scheduling cycle, in milliseconds.",
+	submitCheckDuration := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    ArmadaSchedulerMetricsPrefix + "submit_check_times",
+			Help:    "Time spent in submit check per queue per scheduling cycle, in milliseconds.",
+			Buckets: prometheus.ExponentialBuckets(10.0, 1.1, 110),
 		},
 		[]string{queueLabel},
 	)
@@ -498,7 +499,6 @@ func (m *cycleMetrics) resetLeaderMetrics() {
 	m.scheduledJobs.Reset()
 	m.failedJobs.Reset()
 	m.poolSchedulingOutcome.Reset()
-	m.submitCheckDuration.Reset()
 	m.latestCycleMetrics.Store(newPerCycleMetrics())
 }
 
@@ -538,12 +538,10 @@ func (m *cycleMetrics) ReportPoolSchedulingCycleTime(pool string, cycleTime time
 	m.poolSchedulingCycleTime.WithLabelValues(pool).Observe(float64(cycleTime.Milliseconds()))
 }
 
-func (m *cycleMetrics) ReportSubmitCheckDuration(queue string, duration time.Duration) {
-	m.submitCheckDuration.WithLabelValues(queue).Set(float64(duration) / float64(time.Millisecond))
-}
-
-func (m *cycleMetrics) ResetSubmitCheckDurations() {
-	m.submitCheckDuration.Reset()
+func (m *cycleMetrics) ReportSubmitCheckDuration(durations map[string]time.Duration) {
+	for queue, duration := range durations {
+		m.submitCheckDuration.WithLabelValues(queue).Observe(float64(duration) / float64(time.Millisecond))
+	}
 }
 
 func (m *cycleMetrics) ReportSchedulerResult(ctx *armadacontext.Context, result scheduling.SchedulerResult) {

--- a/internal/scheduler/metrics/cycle_metrics_test.go
+++ b/internal/scheduler/metrics/cycle_metrics_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -135,54 +136,32 @@ func TestReportOutcomes(t *testing.T) {
 func TestReportSubmitCheckDuration(t *testing.T) {
 	m := newCycleMetrics(pulsarutils.NoOpPublisher[*metricevents.Event]{}, "")
 
-	m.ReportSubmitCheckDuration("queue1", 250*time.Millisecond)
-	val := testutil.ToFloat64(m.submitCheckDuration.WithLabelValues("queue1"))
-	assert.InDelta(t, 250.0, val, epsilon)
+	m.ReportSubmitCheckDuration(map[string]time.Duration{
+		"queue1": 250 * time.Millisecond,
+		"queue2": 50 * time.Millisecond,
+		"queue3": 723 * time.Microsecond,
+	})
 
-	// A second call overwrites, not accumulates.
-	m.ReportSubmitCheckDuration("queue1", 100*time.Millisecond)
-	val = testutil.ToFloat64(m.submitCheckDuration.WithLabelValues("queue1"))
-	assert.InDelta(t, 100.0, val, epsilon)
+	assertHistogramObservation(t, m.submitCheckDuration, "queue1", 1, 250.0)
+	assertHistogramObservation(t, m.submitCheckDuration, "queue2", 1, 50.0)
+	assertHistogramObservation(t, m.submitCheckDuration, "queue3", 1, 0.723)
 
-	// Independent label sets are tracked separately.
-	m.ReportSubmitCheckDuration("queue2", 50*time.Millisecond)
-	val2 := testutil.ToFloat64(m.submitCheckDuration.WithLabelValues("queue2"))
-	assert.InDelta(t, 50.0, val2, epsilon)
-	val = testutil.ToFloat64(m.submitCheckDuration.WithLabelValues("queue1"))
-	assert.InDelta(t, 100.0, val, epsilon)
-
-	// Sub-millisecond durations retain microsecond precision (reported as fractional milliseconds).
-	m.ReportSubmitCheckDuration("queue3", 723*time.Microsecond)
-	val3 := testutil.ToFloat64(m.submitCheckDuration.WithLabelValues("queue3"))
-	assert.InDelta(t, 0.723, val3, epsilon)
+	// A subsequent call accumulates (histogram semantics) rather than overwriting.
+	m.ReportSubmitCheckDuration(map[string]time.Duration{
+		"queue1": 100 * time.Millisecond,
+	})
+	assertHistogramObservation(t, m.submitCheckDuration, "queue1", 2, 350.0)
+	assertHistogramObservation(t, m.submitCheckDuration, "queue2", 1, 50.0)
 }
 
-func TestResetSubmitCheckDurations(t *testing.T) {
-	m := newCycleMetrics(pulsarutils.NoOpPublisher[*metricevents.Event]{}, "")
-
-	m.ReportSubmitCheckDuration("queue1", 250*time.Millisecond)
-	m.ReportSubmitCheckDuration("queue2", 100*time.Millisecond)
-
-	m.ResetSubmitCheckDurations()
-
-	// After reset both label sets should return zero (the zero-value Prometheus returns for unset gauges).
-	val1 := testutil.ToFloat64(m.submitCheckDuration.WithLabelValues("queue1"))
-	assert.InDelta(t, 0.0, val1, epsilon)
-	val2 := testutil.ToFloat64(m.submitCheckDuration.WithLabelValues("queue2"))
-	assert.InDelta(t, 0.0, val2, epsilon)
-}
-
-func TestResetLeaderMetrics_ResetsSubmitCheckDuration(t *testing.T) {
-	m := newCycleMetrics(pulsarutils.NoOpPublisher[*metricevents.Event]{}, "")
-
-	m.ReportSubmitCheckDuration("queue1", 500*time.Millisecond)
-	val := testutil.ToFloat64(m.submitCheckDuration.WithLabelValues("queue1"))
-	assert.InDelta(t, 500.0, val, epsilon)
-
-	m.resetLeaderMetrics()
-
-	val = testutil.ToFloat64(m.submitCheckDuration.WithLabelValues("queue1"))
-	assert.InDelta(t, 0.0, val, epsilon)
+func assertHistogramObservation(t *testing.T, vec *prometheus.HistogramVec, queue string, wantCount uint64, wantSumMillis float64) {
+	t.Helper()
+	obs, err := vec.GetMetricWithLabelValues(queue)
+	require.NoError(t, err)
+	metric := &dto.Metric{}
+	require.NoError(t, obs.(prometheus.Metric).Write(metric))
+	assert.Equal(t, wantCount, metric.Histogram.GetSampleCount())
+	assert.InDelta(t, wantSumMillis, metric.Histogram.GetSampleSum(), epsilon)
 }
 
 func TestResetLeaderMetrics_Counters(t *testing.T) {

--- a/internal/scheduler/metrics/cycle_metrics_test.go
+++ b/internal/scheduler/metrics/cycle_metrics_test.go
@@ -132,6 +132,59 @@ func TestReportOutcomes(t *testing.T) {
 	assert.Equal(t, 1.0, errorOutcome)
 }
 
+func TestReportSubmitCheckDuration(t *testing.T) {
+	m := newCycleMetrics(pulsarutils.NoOpPublisher[*metricevents.Event]{}, "")
+
+	m.ReportSubmitCheckDuration("queue1", 250*time.Millisecond)
+	val := testutil.ToFloat64(m.submitCheckDuration.WithLabelValues("queue1"))
+	assert.InDelta(t, 250.0, val, epsilon)
+
+	// A second call overwrites, not accumulates.
+	m.ReportSubmitCheckDuration("queue1", 100*time.Millisecond)
+	val = testutil.ToFloat64(m.submitCheckDuration.WithLabelValues("queue1"))
+	assert.InDelta(t, 100.0, val, epsilon)
+
+	// Independent label sets are tracked separately.
+	m.ReportSubmitCheckDuration("queue2", 50*time.Millisecond)
+	val2 := testutil.ToFloat64(m.submitCheckDuration.WithLabelValues("queue2"))
+	assert.InDelta(t, 50.0, val2, epsilon)
+	val = testutil.ToFloat64(m.submitCheckDuration.WithLabelValues("queue1"))
+	assert.InDelta(t, 100.0, val, epsilon)
+
+	// Sub-millisecond durations retain microsecond precision (reported as fractional milliseconds).
+	m.ReportSubmitCheckDuration("queue3", 723*time.Microsecond)
+	val3 := testutil.ToFloat64(m.submitCheckDuration.WithLabelValues("queue3"))
+	assert.InDelta(t, 0.723, val3, epsilon)
+}
+
+func TestResetSubmitCheckDurations(t *testing.T) {
+	m := newCycleMetrics(pulsarutils.NoOpPublisher[*metricevents.Event]{}, "")
+
+	m.ReportSubmitCheckDuration("queue1", 250*time.Millisecond)
+	m.ReportSubmitCheckDuration("queue2", 100*time.Millisecond)
+
+	m.ResetSubmitCheckDurations()
+
+	// After reset both label sets should return zero (the zero-value Prometheus returns for unset gauges).
+	val1 := testutil.ToFloat64(m.submitCheckDuration.WithLabelValues("queue1"))
+	assert.InDelta(t, 0.0, val1, epsilon)
+	val2 := testutil.ToFloat64(m.submitCheckDuration.WithLabelValues("queue2"))
+	assert.InDelta(t, 0.0, val2, epsilon)
+}
+
+func TestResetLeaderMetrics_ResetsSubmitCheckDuration(t *testing.T) {
+	m := newCycleMetrics(pulsarutils.NoOpPublisher[*metricevents.Event]{}, "")
+
+	m.ReportSubmitCheckDuration("queue1", 500*time.Millisecond)
+	val := testutil.ToFloat64(m.submitCheckDuration.WithLabelValues("queue1"))
+	assert.InDelta(t, 500.0, val, epsilon)
+
+	m.resetLeaderMetrics()
+
+	val = testutil.ToFloat64(m.submitCheckDuration.WithLabelValues("queue1"))
+	assert.InDelta(t, 0.0, val, epsilon)
+}
+
 func TestResetLeaderMetrics_Counters(t *testing.T) {
 	m := newCycleMetrics(pulsarutils.NoOpPublisher[*metricevents.Event]{}, "")
 	poolAndQueueAndPriorityClassTypeLabels := []string{"pool1", "queue1", "priorityClass1", "type1"}

--- a/internal/scheduler/metrics/cycle_metrics_test.go
+++ b/internal/scheduler/metrics/cycle_metrics_test.go
@@ -146,7 +146,6 @@ func TestReportSubmitCheckDuration(t *testing.T) {
 	assertHistogramObservation(t, m.submitCheckDuration, "queue2", 1, 50.0)
 	assertHistogramObservation(t, m.submitCheckDuration, "queue3", 1, 0.723)
 
-	// A subsequent call accumulates (histogram semantics) rather than overwriting.
 	m.ReportSubmitCheckDuration(map[string]time.Duration{
 		"queue1": 100 * time.Millisecond,
 	})

--- a/internal/scheduler/metrics_test.go
+++ b/internal/scheduler/metrics_test.go
@@ -69,7 +69,8 @@ func TestMetricsCollector_TestCollect_QueueMetrics(t *testing.T) {
 			initialJobs: queuedJobs,
 			queues:      []*api.Queue{queue},
 			expected: []prometheus.Metric{
-				commonmetrics.NewQueueSizeMetric(3.0, testfixtures.TestQueue),
+				commonmetrics.NewQueueSizeMetric(3.0, testfixtures.TestQueue, commonmetrics.QueueStateValidated),
+				commonmetrics.NewQueueSizeMetric(0.0, testfixtures.TestQueue, commonmetrics.QueueStateUnvalidated),
 				commonmetrics.NewQueueDistinctSchedulingKeyMetric(1.0, testfixtures.TestQueue),
 				commonmetrics.NewQueuePriceBandBidMetric(0, testfixtures.TestPool, testfixtures.TestQueue, commonmetrics.QueuedPhase, "A"),
 				commonmetrics.NewQueuePriceBandBidMetric(0, testfixtures.TestPool, testfixtures.TestQueue, commonmetrics.RunningPhase, "A"),
@@ -118,7 +119,8 @@ func TestMetricsCollector_TestCollect_QueueMetrics(t *testing.T) {
 			initialJobs: []*jobdb.Job{jobWithTerminatedRun},
 			queues:      []*api.Queue{queue},
 			expected: []prometheus.Metric{
-				commonmetrics.NewQueueSizeMetric(1.0, testfixtures.TestQueue),
+				commonmetrics.NewQueueSizeMetric(1.0, testfixtures.TestQueue, commonmetrics.QueueStateValidated),
+				commonmetrics.NewQueueSizeMetric(0.0, testfixtures.TestQueue, commonmetrics.QueueStateUnvalidated),
 				commonmetrics.NewQueueDistinctSchedulingKeyMetric(1.0, testfixtures.TestQueue),
 				commonmetrics.NewQueuePriceBandBidMetric(0, testfixtures.TestPool, testfixtures.TestQueue, commonmetrics.QueuedPhase, "A"),
 				commonmetrics.NewQueuePriceBandBidMetric(0, testfixtures.TestPool, testfixtures.TestQueue, commonmetrics.RunningPhase, "A"),
@@ -165,7 +167,8 @@ func TestMetricsCollector_TestCollect_QueueMetrics(t *testing.T) {
 			initialJobs: []*jobdb.Job{queuedJobMultiplePools},
 			queues:      []*api.Queue{queue},
 			expected: []prometheus.Metric{
-				commonmetrics.NewQueueSizeMetric(1.0, testfixtures.TestQueue),
+				commonmetrics.NewQueueSizeMetric(1.0, testfixtures.TestQueue, commonmetrics.QueueStateValidated),
+				commonmetrics.NewQueueSizeMetric(0.0, testfixtures.TestQueue, commonmetrics.QueueStateUnvalidated),
 				commonmetrics.NewQueueDistinctSchedulingKeyMetric(1.0, testfixtures.TestQueue),
 				commonmetrics.NewQueuePriceBandBidMetric(0, testfixtures.TestPool, testfixtures.TestQueue, commonmetrics.QueuedPhase, "A"),
 				commonmetrics.NewQueuePriceBandBidMetric(0, testfixtures.TestPool, testfixtures.TestQueue, commonmetrics.RunningPhase, "A"),
@@ -225,11 +228,23 @@ func TestMetricsCollector_TestCollect_QueueMetrics(t *testing.T) {
 				commonmetrics.NewCountQueueResources(1, testfixtures.TestPool2, testfixtures.TestDefaultPriorityClass, testfixtures.TestQueue, "None", "memory", commonmetrics.AccountingRoleSecondary),
 			},
 		},
+		"queued metrics for validated and unvalidated jobs": {
+			initialJobs: []*jobdb.Job{
+				testfixtures.TestQueuedJobDbJob().WithValidated(true),
+				testfixtures.TestQueuedJobDbJob().WithValidated(false),
+			},
+			queues: []*api.Queue{queue},
+			expected: []prometheus.Metric{
+				commonmetrics.NewQueueSizeMetric(1.0, testfixtures.TestQueue, commonmetrics.QueueStateValidated),
+				commonmetrics.NewQueueSizeMetric(1.0, testfixtures.TestQueue, commonmetrics.QueueStateUnvalidated),
+			},
+		},
 		"running metrics": {
 			initialJobs: runningJobs,
 			queues:      []*api.Queue{queue},
 			expected: []prometheus.Metric{
-				commonmetrics.NewQueueSizeMetric(0.0, testfixtures.TestQueue),
+				commonmetrics.NewQueueSizeMetric(0.0, testfixtures.TestQueue, commonmetrics.QueueStateValidated),
+				commonmetrics.NewQueueSizeMetric(0.0, testfixtures.TestQueue, commonmetrics.QueueStateUnvalidated),
 				commonmetrics.NewQueueDistinctSchedulingKeyMetric(0.0, testfixtures.TestQueue),
 				commonmetrics.NewQueuePriceBandBidMetric(0, testfixtures.TestPool, testfixtures.TestQueue, commonmetrics.QueuedPhase, "A"),
 				commonmetrics.NewQueuePriceBandBidMetric(0, testfixtures.TestPool, testfixtures.TestQueue, commonmetrics.RunningPhase, "A"),

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -596,7 +596,7 @@ func (s *Scheduler) addNodeAntiAffinitiesForAttemptedRunsIfSchedulable(ctx *arma
 		// should never happen - requirements haven't changed
 		panic(err)
 	}
-	results, err := s.submitChecker.Check(ctx, []*jobdb.Job{job})
+	results, err := s.submitChecker.Check(ctx, []*jobdb.Job{job}, nil)
 	if err != nil {
 		return nil, false, err
 	}
@@ -1133,7 +1133,13 @@ func (s *Scheduler) submitCheck(ctx *armadacontext.Context, txn *jobdb.Txn) ([]*
 		jobsToCheck = append(jobsToCheck, job)
 	}
 
-	results, err := s.submitChecker.Check(ctx, jobsToCheck)
+	var reportDuration func(queue string, duration time.Duration)
+	if s.metrics.LeaderMetricsEnabled() {
+		s.metrics.ResetSubmitCheckDurations()
+		reportDuration = s.metrics.ReportSubmitCheckDuration
+	}
+
+	results, err := s.submitChecker.Check(ctx, jobsToCheck, reportDuration)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -596,7 +596,7 @@ func (s *Scheduler) addNodeAntiAffinitiesForAttemptedRunsIfSchedulable(ctx *arma
 		// should never happen - requirements haven't changed
 		panic(err)
 	}
-	results, err := s.submitChecker.Check(ctx, []*jobdb.Job{job}, nil)
+	results, _, err := s.submitChecker.Check(ctx, []*jobdb.Job{job})
 	if err != nil {
 		return nil, false, err
 	}
@@ -1133,15 +1133,12 @@ func (s *Scheduler) submitCheck(ctx *armadacontext.Context, txn *jobdb.Txn) ([]*
 		jobsToCheck = append(jobsToCheck, job)
 	}
 
-	var reportDuration func(queue string, duration time.Duration)
-	if s.metrics.LeaderMetricsEnabled() {
-		s.metrics.ResetSubmitCheckDurations()
-		reportDuration = s.metrics.ReportSubmitCheckDuration
-	}
-
-	results, err := s.submitChecker.Check(ctx, jobsToCheck, reportDuration)
+	results, queueDurations, err := s.submitChecker.Check(ctx, jobsToCheck)
 	if err != nil {
 		return nil, err
+	}
+	if s.metrics.LeaderMetricsEnabled() {
+		s.metrics.ReportSubmitCheckDuration(queueDurations)
 	}
 
 	// Only process jobs that Check() returned results for.

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1875,7 +1875,7 @@ type testSubmitChecker struct {
 	checkSuccess bool
 }
 
-func (t *testSubmitChecker) Check(_ *armadacontext.Context, jobs []*jobdb.Job, _ func(queue string, duration time.Duration)) (map[string]schedulingResult, error) {
+func (t *testSubmitChecker) Check(_ *armadacontext.Context, jobs []*jobdb.Job) (map[string]schedulingResult, map[string]time.Duration, error) {
 	result := make(map[string]schedulingResult)
 	for _, job := range jobs {
 		if t.checkSuccess {
@@ -1884,7 +1884,7 @@ func (t *testSubmitChecker) Check(_ *armadacontext.Context, jobs []*jobdb.Job, _
 			result[job.Id()] = schedulingResult{isSchedulable: false, reason: "job not schedulable"}
 		}
 	}
-	return result, nil
+	return result, nil, nil
 }
 
 type testQueueCache struct {

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1875,7 +1875,7 @@ type testSubmitChecker struct {
 	checkSuccess bool
 }
 
-func (t *testSubmitChecker) Check(_ *armadacontext.Context, jobs []*jobdb.Job) (map[string]schedulingResult, error) {
+func (t *testSubmitChecker) Check(_ *armadacontext.Context, jobs []*jobdb.Job, _ func(queue string, duration time.Duration)) (map[string]schedulingResult, error) {
 	result := make(map[string]schedulingResult)
 	for _, job := range jobs {
 		if t.checkSuccess {

--- a/internal/scheduler/submitcheck.go
+++ b/internal/scheduler/submitcheck.go
@@ -55,7 +55,7 @@ type schedulerState struct {
 }
 
 type SubmitScheduleChecker interface {
-	Check(ctx *armadacontext.Context, jobs []*jobdb.Job) (map[string]schedulingResult, error)
+	Check(ctx *armadacontext.Context, jobs []*jobdb.Job, onQueueDone func(queue string, duration time.Duration)) (map[string]schedulingResult, error)
 }
 
 type SubmitChecker struct {
@@ -207,7 +207,7 @@ func (srv *SubmitChecker) getPoolsBySubmissionGroup(submissionGroup string) []st
 	return srv.poolsBySubmissionGroup[submissionGroup]
 }
 
-func (srv *SubmitChecker) Check(ctx *armadacontext.Context, jobs []*jobdb.Job) (map[string]schedulingResult, error) {
+func (srv *SubmitChecker) Check(ctx *armadacontext.Context, jobs []*jobdb.Job, onQueueDone func(queue string, duration time.Duration)) (map[string]schedulingResult, error) {
 	start := srv.clock.Now()
 	state := srv.state.Load()
 	if state == nil {
@@ -222,12 +222,13 @@ func (srv *SubmitChecker) Check(ctx *armadacontext.Context, jobs []*jobdb.Job) (
 
 	results := make(map[string]schedulingResult, len(jobs))
 
-	for _, jobsInQueue := range jobsByQueue {
+	for queue, jobsInQueue := range jobsByQueue {
 		if globalDeadline.exceeded(srv.clock.Now()) {
 			break
 		}
 
-		queueDeadline := newDeadline(srv.submitCheckConfig.MaxDurationPerQueue, srv.clock.Now())
+		queueStart := srv.clock.Now()
+		queueDeadline := newDeadline(srv.submitCheckConfig.MaxDurationPerQueue, queueStart)
 
 		jobsByGang := map[string][]*jobdb.Job{}
 		for _, job := range jobsInQueue {
@@ -256,6 +257,10 @@ func (srv *SubmitChecker) Check(ctx *armadacontext.Context, jobs []*jobdb.Job) (
 				}
 				processedGangs[gangId] = true
 			}
+		}
+
+		if onQueueDone != nil {
+			onQueueDone(queue, srv.clock.Since(queueStart))
 		}
 	}
 	ctx.Infof("Checked %d/%d jobs in %s", len(results), len(jobs), srv.clock.Since(start))

--- a/internal/scheduler/submitcheck.go
+++ b/internal/scheduler/submitcheck.go
@@ -55,7 +55,7 @@ type schedulerState struct {
 }
 
 type SubmitScheduleChecker interface {
-	Check(ctx *armadacontext.Context, jobs []*jobdb.Job, onQueueDone func(queue string, duration time.Duration)) (map[string]schedulingResult, error)
+	Check(ctx *armadacontext.Context, jobs []*jobdb.Job) (map[string]schedulingResult, map[string]time.Duration, error)
 }
 
 type SubmitChecker struct {
@@ -207,11 +207,11 @@ func (srv *SubmitChecker) getPoolsBySubmissionGroup(submissionGroup string) []st
 	return srv.poolsBySubmissionGroup[submissionGroup]
 }
 
-func (srv *SubmitChecker) Check(ctx *armadacontext.Context, jobs []*jobdb.Job, onQueueDone func(queue string, duration time.Duration)) (map[string]schedulingResult, error) {
+func (srv *SubmitChecker) Check(ctx *armadacontext.Context, jobs []*jobdb.Job) (map[string]schedulingResult, map[string]time.Duration, error) {
 	start := srv.clock.Now()
 	state := srv.state.Load()
 	if state == nil {
-		return nil, fmt.Errorf("executor state not loaded")
+		return nil, nil, fmt.Errorf("executor state not loaded")
 	}
 
 	globalDeadline := newDeadline(srv.submitCheckConfig.MaxDuration, start)
@@ -221,6 +221,7 @@ func (srv *SubmitChecker) Check(ctx *armadacontext.Context, jobs []*jobdb.Job, o
 	})
 
 	results := make(map[string]schedulingResult, len(jobs))
+	queueDurations := make(map[string]time.Duration, len(jobsByQueue))
 
 	for queue, jobsInQueue := range jobsByQueue {
 		if globalDeadline.exceeded(srv.clock.Now()) {
@@ -259,12 +260,10 @@ func (srv *SubmitChecker) Check(ctx *armadacontext.Context, jobs []*jobdb.Job, o
 			}
 		}
 
-		if onQueueDone != nil {
-			onQueueDone(queue, srv.clock.Since(queueStart))
-		}
+		queueDurations[queue] = srv.clock.Since(queueStart)
 	}
 	ctx.Infof("Checked %d/%d jobs in %s", len(results), len(jobs), srv.clock.Since(start))
-	return results, nil
+	return results, queueDurations, nil
 }
 
 func (srv *SubmitChecker) getIndividualSchedulingResult(job *jobdb.Job, state *schedulerState) schedulingResult {

--- a/internal/scheduler/submitcheck_test.go
+++ b/internal/scheduler/submitcheck_test.go
@@ -411,7 +411,7 @@ func TestSubmitChecker_CheckJobDbJobs(t *testing.T) {
 			}
 			err := submitCheck.Initialise(ctx)
 			assert.NoError(t, err)
-			results, err := submitCheck.Check(ctx, tc.jobs)
+			results, err := submitCheck.Check(ctx, tc.jobs, nil)
 			require.NoError(t, err)
 
 			require.Equal(t, len(tc.expectedResult), len(results))

--- a/internal/scheduler/submitcheck_test.go
+++ b/internal/scheduler/submitcheck_test.go
@@ -411,7 +411,7 @@ func TestSubmitChecker_CheckJobDbJobs(t *testing.T) {
 			}
 			err := submitCheck.Initialise(ctx)
 			assert.NoError(t, err)
-			results, err := submitCheck.Check(ctx, tc.jobs, nil)
+			results, _, err := submitCheck.Check(ctx, tc.jobs)
 			require.NoError(t, err)
 
 			require.Equal(t, len(tc.expectedResult), len(results))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you: -->

#### What type of PR is this?

Feature / observability enhancement.

#### What this PR does / why we need it

Adds two observability improvements to the scheduler:

1. A new Prometheus histogram metric `armada_scheduler_submit_check_times` (labeled by `queue`) that records the time spent in `SubmitChecker.Check` per queue per scheduling cycle, in milliseconds.
    - `SubmitChecker.Check` now returns a `map[string]time.Duration` of per-queue durations alongside its existing results map.
    - The anti-affinity re-check path (`addNodeAntiAffinitiesForAttemptedRunsIfSchedulable`) discards the durations as it would skew the results.

2. A new `state` label on the existing `armada_queue_size` metric, with values `validated` and `unvalidated`, so queued job counts can be broken down by whether the scheduler has validated the job yet. `CollectQueueMetrics` now takes a `map[string]QueueSizeCounts` (split by validation state) instead of a single integer per queue.

#### Special notes for your reviewer

- The `SubmitScheduleChecker` interface signature changed. The only non-test caller outside of `Scheduler.submitCheck` is `addNodeAntiAffinitiesForAttemptedRunsIfSchedulable`, which intentionally ignores the new return value. I updated the test doubles (`testSubmitChecker`, `submitcheck_test.go`) accordingly.
- `armada_queue_size` gained a label, so any existing alerts/dashboards that reference it without aggregating over `state` will need to be updated. The `prometheusrule.yaml` rule that uses this metric has been adjusted in this PR.