### PR TITLE
Disable only-new-issues from lint check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -62,7 +62,7 @@ jobs:
         uses: golangci/golangci-lint-action@v9
         with:
           version: v2.9.0
-          # Do not enable only-new-only-new-issues
+          # Do not enable only-new-issues
           # While it provides a small performance improvement on PRs,
           # it can mean releases which do a full lint fail resulting in a failed release.
           # The performance improvement on PR is negligible considering the other much longer checks we run

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -62,7 +62,11 @@ jobs:
         uses: golangci/golangci-lint-action@v9
         with:
           version: v2.9.0
-          only-new-issues: true
+          # Do not enable only-new-only-new-issues
+          # While it provides a small performance improvement on PRs,
+          # it can mean releases which do a full lint fail resulting in a failed release.
+          # The performance improvement on PR is negligible considering the other much longer checks we run
+          only-new-issues: false
           skip-cache: true
           args: --timeout=10m --issues-exit-code=1 ./...
 


### PR DESCRIPTION
This flag attempts to run the linting only on changes - which in theory works if master is fully linted

However in practice this often misses issues resulting in master not working

We only discover this at release time (not even master build) which means we have to make further fixes + releases This is the simplest fix - it just removes the bit trying to be "smart" and just ensures the whole code base is linted - if this is fast enough we should just do this

Based on release lints, the difference is minimal


