### PR TITLE
Migrate from `jobs` to `job_metadata`

### DIFF
--- a/config/scheduler/config.yaml
+++ b/config/scheduler/config.yaml
@@ -6,7 +6,7 @@ pulsarSendTimeout: 5s
 internedStringsCacheSize: 100000
 queueRefreshPeriod: 10s
 publishMetricsToPulsar: false
-jobMetadataMigrationPhase: legacy
+jobMetadataMigrationPhase: dualWrite
 metrics:
   port: 9000
   jobStateMetricsResetInterval: 12h

--- a/config/scheduler/config.yaml
+++ b/config/scheduler/config.yaml
@@ -6,7 +6,7 @@ pulsarSendTimeout: 5s
 internedStringsCacheSize: 100000
 queueRefreshPeriod: 10s
 publishMetricsToPulsar: false
-jobMetadataMigrationPhase: dualWrite
+jobMetadataMigrationPhase: cutover
 metrics:
   port: 9000
   jobStateMetricsResetInterval: 12h

--- a/config/scheduleringester/config.yaml
+++ b/config/scheduleringester/config.yaml
@@ -21,6 +21,4 @@ pulsar:
 subscriptionName: "scheduler-ingester"
 batchSize: 10000
 batchDuration: 500ms
-jobMetadataMigrationPhase: legacy
-
-
+jobMetadataMigrationPhase: dualWrite

--- a/config/scheduleringester/config.yaml
+++ b/config/scheduleringester/config.yaml
@@ -21,4 +21,4 @@ pulsar:
 subscriptionName: "scheduler-ingester"
 batchSize: 10000
 batchDuration: 500ms
-jobMetadataMigrationPhase: dualWrite
+jobMetadataMigrationPhase: cutover

--- a/internal/scheduler/configuration/configuration.go
+++ b/internal/scheduler/configuration/configuration.go
@@ -93,7 +93,7 @@ type Configuration struct {
 	PublishMetricsToPulsar bool
 	// JobMetadataMigrationPhase controls whether submit_message and groups are
 	// read from the jobs table, the job_metadata table, or both (coalesced),
-	// during the migration. Required; default ("legacy").
+	// during the migration. Required; default ("cutover").
 	// Operators must coordinate this value with the scheduleringester's JobMetadataMigrationPhase:
 	// a mismatch can cause new submissions to be unreadable
 	// (e.g. ingester=cutover with scheduler=legacy omits submit_message/groups from leases)

--- a/internal/scheduler/database/migrations/039_backfill_job_metadata.sql
+++ b/internal/scheduler/database/migrations/039_backfill_job_metadata.sql
@@ -1,0 +1,10 @@
+-- Backfill job_metadata from any jobs rows whose submit_message / groups still
+-- live only on the jobs table. Intended to run while both services are in
+-- dualWrite phase, immediately before flipping to cutover; covers pre-migration
+-- rows and any row that was inserted in legacy phase and never re-upserted.
+INSERT INTO job_metadata (job_id, submit_message, groups)
+SELECT j.job_id, j.submit_message, j.groups
+FROM jobs j
+WHERE j.submit_message IS NOT NULL
+  AND NOT EXISTS (SELECT 1 FROM job_metadata jm WHERE jm.job_id = j.job_id)
+ON CONFLICT (job_id) DO NOTHING;

--- a/internal/scheduleringester/config.go
+++ b/internal/scheduleringester/config.go
@@ -28,7 +28,7 @@ type Configuration struct {
 	Profiling *profilingconfig.ProfilingConfig
 	// JobMetadataMigrationPhase controls whether submit_message and groups are
 	// written to the jobs table, the job_metadata table, or both, during the
-	// migration. Required; default ("legacy")
+	// migration. Required; default ("cutover")
 	JobMetadataMigrationPhase schedulerdb.JobMetadataMigrationPhase `validate:"required,oneof=legacy dualWrite cutover"`
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you: -->

#### What type of PR is this?

#### What this PR does / why we need it

Third step in the migration from `jobs` to `job_metadata` for `submit_message` and `groups` ([first one](https://github.com/armadaproject/armada/pull/4906), [second one](https://github.com/armadaproject/armada/pull/4912)).

This backfills the remaining data from the jobs table to job_metadata and updates the config flags to stop reading & writing from the `jobs` table for these 2 columns. After this release, the columns should be safe to drop, but that will happen separately, later.