### PR TITLE
Add diagnostic hint catalog for well-known executor failure modes

### DIFF
--- a/internal/executor/diagnostics/diagnostics.go
+++ b/internal/executor/diagnostics/diagnostics.go
@@ -1,0 +1,28 @@
+package diagnostics
+
+import "regexp"
+
+type hint struct {
+	pattern *regexp.Regexp
+	text    string
+}
+
+// builtinHints is consulted in order; first match wins, so place
+// more-specific patterns before broader ones.
+var builtinHints = []hint{
+	{
+		pattern: regexp.MustCompile(`no match for platform in manifest`),
+		text:    "No compatible image was found for the target farm node's architecture; this is often due to an x64/arm64 mismatch, so check the image architecture or build and publish a compatible version.",
+	},
+}
+
+// LookupHint returns user-facing guidance matching the failure message,
+// or "" if no built-in hint applies.
+func LookupHint(message string) string {
+	for _, h := range builtinHints {
+		if h.pattern.MatchString(message) {
+			return h.text
+		}
+	}
+	return ""
+}

--- a/internal/executor/diagnostics/diagnostics_test.go
+++ b/internal/executor/diagnostics/diagnostics_test.go
@@ -1,0 +1,35 @@
+package diagnostics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLookupHint(t *testing.T) {
+	tests := map[string]struct {
+		message       string
+		wantSubstring string
+	}{
+		"empty message returns no hint": {
+			message: "",
+		},
+		"unknown failure returns no hint": {
+			message: "Some unrelated kubelet message",
+		},
+		"platform mismatch matches": {
+			message:       `Failed to pull image "amd64/busybox:latest": rpc error: code = NotFound desc = failed to pull and unpack image "docker.io/amd64/busybox:latest": no match for platform in manifest: not found`,
+			wantSubstring: "x64/arm64",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := LookupHint(tc.message)
+			if tc.wantSubstring == "" {
+				assert.Empty(t, got)
+				return
+			}
+			assert.Contains(t, got, tc.wantSubstring)
+		})
+	}
+}

--- a/internal/executor/diagnostics/doc.go
+++ b/internal/executor/diagnostics/doc.go
@@ -1,0 +1,8 @@
+// Package diagnostics provides a built-in catalog of user-facing hints for
+// well-known job failure modes, identified by regex match against kubelet or
+// container runtime error text.
+//
+// LookupHint returns a hint string for the first matching pattern, or "" when
+// no pattern matches. Patterns are compiled into the binary; for deployment-
+// specific guidance use the categorizer's errorCategories configuration.
+package diagnostics

--- a/internal/executor/reporter/event.go
+++ b/internal/executor/reporter/event.go
@@ -10,6 +10,7 @@ import (
 	networking "k8s.io/api/networking/v1"
 
 	"github.com/armadaproject/armada/internal/executor/categorizer"
+	"github.com/armadaproject/armada/internal/executor/diagnostics"
 	"github.com/armadaproject/armada/internal/executor/domain"
 	"github.com/armadaproject/armada/internal/executor/util"
 	"github.com/armadaproject/armada/pkg/armadaevents"
@@ -83,9 +84,13 @@ func CreateEventForCurrentState(pod *v1.Pod, clusterId string, classifyResult ca
 		})
 		return sequence, nil
 	case v1.PodFailed:
+		reason := util.ExtractPodFailedReason(pod)
+		if hint := diagnostics.LookupHint(reason); hint != "" {
+			reason = fmt.Sprintf("%s\n%s", hint, reason)
+		}
 		return CreateJobFailedEvent(
 			pod,
-			util.ExtractPodFailedReason(pod),
+			reason,
 			util.ExtractPodFailureCause(pod),
 			"",
 			util.ExtractFailedPodContainerStatuses(pod, clusterId),

--- a/internal/executor/service/pod_issue_handler.go
+++ b/internal/executor/service/pod_issue_handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/armadaproject/armada/internal/executor/categorizer"
 	"github.com/armadaproject/armada/internal/executor/configuration"
 	executorContext "github.com/armadaproject/armada/internal/executor/context"
+	"github.com/armadaproject/armada/internal/executor/diagnostics"
 	"github.com/armadaproject/armada/internal/executor/job"
 	"github.com/armadaproject/armada/internal/executor/metrics"
 	"github.com/armadaproject/armada/internal/executor/podchecks"
@@ -155,6 +156,9 @@ func (p *PodIssueHandler) DetectAndRegisterFailedPodIssue(pod *v1.Pod) (bool, er
 
 	isRetryable, message := p.failedPodChecker.IsRetryable(pod, podEvents)
 	if isRetryable {
+		if hint := diagnostics.LookupHint(message); hint != "" {
+			message = fmt.Sprintf("%s\n%s", hint, message)
+		}
 		return p.registerIssue(&runIssue{
 			JobId: jobId,
 			RunId: runId,
@@ -546,10 +550,14 @@ func hasPodIssueSelfResolved(issue *issue) bool {
 }
 
 func createStuckPodMessage(retryable bool, originalMessage string) string {
+	preface := "Unable to start pod - encountered an unrecoverable problem."
 	if retryable {
-		return fmt.Sprintf("Unable to start pod.\n%s", originalMessage)
+		preface = "Unable to start pod."
 	}
-	return fmt.Sprintf("Unable to start pod - encountered an unrecoverable problem.\n%s", originalMessage)
+	if hint := diagnostics.LookupHint(originalMessage); hint != "" {
+		return fmt.Sprintf("%s\n%s\n%s", preface, hint, originalMessage)
+	}
+	return fmt.Sprintf("%s\n%s", preface, originalMessage)
 }
 
 func (p *PodIssueHandler) handleDeletedPod(pod *v1.Pod) {

--- a/internal/executor/service/pod_issue_handler_test.go
+++ b/internal/executor/service/pod_issue_handler_test.go
@@ -795,3 +795,49 @@ func TestCreateDebugMessage(t *testing.T) {
 		})
 	}
 }
+
+func TestCreateStuckPodMessage(t *testing.T) {
+	platformMismatchOriginal := `Failed to pull image "amd64/busybox:latest": rpc error: code = NotFound desc = failed to pull and unpack image "docker.io/amd64/busybox:latest": no match for platform in manifest: not found`
+
+	tests := map[string]struct {
+		retryable          bool
+		originalMessage    string
+		expectedPrefix     string
+		expectHintContains string
+	}{
+		"retryable with no matching hint uses retryable preface": {
+			retryable:       true,
+			originalMessage: "some retryable failure",
+			expectedPrefix:  "Unable to start pod.",
+		},
+		"retryable platform mismatch carries retryable preface and hint": {
+			retryable:          true,
+			originalMessage:    platformMismatchOriginal,
+			expectedPrefix:     "Unable to start pod.",
+			expectHintContains: "x64/arm64",
+		},
+		"non-retryable with no matching hint uses unrecoverable preface": {
+			retryable:       false,
+			originalMessage: "some other unrecoverable failure",
+			expectedPrefix:  "Unable to start pod - encountered an unrecoverable problem.",
+		},
+		"non-retryable platform mismatch carries unrecoverable preface and hint": {
+			retryable:          false,
+			originalMessage:    platformMismatchOriginal,
+			expectedPrefix:     "Unable to start pod - encountered an unrecoverable problem.",
+			expectHintContains: "x64/arm64",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := createStuckPodMessage(tc.retryable, tc.originalMessage)
+			assert.True(t, strings.HasPrefix(result, tc.expectedPrefix),
+				"expected prefix %q, got %q", tc.expectedPrefix, result)
+			if tc.expectHintContains != "" {
+				assert.Contains(t, result, tc.expectHintContains)
+			}
+			assert.Contains(t, result, tc.originalMessage)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

When a job fails for a well-known reason (e.g. wrong-arch image), the user-facing error in Lookout is the raw kubelet text, often opaque. This PR adds a `diagnostics` package that maps such errors to actionable hints; the hint is prepended to the failure message at the three executor sites that build user-facing text (`reporter/event.go` PodFailed branch, `service/pod_issue_handler.go` retryable failed-pod path, and `service/pod_issue_handler.go` `createStuckPodMessage`).

The package is separate from the categorizer because the two are orthogonal: diagnostic hints are always-on and curated, categorization is opt-in and operator-configured. Splitting them avoids forcing a categorizer dependency on hint consumers and lets either side evolve without churning the other.

Adding a hint is a single `{pattern, text}` entry in `builtinHints`. Patterns compile at startup; first match wins. A future PR may move the catalog from compiled-in to config-driven once we see whether operators want deployment-specific entries.

## Validation

To reproduce on local dev:

**1. Submit a wrong-arch job** (`example/platform-mismatch.yaml`):

```yaml
queue: test
jobSetId: platform-mismatch-repro
jobs:
  - namespace: default
    priority: 0
    podSpec:
      terminationGracePeriodSeconds: 0
      restartPolicy: Never
      containers:
        - name: wrong-arch
          # On an arm64 cluster, force-pull the amd64 variant.
          # Flip to arm64v8/busybox if reproducing on an amd64 cluster.
          image: amd64/busybox:latest
          command:
            - sh
            - -c
            - echo should-never-run
          resources:
            requests:
              memory: 64Mi
              cpu: "0.1"
            limits:
              memory: 64Mi
              cpu: "0.1"
```

```bash
armadactl create queue test   # if not already present
armadactl submit example/platform-mismatch.yaml
```

**2. Wait** for the kubelet event-based fail check to fire (typically 1-5 minutes depending on `event_checks` grace period).

**3. Verify** the hint appears in the lookout DB. The `error` column is zlib-compressed bytea, so decode in two steps:

```bash
# Failure metadata
docker exec postgres psql -U postgres -d lookout -c \
  "SELECT job_id, run_id, finished, exit_code
   FROM job_run
   ORDER BY finished DESC NULLS LAST
   LIMIT 1;"

# Decompressed error message (the byte string the Lookout UI shows users)
docker exec postgres psql -U postgres -At -d lookout -c \
  "SELECT encode(error, 'base64') FROM job_run
   ORDER BY finished DESC NULLS LAST LIMIT 1;" \
| python3 -c 'import sys,base64,zlib; print(zlib.decompress(base64.b64decode(sys.stdin.read())).decode())'
```

### Expected (and observed) result

Decompressed `error` column begins with the curated hint, followed by the raw kubelet error preserved verbatim:

```
No compatible image was found for the target farm node's architecture; this is often due to an x64/arm64 mismatch, so check the image architecture or build and publish a compatible version.
Container ... has been in state Waiting for reason ImagePullBackOff (Failed to pull image "amd64/busybox:latest": rpc error: code = NotFound desc = failed to pull and unpack image "docker.io/amd64/busybox:latest": no match for platform in manifest: not found) for more than timeout 1ns
```

Live-validated end-to-end on macOS arm64 (M3) against a k3d cluster.