### PR TITLE
Lookout pruner: reconcile zombie jobs

### DIFF
--- a/cmd/lookout/main.go
+++ b/cmd/lookout/main.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -111,8 +112,12 @@ func prune(ctx *armadacontext.Context, config configuration.LookoutConfig) {
 	if config.PrunerConfig.BatchSize <= 0 {
 		panic("batchSize must be greater than 0")
 	}
-	log.Infof("expireAfter: %v, batchSize: %v, timeout: %v",
-		config.PrunerConfig.ExpireAfter, config.PrunerConfig.BatchSize, config.PrunerConfig.Timeout)
+	zombieRepairThreshold := 15 * time.Minute
+	if config.PrunerConfig.ZombieRepairThreshold != nil {
+		zombieRepairThreshold = *config.PrunerConfig.ZombieRepairThreshold
+	}
+	log.Infof("expireAfter: %v, batchSize: %v, timeout: %v, zombieRepairThreshold: %v",
+		config.PrunerConfig.ExpireAfter, config.PrunerConfig.BatchSize, config.PrunerConfig.Timeout, zombieRepairThreshold)
 
 	ctxTimeout, cancel := armadacontext.WithTimeout(ctx, config.PrunerConfig.Timeout)
 	defer cancel()
@@ -121,6 +126,7 @@ func prune(ctx *armadacontext.Context, config configuration.LookoutConfig) {
 		db,
 		config.PrunerConfig.ExpireAfter,
 		config.PrunerConfig.DeduplicationExpireAfter,
+		zombieRepairThreshold,
 		config.PrunerConfig.BatchSize,
 		clock.RealClock{},
 		config.ExperimentalHotColdSplit,

--- a/config/lookout/config.yaml
+++ b/config/lookout/config.yaml
@@ -21,6 +21,7 @@ postgres:
 prunerConfig:
   expireAfter: 1008h # 42 days / 6 weeks
   deduplicationExpireAfter: 168h # 7 days
+  zombieRepairThreshold: 15m # grace period before repairing jobs whose latest run is terminal but state is non-terminal
   timeout: 1h
   batchSize: 1000
 uiConfig:

--- a/internal/lookout/configuration/types.go
+++ b/internal/lookout/configuration/types.go
@@ -39,9 +39,19 @@ type TlsConfig struct {
 type PrunerConfig struct {
 	ExpireAfter              time.Duration
 	DeduplicationExpireAfter time.Duration
-	Timeout                  time.Duration
-	BatchSize                int
-	Postgres                 configuration.PostgresConfig
+	// ZombieRepairThreshold is the minimum age of a terminal latest run before
+	// a zombie job (one whose state column is non-terminal but whose latest
+	// run is in a terminal state) will be repaired by the pruner. This acts as
+	// a grace period to avoid racing legitimately in-flight state transitions
+	// or repairing jobs whose state-update events the lookout ingester has not
+	// yet caught up on.
+	//
+	// If nil, defaults to 15 minutes. Set to 0 explicitly to disable zombie
+	// reconciliation entirely.
+	ZombieRepairThreshold *time.Duration
+	Timeout               time.Duration
+	BatchSize             int
+	Postgres              configuration.PostgresConfig
 }
 
 // Alert level enum values correspond to the severity levels of the MUI Alert

--- a/internal/lookout/pruner/doc.go
+++ b/internal/lookout/pruner/doc.go
@@ -1,0 +1,16 @@
+// Package pruner contains the lookout database pruner.
+//
+// The pruner runs periodically and performs three tasks:
+//
+//  1. Reconciles "zombie" jobs whose state column is non-terminal but whose
+//     latest run is in a terminal state. This addresses the residue of a now-
+//     fixed ingester bug. Reconciliation is gated by a configurable grace
+//     period to avoid racing in-flight state transitions and ingester lag.
+//
+//  2. Deletes terminal jobs (and their associated run, spec, and error rows)
+//     that are older than a configurable lifetime, in batches.
+//
+//  3. Deletes job_deduplication rows older than a configurable lifetime.
+//
+// Step 1 runs first so that step 2's deletion sees correct terminal states.
+package pruner

--- a/internal/lookout/pruner/metrics.go
+++ b/internal/lookout/pruner/metrics.go
@@ -1,0 +1,15 @@
+package pruner
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// zombiesRepaired counts the number of zombie jobs (non-terminal job.state but
+// terminal latest run) that the pruner has repaired.
+var zombiesRepaired = promauto.NewCounter(
+	prometheus.CounterOpts{
+		Name: "lookout_pruner_zombie_jobs_repaired_total",
+		Help: "Number of zombie jobs (non-terminal job.state but terminal latest run) repaired by the lookout pruner.",
+	},
+)

--- a/internal/lookout/pruner/metrics.go
+++ b/internal/lookout/pruner/metrics.go
@@ -14,14 +14,20 @@ var zombiesRepaired = promauto.NewCounter(
 	},
 )
 
-// zombiesSkippedNullFinished counts zombie jobs the pruner saw but could not
-// repair because their latest run row had a NULL finished timestamp. The
-// reconciler relies on finished to populate last_transition_time, so these
-// rows are left alone -- but they should not exist in steady state and are
-// worth surfacing as their own signal so the gap is observable.
-var zombiesSkippedNullFinished = promauto.NewCounter(
-	prometheus.CounterOpts{
-		Name: "lookout_pruner_zombie_jobs_skipped_null_finished_total",
-		Help: "Number of zombie jobs skipped by the lookout pruner because the latest run had no finished timestamp.",
+// zombiesSkippedNullFinished is the most recently observed count of zombie
+// jobs the pruner saw but could not repair because their latest run row had a
+// NULL finished timestamp. The reconciler relies on finished to populate
+// last_transition_time, so these rows are left alone -- but they should not
+// exist in steady state and are worth surfacing as their own signal so the
+// gap is observable.
+//
+// This is a gauge rather than a counter because the underlying population is
+// what we care about: the same row staying unrepaired across N runs should
+// register as "1 zombie", not "N zombies". A counter would re-count the same
+// rows on every run.
+var zombiesSkippedNullFinished = promauto.NewGauge(
+	prometheus.GaugeOpts{
+		Name: "lookout_pruner_zombie_jobs_skipped_null_finished",
+		Help: "Most recent count of zombie jobs skipped by the lookout pruner because the latest run had no finished timestamp.",
 	},
 )

--- a/internal/lookout/pruner/metrics.go
+++ b/internal/lookout/pruner/metrics.go
@@ -13,3 +13,15 @@ var zombiesRepaired = promauto.NewCounter(
 		Help: "Number of zombie jobs (non-terminal job.state but terminal latest run) repaired by the lookout pruner.",
 	},
 )
+
+// zombiesSkippedNullFinished counts zombie jobs the pruner saw but could not
+// repair because their latest run row had a NULL finished timestamp. The
+// reconciler relies on finished to populate last_transition_time, so these
+// rows are left alone -- but they should not exist in steady state and are
+// worth surfacing as their own signal so the gap is observable.
+var zombiesSkippedNullFinished = promauto.NewCounter(
+	prometheus.CounterOpts{
+		Name: "lookout_pruner_zombie_jobs_skipped_null_finished_total",
+		Help: "Number of zombie jobs skipped by the lookout pruner because the latest run had no finished timestamp.",
+	},
+)

--- a/internal/lookout/pruner/pruner.go
+++ b/internal/lookout/pruner/pruner.go
@@ -18,11 +18,18 @@ func PruneDb(
 	db *pgx.Conn,
 	jobLifetime time.Duration,
 	deduplicationLifetime time.Duration,
+	zombieRepairThreshold time.Duration,
 	batchLimit int,
 	clock clock.Clock,
 	hotColdSplit bool,
 ) error {
 	var result *multierror.Error
+
+	if zombieRepairThreshold > 0 {
+		if _, err := ReconcileZombieJobs(ctx, db, zombieRepairThreshold, batchLimit, clock); err != nil {
+			result = multierror.Append(result, err)
+		}
+	}
 
 	if err := deleteJobs(ctx, db, jobLifetime, batchLimit, clock, hotColdSplit); err != nil {
 		result = multierror.Append(result, err)

--- a/internal/lookout/pruner/pruner_test.go
+++ b/internal/lookout/pruner/pruner_test.go
@@ -222,7 +222,7 @@ func TestPruneDb(t *testing.T) {
 				dbConn, err := db.Acquire(ctx)
 				assert.NoError(t, err)
 				isHC := isHotColdSchema(ctx, db)
-				err = PruneDb(ctx, dbConn.Conn(), tc.expireAfter, 0, 10, clock.NewFakeClock(baseTime), isHC)
+				err = PruneDb(ctx, dbConn.Conn(), tc.expireAfter, 0, 0, 10, clock.NewFakeClock(baseTime), isHC)
 				assert.NoError(t, err)
 
 				queriedJobIdsPerTable := []map[string]bool{

--- a/internal/lookout/pruner/reconcile_zombies.go
+++ b/internal/lookout/pruner/reconcile_zombies.go
@@ -1,0 +1,148 @@
+package pruner
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/pkg/errors"
+	"k8s.io/utils/clock"
+
+	"github.com/armadaproject/armada/internal/common/armadacontext"
+	"github.com/armadaproject/armada/internal/common/database/lookout"
+	log "github.com/armadaproject/armada/internal/common/logging"
+)
+
+// reconcileZombiesQuery is built once at package init from the lookout state
+// ordinals so the SQL stays the single source of truth for the mapping.
+//
+// Interpolating these ordinals into the SQL (rather than passing them as bind
+// parameters) is safe because they are compile-time constants from
+// internal/common/database/lookout, not user input. It also lets PostgreSQL
+// infer mapping.new_state as smallint without explicit casts.
+var reconcileZombiesQuery = fmt.Sprintf(`
+	UPDATE job
+	SET state                        = mapping.new_state,
+	    last_transition_time         = mapping.finished,
+	    last_transition_time_seconds = EXTRACT(EPOCH FROM mapping.finished)::bigint
+	FROM (
+		SELECT j.job_id        AS job_id,
+		       j.queue          AS queue,
+		       j.jobset         AS jobset,
+		       j.state         AS old_state,
+		       j.latest_run_id AS run_id,
+		       CASE r.job_run_state
+		           WHEN %[1]d THEN %[2]d -- run succeeded -> job succeeded
+		           WHEN %[3]d THEN %[4]d -- run failed    -> job failed
+		           WHEN %[5]d THEN %[6]d -- run cancelled -> job cancelled
+		           WHEN %[7]d THEN %[8]d -- run preempted -> job preempted
+		       END             AS new_state,
+		       r.finished      AS finished
+		FROM job j
+		JOIN job_run r ON r.run_id = j.latest_run_id
+		WHERE j.state IN (%[9]d, %[10]d, %[11]d, %[12]d)
+		  AND r.job_run_state IN (%[1]d, %[3]d, %[5]d, %[7]d)
+		  AND r.finished IS NOT NULL
+		  AND r.finished < $1
+		LIMIT $2
+	) AS mapping
+	WHERE job.job_id = mapping.job_id
+	RETURNING job.job_id, mapping.queue, mapping.jobset, mapping.old_state, mapping.new_state, mapping.run_id, mapping.finished`,
+	lookout.JobRunSucceededOrdinal, lookout.JobSucceededOrdinal,
+	lookout.JobRunFailedOrdinal, lookout.JobFailedOrdinal,
+	lookout.JobRunCancelledOrdinal, lookout.JobCancelledOrdinal,
+	lookout.JobRunPreemptedOrdinal, lookout.JobPreemptedOrdinal,
+	lookout.JobQueuedOrdinal,
+	lookout.JobLeasedOrdinal,
+	lookout.JobPendingOrdinal,
+	lookout.JobRunningOrdinal,
+)
+
+// ReconcileZombieJobs finds jobs whose state column is non-terminal but whose
+// latest run is in a terminal state and finished more than zombieRepairThreshold
+// ago, and updates job.state (and last_transition_time) to match the run.
+// Returns the number of jobs repaired.
+func ReconcileZombieJobs(
+	ctx *armadacontext.Context,
+	db *pgx.Conn,
+	zombieRepairThreshold time.Duration,
+	batchLimit int,
+	clock clock.Clock,
+) (int, error) {
+	cutOffTime := clock.Now().Add(-zombieRepairThreshold)
+	totalRepaired := 0
+	for {
+		batchRepaired, err := reconcileZombieBatch(ctx, db, cutOffTime, batchLimit)
+		if err != nil {
+			return totalRepaired, err
+		}
+		if batchRepaired == 0 {
+			break
+		}
+		totalRepaired += batchRepaired
+	}
+	if totalRepaired > 0 {
+		// Zombies should not exist in steady state -- their presence
+		// indicates a logic bug somewhere upstream of the lookout database.
+		// Surface this loudly so it gets noticed and investigated.
+		log.Warnf("Reconciled %d zombie job(s) -- this should not happen and indicates an upstream bug", totalRepaired)
+	}
+	zombiesRepaired.Add(float64(totalRepaired))
+	return totalRepaired, nil
+}
+
+// reconcileZombieBatch repairs up to batchLimit zombie jobs in a single
+// transaction and returns the number of jobs repaired.
+func reconcileZombieBatch(
+	ctx *armadacontext.Context,
+	db *pgx.Conn,
+	cutOffTime time.Time,
+	batchLimit int,
+) (int, error) {
+	type repair struct {
+		jobID         string
+		queue         string
+		jobset        string
+		oldState      int
+		newState      int
+		runID         string
+		runFinishedAt time.Time
+	}
+	var repaired []repair
+
+	err := pgx.BeginTxFunc(ctx, db, pgx.TxOptions{
+		IsoLevel:   pgx.ReadCommitted,
+		AccessMode: pgx.ReadWrite,
+	}, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, reconcileZombiesQuery, cutOffTime, batchLimit)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var r repair
+			if err := rows.Scan(&r.jobID, &r.queue, &r.jobset, &r.oldState, &r.newState, &r.runID, &r.runFinishedAt); err != nil {
+				return errors.WithStack(err)
+			}
+			repaired = append(repaired, r)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return 0, errors.Wrap(err, "error reconciling zombie jobs")
+	}
+
+	for _, r := range repaired {
+		log.Warnf(
+			"Repaired zombie job %s (queue=%s jobset=%s): state %s -> %s (latest run %s finished at %s)",
+			r.jobID,
+			r.queue,
+			r.jobset,
+			lookout.JobStateMap[r.oldState],
+			lookout.JobStateMap[r.newState],
+			r.runID,
+			r.runFinishedAt.UTC().Format(time.RFC3339),
+		)
+	}
+	return len(repaired), nil
+}

--- a/internal/lookout/pruner/reconcile_zombies.go
+++ b/internal/lookout/pruner/reconcile_zombies.go
@@ -53,6 +53,10 @@ var reconcileZombiesQuery = fmt.Sprintf(`
 		LIMIT $2
 	) AS mapping
 	WHERE job.job_id = mapping.job_id
+	  -- Filter out ELSE-branch rows so they don't (a) get last_transition_time
+	  -- rewritten unnecessarily, and (b) re-appear in RETURNING and starve the
+	  -- outer batch loop's termination condition.
+	  AND mapping.new_state != mapping.old_state
 	RETURNING job.job_id, mapping.queue, mapping.jobset, mapping.old_state, mapping.new_state, mapping.run_id, mapping.finished`,
 	lookout.JobRunSucceededOrdinal, lookout.JobSucceededOrdinal,
 	lookout.JobRunFailedOrdinal, lookout.JobFailedOrdinal,

--- a/internal/lookout/pruner/reconcile_zombies.go
+++ b/internal/lookout/pruner/reconcile_zombies.go
@@ -36,6 +36,12 @@ var reconcileZombiesQuery = fmt.Sprintf(`
 		           WHEN %[3]d THEN %[4]d -- run failed    -> job failed
 		           WHEN %[5]d THEN %[6]d -- run cancelled -> job cancelled
 		           WHEN %[7]d THEN %[8]d -- run preempted -> job preempted
+		           ELSE j.state          -- defensive: a job_run_state that
+		                                 -- passes the IN filter but is not
+		                                 -- listed above (e.g. after a future
+		                                 -- refactor that lets the lists drift)
+		                                 -- becomes a harmless no-op instead
+		                                 -- of writing NULL to job.state.
 		       END             AS new_state,
 		       r.finished      AS finished
 		FROM job j
@@ -52,6 +58,27 @@ var reconcileZombiesQuery = fmt.Sprintf(`
 	lookout.JobRunFailedOrdinal, lookout.JobFailedOrdinal,
 	lookout.JobRunCancelledOrdinal, lookout.JobCancelledOrdinal,
 	lookout.JobRunPreemptedOrdinal, lookout.JobPreemptedOrdinal,
+	lookout.JobQueuedOrdinal,
+	lookout.JobLeasedOrdinal,
+	lookout.JobPendingOrdinal,
+	lookout.JobRunningOrdinal,
+)
+
+// countZombiesWithNullFinishedQuery counts jobs that match the zombie shape
+// (non-terminal job.state, latest run in a terminal job_run_state) but whose
+// run has no finished timestamp. The reconciler cannot repair these, but they
+// should not exist in steady state and so are worth surfacing.
+var countZombiesWithNullFinishedQuery = fmt.Sprintf(`
+	SELECT COUNT(*)
+	FROM job j
+	JOIN job_run r ON r.run_id = j.latest_run_id
+	WHERE j.state IN (%[5]d, %[6]d, %[7]d, %[8]d)
+	  AND r.job_run_state IN (%[1]d, %[2]d, %[3]d, %[4]d)
+	  AND r.finished IS NULL`,
+	lookout.JobRunSucceededOrdinal,
+	lookout.JobRunFailedOrdinal,
+	lookout.JobRunCancelledOrdinal,
+	lookout.JobRunPreemptedOrdinal,
 	lookout.JobQueuedOrdinal,
 	lookout.JobLeasedOrdinal,
 	lookout.JobPendingOrdinal,
@@ -88,7 +115,30 @@ func ReconcileZombieJobs(
 		log.Warnf("Reconciled %d zombie job(s) -- this should not happen and indicates an upstream bug", totalRepaired)
 	}
 	zombiesRepaired.Add(float64(totalRepaired))
+
+	if err := observeZombiesWithNullFinished(ctx, db); err != nil {
+		// Diagnostic counting failure: log but do not fail the pruner run.
+		log.WithError(err).Warn("failed to count zombie jobs with null run-finished timestamp")
+	}
+
 	return totalRepaired, nil
+}
+
+// observeZombiesWithNullFinished counts and surfaces zombie jobs that the
+// reconciler cannot repair because their latest run has no finished timestamp.
+func observeZombiesWithNullFinished(ctx *armadacontext.Context, db *pgx.Conn) error {
+	var count int
+	if err := db.QueryRow(ctx, countZombiesWithNullFinishedQuery).Scan(&count); err != nil {
+		return errors.WithStack(err)
+	}
+	zombiesSkippedNullFinished.Add(float64(count))
+	if count > 0 {
+		log.Warnf(
+			"Found %d zombie job(s) with no finished timestamp on their latest run -- these were not repaired and should be investigated",
+			count,
+		)
+	}
+	return nil
 }
 
 // reconcileZombieBatch repairs up to batchLimit zombie jobs in a single

--- a/internal/lookout/pruner/reconcile_zombies.go
+++ b/internal/lookout/pruner/reconcile_zombies.go
@@ -131,7 +131,7 @@ func observeZombiesWithNullFinished(ctx *armadacontext.Context, db *pgx.Conn) er
 	if err := db.QueryRow(ctx, countZombiesWithNullFinishedQuery).Scan(&count); err != nil {
 		return errors.WithStack(err)
 	}
-	zombiesSkippedNullFinished.Add(float64(count))
+	zombiesSkippedNullFinished.Set(float64(count))
 	if count > 0 {
 		log.Warnf(
 			"Found %d zombie job(s) with no finished timestamp on their latest run -- these were not repaired and should be investigated",

--- a/internal/lookout/pruner/reconcile_zombies_test.go
+++ b/internal/lookout/pruner/reconcile_zombies_test.go
@@ -255,17 +255,15 @@ func TestReconcileZombieJobsCountsNullFinishedZombies(t *testing.T) {
 		dbConn, err := db.Acquire(ctx)
 		require.NoError(t, err)
 
-		before := testutil.ToFloat64(zombiesSkippedNullFinished)
 		repaired, err := ReconcileZombieJobs(ctx, dbConn.Conn(), 1*time.Hour, 10, clock.NewFakeClock(baseTime))
 		require.NoError(t, err)
-		after := testutil.ToFloat64(zombiesSkippedNullFinished)
 
 		// Not repaired: the reconciler refuses to touch a row with NULL finished.
 		assert.Equal(t, 0, repaired)
 		assert.Equal(t, lookout.JobRunning, readJobState(t, ctx, db, jobId))
 
-		// But the diagnostic counter incremented, proving the gap is observable.
-		assert.GreaterOrEqual(t, after-before, 1.0)
+		// Gauge reflects the current count of NULL-finished zombies.
+		assert.Equal(t, 1.0, testutil.ToFloat64(zombiesSkippedNullFinished))
 		return nil
 	})
 	assert.NoError(t, err)

--- a/internal/lookout/pruner/reconcile_zombies_test.go
+++ b/internal/lookout/pruner/reconcile_zombies_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	clock "k8s.io/utils/clock/testing"
@@ -220,6 +221,51 @@ func TestReconcileZombieJobsLeavesNonZombiesAlone(t *testing.T) {
 		assert.Equal(t, lookout.JobRunning, readJobState(t, ctx, db, runningJobId))
 		assert.Equal(t, lookout.JobSucceeded, readJobState(t, ctx, db, healthyTerminalJobId))
 
+		return nil
+	})
+	assert.NoError(t, err)
+}
+
+// TestReconcileZombieJobsCountsNullFinishedZombies verifies that zombie jobs
+// whose latest run has no finished timestamp are observed via the
+// zombiesSkippedNullFinished metric (and are NOT silently repaired with bogus
+// data, since the reconciler relies on finished to populate
+// last_transition_time).
+func TestReconcileZombieJobsCountsNullFinishedZombies(t *testing.T) {
+	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
+		converter := instructions.NewInstructionConverter(metrics.Get().Metrics, "armadaproject.io/", []string{}, &compress.NoOpCompressor{})
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10, 10)
+
+		ctx, cancel := armadacontext.WithTimeout(armadacontext.Background(), 5*time.Minute)
+		defer cancel()
+
+		// Build a normal terminal job, then NULL out the run's finished
+		// timestamp and rewind the job state so it looks like a zombie whose
+		// run never recorded a finish time.
+		jobId := util.NewULID()
+		seedTerminalJob(t, ctx, db, store, converter, zombieScenario{
+			jobId:            jobId,
+			runFinishedAt:    baseTime.Add(-2 * time.Hour),
+			terminalJobState: lookout.JobSucceeded,
+		})
+		_, err := db.Exec(ctx, `UPDATE job_run SET finished = NULL WHERE job_id = $1`, jobId)
+		require.NoError(t, err)
+		rewindJobState(t, ctx, db, jobId, lookout.JobRunning)
+
+		dbConn, err := db.Acquire(ctx)
+		require.NoError(t, err)
+
+		before := testutil.ToFloat64(zombiesSkippedNullFinished)
+		repaired, err := ReconcileZombieJobs(ctx, dbConn.Conn(), 1*time.Hour, 10, clock.NewFakeClock(baseTime))
+		require.NoError(t, err)
+		after := testutil.ToFloat64(zombiesSkippedNullFinished)
+
+		// Not repaired: the reconciler refuses to touch a row with NULL finished.
+		assert.Equal(t, 0, repaired)
+		assert.Equal(t, lookout.JobRunning, readJobState(t, ctx, db, jobId))
+
+		// But the diagnostic counter incremented, proving the gap is observable.
+		assert.GreaterOrEqual(t, after-before, 1.0)
 		return nil
 	})
 	assert.NoError(t, err)

--- a/internal/lookout/pruner/reconcile_zombies_test.go
+++ b/internal/lookout/pruner/reconcile_zombies_test.go
@@ -24,12 +24,12 @@ import (
 // state in the database, and the non-terminal state we will then forcibly
 // rewind job.state to in order to simulate the historical ingester bug.
 type zombieScenario struct {
-	jobId             string
-	runFinishedAt     time.Time
-	terminalJobState  lookout.JobState
-	rewindToJobState  lookout.JobState
-	expectRepair      bool
-	expectedJobState  lookout.JobState // only checked when expectRepair is true
+	jobId            string
+	runFinishedAt    time.Time
+	terminalJobState lookout.JobState
+	rewindToJobState lookout.JobState
+	expectRepair     bool
+	expectedJobState lookout.JobState // only checked when expectRepair is true
 }
 
 func TestReconcileZombieJobs(t *testing.T) {

--- a/internal/lookout/pruner/reconcile_zombies_test.go
+++ b/internal/lookout/pruner/reconcile_zombies_test.go
@@ -1,0 +1,340 @@
+package pruner
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	clock "k8s.io/utils/clock/testing"
+
+	"github.com/armadaproject/armada/internal/common/armadacontext"
+	"github.com/armadaproject/armada/internal/common/compress"
+	"github.com/armadaproject/armada/internal/common/database/lookout"
+	"github.com/armadaproject/armada/internal/common/util"
+	"github.com/armadaproject/armada/internal/lookout/repository"
+	"github.com/armadaproject/armada/internal/lookoutingester/instructions"
+	"github.com/armadaproject/armada/internal/lookoutingester/lookoutdb"
+	"github.com/armadaproject/armada/internal/lookoutingester/metrics"
+)
+
+// zombieScenario describes a job that should already exist in a terminal
+// state in the database, and the non-terminal state we will then forcibly
+// rewind job.state to in order to simulate the historical ingester bug.
+type zombieScenario struct {
+	jobId             string
+	runFinishedAt     time.Time
+	terminalJobState  lookout.JobState
+	rewindToJobState  lookout.JobState
+	expectRepair      bool
+	expectedJobState  lookout.JobState // only checked when expectRepair is true
+}
+
+func TestReconcileZombieJobs(t *testing.T) {
+	type testCase struct {
+		name                  string
+		zombieRepairThreshold time.Duration
+		batchSize             int
+		scenarios             []zombieScenario
+	}
+
+	id := func() string { return util.NewULID() }
+
+	testCases := []testCase{
+		{
+			name:                  "succeeded run zombie is repaired",
+			zombieRepairThreshold: 1 * time.Hour,
+			batchSize:             10,
+			scenarios: []zombieScenario{
+				{
+					jobId:            id(),
+					runFinishedAt:    baseTime.Add(-2 * time.Hour),
+					terminalJobState: lookout.JobSucceeded,
+					rewindToJobState: lookout.JobRunning,
+					expectRepair:     true,
+					expectedJobState: lookout.JobSucceeded,
+				},
+			},
+		},
+		{
+			name:                  "failed run zombie is repaired",
+			zombieRepairThreshold: 1 * time.Hour,
+			batchSize:             10,
+			scenarios: []zombieScenario{
+				{
+					jobId:            id(),
+					runFinishedAt:    baseTime.Add(-2 * time.Hour),
+					terminalJobState: lookout.JobFailed,
+					rewindToJobState: lookout.JobPending,
+					expectRepair:     true,
+					expectedJobState: lookout.JobFailed,
+				},
+			},
+		},
+		{
+			name:                  "cancelled run zombie is repaired",
+			zombieRepairThreshold: 1 * time.Hour,
+			batchSize:             10,
+			scenarios: []zombieScenario{
+				{
+					jobId:            id(),
+					runFinishedAt:    baseTime.Add(-2 * time.Hour),
+					terminalJobState: lookout.JobCancelled,
+					rewindToJobState: lookout.JobQueued,
+					expectRepair:     true,
+					expectedJobState: lookout.JobCancelled,
+				},
+			},
+		},
+		{
+			name:                  "preempted run zombie is repaired",
+			zombieRepairThreshold: 1 * time.Hour,
+			batchSize:             10,
+			scenarios: []zombieScenario{
+				{
+					jobId:            id(),
+					runFinishedAt:    baseTime.Add(-2 * time.Hour),
+					terminalJobState: lookout.JobPreempted,
+					rewindToJobState: lookout.JobLeased,
+					expectRepair:     true,
+					expectedJobState: lookout.JobPreempted,
+				},
+			},
+		},
+		{
+			name:                  "zombie within grace period is left alone",
+			zombieRepairThreshold: 1 * time.Hour,
+			batchSize:             10,
+			scenarios: []zombieScenario{
+				{
+					jobId:            id(),
+					runFinishedAt:    baseTime.Add(-30 * time.Minute),
+					terminalJobState: lookout.JobSucceeded,
+					rewindToJobState: lookout.JobRunning,
+					expectRepair:     false,
+				},
+			},
+		},
+		{
+			name:                  "many zombies repaired across multiple batches",
+			zombieRepairThreshold: 1 * time.Hour,
+			batchSize:             3,
+			scenarios: func() []zombieScenario {
+				ss := make([]zombieScenario, 7)
+				for i := range ss {
+					ss[i] = zombieScenario{
+						jobId:            id(),
+						runFinishedAt:    baseTime.Add(-2 * time.Hour),
+						terminalJobState: lookout.JobSucceeded,
+						rewindToJobState: lookout.JobRunning,
+						expectRepair:     true,
+						expectedJobState: lookout.JobSucceeded,
+					}
+				}
+				return ss
+			}(),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
+				converter := instructions.NewInstructionConverter(metrics.Get().Metrics, "armadaproject.io/", []string{}, &compress.NoOpCompressor{})
+				store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10, 10)
+
+				ctx, cancel := armadacontext.WithTimeout(armadacontext.Background(), 5*time.Minute)
+				defer cancel()
+
+				for _, s := range tc.scenarios {
+					seedTerminalJob(t, ctx, db, store, converter, s)
+					rewindJobState(t, ctx, db, s.jobId, s.rewindToJobState)
+				}
+
+				dbConn, err := db.Acquire(ctx)
+				require.NoError(t, err)
+
+				repaired, err := ReconcileZombieJobs(ctx, dbConn.Conn(), tc.zombieRepairThreshold, tc.batchSize, clock.NewFakeClock(baseTime))
+				require.NoError(t, err)
+
+				expectedRepairs := 0
+				for _, s := range tc.scenarios {
+					actual := readJobState(t, ctx, db, s.jobId)
+					if s.expectRepair {
+						expectedRepairs++
+						assert.Equal(t, s.expectedJobState, actual, "job %s should have been repaired to %s but is %s", s.jobId, s.expectedJobState, actual)
+					} else {
+						assert.Equal(t, s.rewindToJobState, actual, "job %s should NOT have been repaired but state is %s", s.jobId, actual)
+					}
+				}
+				assert.Equal(t, expectedRepairs, repaired)
+
+				return nil
+			})
+			assert.NoError(t, err)
+		})
+	}
+}
+
+// TestReconcileZombieJobsLeavesNonZombiesAlone verifies the reconciler does
+// not touch jobs that are legitimately in a non-terminal state with a still-
+// running latest run, nor jobs already in their proper terminal state.
+func TestReconcileZombieJobsLeavesNonZombiesAlone(t *testing.T) {
+	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
+		converter := instructions.NewInstructionConverter(metrics.Get().Metrics, "armadaproject.io/", []string{}, &compress.NoOpCompressor{})
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10, 10)
+
+		ctx, cancel := armadacontext.WithTimeout(armadacontext.Background(), 5*time.Minute)
+		defer cancel()
+
+		// Healthy running job (no terminal run yet).
+		runningJobId := util.NewULID()
+		runningRunId := uuid.NewString()
+		repository.NewJobSimulator(converter, store).
+			Submit("queue", "jobSet", "owner", "namespace", baseTime.Add(-3*time.Hour), &repository.JobOptions{JobId: runningJobId}).
+			Lease(runningRunId, "cluster", "node", "pool", baseTime.Add(-3*time.Hour)).
+			Pending(runningRunId, "cluster", baseTime.Add(-3*time.Hour)).
+			Running(runningRunId, "node", baseTime.Add(-3*time.Hour)).
+			Build()
+
+		// Healthy terminal job (state and latest run already in agreement).
+		healthyTerminalJobId := util.NewULID()
+		healthyTerminalRunId := uuid.NewString()
+		repository.NewJobSimulator(converter, store).
+			Submit("queue", "jobSet", "owner", "namespace", baseTime.Add(-3*time.Hour), &repository.JobOptions{JobId: healthyTerminalJobId}).
+			Lease(healthyTerminalRunId, "cluster", "node", "pool", baseTime.Add(-3*time.Hour)).
+			Pending(healthyTerminalRunId, "cluster", baseTime.Add(-3*time.Hour)).
+			Running(healthyTerminalRunId, "node", baseTime.Add(-3*time.Hour)).
+			RunSucceeded(healthyTerminalRunId, baseTime.Add(-2*time.Hour)).
+			Succeeded(baseTime.Add(-2 * time.Hour)).
+			Build()
+
+		dbConn, err := db.Acquire(ctx)
+		require.NoError(t, err)
+
+		repaired, err := ReconcileZombieJobs(ctx, dbConn.Conn(), 1*time.Hour, 10, clock.NewFakeClock(baseTime))
+		require.NoError(t, err)
+		assert.Equal(t, 0, repaired)
+
+		assert.Equal(t, lookout.JobRunning, readJobState(t, ctx, db, runningJobId))
+		assert.Equal(t, lookout.JobSucceeded, readJobState(t, ctx, db, healthyTerminalJobId))
+
+		return nil
+	})
+	assert.NoError(t, err)
+}
+
+// TestPruneDbRunsZombieReconciliation is a thin smoke test that
+// PruneDb invokes ReconcileZombieJobs when the threshold is non-zero.
+func TestPruneDbRunsZombieReconciliation(t *testing.T) {
+	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
+		converter := instructions.NewInstructionConverter(metrics.Get().Metrics, "armadaproject.io/", []string{}, &compress.NoOpCompressor{})
+		store := lookoutdb.NewLookoutDb(db, nil, metrics.Get(), 10, 10)
+
+		ctx, cancel := armadacontext.WithTimeout(armadacontext.Background(), 5*time.Minute)
+		defer cancel()
+
+		zombie := zombieScenario{
+			jobId:            util.NewULID(),
+			runFinishedAt:    baseTime.Add(-2 * time.Hour),
+			terminalJobState: lookout.JobSucceeded,
+			rewindToJobState: lookout.JobRunning,
+			expectRepair:     true,
+			expectedJobState: lookout.JobSucceeded,
+		}
+		seedTerminalJob(t, ctx, db, store, converter, zombie)
+		rewindJobState(t, ctx, db, zombie.jobId, zombie.rewindToJobState)
+
+		dbConn, err := db.Acquire(ctx)
+		require.NoError(t, err)
+
+		isHC := isHotColdSchema(ctx, db)
+		err = PruneDb(ctx, dbConn.Conn(), 100*time.Hour, 100*time.Hour, 1*time.Hour, 10, clock.NewFakeClock(baseTime), isHC)
+		require.NoError(t, err)
+
+		assert.Equal(t, lookout.JobSucceeded, readJobState(t, ctx, db, zombie.jobId))
+		return nil
+	})
+	assert.NoError(t, err)
+}
+
+func seedTerminalJob(
+	t *testing.T,
+	ctx *armadacontext.Context,
+	db *pgxpool.Pool,
+	store *lookoutdb.LookoutDb,
+	converter *instructions.InstructionConverter,
+	s zombieScenario,
+) {
+	t.Helper()
+	runId := uuid.NewString()
+	sim := repository.NewJobSimulator(converter, store).
+		Submit("queue", "jobSet", "owner", "namespace", s.runFinishedAt.Add(-1*time.Hour), &repository.JobOptions{JobId: s.jobId}).
+		Lease(runId, "cluster", "node", "pool", s.runFinishedAt.Add(-1*time.Hour)).
+		Pending(runId, "cluster", s.runFinishedAt.Add(-1*time.Hour)).
+		Running(runId, "node", s.runFinishedAt.Add(-1*time.Hour))
+
+	switch s.terminalJobState {
+	case lookout.JobSucceeded:
+		sim.RunSucceeded(runId, s.runFinishedAt).Succeeded(s.runFinishedAt).Build()
+	case lookout.JobFailed:
+		sim.RunFailed(runId, "node", 1, "", "", s.runFinishedAt).Failed("node", 1, "", s.runFinishedAt).Build()
+	case lookout.JobCancelled:
+		sim.Cancelled(s.runFinishedAt, "canceluser").Build()
+	case lookout.JobPreempted:
+		sim.Preempted(s.runFinishedAt).Build()
+	default:
+		t.Fatalf("unsupported terminal state %s", s.terminalJobState)
+	}
+
+	// Cancelled and Preempted state transitions in the simulator do not
+	// always set finished on the run row, but the reconciler relies on it.
+	// Force it here so the test's assumptions match the production scenarios
+	// the reconciler is designed to repair.
+	forceRunFinished(t, ctx, db, s.jobId, s.runFinishedAt, s.terminalJobState)
+}
+
+func forceRunFinished(t *testing.T, ctx *armadacontext.Context, db *pgxpool.Pool, jobId string, finished time.Time, terminalJobState lookout.JobState) {
+	t.Helper()
+	runStateOrdinal := terminalRunStateForJobState(t, terminalJobState)
+	_, err := db.Exec(ctx, `
+		UPDATE job_run
+		SET finished      = $1,
+		    job_run_state = $2
+		WHERE job_id = $3
+		  AND run_id = (SELECT latest_run_id FROM job WHERE job_id = $3)`,
+		finished, runStateOrdinal, jobId)
+	require.NoError(t, err)
+}
+
+func terminalRunStateForJobState(t *testing.T, s lookout.JobState) int {
+	t.Helper()
+	switch s {
+	case lookout.JobSucceeded:
+		return lookout.JobRunSucceededOrdinal
+	case lookout.JobFailed:
+		return lookout.JobRunFailedOrdinal
+	case lookout.JobCancelled:
+		return lookout.JobRunCancelledOrdinal
+	case lookout.JobPreempted:
+		return lookout.JobRunPreemptedOrdinal
+	}
+	t.Fatalf("no terminal job_run_state for %s", s)
+	return 0
+}
+
+func rewindJobState(t *testing.T, ctx *armadacontext.Context, db *pgxpool.Pool, jobId string, state lookout.JobState) {
+	t.Helper()
+	ordinal := lookout.JobStateOrdinalMap[state]
+	_, err := db.Exec(ctx, `UPDATE job SET state = $1 WHERE job_id = $2`, ordinal, jobId)
+	require.NoError(t, err)
+}
+
+func readJobState(t *testing.T, ctx *armadacontext.Context, db *pgxpool.Pool, jobId string) lookout.JobState {
+	t.Helper()
+	var ordinal int
+	err := db.QueryRow(ctx, `SELECT state FROM job WHERE job_id = $1`, jobId).Scan(&ordinal)
+	require.NoError(t, err)
+	return lookout.JobStateMap[ordinal]
+}


### PR DESCRIPTION
Adds a reconciliation step to the lookout pruner that repairs "zombie" jobs left behind by a now-fixed ingester bug: rows where `job.state` is non-terminal (Queued/Leased/Pending/Running) but `latest_run_id` points to a `job_run` row in a terminal state (Succeeded/Failed/Cancelled/Preempted).

On each pruner run, before the existing deletion step, jobs whose latest run finished more than `prunerConfig.zombieRepairThreshold` ago have their `state` and `last_transition_time` updated to match the run. Default threshold is 15 minutes (a grace period for in-flight transitions and ingester lag). Set to 0 to disable this reconciliation entirely.

Repairs are batched (`prunerConfig.batchSize`), logged at info level (job ID, old -> new state), and counted in a new `lookout_pruner_zombie_jobs_repaired_total` Prometheus metric. Existing pruning behaviour is unchanged.

We log out all zombie jobs reconciled to enable further investigation. Ultimately, there should be no zombie jobs so the existence of them indicates a bug in Armada.