### PR TITLE
chore: add .lscache files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ test-reports
 *.suo
 *.user
 *.userosscache
+*.lscache
 *.sln.docstates
 [Dd]ebug/
 [Dd]ebugPublic/


### PR DESCRIPTION
These are LightSwitch cache files which VS Code generates for .NET files.