### PR TITLE
Use current_schema() in lookouthc partitioner catalogue queries

### DIFF
--- a/internal/lookouthc/schema/schema.go
+++ b/internal/lookouthc/schema/schema.go
@@ -80,7 +80,7 @@ const (
 func detectJobTableState(ctx *armadacontext.Context, q pgx.Tx) (jobTableState, string, error) {
 	var exists bool
 	if err := q.QueryRow(ctx,
-		`SELECT EXISTS (SELECT 1 FROM pg_class WHERE relname = 'job' AND relkind IN ('r', 'p') AND relnamespace = 'public'::regnamespace)`,
+		`SELECT EXISTS (SELECT 1 FROM pg_class WHERE relname = 'job' AND relkind IN ('r', 'p') AND relnamespace = current_schema()::regnamespace)`,
 	).Scan(&exists); err != nil {
 		return jobStateUnknown, "", err
 	}
@@ -92,7 +92,7 @@ func detectJobTableState(ctx *armadacontext.Context, q pgx.Tx) (jobTableState, s
 	if err := q.QueryRow(ctx,
 		`SELECT EXISTS (SELECT 1 FROM pg_partitioned_table pt
                         JOIN pg_class c ON c.oid = pt.partrelid
-                        WHERE c.relname = 'job' AND c.relnamespace = 'public'::regnamespace)`,
+                        WHERE c.relname = 'job' AND c.relnamespace = current_schema()::regnamespace)`,
 	).Scan(&isPartitioned); err != nil {
 		return jobStateUnknown, "", err
 	}
@@ -118,7 +118,7 @@ func findShapeMismatch(ctx *armadacontext.Context, q pgx.Tx) (string, error) {
 		SELECT c.relname FROM pg_inherits i
 		JOIN pg_class c ON c.oid = i.inhrelid
 		JOIN pg_class p ON p.oid = i.inhparent
-		WHERE p.relname = 'job' AND p.relnamespace = 'public'::regnamespace
+		WHERE p.relname = 'job' AND p.relnamespace = current_schema()::regnamespace
 		ORDER BY c.relname
 	`)
 	if err != nil {
@@ -151,7 +151,7 @@ func findShapeMismatch(ctx *armadacontext.Context, q pgx.Tx) (string, error) {
 		if err := q.QueryRow(ctx, `
 			SELECT pg_get_expr(c.relpartbound, c.oid)
 			FROM pg_class c
-			WHERE c.relname = $1 AND c.relnamespace = 'public'::regnamespace
+			WHERE c.relname = $1 AND c.relnamespace = current_schema()::regnamespace
 		`, partition).Scan(&expr); err != nil {
 			return "", err
 		}
@@ -199,7 +199,7 @@ func findShapeMismatch(ctx *armadacontext.Context, q pgx.Tx) (string, error) {
 	rows, err = q.Query(ctx, `
 		SELECT column_name, data_type, is_nullable = 'NO'
 		FROM information_schema.columns
-		WHERE table_name = 'job' AND table_schema = 'public'
+		WHERE table_name = 'job' AND table_schema = current_schema()
 		ORDER BY ordinal_position
 	`)
 	if err != nil {
@@ -235,7 +235,7 @@ func findShapeMismatch(ctx *armadacontext.Context, q pgx.Tx) (string, error) {
 		JOIN pg_class t ON t.oid = c.conrelid
 		JOIN LATERAL unnest(c.conkey) WITH ORDINALITY AS x(attnum, ord) ON true
 		JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = x.attnum
-		WHERE t.relname = 'job' AND t.relnamespace = 'public'::regnamespace AND c.contype = 'p'
+		WHERE t.relname = 'job' AND t.relnamespace = current_schema()::regnamespace AND c.contype = 'p'
 	`).Scan(&pkColumns); err != nil {
 		return "", err
 	}
@@ -257,7 +257,7 @@ func findShapeMismatch(ctx *armadacontext.Context, q pgx.Tx) (string, error) {
 	for _, idx := range expectedParentIndexes {
 		var exists bool
 		if err := q.QueryRow(ctx,
-			`SELECT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname = 'public' AND tablename = 'job' AND indexname = $1)`,
+			`SELECT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname = current_schema() AND tablename = 'job' AND indexname = $1)`,
 			idx).Scan(&exists); err != nil {
 			return "", err
 		}
@@ -268,7 +268,7 @@ func findShapeMismatch(ctx *armadacontext.Context, q pgx.Tx) (string, error) {
 
 	var activeIdxExists bool
 	if err := q.QueryRow(ctx,
-		`SELECT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname = 'public' AND tablename = 'job_active' AND indexname = 'idx_job_active_queue_jobset')`,
+		`SELECT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname = current_schema() AND tablename = 'job_active' AND indexname = 'idx_job_active_queue_jobset')`,
 	).Scan(&activeIdxExists); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
The partitioner's catalogue queries hard-coded 'public' when looking up the job table, its partitions, columns, primary key, and indexes. In a deployment which sets a non-public search_path, the queries would report the job table as missing.

Replace the hard-coded 'public' with current_schema() so the queries resolve against the same schema where the unqualified DDL (migrations and target_schema.sql) creates and renames tables.