### PR TITLE
Lookout Ingester: propagate context cancellation from Store() to prevent "zombie" jobs

### DIFF
--- a/internal/lookoutingester/lookoutdb/insertion.go
+++ b/internal/lookoutingester/lookoutdb/insertion.go
@@ -426,6 +426,9 @@ func (l *LookoutDb) CreateJobsScalar(ctx *armadacontext.Context, instructions []
 		})
 		if err != nil {
 			log.WithError(err).Warnf("Create job for job %s, jobset %s failed", i.JobId, i.JobSet)
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
 		}
 	}
 	return nil
@@ -550,6 +553,9 @@ func (l *LookoutDb) UpdateJobsScalar(ctx *armadacontext.Context, instructions []
 		})
 		if err != nil {
 			log.WithError(err).Warnf("Updating job %s failed", i.JobId)
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
 		}
 	}
 	return nil
@@ -631,6 +637,9 @@ func (l *LookoutDb) CreateJobSpecsScalar(ctx *armadacontext.Context, instruction
 		})
 		if err != nil {
 			log.WithError(err).Warnf("Create job spec for job %s, jobset %s failed", i.JobId, i.JobSet)
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
 		}
 	}
 	return nil
@@ -751,6 +760,9 @@ func (l *LookoutDb) CreateJobRunsScalar(ctx *armadacontext.Context, instructions
 		})
 		if err != nil {
 			log.WithError(err).Warnf("Create job run for job %s, run %s failed", i.JobId, i.RunId)
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
 		}
 	}
 	return nil
@@ -888,6 +900,9 @@ func (l *LookoutDb) UpdateJobRunsScalar(ctx *armadacontext.Context, instructions
 		})
 		if err != nil {
 			log.WithError(err).Warnf("Updating job run %s failed", i.RunId)
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
 		}
 	}
 	return nil
@@ -962,6 +977,9 @@ func (l *LookoutDb) CreateJobErrorsScalar(ctx *armadacontext.Context, instructio
 		})
 		if err != nil {
 			log.WithError(err).Warnf("Create job error for job %s, failed", i.JobId)
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
 		}
 	}
 	return nil

--- a/internal/lookoutingester/lookoutdb/insertion.go
+++ b/internal/lookoutingester/lookoutdb/insertion.go
@@ -3,7 +3,6 @@ package lookoutdb
 import (
 	"fmt"
 	"regexp"
-	"sync"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -41,8 +40,13 @@ func NewLookoutDb(db *pgxpool.Pool, fatalErrors []*regexp.Regexp, metrics *metri
 // * New Job Creations
 // * Job Updates, New Job Creations, New User Annotations
 // * Job Run Updates
-// In each case we first try to bach insert the rows using the postgres copy protocol.  If this fails then we try a
-// slower, serial insert and discard any rows that cannot be inserted.
+// In each case we first try to batch insert the rows using the postgres copy protocol. If this
+// fails then we try a slower, serial insert and discard any rows that cannot be inserted.
+//
+// If the context is cancelled (e.g. ingester shutdown) Store returns the cancellation error
+// rather than silently dropping the remaining work. Callers must rely on this to decide
+// whether to ack the underlying Pulsar messages: ack only on a nil return, otherwise the
+// affected messages must be left for redelivery to avoid jobs becoming zombies in Lookout.
 func (l *LookoutDb) Store(ctx *armadacontext.Context, instructions *model.InstructionSet) error {
 	// We might have multiple updates for the same job or job run
 	// These can be conflated to help performance
@@ -54,39 +58,36 @@ func (l *LookoutDb) Store(ctx *armadacontext.Context, instructions *model.Instru
 
 	start := time.Now()
 	// Jobs need to be ingested first as other updates may reference these
-	wgJobIngestion := sync.WaitGroup{}
-	wgJobIngestion.Add(2)
-	go func() {
-		defer wgJobIngestion.Done()
-		l.CreateJobs(ctx, instructions.JobsToCreate)
-	}()
-	go func() {
-		defer wgJobIngestion.Done()
-		l.CreateJobSpecs(ctx, instructions.JobsToCreate)
-	}()
+	jobIngestionGroup, jobIngestionCtx := armadacontext.ErrGroup(ctx)
+	jobIngestionGroup.Go(func() error {
+		return l.CreateJobs(jobIngestionCtx, instructions.JobsToCreate)
+	})
+	jobIngestionGroup.Go(func() error {
+		return l.CreateJobSpecs(jobIngestionCtx, instructions.JobsToCreate)
+	})
+	if err := jobIngestionGroup.Wait(); err != nil {
+		return err
+	}
 
-	wgJobIngestion.Wait()
-
-	// Now we can job updates, annotations and new job runs
-	wg := sync.WaitGroup{}
-	wg.Add(3)
-	go func() {
-		defer wg.Done()
-		l.UpdateJobs(ctx, jobsToUpdate)
-	}()
-	go func() {
-		defer wg.Done()
-		l.CreateJobRuns(ctx, instructions.JobRunsToCreate)
-	}()
-	go func() {
-		defer wg.Done()
-		l.CreateJobErrors(ctx, instructions.JobErrorsToCreate)
-	}()
-
-	wg.Wait()
+	// Now we can do job updates, annotations and new job runs
+	jobUpdateGroup, jobUpdateCtx := armadacontext.ErrGroup(ctx)
+	jobUpdateGroup.Go(func() error {
+		return l.UpdateJobs(jobUpdateCtx, jobsToUpdate)
+	})
+	jobUpdateGroup.Go(func() error {
+		return l.CreateJobRuns(jobUpdateCtx, instructions.JobRunsToCreate)
+	})
+	jobUpdateGroup.Go(func() error {
+		return l.CreateJobErrors(jobUpdateCtx, instructions.JobErrorsToCreate)
+	})
+	if err := jobUpdateGroup.Wait(); err != nil {
+		return err
+	}
 
 	// Finally, we can update the job runs
-	l.UpdateJobRuns(ctx, jobRunsToUpdate)
+	if err := l.UpdateJobRuns(ctx, jobRunsToUpdate); err != nil {
+		return err
+	}
 
 	taken := time.Since(start)
 	if numRowsToChange != 0 && taken != 0 {
@@ -95,86 +96,101 @@ func (l *LookoutDb) Store(ctx *armadacontext.Context, instructions *model.Instru
 	return nil
 }
 
-func (l *LookoutDb) CreateJobs(ctx *armadacontext.Context, instructions []*model.CreateJobInstruction) {
+func (l *LookoutDb) CreateJobs(ctx *armadacontext.Context, instructions []*model.CreateJobInstruction) error {
 	if len(instructions) == 0 {
-		return
+		return nil
 	}
 	start := time.Now()
 	err := l.CreateJobsBatch(ctx, instructions)
 	if err != nil {
 		log.WithError(err).Warn("Creating jobs via batch failed, will attempt to insert serially (this might be slow).")
-		l.CreateJobsScalar(ctx, instructions)
+		if scalarErr := l.CreateJobsScalar(ctx, instructions); scalarErr != nil {
+			return scalarErr
+		}
 	}
 	taken := time.Since(start)
 	l.metrics.RecordAvRowChangeTimeByOperation("job", commonmetrics.DBOperationInsert, len(instructions), taken)
 	l.metrics.RecordRowsChange("job", commonmetrics.DBOperationInsert, len(instructions))
 	log.Infof("Inserted %d jobs in %s", len(instructions), taken)
+	return nil
 }
 
-func (l *LookoutDb) CreateJobSpecs(ctx *armadacontext.Context, instructions []*model.CreateJobInstruction) {
+func (l *LookoutDb) CreateJobSpecs(ctx *armadacontext.Context, instructions []*model.CreateJobInstruction) error {
 	if len(instructions) == 0 {
-		return
+		return nil
 	}
 	start := time.Now()
 	err := l.CreateJobSpecsBatch(ctx, instructions)
 	if err != nil {
 		log.WithError(err).Warn("Creating job specs via batch failed, will attempt to insert serially (this might be slow).")
-		l.CreateJobSpecsScalar(ctx, instructions)
+		if scalarErr := l.CreateJobSpecsScalar(ctx, instructions); scalarErr != nil {
+			return scalarErr
+		}
 	}
 	taken := time.Since(start)
 	l.metrics.RecordAvRowChangeTimeByOperation("job_spec", commonmetrics.DBOperationInsert, len(instructions), taken)
 	l.metrics.RecordRowsChange("job_spec", commonmetrics.DBOperationInsert, len(instructions))
 	log.Infof("Inserted %d job specs in %s", len(instructions), taken)
+	return nil
 }
 
-func (l *LookoutDb) UpdateJobs(ctx *armadacontext.Context, instructions []*model.UpdateJobInstruction) {
+func (l *LookoutDb) UpdateJobs(ctx *armadacontext.Context, instructions []*model.UpdateJobInstruction) error {
 	if len(instructions) == 0 {
-		return
+		return nil
 	}
 	start := time.Now()
 	instructions = l.filterEventsForTerminalJobs(ctx, l.db, instructions, l.metrics)
 	err := l.UpdateJobsBatch(ctx, instructions)
 	if err != nil {
 		log.WithError(err).Warn("Updating jobs via batch failed, will attempt to insert serially (this might be slow).")
-		l.UpdateJobsScalar(ctx, instructions)
+		if scalarErr := l.UpdateJobsScalar(ctx, instructions); scalarErr != nil {
+			return scalarErr
+		}
 	}
 	taken := time.Since(start)
 	l.metrics.RecordAvRowChangeTimeByOperation("job", commonmetrics.DBOperationUpdate, len(instructions), taken)
 	l.metrics.RecordRowsChange("job", commonmetrics.DBOperationUpdate, len(instructions))
 	l.recordStateUpdates(instructions)
 	log.Infof("Updated %d jobs in %s", len(instructions), taken)
+	return nil
 }
 
-func (l *LookoutDb) CreateJobRuns(ctx *armadacontext.Context, instructions []*model.CreateJobRunInstruction) {
+func (l *LookoutDb) CreateJobRuns(ctx *armadacontext.Context, instructions []*model.CreateJobRunInstruction) error {
 	if len(instructions) == 0 {
-		return
+		return nil
 	}
 	start := time.Now()
 	err := l.CreateJobRunsBatch(ctx, instructions)
 	if err != nil {
 		log.WithError(err).Warn("Creating job runs via batch failed, will attempt to insert serially (this might be slow).")
-		l.CreateJobRunsScalar(ctx, instructions)
+		if scalarErr := l.CreateJobRunsScalar(ctx, instructions); scalarErr != nil {
+			return scalarErr
+		}
 	}
 	taken := time.Since(start)
 	l.metrics.RecordAvRowChangeTimeByOperation("job_run", commonmetrics.DBOperationInsert, len(instructions), taken)
 	l.metrics.RecordRowsChange("job_run", commonmetrics.DBOperationInsert, len(instructions))
 	log.Infof("Inserted %d job runs in %s", len(instructions), taken)
+	return nil
 }
 
-func (l *LookoutDb) UpdateJobRuns(ctx *armadacontext.Context, instructions []*model.UpdateJobRunInstruction) {
+func (l *LookoutDb) UpdateJobRuns(ctx *armadacontext.Context, instructions []*model.UpdateJobRunInstruction) error {
 	if len(instructions) == 0 {
-		return
+		return nil
 	}
 	start := time.Now()
 	err := l.UpdateJobRunsBatch(ctx, instructions)
 	if err != nil {
 		log.WithError(err).Warn("Updating job runs via batch failed, will attempt to insert serially (this might be slow).")
-		l.UpdateJobRunsScalar(ctx, instructions)
+		if scalarErr := l.UpdateJobRunsScalar(ctx, instructions); scalarErr != nil {
+			return scalarErr
+		}
 	}
 	taken := time.Since(start)
 	l.metrics.RecordAvRowChangeTimeByOperation("job_run", commonmetrics.DBOperationUpdate, len(instructions), taken)
 	l.metrics.RecordRowsChange("job_run", commonmetrics.DBOperationUpdate, len(instructions))
 	log.Infof("Updated %d job runs in %s", len(instructions), taken)
+	return nil
 }
 
 func (l *LookoutDb) recordStateUpdates(instructions []*model.UpdateJobInstruction) {
@@ -209,20 +225,23 @@ func (l *LookoutDb) recordStateUpdates(instructions []*model.UpdateJobInstructio
 	}
 }
 
-func (l *LookoutDb) CreateJobErrors(ctx *armadacontext.Context, instructions []*model.CreateJobErrorInstruction) {
+func (l *LookoutDb) CreateJobErrors(ctx *armadacontext.Context, instructions []*model.CreateJobErrorInstruction) error {
 	if len(instructions) == 0 {
-		return
+		return nil
 	}
 	start := time.Now()
 	err := l.CreateJobErrorsBatch(ctx, instructions)
 	if err != nil {
 		log.WithError(err).Warn("Creating job errors via batch failed, will attempt to insert serially (this might be slow).")
-		l.CreateJobErrorsScalar(ctx, instructions)
+		if scalarErr := l.CreateJobErrorsScalar(ctx, instructions); scalarErr != nil {
+			return scalarErr
+		}
 	}
 	taken := time.Since(start)
 	l.metrics.RecordAvRowChangeTimeByOperation("job_error", commonmetrics.DBOperationInsert, len(instructions), taken)
 	l.metrics.RecordRowsChange("job_error", commonmetrics.DBOperationInsert, len(instructions))
 	log.Infof("Inserted %d job errors in %s", len(instructions), taken)
+	return nil
 }
 
 func (l *LookoutDb) CreateJobsBatch(ctx *armadacontext.Context, instructions []*model.CreateJobInstruction) error {
@@ -339,8 +358,22 @@ func (l *LookoutDb) CreateJobsBatch(ctx *armadacontext.Context, instructions []*
 	})
 }
 
-// CreateJobsScalar will insert jobs one by one into the database
-func (l *LookoutDb) CreateJobsScalar(ctx *armadacontext.Context, instructions []*model.CreateJobInstruction) {
+// CreateJobsScalar will insert jobs one by one into the database.
+//
+// The Scalar* methods in this file all share the following error-handling policy:
+//
+//   - On context cancellation (e.g. ingester shutdown), bail out immediately and return
+//     ctx.Err(). This propagates up through Store so the ingestion pipeline does not ack
+//     the affected Pulsar messages, and they are re-processed on the next consumer start.
+//     Without this, mid-batch shutdowns silently drop DB writes while the pipeline acks
+//     the messages, leaving jobs as zombies in Lookout.
+//
+//   - On any other per-row error, log a warning and continue with the next row. This
+//     prevents one poisoned row (e.g. malformed data the DB rejects as non-retryable)
+//     from blocking the whole batch from being acked and stalling the ingester. Genuinely
+//     fatal errors should be expressed via the fatalErrors regex list rather than handled
+//     here.
+func (l *LookoutDb) CreateJobsScalar(ctx *armadacontext.Context, instructions []*model.CreateJobInstruction) error {
 	sqlStatement := `INSERT INTO job (
 			job_id,
 			queue,
@@ -363,6 +396,9 @@ func (l *LookoutDb) CreateJobsScalar(ctx *armadacontext.Context, instructions []
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
 		ON CONFLICT DO NOTHING`
 	for _, i := range instructions {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		err := l.withDatabaseRetryInsert(ctx, func() error {
 			_, err := l.db.Exec(ctx, sqlStatement,
 				i.JobId,
@@ -392,6 +428,7 @@ func (l *LookoutDb) CreateJobsScalar(ctx *armadacontext.Context, instructions []
 			log.WithError(err).Warnf("Create job for job %s, jobset %s failed", i.JobId, i.JobSet)
 		}
 	}
+	return nil
 }
 
 func (l *LookoutDb) UpdateJobsBatch(ctx *armadacontext.Context, instructions []*model.UpdateJobInstruction) error {
@@ -477,7 +514,7 @@ func (l *LookoutDb) UpdateJobsBatch(ctx *armadacontext.Context, instructions []*
 	})
 }
 
-func (l *LookoutDb) UpdateJobsScalar(ctx *armadacontext.Context, instructions []*model.UpdateJobInstruction) {
+func (l *LookoutDb) UpdateJobsScalar(ctx *armadacontext.Context, instructions []*model.UpdateJobInstruction) error {
 	sqlStatement := `UPDATE job
 		SET
 			priority                     = coalesce($2, priority),
@@ -491,6 +528,9 @@ func (l *LookoutDb) UpdateJobsScalar(ctx *armadacontext.Context, instructions []
 			cancel_user                  = coalesce($10, job.cancel_user)
 		WHERE job_id = $1`
 	for _, i := range instructions {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		err := l.withDatabaseRetryInsert(ctx, func() error {
 			_, err := l.db.Exec(ctx, sqlStatement,
 				i.JobId,
@@ -512,6 +552,7 @@ func (l *LookoutDb) UpdateJobsScalar(ctx *armadacontext.Context, instructions []
 			log.WithError(err).Warnf("Updating job %s failed", i.JobId)
 		}
 	}
+	return nil
 }
 
 func (l *LookoutDb) CreateJobSpecsBatch(ctx *armadacontext.Context, instructions []*model.CreateJobInstruction) error {
@@ -567,7 +608,7 @@ func (l *LookoutDb) CreateJobSpecsBatch(ctx *armadacontext.Context, instructions
 	})
 }
 
-func (l *LookoutDb) CreateJobSpecsScalar(ctx *armadacontext.Context, instructions []*model.CreateJobInstruction) {
+func (l *LookoutDb) CreateJobSpecsScalar(ctx *armadacontext.Context, instructions []*model.CreateJobInstruction) error {
 	sqlStatement := `INSERT INTO job_spec (
 			job_id,
 			job_spec
@@ -575,6 +616,9 @@ func (l *LookoutDb) CreateJobSpecsScalar(ctx *armadacontext.Context, instruction
 		VALUES ($1, $2)
 		ON CONFLICT DO NOTHING`
 	for _, i := range instructions {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		err := l.withDatabaseRetryInsert(ctx, func() error {
 			_, err := l.db.Exec(ctx, sqlStatement,
 				i.JobId,
@@ -589,6 +633,7 @@ func (l *LookoutDb) CreateJobSpecsScalar(ctx *armadacontext.Context, instruction
 			log.WithError(err).Warnf("Create job spec for job %s, jobset %s failed", i.JobId, i.JobSet)
 		}
 	}
+	return nil
 }
 
 func (l *LookoutDb) CreateJobRunsBatch(ctx *armadacontext.Context, instructions []*model.CreateJobRunInstruction) error {
@@ -670,7 +715,7 @@ func (l *LookoutDb) CreateJobRunsBatch(ctx *armadacontext.Context, instructions 
 	})
 }
 
-func (l *LookoutDb) CreateJobRunsScalar(ctx *armadacontext.Context, instructions []*model.CreateJobRunInstruction) {
+func (l *LookoutDb) CreateJobRunsScalar(ctx *armadacontext.Context, instructions []*model.CreateJobRunInstruction) error {
 	sqlStatement := `INSERT INTO job_run (
 			run_id,
 			job_id,
@@ -684,6 +729,9 @@ func (l *LookoutDb) CreateJobRunsScalar(ctx *armadacontext.Context, instructions
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 		ON CONFLICT DO NOTHING`
 	for _, i := range instructions {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		err := l.withDatabaseRetryInsert(ctx, func() error {
 			_, err := l.db.Exec(ctx, sqlStatement,
 				i.RunId,
@@ -705,6 +753,7 @@ func (l *LookoutDb) CreateJobRunsScalar(ctx *armadacontext.Context, instructions
 			log.WithError(err).Warnf("Create job run for job %s, run %s failed", i.JobId, i.RunId)
 		}
 	}
+	return nil
 }
 
 func (l *LookoutDb) UpdateJobRunsBatch(ctx *armadacontext.Context, instructions []*model.UpdateJobRunInstruction) error {
@@ -798,7 +847,7 @@ func (l *LookoutDb) UpdateJobRunsBatch(ctx *armadacontext.Context, instructions 
 	})
 }
 
-func (l *LookoutDb) UpdateJobRunsScalar(ctx *armadacontext.Context, instructions []*model.UpdateJobRunInstruction) {
+func (l *LookoutDb) UpdateJobRunsScalar(ctx *armadacontext.Context, instructions []*model.UpdateJobRunInstruction) error {
 	sqlStatement := `UPDATE job_run
 		SET
 			node                 = coalesce($2, node),
@@ -814,6 +863,9 @@ func (l *LookoutDb) UpdateJobRunsScalar(ctx *armadacontext.Context, instructions
 			failure_subcategory  = coalesce($12, failure_subcategory)
 		WHERE run_id = $1`
 	for _, i := range instructions {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		err := l.withDatabaseRetryInsert(ctx, func() error {
 			_, err := l.db.Exec(ctx, sqlStatement,
 				i.RunId,
@@ -838,6 +890,7 @@ func (l *LookoutDb) UpdateJobRunsScalar(ctx *armadacontext.Context, instructions
 			log.WithError(err).Warnf("Updating job run %s failed", i.RunId)
 		}
 	}
+	return nil
 }
 
 func (l *LookoutDb) CreateJobErrorsBatch(ctx *armadacontext.Context, instructions []*model.CreateJobErrorInstruction) error {
@@ -890,11 +943,14 @@ func (l *LookoutDb) CreateJobErrorsBatch(ctx *armadacontext.Context, instruction
 	})
 }
 
-func (l *LookoutDb) CreateJobErrorsScalar(ctx *armadacontext.Context, instructions []*model.CreateJobErrorInstruction) {
+func (l *LookoutDb) CreateJobErrorsScalar(ctx *armadacontext.Context, instructions []*model.CreateJobErrorInstruction) error {
 	sqlStatement := `INSERT INTO job_error (job_id, error)
 		VALUES ($1, $2)
 		ON CONFLICT DO NOTHING`
 	for _, i := range instructions {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		err := l.withDatabaseRetryInsert(ctx, func() error {
 			_, err := l.db.Exec(ctx, sqlStatement,
 				i.JobId,
@@ -908,6 +964,7 @@ func (l *LookoutDb) CreateJobErrorsScalar(ctx *armadacontext.Context, instructio
 			log.WithError(err).Warnf("Create job error for job %s, failed", i.JobId)
 		}
 	}
+	return nil
 }
 
 func batchInsert(ctx *armadacontext.Context, db *pgxpool.Pool, createTmp func(pgx.Tx) error,

--- a/internal/lookoutingester/lookoutdb/insertion_test.go
+++ b/internal/lookoutingester/lookoutdb/insertion_test.go
@@ -718,6 +718,28 @@ func TestStoreReturnsErrorOnContextCancellation(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TestScalarMethodsReturnErrorOnContextCancellation verifies that each scalar method propagates
+// context cancellation rather than swallowing it. Targets the specific edge case where the
+// cancellation lands on the last (or only) iteration of the per-row loop: without the post-call
+// ctx.Err() recheck the loop simply exits and the function returns nil, silently losing the
+// cancellation and allowing the pipeline to ack messages whose DB writes never succeeded.
+func TestScalarMethodsReturnErrorOnContextCancellation(t *testing.T) {
+	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
+		ldb := NewLookoutDb(db, fatalErrors, m, 10, 10)
+		ctx, cancel := armadacontext.WithCancel(armadacontext.Background())
+		cancel()
+
+		assert.Error(t, ldb.CreateJobsScalar(ctx, defaultInstructionSet().JobsToCreate))
+		assert.Error(t, ldb.CreateJobSpecsScalar(ctx, defaultInstructionSet().JobsToCreate))
+		assert.Error(t, ldb.UpdateJobsScalar(ctx, defaultInstructionSet().JobsToUpdate))
+		assert.Error(t, ldb.CreateJobRunsScalar(ctx, defaultInstructionSet().JobRunsToCreate))
+		assert.Error(t, ldb.UpdateJobRunsScalar(ctx, defaultInstructionSet().JobRunsToUpdate))
+		assert.Error(t, ldb.CreateJobErrorsScalar(ctx, defaultInstructionSet().JobErrorsToCreate))
+		return nil
+	})
+	assert.NoError(t, err)
+}
+
 func TestStore(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		ldb := NewLookoutDb(db, fatalErrors, m, 10, 10)

--- a/internal/lookoutingester/lookoutdb/insertion_test.go
+++ b/internal/lookoutingester/lookoutdb/insertion_test.go
@@ -700,6 +700,24 @@ func TestStoreWithEmptyInstructionSet(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TestStoreReturnsErrorOnContextCancellation guards against the silent-message-loss bug where
+// a context cancellation during Store (e.g. ingester shutdown) caused per-row SQL failures
+// to be logged-and-ignored, while Store itself returned nil. The pipeline would then ack the
+// Pulsar messages despite no DB writes having succeeded, leaving jobs as zombies in Lookout.
+// Store must propagate the cancellation error so the pipeline does not ack the affected
+// messages and they are re-processed on the next run.
+func TestStoreReturnsErrorOnContextCancellation(t *testing.T) {
+	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
+		ldb := NewLookoutDb(db, fatalErrors, m, 10, 10)
+		ctx, cancel := armadacontext.WithCancel(armadacontext.Background())
+		cancel()
+		err := ldb.Store(ctx, defaultInstructionSet())
+		assert.Error(t, err)
+		return nil
+	})
+	assert.NoError(t, err)
+}
+
 func TestStore(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		ldb := NewLookoutDb(db, fatalErrors, m, 10, 10)


### PR DESCRIPTION
The Lookout ingester silently dropped DB writes when its context was cancelled mid-batch (e.g. on shutdown): per-row failures were logged, `Store` returned `nil`, and the pipeline acked the Pulsar messages, leaving jobs as "zombies" in Lookout (runs terminal, parent job object stuck in Running). The `*Scalar()` methods now bail on `ctx.Err()`, the wrapper methods propagate that error, and `Store` returns it so the pipeline does not ack and the messages are redelivered.

Note that existing zombies are not backfilled by this change.