### PR TITLE
Move executor categorization enable flag under errorCategories.enabled

### DIFF
--- a/config/executor/config.yaml
+++ b/config/executor/config.yaml
@@ -8,6 +8,8 @@ application:
   deleteConcurrencyLimit: 2
   jobLeaseRequestTimeout: "30s"
   maxLeasedJobs: 100
+  errorCategories:
+    enabled: false
 task:
   utilisationReportingInterval: 1s
   missingJobEventReconciliationInterval: 15s

--- a/e2e/config/executor_config.yaml
+++ b/e2e/config/executor_config.yaml
@@ -1,6 +1,6 @@
 application:
-  enableJobErrorCategorization: true
   errorCategories:
+    enabled: true
     defaultCategory: "uncategorized"
     categories:
       - name: oom

--- a/internal/executor/application.go
+++ b/internal/executor/application.go
@@ -203,7 +203,7 @@ func setupExecutorApiComponents(
 	}
 
 	var classifier *categorizer.Classifier
-	if config.Application.EnableJobErrorCategorization {
+	if config.Application.ErrorCategories.Enabled {
 		classifier, err = categorizer.NewClassifier(config.Application.ErrorCategories)
 		if err != nil {
 			ctx.Fatalf("Config error in error categories: %s", err)

--- a/internal/executor/categorizer/doc.go
+++ b/internal/executor/categorizer/doc.go
@@ -21,6 +21,7 @@
 //
 //	application:
 //	  errorCategories:
+//	    enabled: true
 //	    defaultCategory: "uncategorized"
 //	    defaultSubcategory: "unknown"
 //	    categories:

--- a/internal/executor/categorizer/types.go
+++ b/internal/executor/categorizer/types.go
@@ -4,6 +4,9 @@ import "github.com/armadaproject/armada/internal/common/errormatch"
 
 // ErrorCategoriesConfig is the top-level config for failure classification.
 type ErrorCategoriesConfig struct {
+	// Enabled toggles failure classification on pod errors. When false, no
+	// failure_category or failure_subcategory is set on error events.
+	Enabled bool `yaml:"enabled"`
 	// DefaultCategory is the category assigned when no rule matches.
 	// If empty, no category is assigned when no rule matches.
 	DefaultCategory string `yaml:"defaultCategory"`

--- a/internal/executor/configuration/types.go
+++ b/internal/executor/configuration/types.go
@@ -27,11 +27,8 @@ type ApplicationConfiguration struct {
 	// MaxLeasedJobs is the maximum jobs the executor should have in Leased state ay any one time (i.e jobs not submitted to kubernetes)
 	// It is largely used to calculate how many new jobs to request from the scheduler
 	MaxLeasedJobs int
-	// EnableJobErrorCategorization enables failure classification on pod errors.
-	// When false, no failure_category or failure_subcategory is set on error events.
-	EnableJobErrorCategorization bool `yaml:"enableJobErrorCategorization"`
 	// ErrorCategories defines category rules for classifying pod failures.
-	// Only used when EnableJobErrorCategorization is true.
+	// Set ErrorCategories.Enabled to true to turn classification on.
 	ErrorCategories categorizer.ErrorCategoriesConfig `yaml:"errorCategories"`
 }
 


### PR DESCRIPTION
## Summary

Move the executor's failure-classification feature flag from `application.enableJobErrorCategorization` to `application.errorCategories.enabled`. The flag now lives with the rules it gates rather than as a separate top-level boolean.

Shipped default in `config/executor/config.yaml` is `enabled: false`.

## Why

The flag was added in a separate refactor PR after the categorizer config already existed at the top level, which left the on/off switch sitting next to (rather than inside) the thing it controls. The nested form is cohesive: an operator reading or writing categorization config sees `enabled` as a sibling of `defaultCategory`, `categories`, etc.

Code-side, this also lets future validation (e.g. "if `enabled: true` then `categories` must be non-empty") live inside `categorizer.ErrorCategoriesConfig.Validate()` rather than spanning two structs.

## Migration

This is a **breaking config change** for any operator deployment that sets `enableJobErrorCategorization: true` today.

Before:
```yaml
application:
  enableJobErrorCategorization: true
  errorCategories:
    defaultCategory: "uncategorized"
    categories: [...]
```

After:
```yaml
application:
  errorCategories:
    enabled: true
    defaultCategory: "uncategorized"
    categories: [...]
```

If `errorCategories.enabled` is unset/`false`, the executor skips classifier construction entirely (same behavior as the old flag being off). The shipped default in `config/executor/config.yaml` is `enabled: false`, so categorization remains opt-in.

## Validation

- `go test ./internal/executor/...` passes.
- `golangci-lint run ./internal/executor/...` clean.
- `e2e/config/executor_config.yaml` updated to the new shape (still enabled in e2e where rules are exercised).
- `config/executor/config.yaml` adds `errorCategories.enabled: false` as the explicit shipped default.