### PR TITLE
Surface and categorize platform-mismatch image pull failures

### DIFF
--- a/internal/executor/categorizer/classifier.go
+++ b/internal/executor/categorizer/classifier.go
@@ -24,6 +24,7 @@ type rule struct {
 	containerName        string
 	onExitCodes          *errormatch.ExitCodeMatcher
 	onTerminationMessage *regexp.Regexp
+	onPodError           *regexp.Regexp
 	onConditions         []string
 	subcategory          string
 }
@@ -99,11 +100,14 @@ func buildRule(cfg CategoryRule) (rule, error) {
 	if cfg.OnTerminationMessage != nil {
 		matcherCount++
 	}
+	if cfg.OnPodError != nil {
+		matcherCount++
+	}
 	if matcherCount == 0 {
-		return rule{}, fmt.Errorf("rule must specify one of onConditions, onExitCodes, or onTerminationMessage")
+		return rule{}, fmt.Errorf("rule must specify one of onConditions, onExitCodes, onTerminationMessage, or onPodError")
 	}
 	if matcherCount > 1 {
-		return rule{}, fmt.Errorf("rule must specify only one of onConditions, onExitCodes, or onTerminationMessage")
+		return rule{}, fmt.Errorf("rule must specify only one of onConditions, onExitCodes, onTerminationMessage, or onPodError")
 	}
 
 	for _, cond := range cfg.OnConditions {
@@ -126,20 +130,30 @@ func buildRule(cfg CategoryRule) (rule, error) {
 		}
 	}
 
-	var compiledRegex *regexp.Regexp
+	var terminationRegex *regexp.Regexp
 	if cfg.OnTerminationMessage != nil {
 		re, err := regexp.Compile(cfg.OnTerminationMessage.Pattern)
 		if err != nil {
-			return rule{}, fmt.Errorf("invalid regex %q: %w", cfg.OnTerminationMessage.Pattern, err)
+			return rule{}, fmt.Errorf("invalid onTerminationMessage regex %q: %w", cfg.OnTerminationMessage.Pattern, err)
 		}
-		compiledRegex = re
+		terminationRegex = re
+	}
+
+	var podErrorRegex *regexp.Regexp
+	if cfg.OnPodError != nil {
+		re, err := regexp.Compile(cfg.OnPodError.Pattern)
+		if err != nil {
+			return rule{}, fmt.Errorf("invalid onPodError regex %q: %w", cfg.OnPodError.Pattern, err)
+		}
+		podErrorRegex = re
 	}
 
 	return rule{
 		containerName:        cfg.ContainerName,
 		onExitCodes:          cfg.OnExitCodes,
 		onConditions:         cfg.OnConditions,
-		onTerminationMessage: compiledRegex,
+		onTerminationMessage: terminationRegex,
+		onPodError:           podErrorRegex,
 		subcategory:          cfg.Subcategory,
 	}, nil
 }
@@ -148,7 +162,13 @@ func buildRule(cfg CategoryRule) (rule, error) {
 // Rules are evaluated in config order; the first matching rule wins.
 // Returns empty result if the receiver is nil or the pod is nil.
 // Returns (defaultCategory, defaultSubcategory) if no rules match.
-func (c *Classifier) Classify(pod *v1.Pod) ClassifyResult {
+//
+// podErrorMessage is the pod-level kubelet/runtime error captured for failures
+// that happen before or around startup (image pull, missing volume, missing
+// config, etc.), where the kubelet may have rotated the original error out of
+// pod.Status (ErrImagePull -> ImagePullBackOff) before we inspect it. It is
+// matched only by onPodError rules. Pass "" when no such text is available.
+func (c *Classifier) Classify(pod *v1.Pod, podErrorMessage string) ClassifyResult {
 	if c == nil || pod == nil {
 		return ClassifyResult{}
 	}
@@ -157,7 +177,7 @@ func (c *Classifier) Classify(pod *v1.Pod) ClassifyResult {
 
 	for _, cat := range c.categories {
 		for _, r := range cat.rules {
-			if ruleMatches(r, containers, podReason) {
+			if ruleMatches(r, containers, podReason, podErrorMessage) {
 				return ClassifyResult{Category: cat.name, Subcategory: r.subcategory}
 			}
 		}
@@ -165,10 +185,11 @@ func (c *Classifier) Classify(pod *v1.Pod) ClassifyResult {
 	return ClassifyResult{Category: c.defaultCategory, Subcategory: c.defaultSubcategory}
 }
 
-// ruleMatches evaluates a single rule. When containerName is set, only that
-// container is considered. It checks the first non-nil matcher:
-// conditions > exit codes > termination message.
-func ruleMatches(r rule, containers []containerInfo, podReason string) bool {
+// ruleMatches evaluates a single rule. Container-level matchers honor the
+// rule's containerName scope (when set); onPodError ignores it because the
+// pod-level error has no container attribution. Exactly one matcher is set
+// per rule (validated at NewClassifier).
+func ruleMatches(r rule, containers []containerInfo, podReason, podErrorMessage string) bool {
 	filtered := containers
 	if r.containerName != "" {
 		filtered = filterByName(containers, r.containerName)
@@ -181,6 +202,9 @@ func ruleMatches(r rule, containers []containerInfo, podReason string) bool {
 	}
 	if r.onTerminationMessage != nil {
 		return matchesTerminationMessage(r.onTerminationMessage, filtered)
+	}
+	if r.onPodError != nil {
+		return podErrorMessage != "" && errormatch.MatchPattern(r.onPodError, podErrorMessage)
 	}
 	return false
 }

--- a/internal/executor/categorizer/classifier_test.go
+++ b/internal/executor/categorizer/classifier_test.go
@@ -15,6 +15,7 @@ func TestClassify(t *testing.T) {
 	tests := map[string]struct {
 		config              ErrorCategoriesConfig
 		pod                 *v1.Pod
+		podErrorMessage     string
 		expectedCategory    string
 		expectedSubcategory string
 	}{
@@ -281,13 +282,76 @@ func TestClassify(t *testing.T) {
 			pod:              podWithTerminatedContainer(1, "Error", ""),
 			expectedCategory: "",
 		},
+		"onPodError matches the captured kubelet error": {
+			config: ErrorCategoriesConfig{Categories: []CategoryConfig{
+				{Name: "infrastructure", Rules: []CategoryRule{
+					{OnPodError: &errormatch.RegexMatcher{Pattern: "no match for platform in manifest"}, Subcategory: "platform_mismatch"},
+				}},
+			}},
+			pod: &v1.Pod{Status: v1.PodStatus{
+				Phase: v1.PodPending,
+				ContainerStatuses: []v1.ContainerStatus{
+					{Name: "main", State: v1.ContainerState{
+						Waiting: &v1.ContainerStateWaiting{Reason: "ImagePullBackOff", Message: "Back-off pulling image"},
+					}},
+				},
+			}},
+			podErrorMessage:     `Failed to pull image "amd64/busybox:latest": no match for platform in manifest: not found`,
+			expectedCategory:    "infrastructure",
+			expectedSubcategory: "platform_mismatch",
+		},
+		"empty podErrorMessage does not match onPodError": {
+			config: ErrorCategoriesConfig{Categories: []CategoryConfig{
+				{Name: "infrastructure", Rules: []CategoryRule{
+					{OnPodError: &errormatch.RegexMatcher{Pattern: "anything"}, Subcategory: "x"},
+				}},
+			}},
+			pod:              &v1.Pod{Status: v1.PodStatus{Phase: v1.PodPending}},
+			podErrorMessage:  "",
+			expectedCategory: "",
+		},
+		"onPodError ignores ContainerName scope (pod-level error has no container attribution)": {
+			config: ErrorCategoriesConfig{Categories: []CategoryConfig{
+				{Name: "infrastructure", Rules: []CategoryRule{
+					{ContainerName: "init", OnPodError: &errormatch.RegexMatcher{Pattern: "no match for platform in manifest"}, Subcategory: "platform_mismatch"},
+				}},
+			}},
+			pod: &v1.Pod{Status: v1.PodStatus{
+				Phase: v1.PodPending,
+				ContainerStatuses: []v1.ContainerStatus{
+					{Name: "main", State: v1.ContainerState{
+						Waiting: &v1.ContainerStateWaiting{Reason: "ImagePullBackOff", Message: "Back-off pulling image"},
+					}},
+				},
+			}},
+			podErrorMessage:     `Failed to pull image "amd64/busybox:latest": no match for platform in manifest: not found`,
+			expectedCategory:    "infrastructure",
+			expectedSubcategory: "platform_mismatch",
+		},
+		"onTerminationMessage does not match pod-level podErrorMessage": {
+			config: ErrorCategoriesConfig{Categories: []CategoryConfig{
+				{Name: "infrastructure", Rules: []CategoryRule{
+					{OnTerminationMessage: &errormatch.RegexMatcher{Pattern: "no match for platform in manifest"}, Subcategory: "should_not_fire"},
+				}},
+			}},
+			pod: &v1.Pod{Status: v1.PodStatus{
+				Phase: v1.PodPending,
+				ContainerStatuses: []v1.ContainerStatus{
+					{Name: "main", State: v1.ContainerState{
+						Waiting: &v1.ContainerStateWaiting{Reason: "ImagePullBackOff", Message: "Back-off pulling image"},
+					}},
+				},
+			}},
+			podErrorMessage:  `Failed to pull image "amd64/busybox:latest": no match for platform in manifest: not found`,
+			expectedCategory: "",
+		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			classifier, err := NewClassifier(tc.config)
 			require.NoError(t, err)
-			result := classifier.Classify(tc.pod)
+			result := classifier.Classify(tc.pod, tc.podErrorMessage)
 			assert.Equal(t, tc.expectedCategory, result.Category)
 			assert.Equal(t, tc.expectedSubcategory, result.Subcategory)
 		})
@@ -346,13 +410,21 @@ func TestNewClassifier_ValidationErrors(t *testing.T) {
 			}},
 			errContains: "requires at least one value",
 		},
-		"invalid regex": {
+		"invalid onTerminationMessage regex": {
 			config: ErrorCategoriesConfig{Categories: []CategoryConfig{
 				{Name: "bad", Rules: []CategoryRule{
 					{OnTerminationMessage: &errormatch.RegexMatcher{Pattern: "[invalid"}},
 				}},
 			}},
-			errContains: "invalid regex",
+			errContains: "invalid onTerminationMessage regex",
+		},
+		"invalid onPodError regex": {
+			config: ErrorCategoriesConfig{Categories: []CategoryConfig{
+				{Name: "bad", Rules: []CategoryRule{
+					{OnPodError: &errormatch.RegexMatcher{Pattern: "[invalid"}},
+				}},
+			}},
+			errContains: "invalid onPodError regex",
 		},
 		"empty rules": {
 			config:      ErrorCategoriesConfig{Categories: []CategoryConfig{{Name: "empty", Rules: nil}}},

--- a/internal/executor/categorizer/types.go
+++ b/internal/executor/categorizer/types.go
@@ -23,12 +23,21 @@ type CategoryConfig struct {
 
 // CategoryRule defines a single matching condition. Exactly one matcher must
 // be set per rule (validated by NewClassifier). Rules within a category are OR'd.
-// When ContainerName is set, only failures from that container are considered.
-// When empty, failures from any container can match (default).
+//
+// Container-level matchers (OnConditions, OnExitCodes, OnTerminationMessage)
+// inspect per-container state from pod.Status; ContainerName scopes them to a
+// specific container when set, otherwise any container can match.
+//
+// OnPodError is pod-level: it matches the kubelet/runtime error captured for
+// failures that happen before or around startup (image pull, missing volume,
+// missing config), where no container has terminated with a usable
+// terminationMessage. ContainerName is ignored for OnPodError because the
+// captured text has no container attribution.
 type CategoryRule struct {
 	ContainerName        string                      `yaml:"containerName,omitempty"`
 	OnExitCodes          *errormatch.ExitCodeMatcher `yaml:"onExitCodes,omitempty"`
 	OnTerminationMessage *errormatch.RegexMatcher    `yaml:"onTerminationMessage,omitempty"`
+	OnPodError           *errormatch.RegexMatcher    `yaml:"onPodError,omitempty"`
 	OnConditions         []string                    `yaml:"onConditions,omitempty"`
 	Subcategory          string                      `yaml:"subcategory,omitempty"`
 }

--- a/internal/executor/diagnostics/diagnostics.go
+++ b/internal/executor/diagnostics/diagnostics.go
@@ -1,0 +1,34 @@
+// Package diagnostics provides user-facing guidance for well-known job
+// failure modes Armada recognizes by their kubelet/runtime error text.
+//
+// The catalog is curated by the Armada team and universal across deployments;
+// it is not operator-configurable. Operators wanting deployment-specific
+// hints should use the categorizer's errorCategories config.
+package diagnostics
+
+import "regexp"
+
+type hint struct {
+	pattern *regexp.Regexp
+	text    string
+}
+
+// builtinHints is consulted in order; first match wins, so place
+// more-specific patterns before broader ones.
+var builtinHints = []hint{
+	{
+		pattern: regexp.MustCompile(`no match for platform in manifest`),
+		text:    "No compatible image was found for the target farm node's architecture; this is often due to an x64/arm64 mismatch, so check the image architecture or build and publish a compatible version.",
+	},
+}
+
+// LookupHint returns user-facing guidance matching the failure message,
+// or "" if no built-in hint applies.
+func LookupHint(message string) string {
+	for _, h := range builtinHints {
+		if h.pattern.MatchString(message) {
+			return h.text
+		}
+	}
+	return ""
+}

--- a/internal/executor/diagnostics/diagnostics_test.go
+++ b/internal/executor/diagnostics/diagnostics_test.go
@@ -1,0 +1,35 @@
+package diagnostics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLookupHint(t *testing.T) {
+	tests := map[string]struct {
+		message       string
+		wantSubstring string
+	}{
+		"empty message returns no hint": {
+			message: "",
+		},
+		"unknown failure returns no hint": {
+			message: "Some unrelated kubelet message",
+		},
+		"platform mismatch matches": {
+			message:       `Failed to pull image "amd64/busybox:latest": rpc error: code = NotFound desc = failed to pull and unpack image "docker.io/amd64/busybox:latest": no match for platform in manifest: not found`,
+			wantSubstring: "x64/arm64",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := LookupHint(tc.message)
+			if tc.wantSubstring == "" {
+				assert.Empty(t, got)
+				return
+			}
+			assert.Contains(t, got, tc.wantSubstring)
+		})
+	}
+}

--- a/internal/executor/reporter/event.go
+++ b/internal/executor/reporter/event.go
@@ -10,6 +10,7 @@ import (
 	networking "k8s.io/api/networking/v1"
 
 	"github.com/armadaproject/armada/internal/executor/categorizer"
+	"github.com/armadaproject/armada/internal/executor/diagnostics"
 	"github.com/armadaproject/armada/internal/executor/domain"
 	"github.com/armadaproject/armada/internal/executor/util"
 	"github.com/armadaproject/armada/pkg/armadaevents"
@@ -83,9 +84,13 @@ func CreateEventForCurrentState(pod *v1.Pod, clusterId string, classifyResult ca
 		})
 		return sequence, nil
 	case v1.PodFailed:
+		reason := util.ExtractPodFailedReason(pod)
+		if hint := diagnostics.LookupHint(reason); hint != "" {
+			reason = fmt.Sprintf("%s\n%s", hint, reason)
+		}
 		return CreateJobFailedEvent(
 			pod,
-			util.ExtractPodFailedReason(pod),
+			reason,
 			util.ExtractPodFailureCause(pod),
 			"",
 			util.ExtractFailedPodContainerStatuses(pod, clusterId),

--- a/internal/executor/reporter/event_test.go
+++ b/internal/executor/reporter/event_test.go
@@ -81,7 +81,7 @@ func TestCreateEventForCurrentState_WhenPodFailed_WithClassifier(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	result, err := CreateEventForCurrentState(pod, "cluster1", classifier.Classify(pod))
+	result, err := CreateEventForCurrentState(pod, "cluster1", classifier.Classify(pod, ""))
 	assert.NoError(t, err)
 
 	assert.Len(t, result.Events, 1)

--- a/internal/executor/service/job_state_reporter.go
+++ b/internal/executor/service/job_state_reporter.go
@@ -93,7 +93,9 @@ func (stateReporter *JobStateReporter) reportCurrentStatus(pod *v1.Pod) {
 
 	var classifyResult categorizer.ClassifyResult
 	if pod.Status.Phase == v1.PodFailed {
-		classifyResult = stateReporter.classifier.Classify(pod)
+		// PodFailed implies a terminated container; the termination message
+		// lives in pod state, no extra message is needed.
+		classifyResult = stateReporter.classifier.Classify(pod, "")
 	}
 
 	event, err := reporter.CreateEventForCurrentState(pod, stateReporter.clusterContext.GetClusterId(), classifyResult)

--- a/internal/executor/service/pod_issue_handler.go
+++ b/internal/executor/service/pod_issue_handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/armadaproject/armada/internal/executor/categorizer"
 	"github.com/armadaproject/armada/internal/executor/configuration"
 	executorContext "github.com/armadaproject/armada/internal/executor/context"
+	"github.com/armadaproject/armada/internal/executor/diagnostics"
 	"github.com/armadaproject/armada/internal/executor/job"
 	"github.com/armadaproject/armada/internal/executor/metrics"
 	"github.com/armadaproject/armada/internal/executor/podchecks"
@@ -39,8 +40,16 @@ const (
 
 type podIssue struct {
 	// A copy of the pod when an issue was detected
-	OriginalPodState  *v1.Pod
-	Message           string
+	OriginalPodState *v1.Pod
+	// User-facing failure text. May include a curated diagnostic hint and a
+	// generic preface in addition to the raw kubelet/runtime error.
+	Message string
+	// Pod-level kubelet/runtime error captured before/around startup (image pull,
+	// missing volume, missing config, scheduler-rejected). Empty when the issue
+	// source is Armada-internal (e.g. stuck terminating, active deadline exceeded)
+	// or post-startup. Fed to the failure categorizer as the input for onPodError
+	// rules.
+	PodErrorMessage   string
 	DebugMessage      string
 	Retryable         bool
 	DeletionRequested bool
@@ -153,14 +162,19 @@ func (p *PodIssueHandler) DetectAndRegisterFailedPodIssue(pod *v1.Pod) (bool, er
 		return false, fmt.Errorf("Failed retrieving pod events for pod %s: %v", pod.Name, err)
 	}
 
-	isRetryable, message := p.failedPodChecker.IsRetryable(pod, podEvents)
+	isRetryable, podErrorMessage := p.failedPodChecker.IsRetryable(pod, podEvents)
 	if isRetryable {
+		message := podErrorMessage
+		if hint := diagnostics.LookupHint(podErrorMessage); hint != "" {
+			message = fmt.Sprintf("%s\n%s", hint, podErrorMessage)
+		}
 		return p.registerIssue(&runIssue{
 			JobId: jobId,
 			RunId: runId,
 			PodIssue: &podIssue{
 				OriginalPodState:  pod.DeepCopy(),
 				Message:           message,
+				PodErrorMessage:   podErrorMessage,
 				DebugMessage:      createDebugMessage(podEvents),
 				Retryable:         true,
 				DeletionRequested: false,
@@ -300,6 +314,7 @@ func (p *PodIssueHandler) detectPodIssues(allManagedPods []*v1.Pod) {
 				issue := &podIssue{
 					OriginalPodState: pod.DeepCopy(),
 					Message:          message,
+					PodErrorMessage:  podCheckMessage,
 					DebugMessage:     debugMessage,
 					Retryable:        retryable,
 					Type:             podIssueType,
@@ -425,7 +440,11 @@ func (p *PodIssueHandler) handleNonRetryableJobIssue(issue *issue) {
 		log.Infof("Handling non-retryable issue detected for job %s run %s", issue.RunIssue.JobId, issue.RunIssue.RunId)
 		podIssue := issue.RunIssue.PodIssue
 
-		result := p.classifier.Classify(podIssue.OriginalPodState)
+		// Pass podIssue.PodErrorMessage: kubelet rotates Waiting state from
+		// ErrImagePull to ImagePullBackOff during the detection window, so the raw
+		// containerd error survives only in this captured field. The categorizer's
+		// onPodError rules match against it.
+		result := p.classifier.Classify(podIssue.OriginalPodState, podIssue.PodErrorMessage)
 		clusterId := p.clusterContext.GetClusterId()
 
 		failedEvent, err := reporter.CreateJobFailedEvent(
@@ -546,6 +565,9 @@ func hasPodIssueSelfResolved(issue *issue) bool {
 }
 
 func createStuckPodMessage(retryable bool, originalMessage string) string {
+	if hint := diagnostics.LookupHint(originalMessage); hint != "" {
+		return fmt.Sprintf("%s\n%s", hint, originalMessage)
+	}
 	if retryable {
 		return fmt.Sprintf("Unable to start pod.\n%s", originalMessage)
 	}

--- a/internal/executor/service/pod_issue_handler_test.go
+++ b/internal/executor/service/pod_issue_handler_test.go
@@ -154,6 +154,104 @@ func TestPodIssueService_FailureCategorySet_WhenClassifierConfigured(t *testing.
 	assert.NotEmpty(t, failedEvent.JobRunErrors.Errors[0].GetPodError().ContainerErrors)
 }
 
+// TestPodIssueService_PlatformMismatchClassifiedAndPropagatedToErrorField is the
+// realistic end-to-end shape: an operator-defined onPodError rule matches the
+// kubelet error captured in podIssue.PodErrorMessage, the categorization flows
+// into the JobRunErrors event, and the user-facing PodError.Message (which the
+// lookout ingester stores verbatim into lookoutdb.job_run.error) contains both
+// the curated hint and the raw runtime error.
+func TestPodIssueService_PlatformMismatchClassifiedAndPropagatedToErrorField(t *testing.T) {
+	classifier, err := categorizer.NewClassifier(categorizer.ErrorCategoriesConfig{
+		Categories: []categorizer.CategoryConfig{
+			{
+				Name: "infrastructure",
+				Rules: []categorizer.CategoryRule{
+					{OnPodError: &errormatch.RegexMatcher{Pattern: "no match for platform in manifest"}, Subcategory: "platform_mismatch"},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	podIssueService, _, fakeClusterContext, eventReporter, err := setupTestComponentsWithClassifier([]*job.RunState{}, classifier)
+	require.NoError(t, err)
+
+	const rawKubeletError = `Failed to pull image "amd64/busybox:latest": no match for platform in manifest`
+	pod := makeUnretryableStuckPod()
+	pod.Status.ContainerStatuses[0].State.Waiting.Message = rawKubeletError
+	addPod(t, fakeClusterContext, pod)
+
+	podIssueService.HandlePodIssues()
+
+	require.Len(t, eventReporter.ReceivedEvents, 1)
+	failedEvent, ok := eventReporter.ReceivedEvents[0].Event.Events[0].Event.(*armadaevents.EventSequence_Event_JobRunErrors)
+	require.True(t, ok)
+
+	// Categorization: onPodError rule fired against PodErrorMessage (raw kubelet text).
+	assert.Equal(t, "infrastructure", failedEvent.JobRunErrors.Errors[0].GetFailureCategory())
+	assert.Equal(t, "platform_mismatch", failedEvent.JobRunErrors.Errors[0].GetFailureSubcategory())
+
+	// PodError.Message is propagated verbatim by the lookout ingester into
+	// lookoutdb.job_run.error (see internal/lookoutingester/instructions/instructions.go).
+	// The column users read in Lookout must contain BOTH the curated hint and the
+	// raw kubelet error, so platform-aware diagnosis works without losing fidelity.
+	podErrorMessage := failedEvent.JobRunErrors.Errors[0].GetPodError().Message
+	assert.Contains(t, podErrorMessage, "x64/arm64",
+		"lookoutdb error column must include the architecture-mismatch hint")
+	assert.Contains(t, podErrorMessage, "no match for platform in manifest",
+		"lookoutdb error column must preserve the raw kubelet error verbatim")
+}
+
+// TestPodIssueService_OnPodErrorIsolatedFromHintText enforces that podIssue.PodErrorMessage
+// (the input to onPodError matching) holds only the kubelet/runtime error, never the
+// hint-augmented user-facing Message. The rule below targets "x64/arm64", a phrase that
+// appears in the curated diagnostic hint but NOT in the raw kubelet error triggering it.
+// If a future regression piped Message into PodErrorMessage, this rule would fire spuriously.
+func TestPodIssueService_OnPodErrorIsolatedFromHintText(t *testing.T) {
+	classifier, err := categorizer.NewClassifier(categorizer.ErrorCategoriesConfig{
+		Categories: []categorizer.CategoryConfig{
+			{
+				Name: "leaked-from-hint",
+				Rules: []categorizer.CategoryRule{
+					{OnPodError: &errormatch.RegexMatcher{Pattern: "x64/arm64"}, Subcategory: "leak"},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	podIssueService, _, fakeClusterContext, eventReporter, err := setupTestComponentsWithClassifier([]*job.RunState{}, classifier)
+	require.NoError(t, err)
+
+	// Raw Waiting.Message: contains "no match for platform in manifest" (which triggers the
+	// platform-mismatch hint) but does NOT contain "x64/arm64" (which only appears in the hint text).
+	const rawKubeletError = `Failed to pull image "amd64/busybox:latest": no match for platform in manifest`
+	pod := makeUnretryableStuckPod()
+	pod.Status.ContainerStatuses[0].State.Waiting.Message = rawKubeletError
+	addPod(t, fakeClusterContext, pod)
+
+	podIssueService.HandlePodIssues()
+
+	require.Len(t, eventReporter.ReceivedEvents, 1)
+	failedEvent, ok := eventReporter.ReceivedEvents[0].Event.Events[0].Event.(*armadaevents.EventSequence_Event_JobRunErrors)
+	require.True(t, ok)
+
+	// PodError.Message is propagated verbatim by the lookout ingester into
+	// lookoutdb.job_run.error (see internal/lookoutingester/instructions/instructions.go),
+	// so asserting on it here equates to asserting on the column the user reads.
+	podErrorMessage := failedEvent.JobRunErrors.Errors[0].GetPodError().Message
+	assert.Contains(t, podErrorMessage, "x64/arm64",
+		"user-facing message must include the architecture-mismatch hint")
+	assert.Contains(t, podErrorMessage, "no match for platform in manifest",
+		"user-facing message must preserve the raw kubelet error verbatim")
+
+	// onPodError must have seen only the raw kubelet text via PodErrorMessage,
+	// so the "x64/arm64" rule (which only matches the hint phrase) must NOT fire.
+	assert.Equal(t, "", failedEvent.JobRunErrors.Errors[0].GetFailureCategory(),
+		"onPodError matched hint-augmented text instead of PodErrorMessage")
+	assert.Equal(t, "", failedEvent.JobRunErrors.Errors[0].GetFailureSubcategory())
+}
+
 func TestPodIssueService_OnlyDeletesPod_IfStuckTerminatingButDeletedByExecutor(t *testing.T) {
 	podIssueService, _, fakeClusterContext, eventsReporter, err := setupTestComponents([]*job.RunState{})
 	require.NoError(t, err)
@@ -792,6 +890,47 @@ func TestCreateDebugMessage(t *testing.T) {
 				assert.NotContains(t, result, "[truncated]")
 				assert.Contains(t, result, tt.events[0].Message)
 			}
+		})
+	}
+}
+
+func TestCreateStuckPodMessage(t *testing.T) {
+	platformMismatchOriginal := `Failed to pull image "amd64/busybox:latest": rpc error: code = NotFound desc = failed to pull and unpack image "docker.io/amd64/busybox:latest": no match for platform in manifest: not found`
+
+	tests := map[string]struct {
+		retryable       bool
+		originalMessage string
+		expectedPrefix  string
+	}{
+		"retryable with no matching hint uses generic preface": {
+			retryable:       true,
+			originalMessage: "some retryable failure",
+			expectedPrefix:  "Unable to start pod.",
+		},
+		"retryable platform mismatch surfaces targeted hint": {
+			retryable:       true,
+			originalMessage: platformMismatchOriginal,
+			expectedPrefix:  "No compatible image was found for the target farm node's architecture",
+		},
+		"non-retryable with no matching hint uses generic preface": {
+			retryable:       false,
+			originalMessage: "some other unrecoverable failure",
+			expectedPrefix:  "Unable to start pod - encountered an unrecoverable problem.",
+		},
+		"non-retryable platform mismatch surfaces targeted hint": {
+			retryable:       false,
+			originalMessage: platformMismatchOriginal,
+			expectedPrefix:  "No compatible image was found for the target farm node's architecture",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := createStuckPodMessage(tc.retryable, tc.originalMessage)
+			assert.True(t, strings.HasPrefix(result, tc.expectedPrefix),
+				"expected message to start with %q, got %q", tc.expectedPrefix, result)
+			assert.Contains(t, result, tc.originalMessage,
+				"original kubelet error must always be preserved verbatim")
 		})
 	}
 }


### PR DESCRIPTION
## Summary

When a container image is built for the wrong CPU architecture (e.g. an `amd64` image scheduled onto an `arm64` node), the kubelet error "no match for platform in manifest" is opaque and the pod stays `Waiting` until Armada gives up. Users see a generic stuck-pod failure with no actionable signal.

This PR adds an Armada-curated diagnostic-hint catalog for well-known failure modes (starting with platform mismatch), wires it into the executor's user-facing failure messages, and gives operators a new `onPodError` matcher to categorize pre-startup pod errors as `infrastructure/platform_mismatch` (or whatever taxonomy they prefer).

## Approach

- **New package `internal/executor/diagnostics`** — single entry point `LookupHint(message) string`. Curated by Armada (not operator-configurable); deployment-specific hints belong in `errorCategories` config.
- **Three wired call sites**: `reporter/event.go` (PodFailed branch), `service/pod_issue_handler.go` (retryable failed-pod path, stuck-pending path).
- **New categorizer matcher `onPodError`** — matches the pod-level kubelet/runtime error captured for failures that happen before or around startup (image pull, missing volume, missing config). Distinct from `onTerminationMessage`, which continues to match container-level `Terminated.Message` strings (with `containerName` scoping). Each matcher has a single data source, no overlap, no edge cases.
- **`Classify(pod, podErrorMessage string)`** — the captured pod-level error is passed in because kubelet rotates `Waiting.Reason` from `ErrImagePull` to `ImagePullBackOff` and drops the original error from pod state before Armada inspects it. The argument is matched only by `onPodError` rules.
- **`podIssue.PodErrorMessage`** — captured kubelet/runtime text fed to the classifier, separate from the hint-augmented user-facing `Message`.

## Validation

To reproduce:

**1. Add an `onPodError` rule to your executor config** (drop into `_local/executor/config.yaml` under the `application:` block):

```yaml
application:
  errorCategories:
    defaultCategory: "uncategorized"
    defaultSubcategory: "unknown"
    categories:
      - name: infrastructure
        rules:
          - onPodError:
              pattern: "no match for platform in manifest"
            subcategory: "platform_mismatch"
```

`onPodError` matches pod-level kubelet/runtime errors (image pull, missing volume, etc.). Categorization is opt-in: Armada ships no default rules.

**2. Submit a wrong-arch job** (`example/platform-mismatch.yaml`):

```yaml
queue: test
jobSetId: platform-mismatch-repro
jobs:
  - namespace: default
    priority: 0
    podSpec:
      terminationGracePeriodSeconds: 0
      restartPolicy: Never
      containers:
        - name: wrong-arch
          # On an arm64 cluster, force-pull the amd64 variant.
          # Flip to arm64v8/busybox if reproducing on an amd64 cluster.
          image: amd64/busybox:latest
          command: ["sh", "-c", "echo should-never-run"]
          resources:
            requests: { memory: 64Mi, cpu: "0.1" }
            limits:   { memory: 64Mi, cpu: "0.1" }
```

```bash
armadactl create queue test   # if not already present
armadactl submit example/platform-mismatch.yaml
```

**3. Wait** for the kubelet event-based fail check to fire (typically 1-5 minutes depending on `event_checks` grace period).

**4. Verify** the failure message and categorization land in the lookout DB. The `error` column is zlib-compressed bytea, so decode in two steps:

```bash
# Categorization columns
docker exec postgres psql -U postgres -d lookout -c \
  "SELECT job_id, run_id, finished, failure_category, failure_subcategory
   FROM job_run
   ORDER BY finished DESC NULLS LAST
   LIMIT 1;"

# Decompressed error message (the byte string the Lookout UI shows users)
docker exec postgres psql -U postgres -At -d lookout -c \
  "SELECT encode(error, 'base64') FROM job_run
   ORDER BY finished DESC NULLS LAST LIMIT 1;" \
| python3 -c 'import sys,base64,zlib; print(zlib.decompress(base64.b64decode(sys.stdin.read())).decode())'
```

### Expected (and observed) result

```
 failure_category | failure_subcategory
------------------+---------------------
 infrastructure   | platform_mismatch
```

Decompressed `error` column:

```
No compatible image was found for the target farm node's architecture; this is often due to an x64/arm64 mismatch, so check the image architecture or build and publish a compatible version.
Container ... has been in state Waiting for reason ImagePullBackOff (Failed to pull image "amd64/busybox:latest": rpc error: code = NotFound desc = failed to pull and unpack image "docker.io/amd64/busybox:latest": no match for platform in manifest: not found) for more than timeout 1ns
```

The first paragraph is the Armada-curated hint (always present, regardless of categorizer config). The second paragraph is the raw kubelet error preserved verbatim. The Lookout UI run detail panel renders this directly.

Live-validated end-to-end on macOS arm64 (M3) against a k3d cluster, branch `e9f84d7a1`.