### PR TITLE
binoculars: log node name and user on cordon success/failure (#4897)

### DIFF
--- a/internal/binoculars/service/cordon.go
+++ b/internal/binoculars/service/cordon.go
@@ -16,6 +16,7 @@ import (
 	"github.com/armadaproject/armada/internal/common/auth"
 	"github.com/armadaproject/armada/internal/common/auth/permission"
 	"github.com/armadaproject/armada/internal/common/cluster"
+	log "github.com/armadaproject/armada/internal/common/logging"
 	"github.com/armadaproject/armada/internal/server/permissions"
 	"github.com/armadaproject/armada/pkg/api/binoculars"
 )
@@ -50,13 +51,21 @@ func (c *KubernetesCordonService) CordonNode(ctx *armadacontext.Context, request
 		return status.Error(codes.PermissionDenied, err.Error())
 	}
 
-	additionalLabels := templateLabels(c.config.AdditionalLabels, auth.GetPrincipal(ctx).GetName())
+	user := auth.GetPrincipal(ctx).GetName()
+	additionalLabels := templateLabels(c.config.AdditionalLabels, user)
 	patch := createCordonPatch(additionalLabels)
 	patchBytes, err := GetPatchBytes(patch)
+	if err != nil {
+		return fmt.Errorf("failed to build cordon patch for node %s: %w", request.NodeName, err)
+	}
 
 	client := c.clientProvider.Client()
 	_, err = client.CoreV1().Nodes().Patch(ctx, request.NodeName, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
-	return err
+	if err != nil {
+		return fmt.Errorf("failed to cordon node %s: %w", request.NodeName, err)
+	}
+	log.WithFields(map[string]any{"node": request.NodeName, "user": user}).Info("cordoned node")
+	return nil
 }
 
 func templateLabels(labels map[string]string, user string) map[string]string {


### PR DESCRIPTION
## Summary

Closes #4897.

When a user cordons a node via lookout → binoculars, the binoculars log only contained generic gRPC API call records (method, time_ms, peer address) — there was no indication of which node was cordoned, and the patch error was silently returned without context.

This PR adds:

1. **Success log** with `node` and `user` as structured fields, so an operator can grep `cordoned node` and immediately see who cordoned what — no log-line joining required.
2. **Wrapped returned errors** with the node name so the gRPC client (lookout) sees `failed to cordon node X: <reason>`, and the gRPC interceptor's `FinishCall` ERROR log inherits the same wrapped text in its `grpc.error` field.
3. **Bonus fix:** the previously-swallowed `GetPatchBytes` error is now handled explicitly.

There's no explicit `log.Errorf` on the failure paths because the gRPC interceptor (`internal/common/grpc/grpc.go:166-175`) already emits the `finished call` log at ERROR level on non-OK responses, with the wrapped error text in `grpc.error` — that already carries the node name from this PR's wrapping. A service-level `log.Errorf` would just double-emit the same context.

## How to validate

Reproducible recipe against the local stack.

### 1. Boot the local stack

```bash
docker compose -f _local/docker-compose-deps.yaml up -d
scripts/localdev-init.sh
goreman -f _local/procfiles/no-auth.Procfile start
```

Wait until binoculars logs `Grpc listening on 50053`.

### 2. Grant the cordon permission to anonymous (no-auth profile only)

The default `_local/binoculars/config.yaml` does not grant `cordon_nodes`. Add to that file:

```yaml
auth:
  permissionGroupMapping:
    cordon_nodes: ["everyone"]
```

Restart goreman so binoculars picks up the new config. (Skip this step under the auth profile — grant `cordon_nodes` to your usual group instead.)

### 3. Success path

Pick any node from your cluster (`kubectl get nodes`), then:

```bash
grpcurl -plaintext -import-path ./proto -import-path . \
  -proto pkg/api/binoculars/binoculars.proto \
  -d '{"node_name":"<your-node-name>"}' \
  localhost:50053 binoculars.Binoculars/Cordon
```

Expected gRPC response:
```
{}
```

Expected new binoculars log line (the cordon-specific one this PR adds):
```
INFO cordon.go:67 cordoned node node=<your-node-name> user=<principal>
```

Verify the patch landed in Kubernetes:
```bash
kubectl get node <your-node-name> -o json | jq '.spec.unschedulable, .metadata.labels'
```

Expected: `unschedulable: true` and the configured `armadaproject.io/cordon-reason` / `armadaproject.io/cordon-user` labels.

### 4. Failure path

Cordon a non-existent node:

```bash
grpcurl -plaintext -import-path ./proto -import-path . \
  -proto pkg/api/binoculars/binoculars.proto \
  -d '{"node_name":"does-not-exist"}' \
  localhost:50053 binoculars.Binoculars/Cordon
```

Expected gRPC error (wrapped error message includes the node name):
```
ERROR:
  Code: Unknown
  Message: failed to cordon node does-not-exist: nodes "does-not-exist" not found
```

Expected single ERROR log line (from the interceptor; no service-level duplicate):
```
ERROR grpc.go:175 finished call grpc.code=Unknown grpc.error="rpc error: code = Unknown desc = failed to cordon node does-not-exist: nodes \"does-not-exist\" not found" requestId=<rid> user=<principal>
```

### 5. Cleanup

```bash
kubectl uncordon <your-node-name>
```

### Other checks

- `go test ./internal/binoculars/service/` — passes (existing `TestCordonNode_InvalidNodeName` still works because `%w` preserves the error chain for `errors.IsNotFound`)
- `golangci-lint run ./internal/binoculars/service/...` — 0 issues
- Live-validated end-to-end on macOS arm64 (M3) against a local k3d cluster
