### PR TITLE
Add DryRunTxn to JobDb

### DIFF
--- a/internal/scheduler/jobdb/jobdb.go
+++ b/internal/scheduler/jobdb/jobdb.go
@@ -368,15 +368,15 @@ func (jobDb *JobDb) WriteTxn() *Txn {
 	}
 }
 
-// SnapshotTxn returns a writable transaction over an isolated snapshot of the current db state.
+// DryRunTxn returns a writable transaction over an isolated snapshot of the current db state.
 // Mutations are local to the snapshot and are never committed back to the db.
 // This is useful for processes that need to speculatively modify state without affecting the real db.
-func (jobDb *JobDb) SnapshotTxn() *Txn {
+func (jobDb *JobDb) DryRunTxn() *Txn {
 	jobDb.copyMutex.Lock()
 	defer jobDb.copyMutex.Unlock()
 	return &Txn{
 		readOnly:           false,
-		snapshotOnly:       true,
+		dryRun:             true,
 		jobsById:           jobDb.jobsById,
 		jobsByRunId:        jobDb.jobsByRunId,
 		jobsByGangKey:      maps.Clone(jobDb.jobsByGangKey),
@@ -409,9 +409,9 @@ func (jobDb *JobDb) CumulativeInternedStringsCount() uint64 {
 // until the transaction is committed.
 type Txn struct {
 	readOnly bool
-	// snapshotOnly transactions allow mutations but Commit is a no-op — changes are never written back to the db.
-	// Created via SnapshotTxn(); useful for speculative state manipulation without affecting the real db.
-	snapshotOnly bool
+	// dryRun transactions allow mutations but Commit is a no-op — changes are never written back to the db.
+	// Created via DryRunTxn(); useful for speculative state manipulation without affecting the real db.
+	dryRun bool
 	// Map from job ids to jobs.
 	jobsById *immutable.Map[string, *Job]
 	// Map from run ids to jobs.
@@ -438,7 +438,10 @@ type Txn struct {
 }
 
 func (txn *Txn) Commit() {
-	if txn.readOnly || txn.snapshotOnly || !txn.active {
+	if txn.readOnly || !txn.active {
+		return
+	}
+	if txn.dryRun {
 		txn.active = false
 		return
 	}
@@ -544,7 +547,10 @@ func (txn *Txn) AssertEqual(otherTxn *Txn) error {
 }
 
 func (txn *Txn) Abort() {
-	if txn.readOnly || txn.snapshotOnly || !txn.active {
+	if txn.readOnly || !txn.active {
+		return
+	}
+	if txn.dryRun {
 		txn.active = false
 		return
 	}

--- a/internal/scheduler/jobdb/jobdb.go
+++ b/internal/scheduler/jobdb/jobdb.go
@@ -368,6 +368,28 @@ func (jobDb *JobDb) WriteTxn() *Txn {
 	}
 }
 
+// SnapshotTxn returns a writable transaction over an isolated snapshot of the current db state.
+// Mutations are local to the snapshot and are never committed back to the db.
+// This is useful for processes that need to speculatively modify state without affecting the real db.
+func (jobDb *JobDb) SnapshotTxn() *Txn {
+	jobDb.copyMutex.Lock()
+	defer jobDb.copyMutex.Unlock()
+	return &Txn{
+		readOnly:           false,
+		snapshotOnly:       true,
+		jobsById:           jobDb.jobsById,
+		jobsByRunId:        jobDb.jobsByRunId,
+		jobsByGangKey:      maps.Clone(jobDb.jobsByGangKey),
+		jobsByQueue:        maps.Clone(jobDb.jobsByQueue),
+		jobsByPoolAndQueue: deepClone(jobDb.jobsByPoolAndQueue),
+		leasedJobs:         jobDb.leasedJobs,
+		terminalJobs:       jobDb.terminalJobs,
+		unvalidatedJobs:    jobDb.unvalidatedJobs,
+		active:             true,
+		jobDb:              jobDb,
+	}
+}
+
 func deepClone(original map[string]map[string]immutable.SortedSet[*Job]) map[string]map[string]immutable.SortedSet[*Job] {
 	clone := make(map[string]map[string]immutable.SortedSet[*Job])
 	for key, innerMap := range original {
@@ -387,6 +409,9 @@ func (jobDb *JobDb) CumulativeInternedStringsCount() uint64 {
 // until the transaction is committed.
 type Txn struct {
 	readOnly bool
+	// snapshotOnly transactions allow mutations but Commit is a no-op — changes are never written back to the db.
+	// Created via SnapshotTxn(); useful for speculative state manipulation without affecting the real db.
+	snapshotOnly bool
 	// Map from job ids to jobs.
 	jobsById *immutable.Map[string, *Job]
 	// Map from run ids to jobs.
@@ -413,7 +438,8 @@ type Txn struct {
 }
 
 func (txn *Txn) Commit() {
-	if txn.readOnly || !txn.active {
+	if txn.readOnly || txn.snapshotOnly || !txn.active {
+		txn.active = false
 		return
 	}
 	txn.jobDb.copyMutex.Lock()
@@ -518,7 +544,8 @@ func (txn *Txn) AssertEqual(otherTxn *Txn) error {
 }
 
 func (txn *Txn) Abort() {
-	if txn.readOnly || !txn.active {
+	if txn.readOnly || txn.snapshotOnly || !txn.active {
+		txn.active = false
 		return
 	}
 	txn.active = false

--- a/internal/scheduler/jobdb/jobdb_test.go
+++ b/internal/scheduler/jobdb/jobdb_test.go
@@ -440,7 +440,7 @@ func TestJobDb_TestTransactions(t *testing.T) {
 	assert.Error(t, txn1.Upsert([]*Job{job})) // should be error as you can't insert after committing
 }
 
-func TestSnapshotTxn_LocalChangesVisible(t *testing.T) {
+func TestDryRunTxn_LocalChangesVisible(t *testing.T) {
 	jobDb := NewTestJobDb()
 
 	// Seed the real db with one job.
@@ -449,22 +449,22 @@ func TestSnapshotTxn_LocalChangesVisible(t *testing.T) {
 	require.NoError(t, writeTxn.Upsert([]*Job{job}))
 	writeTxn.Commit()
 
-	snapshotTxn := jobDb.SnapshotTxn()
+	dryRunTxn := jobDb.DryRunTxn()
 
 	// The original job should be visible in the snapshot.
-	assert.NotNil(t, snapshotTxn.GetById(job.Id()))
+	assert.NotNil(t, dryRunTxn.GetById(job.Id()))
 
 	// Upsert a new job into the snapshot — it should be visible within the snapshot.
 	newSnapJob := newJob().WithQueued(true)
-	require.NoError(t, snapshotTxn.Upsert([]*Job{newSnapJob}))
-	assert.NotNil(t, snapshotTxn.GetById(newSnapJob.Id()))
+	require.NoError(t, dryRunTxn.Upsert([]*Job{newSnapJob}))
+	assert.NotNil(t, dryRunTxn.GetById(newSnapJob.Id()))
 
 	// Delete the original job from the snapshot — it should be gone within the snapshot.
-	require.NoError(t, snapshotTxn.BatchDelete([]string{job.Id()}))
-	assert.Nil(t, snapshotTxn.GetById(job.Id()))
+	require.NoError(t, dryRunTxn.BatchDelete([]string{job.Id()}))
+	assert.Nil(t, dryRunTxn.GetById(job.Id()))
 }
 
-func TestSnapshotTxn_CommitDoesNotModifyDb(t *testing.T) {
+func TestDryRunTxn_CommitDoesNotModifyDb(t *testing.T) {
 	jobDb := NewTestJobDb()
 
 	// Seed the real db with one job.
@@ -473,13 +473,13 @@ func TestSnapshotTxn_CommitDoesNotModifyDb(t *testing.T) {
 	require.NoError(t, writeTxn.Upsert([]*Job{job}))
 	writeTxn.Commit()
 
-	snapshotTxn := jobDb.SnapshotTxn()
+	dryRunTxn := jobDb.DryRunTxn()
 
 	// Mutate the snapshot: add a new job and delete the seeded one.
 	newSnapJob := newJob().WithQueued(true)
-	require.NoError(t, snapshotTxn.Upsert([]*Job{newSnapJob}))
-	require.NoError(t, snapshotTxn.BatchDelete([]string{job.Id()}))
-	snapshotTxn.Commit()
+	require.NoError(t, dryRunTxn.Upsert([]*Job{newSnapJob}))
+	require.NoError(t, dryRunTxn.BatchDelete([]string{job.Id()}))
+	dryRunTxn.Commit()
 
 	// The real db must be unchanged after committing the snapshot.
 	realTxn := jobDb.ReadTxn()
@@ -489,6 +489,29 @@ func TestSnapshotTxn_CommitDoesNotModifyDb(t *testing.T) {
 		"snapshot-only job must not appear in the real db after snapshot commit")
 
 	// A subsequent WriteTxn must not be blocked (writerMutex was never held).
+	secondWrite := jobDb.WriteTxn()
+	secondWrite.Abort()
+}
+
+func TestDryRunTxn_AbortDoesNotModifyDb(t *testing.T) {
+	jobDb := NewTestJobDb()
+
+	job := newJob().WithQueued(true)
+	writeTxn := jobDb.WriteTxn()
+	require.NoError(t, writeTxn.Upsert([]*Job{job}))
+	writeTxn.Commit()
+
+	dryRunTxn := jobDb.DryRunTxn()
+	newJob := newJob().WithQueued(true)
+	require.NoError(t, dryRunTxn.Upsert([]*Job{newJob}))
+	dryRunTxn.Abort() // must not panic (writerMutex was never acquired)
+
+	// Real db must be unchanged after abort.
+	realTxn := jobDb.ReadTxn()
+	assert.NotNil(t, realTxn.GetById(job.Id()))
+	assert.Nil(t, realTxn.GetById(newJob.Id()))
+
+	// writerMutex must not be held.
 	secondWrite := jobDb.WriteTxn()
 	secondWrite.Abort()
 }

--- a/internal/scheduler/jobdb/jobdb_test.go
+++ b/internal/scheduler/jobdb/jobdb_test.go
@@ -451,15 +451,15 @@ func TestDryRunTxn_LocalChangesVisible(t *testing.T) {
 
 	dryRunTxn := jobDb.DryRunTxn()
 
-	// The original job should be visible in the snapshot.
+	// The original job should be visible in the txn.
 	assert.NotNil(t, dryRunTxn.GetById(job.Id()))
 
-	// Upsert a new job into the snapshot — it should be visible within the snapshot.
+	// Upsert a new job into the txn — it should be visible within the txn.
 	newSnapJob := newJob().WithQueued(true)
 	require.NoError(t, dryRunTxn.Upsert([]*Job{newSnapJob}))
 	assert.NotNil(t, dryRunTxn.GetById(newSnapJob.Id()))
 
-	// Delete the original job from the snapshot — it should be gone within the snapshot.
+	// Delete the original job from the txn — it should be gone within the txn.
 	require.NoError(t, dryRunTxn.BatchDelete([]string{job.Id()}))
 	assert.Nil(t, dryRunTxn.GetById(job.Id()))
 }
@@ -475,18 +475,18 @@ func TestDryRunTxn_CommitDoesNotModifyDb(t *testing.T) {
 
 	dryRunTxn := jobDb.DryRunTxn()
 
-	// Mutate the snapshot: add a new job and delete the seeded one.
-	newSnapJob := newJob().WithQueued(true)
-	require.NoError(t, dryRunTxn.Upsert([]*Job{newSnapJob}))
+	// Mutate the txn: add a new job and delete the original one.
+	newJob := newJob().WithQueued(true)
+	require.NoError(t, dryRunTxn.Upsert([]*Job{newJob}))
 	require.NoError(t, dryRunTxn.BatchDelete([]string{job.Id()}))
 	dryRunTxn.Commit()
 
-	// The real db must be unchanged after committing the snapshot.
+	// The real db must be unchanged after committing the txn.
 	realTxn := jobDb.ReadTxn()
 	assert.NotNil(t, realTxn.GetById(job.Id()),
-		"original job should still exist in the real db after snapshot commit")
-	assert.Nil(t, realTxn.GetById(newSnapJob.Id()),
-		"snapshot-only job must not appear in the real db after snapshot commit")
+		"original job should still exist in the real db after dry run commit")
+	assert.Nil(t, realTxn.GetById(newJob.Id()),
+		"dry run only job must not appear in the real db after dry run commit")
 
 	// A subsequent WriteTxn must not be blocked (writerMutex was never held).
 	secondWrite := jobDb.WriteTxn()

--- a/internal/scheduler/jobdb/jobdb_test.go
+++ b/internal/scheduler/jobdb/jobdb_test.go
@@ -440,6 +440,59 @@ func TestJobDb_TestTransactions(t *testing.T) {
 	assert.Error(t, txn1.Upsert([]*Job{job})) // should be error as you can't insert after committing
 }
 
+func TestSnapshotTxn_LocalChangesVisible(t *testing.T) {
+	jobDb := NewTestJobDb()
+
+	// Seed the real db with one job.
+	job := newJob().WithQueued(true)
+	writeTxn := jobDb.WriteTxn()
+	require.NoError(t, writeTxn.Upsert([]*Job{job}))
+	writeTxn.Commit()
+
+	snapshotTxn := jobDb.SnapshotTxn()
+
+	// The original job should be visible in the snapshot.
+	assert.NotNil(t, snapshotTxn.GetById(job.Id()))
+
+	// Upsert a new job into the snapshot — it should be visible within the snapshot.
+	newSnapJob := newJob().WithQueued(true)
+	require.NoError(t, snapshotTxn.Upsert([]*Job{newSnapJob}))
+	assert.NotNil(t, snapshotTxn.GetById(newSnapJob.Id()))
+
+	// Delete the original job from the snapshot — it should be gone within the snapshot.
+	require.NoError(t, snapshotTxn.BatchDelete([]string{job.Id()}))
+	assert.Nil(t, snapshotTxn.GetById(job.Id()))
+}
+
+func TestSnapshotTxn_CommitDoesNotModifyDb(t *testing.T) {
+	jobDb := NewTestJobDb()
+
+	// Seed the real db with one job.
+	job := newJob().WithQueued(true)
+	writeTxn := jobDb.WriteTxn()
+	require.NoError(t, writeTxn.Upsert([]*Job{job}))
+	writeTxn.Commit()
+
+	snapshotTxn := jobDb.SnapshotTxn()
+
+	// Mutate the snapshot: add a new job and delete the seeded one.
+	newSnapJob := newJob().WithQueued(true)
+	require.NoError(t, snapshotTxn.Upsert([]*Job{newSnapJob}))
+	require.NoError(t, snapshotTxn.BatchDelete([]string{job.Id()}))
+	snapshotTxn.Commit()
+
+	// The real db must be unchanged after committing the snapshot.
+	realTxn := jobDb.ReadTxn()
+	assert.NotNil(t, realTxn.GetById(job.Id()),
+		"original job should still exist in the real db after snapshot commit")
+	assert.Nil(t, realTxn.GetById(newSnapJob.Id()),
+		"snapshot-only job must not appear in the real db after snapshot commit")
+
+	// A subsequent WriteTxn must not be blocked (writerMutex was never held).
+	secondWrite := jobDb.WriteTxn()
+	secondWrite.Abort()
+}
+
 func TestJobDb_TestBatchDelete(t *testing.T) {
 	jobDb := NewTestJobDb()
 	job1 := newJob().WithQueued(true).WithNewRun("executor", "nodeId", "nodeName", "pool", 5)


### PR DESCRIPTION
This is a new transaction type that allows local mutation but cannot have its changes committed back to the main db

The purpose of this is to allow side routines to have a functional (writable) transaction that they can use but has no risk of impacting the main db

This is precusor work to splitting the scheduling_algo into a separate go routine
 - It'll use jobdb snapshots to schedule with, but then communicate its desired changed back to the main thread rather than commit back to the jobdb directly to avoid conflicts. (Such as marking a job as scheduled, when it has already been cancelled)

