### PR TITLE
Skip empty messages when aggregating pending-pod event-check results

### DIFF
--- a/internal/executor/podchecks/event_checks.go
+++ b/internal/executor/podchecks/event_checks.go
@@ -65,7 +65,9 @@ func (ec *eventChecks) getAction(podName string, podEvents []*v1.Event, timeInSt
 	for _, event := range podEvents {
 		action, message := ec.getEventAction(podName, event, timeInState)
 		resultAction = maxAction(resultAction, action)
-		resultMessages = append(resultMessages, message)
+		if message != "" {
+			resultMessages = append(resultMessages, message)
+		}
 	}
 	return resultAction, strings.Join(resultMessages, "\n")
 }

--- a/internal/executor/podchecks/event_checks_test.go
+++ b/internal/executor/podchecks/event_checks_test.go
@@ -121,6 +121,25 @@ func Test_getAction_WhenOneEvent_NegativeRegex_Works(t *testing.T) {
 	assert.NotEmpty(t, message)
 }
 
+func Test_getAction_WhenSomeEventsMatch_OnlyMatchedMessagesAreIncluded(t *testing.T) {
+	ec, err := newEventChecks([]config.EventCheck{
+		{Action: config.ActionFail, Regexp: "Failed to pull image", Type: "Warning", GracePeriod: time.Minute},
+	})
+	assert.Nil(t, err)
+
+	matchedMessage := `Failed to pull image "amd64/busybox:latest": no match for platform in manifest`
+	action, message := ec.getAction("my-pod", []*v1.Event{
+		{Message: "Successfully assigned default/my-pod to node-1", Type: "Normal"},
+		{Message: "Pulling image \"amd64/busybox:latest\"", Type: "Normal"},
+		{Message: matchedMessage, Type: "Warning"},
+		{Message: "Back-off pulling image", Type: "Warning"},
+	}, time.Minute*2)
+
+	assert.Equal(t, ActionFail, action)
+	assert.Equal(t, matchedMessage, message)
+	assert.NotContains(t, message, "\n\n", "consecutive newlines indicate non-matching events were joined into the result instead of being skipped")
+}
+
 func Test_newEventChecks_InvalidRegexp_ReturnsError(t *testing.T) {
 	ec, err := newEventChecks([]config.EventCheck{{Action: config.ActionFail, Regexp: "[", Type: config.EventTypeNormal}})
 	assert.Nil(t, ec)


### PR DESCRIPTION
## Summary

`pendingPodChecks.getAction` in `internal/executor/podchecks/event_checks.go` iterates every event on a failing pod, calling `getEventAction` for each. Events that don't match any configured check return `("", ActionWait)`. The function appended those empty strings to the result list anyway, then `strings.Join(..., "\n")` produced multiple consecutive newlines.

End-user impact: when kubelet emits multiple events on a failing pod (Scheduled, Pulling, Failed, BackOff, etc.) and only one matches a check, the failure message that lands in `lookoutdb.job_run.error` ends up with several blank lines between the preface and the actual error text.

## Fix

Skip empty messages before appending. One-line change.

```go
if message != "" {
    resultMessages = append(resultMessages, message)
}
```

Empty strings are dead weight in a `\n`-joined list; nothing else relied on their presence.

## Validation

Live impact: removes 4-6 spurious blank lines from the user-facing failure message in Lookout when k8s emits more than one event on the failing pod.