### PR TITLE
Fix stale metrics from non-leader scheduler replicas

### DIFF
--- a/deployment/armada/templates/prometheusrule.yaml
+++ b/deployment/armada/templates/prometheusrule.yaml
@@ -33,20 +33,37 @@ spec:
             sum(sum(armada:queue:resource:queued{namespace="{{ .Release.Namespace }}", resourceType="cpu"} > bool 0) by (queueName, pool) * (1 / armada:queue:priority{namespace="{{ .Release.Namespace }}"})) by (pool)
             * 100
 
+        # Filter to leader instance only to prevent stale series from non-leader replicas.
+        # Deduplicate by instance first (handles multiple scrapers), then filter by leader status.
         - record: armada:queue:resource:queued
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: max(sum(armada_queue_resource_queued{namespace="{{ .Release.Namespace }}"}) by (instance, pool, queueName, resourceType, accounting_role)) by (pool, queueName, resourceType, accounting_role)
+          expr: >
+            max(
+              max(armada_queue_resource_queued{namespace="{{ .Release.Namespace }}"}) by (instance, pool, queueName, priceBand, resourceType, accounting_role)
+              * on (instance) group_left()
+              (max by (instance) (armada_scheduler_leader_status{namespace="{{ .Release.Namespace }}"} == 1))
+            ) by (pool, queueName, priceBand, resourceType, accounting_role)
 
         - record: armada:queue:resource:allocated
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: max(sum(armada_queue_resource_allocated{namespace="{{ .Release.Namespace }}"}) by (instance, pool, cluster, queueName, resourceType, nodeType, reservation, physical_pool, scalable_unit)) by (pool, cluster, queueName, resourceType, nodeType, reservation, physical_pool, scalable_unit)
+          expr: >
+            max(
+              max(armada_queue_resource_allocated{namespace="{{ .Release.Namespace }}"}) by (instance, pool, cluster, queueName, priceBand, resourceType, nodeType, reservation, physical_pool, scalable_unit)
+              * on (instance) group_left()
+              (max by (instance) (armada_scheduler_leader_status{namespace="{{ .Release.Namespace }}"} == 1))
+            ) by (pool, cluster, queueName, priceBand, resourceType, nodeType, reservation, physical_pool, scalable_unit)
 
         - record: armada:queue:resource:used
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: max(sum(armada_queue_resource_used{namespace="{{ .Release.Namespace }}"}) by (instance, pool, cluster, queueName, resourceType, nodeType, reservation, physical_pool, scalable_unit)) by (pool, cluster, queueName, resourceType, nodeType, reservation, physical_pool, scalable_unit)
+          expr: >
+            max(
+              max(armada_queue_resource_used{namespace="{{ .Release.Namespace }}"}) by (instance, pool, cluster, queueName, resourceType, nodeType, reservation, physical_pool, scalable_unit)
+              * on (instance) group_left()
+              (max by (instance) (armada_scheduler_leader_status{namespace="{{ .Release.Namespace }}"} == 1))
+            ) by (pool, cluster, queueName, resourceType, nodeType, reservation, physical_pool, scalable_unit)
 
         - record: armada:grpc:server:histogram95
           labels:
@@ -66,20 +83,40 @@ spec:
         - record: armada:resource:available_capacity
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: max(armada_cluster_available_capacity{namespace="{{ .Release.Namespace }}"}) by (pool, cluster, resourceType, nodeType, reservation, physical_pool, capacity_class, scalable_unit)
+          expr: >
+            max(
+              max(armada_cluster_available_capacity{namespace="{{ .Release.Namespace }}"}) by (instance, pool, cluster, resourceType, nodeType, reservation, physical_pool, capacity_class, scalable_unit)
+              * on (instance) group_left()
+              (max by (instance) (armada_scheduler_leader_status{namespace="{{ .Release.Namespace }}"} == 1))
+            ) by (pool, cluster, resourceType, nodeType, reservation, physical_pool, capacity_class, scalable_unit)
 
         - record: armada:resource:farm_capacity
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: max(armada_cluster_farm_capacity{namespace="{{ .Release.Namespace }}"}) by (pool, cluster, resourceType, nodeType, reservation, physical_pool, capacity_class, scalable_unit)
+          expr: >
+            max(
+              max(armada_cluster_farm_capacity{namespace="{{ .Release.Namespace }}"}) by (instance, pool, cluster, resourceType, nodeType, reservation, physical_pool, capacity_class, scalable_unit)
+              * on (instance) group_left()
+              (max by (instance) (armada_scheduler_leader_status{namespace="{{ .Release.Namespace }}"} == 1))
+            ) by (pool, cluster, resourceType, nodeType, reservation, physical_pool, capacity_class, scalable_unit)
 
         - record: armada:resource:capacity
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: max(armada_cluster_capacity{namespace="{{ .Release.Namespace }}"}) by (pool, cluster, resourceType, nodeType, reservation, physical_pool, capacity_class, scalable_unit)
+          expr: >
+            max(
+              max(armada_cluster_capacity{namespace="{{ .Release.Namespace }}"}) by (instance, pool, cluster, resourceType, nodeType, reservation, physical_pool, capacity_class, scalable_unit)
+              * on (instance) group_left()
+              (max by (instance) (armada_scheduler_leader_status{namespace="{{ .Release.Namespace }}"} == 1))
+            ) by (pool, cluster, resourceType, nodeType, reservation, physical_pool, capacity_class, scalable_unit)
 
         - record: armada:queue:pod_phase:count
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: max(armada_queue_leased_pod_count{namespace="{{ .Release.Namespace }}"}) by (pool, cluster, queueName, phase, nodeType, reservation)
+          expr: >
+            max(
+              max(armada_queue_leased_pod_count{namespace="{{ .Release.Namespace }}"}) by (instance, pool, cluster, queueName, phase, nodeType, reservation)
+              * on (instance) group_left()
+              (max by (instance) (armada_scheduler_leader_status{namespace="{{ .Release.Namespace }}"} == 1))
+            ) by (pool, cluster, queueName, phase, nodeType, reservation)
 {{- end }}

--- a/internal/scheduler/leader/leader_metrics.go
+++ b/internal/scheduler/leader/leader_metrics.go
@@ -39,6 +39,15 @@ func (l *LeaderStatusMetricsCollector) onStartedLeading(*armadacontext.Context) 
 	l.isCurrentlyLeader = true
 }
 
+// MarkAsLeading sets the leader status to true. Used in standalone mode where
+// the instance is always the leader.
+func (l *LeaderStatusMetricsCollector) MarkAsLeading() {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
+	l.isCurrentlyLeader = true
+}
+
 func (l *LeaderStatusMetricsCollector) onStoppedLeading() {
 	l.lock.Lock()
 	defer l.lock.Unlock()

--- a/internal/scheduler/schedulerapp.go
+++ b/internal/scheduler/schedulerapp.go
@@ -446,7 +446,13 @@ func createLeaderController(ctx *armadacontext.Context, config schedulerconfig.L
 	switch mode := strings.ToLower(config.Mode); mode {
 	case "standalone":
 		ctx.Infof("Scheduler will run in standalone mode")
-		return leader.NewStandaloneLeaderController(), nil
+		leaderController := leader.NewStandaloneLeaderController()
+		// Register leader status metric so recording rules work consistently.
+		// In standalone mode, this always reports 1 (always leader).
+		leaderStatusMetrics := leader.NewLeaderStatusMetricsCollector(metrics.ArmadaSchedulerMetricsPrefix, config.PodName)
+		leaderStatusMetrics.MarkAsLeading()
+		prometheus.MustRegister(leaderStatusMetrics)
+		return leaderController, nil
 	case "kubernetes":
 		ctx.Infof("Scheduler will run kubernetes mode")
 		clusterConfig, err := loadClusterConfig(ctx)


### PR DESCRIPTION
In multi-replica deployments with leader election, non-leader instances emit stale metrics that persist in Prometheus. Recording rules using max() would pick up these outdated values.

Filter all scheduler recording rules by armada_scheduler_leader_status to only aggregate from the current leader. Emit this metric in standalone mode as well for consistency.