### PR TITLE
Add developer doc for job lifecycle events

### DIFF
--- a/docs/developer/job-lifecycle-events.md
+++ b/docs/developer/job-lifecycle-events.md
@@ -154,7 +154,7 @@ stateDiagram-v2
 | Pending                    | LeaseReturned | `JobRunErrors` (`PodLeaseReturned`)                                                                 |
 | Leased / Pending / Running | LeaseExpired  | `JobRunErrors` (`LeaseExpired`, emitted on stale executor)                                          |
 
-`MaxRunsExceeded`, `UnableToSchedule`, and `Terminated` exist as enum values in the Lookout run-state enum but are not driven by any current emission path. When the scheduler caps retries with a `MaxRunsExceeded` reason, lookout's `JobRunErrors` handler falls into the default case and records the run as `Failed`.
+`MaxRunsExceeded`, `UnableToSchedule`, and `Terminated` exist as enum values in the Lookout run-state enum but are not driven by any current emission path. When the scheduler caps retries it emits `MaxRunsExceeded` only as a job-level `JobErrors`, which reaches lookout's job-level handler (recording the job as `Failed`), never the run-level `JobRunErrors` handler. The run itself was already recorded as `Failed` or `LeaseReturned` by the earlier run-level error that triggered the final retry.
 
 ## Event vocabulary
 
@@ -188,7 +188,7 @@ The `Error.reason` oneof inside `JobRunErrors` has eleven variants: `KubernetesE
 | Internal event             | External event                                    | Notes                                                                                                       |
 | -------------------------- | ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
 | `JobSucceeded` (job-level) | `JobSucceededEvent`                               |                                                                                                             |
-| `JobErrors` (job-level)    | `JobFailedEvent` (for terminal)                   | Carries reason, category, subcategory.                                                                      |
+| `JobErrors` (job-level)    | `JobFailedEvent` (for terminal)                   | Reason-discriminated conversion. Carries reason, category, subcategory.                                      |
 | `CancelledJob`             | `JobCancelledEvent`                               |                                                                                                             |
 | `JobRunPreempted`          | `JobPreemptedEvent`                               |                                                                                                             |
 | `JobRunErrors`             | `JobLeaseReturnedEvent` or `JobLeaseExpiredEvent` | Only for `PodLeaseReturned` and `LeaseExpired` reasons. All other reasons ignored at the conversion layer.  |
@@ -296,7 +296,7 @@ The conversion layer converts the scheduler's job-level `JobErrors` to `JobFaile
 
 ### Path B: executor's issue handler detects a problem first
 
-The issue handler watches managed pods for failure modes that surface before the pod's terminal phase. Its `podIssueType` enum has seven values: `UnableToSchedule`, `StuckStartingUp`, `FailedStartingUp`, `StuckTerminating`, `ActiveDeadlineExceeded`, `ExternallyDeleted`, and `ErrorDuringIssueHandling`. When it decides a pod is broken, it emits the failure event at detection time and then deletes the pod.
+The issue handler watches managed pods for failure modes that surface before the pod's terminal phase. Its `podIssueType` enum has seven values: `UnableToSchedule`, `StuckStartingUp`, `StuckTerminating`, `ActiveDeadlineExceeded`, `ExternallyDeleted`, `ErrorDuringIssueHandling`, and `FailedStartingUp`. When it decides a pod is broken, it emits the failure event at detection time and then deletes the pod.
 
 Events fired in this flow:
 

--- a/docs/developer/job-lifecycle-events.md
+++ b/docs/developer/job-lifecycle-events.md
@@ -247,7 +247,7 @@ Two emission paths reach this flow, depending on who detected the failure.
 
 ### Path A: pod reaches terminal phase
 
-- **Run state:** `Running` to `Failed`.
+- **Run state:** `Running` to `Failed` (a pod that exits before it is observed `Running`, for example an immediate non-zero exit, goes `Pending` to `Failed`).
 - **Job state:** to `Failed` if terminal, or stays non-terminal if requeued.
 
 Events fired in this flow:
@@ -421,4 +421,4 @@ sequenceDiagram
     Note over E: phase-report skipped<br/>(deletion annotation)
 ```
 
-The executor's cancel path emits no events. Cancellation is a clean teardown driven entirely by the scheduler. The scheduler ingester ignores `JobRunCancelled` (it is in the explicit ignore list) and writes job-level cancellation via `MarkJobsCancelled` from `CancelledJob`. The lookout ingester writes both the run and job state. The conversion layer ignores `JobRunCancelled` and converts `CancelledJob` to `JobCancelledEvent` for the API stream.
+The executor's cancel path emits no events. Cancellation is a clean teardown driven entirely by the scheduler. The scheduler ingester ignores `JobRunCancelled` (it is in the explicit ignore list) and writes cancellation via `MarkJobsCancelled` from `CancelledJob`. `MarkJobsCancelled` also stamps the runs table (`cancelled=true`, `terminated_timestamp`) keyed on `job_id`, so the run's cancelled state in the scheduler database comes from this job-level cascade rather than from the ignored `JobRunCancelled`. The lookout ingester writes both the run and job state. The conversion layer ignores `JobRunCancelled` and converts `CancelledJob` to `JobCancelledEvent` for the API stream.

--- a/docs/developer/job-lifecycle-events.md
+++ b/docs/developer/job-lifecycle-events.md
@@ -1,112 +1,187 @@
 # Job lifecycle: states, transitions, and events
 
-Armada's job and run lifecycle is event-driven. This doc covers the state machines and the events that drive transitions between states, for the four terminal flows: succeeded, failed, preempted, cancelled.
+- [Job lifecycle: states, transitions, and events](#job-lifecycle-states-transitions-and-events)
+  - [Topology](#topology)
+  - [Components](#components)
+  - [Transport and edge cases](#transport-and-edge-cases)
+  - [State machines](#state-machines)
+    - [Job state](#job-state)
+    - [Run state](#run-state)
+  - [Event vocabulary](#event-vocabulary)
+  - [Job succeeded](#job-succeeded)
+  - [Job failed](#job-failed)
+    - [Path A: pod reaches terminal phase](#path-a-pod-reaches-terminal-phase)
+    - [Path B: executor's issue handler detects a problem first](#path-b-executors-issue-handler-detects-a-problem-first)
+  - [Job preempted](#job-preempted)
+    - [Known issues](#known-issues)
+  - [Job cancelled](#job-cancelled)
+
+Armada's job and run lifecycle is event-driven. This doc covers the architecture, the state machines, the events that drive transitions, and the four terminal flows: succeeded, failed, preempted, cancelled.
 
 For higher-level context on scheduling and preemption mechanics, see [scheduling_and_preempting_jobs.md](../scheduling_and_preempting_jobs.md).
 
 ## Topology
 
-Armada is a multi-cluster system. The control plane runs once, centrally. Each worker Kubernetes cluster runs its own executor process that connects the cluster to the control plane.
+Armada is a multi-cluster system. The control plane runs once, centrally. Each worker Kubernetes cluster runs its own executor process.
 
+```mermaid
+flowchart LR
+    subgraph CP["Control plane"]
+        direction TB
+        S[Server]
+        Sc[Scheduler]
+        I[Ingesters]
+        P[(Pulsar<br/>internal)]
+    end
+    subgraph Workers["Worker clusters"]
+        direction TB
+        E1[Executor + k8s]
+        E2[Executor + k8s]
+        E3[Executor + k8s]
+    end
+    Sc <-->|gRPC| E1
+    Sc <-->|gRPC| E2
+    Sc <-->|gRPC| E3
 ```
-                                Worker clusters
-                              +-----------------+
-                              | Executor + k8s  |
-                              +-----------------+
-+----------------+   gRPC     +-----------------+
-| Control plane  | <--------> | Executor + k8s  |
-| (server,       |   Pulsar   +-----------------+
-|  scheduler,    | <--------> +-----------------+
-|  ingesters)    |            | Executor + k8s  |
-+----------------+            +-----------------+
-```
 
-Two transports carry information between the control plane and an executor:
+Pulsar is the control plane's internal event bus. Server and scheduler publish to Pulsar. The ingesters consume from it. Executors do not interact with Pulsar directly.
 
-- **Pulsar.** Event bus, persistent log. All lifecycle events flow through Pulsar. Both the control-plane components and the executors publish to and subscribe from Pulsar.
-- **gRPC lease stream.** Bidirectional connection initiated by the executor. The scheduler uses it to push lease, preempt, and cancel instructions to a specific executor; the executor uses it to ack and to request more work.
+Executors reach the control plane through one gRPC service, `ExecutorApi`, served by the scheduler:
 
-A consequence relevant to the rest of this doc: a single logical action (for example, preempting a run) can trigger both a Pulsar publication and a gRPC message, and the two paths are not synchronised with each other. The scheduler's Pulsar emission and the executor's subsequent Pulsar emission for the same logical action have no guaranteed ordering relative to each other, only a typical-case ordering driven by the gRPC round trip.
+- **`LeaseJobRuns`**: a bidirectional stream initiated by the executor. The executor sends `LeaseRequest` messages with its current state and capacity. The scheduler sends back `LeaseStreamMessage` values containing new leases, cancel-runs instructions, preempt-runs instructions, or end markers.
+- **`ReportEvents`**: a unary call. The executor sends batches of run-level event sequences to the scheduler. The scheduler's handler authorises the caller and republishes the events to Pulsar.
 
-## Cast
+This matters for the preempt flow below: a single logical action can trigger two separate Pulsar publications, one from the scheduler directly and one relayed from the executor via `ReportEvents`. The two paths converge at Pulsar but have no guaranteed ordering relative to each other. The typical-case ordering is driven by the gRPC round trip.
 
-A job has at most one active run at a time. A run is one attempt to actually start the pod.
+## Components
+
+A run is one attempt to actually start the pod. A job has at most one active run at a time.
 
 Control-plane components:
 
 - **Server.** Accepts job submissions and cancel requests over its gRPC API. Validates them and publishes the resulting events to Pulsar.
-- **Scheduler.** Owns scheduling decisions. Maintains an in-memory job database (`jobdb`) periodically reconciled from the scheduler Postgres database. Decides which jobs to lease, which to preempt, which to mark terminal. Emits both run-level and job-level decision events to Pulsar. State transitions are computed in the scheduler's cycle from the current run and job flags, then persisted via emitted events that the scheduler ingester writes back to Postgres.
-- **Scheduler ingester.** Consumes events from Pulsar, writes to the scheduler Postgres database. The database is the canonical state store; the scheduler's `jobdb` is a cached view.
-- **Lookout ingester.** Consumes the same events independently, writes to the Lookout Postgres database. Drives what users see in the Lookout UI.
-- **Event ingester.** Consumes events into Redis to back the external event-stream API that external watchers consume.
-- **Conversion layer.** Code inside the API server (the same server that accepts submissions). Translates internal proto events into the external API event vocabulary when serving event-stream requests. Many internal events have no external counterpart.
+- **Scheduler.** Owns scheduling decisions. Maintains an in-memory `jobdb`, reconciled from the scheduler Postgres database on each cycle. Emits its own run-level decision events (`JobRunLeased`, `JobRunPreempted`, `JobRunCancelled`, decision-time `JobRunErrors`) and all job-level events to Pulsar.
+- **Scheduler ingester.** Consumes events from Pulsar and writes to the scheduler Postgres database. The database is canonical. `jobdb` is a cached view of it.
+- **Lookout ingester.** Consumes the same events independently and writes to the Lookout Postgres database, which drives the Lookout UI.
+- **Event ingester.** Consumes events into Redis to back the external event-stream API.
 
 Worker-cluster components:
 
-- **Executor.** One per worker cluster, running inside that cluster. Holds the gRPC lease stream to the control plane's scheduler. Creates pods in its local Kubernetes API, watches them via a pod informer. Emits run-level observation events to Pulsar.
+- **Executor.** One per worker cluster, running inside that cluster. Holds an open `LeaseJobRuns` stream and uses `ReportEvents` to send run events back. Creates and watches pods via the local Kubernetes API. Produces `JobRunAssigned`, `JobRunRunning`, `JobRunSucceeded`, and `JobRunErrors` from observed pod state, plus `JobRunPreempted` and `JobRunErrors` from the preempt processor and issue handler when acting on scheduler instructions.
+
+Before deleting a pod it owns (cancel, preempt, or detected issue), the executor writes the `deletion_requested` annotation (`domain.MarkedForDeletion`). The state reporter's informer path then skips terminal-phase reporting for annotated pods, preventing a duplicate terminal event for pods the executor is itself killing.
+
+## Transport and edge cases
+
+A few transport-level behaviours affect how the flows below behave under failure.
+
+**Executor event reporting is buffered, batched, and not retried at the reporter level.** The job-event reporter buffers events in a 1M-slot channel, drains every two seconds or when the batch fills, and sends each batch through one `ReportEvents` call. On failure, per-event callbacks see the error but the reporter itself does not retry. Retries happen one layer up. The state reporter's reconciliation pass re-emits terminal-phase events for pods whose current phase has not been marked reported. The issue handler retries via its in-process `Reported` marker, which is lost on executor restart. The preempt processor retries via the `JobPreemptedAnnotation` pod annotation, which survives restart. Both handlers only set their marker after a successful `Report`, so a failed call gets retried on the next handler tick.
+
+**Lease expiry is detected by the scheduler from executor heartbeat staleness.** Executors send `LeaseRequest` messages over the `LeaseJobRuns` stream as their heartbeat. The scheduler tracks the last time it heard from each executor. When an executor goes stale (no heartbeat within the scheduler's `executorTimeout`), the next scheduling cycle iterates jobs whose latest run belongs to that executor and emits `JobRunErrors` with a `LeaseExpired` reason for each one. The scheduler cannot distinguish "executor went away" from "stream momentarily lost". It acts on the heartbeat absence either way.
+
+**Pulsar redelivery is effectively idempotent at the ingesters' terminal-state writes.** `MarkRunsSucceeded`, `MarkRunsFailed`, and `MarkRunsPreempted` write timestamps taken from each event's `Created` field. A redelivered event carries the same `Created` value as the original, so a duplicate write produces the same column value. The `job_run_errors` table is upserted on `run_id`, so a redelivered `JobRunErrors` overwrites with identical bytes. `JobRunCancelled` is not written to the runs table at all by the scheduler ingester (it is in the explicit ignore list). Job-level cancellation is tracked separately via `CancelledJob` and `MarkJobsCancelled`. The exception to this idempotence is the preempt flow's double emission described in [Preempted known issues](#known-issues): there the second emission is a different event with different content, not a redelivery.
 
 ## State machines
 
-Armada tracks state at two levels: per job and per run. Lookout's enums capture the public-facing state vocabulary, defined in `internal/common/database/lookout/jobstates.go`.
+Armada surfaces state at two levels: per job and per run. The public-facing vocabulary lives in Lookout's enums, defined in `internal/common/database/lookout/jobstates.go`.
+
+The scheduler's internal model tracks boolean flags (`queued`, `failed`, `succeeded`, `cancelled`, plus `validated` for pre-queue validation) rather than a single state value. The mutually-exclusive states are Queued, Running, Cancelled, Failed, and Succeeded. From Queued, the job can transition to Running, Cancelled, or Failed. From Running, it can transition to Queued (requeue), Cancelled, Failed, or Succeeded. The scheduler's `Running` collapses Lookout's `Leased`, `Pending`, and `Running` into one. `Preempted` and `Rejected` are surfaced by Lookout from the reason inside a `JobErrors` event, not as scheduler-internal states. The tables below show the Lookout view, which is what API consumers see.
 
 ### Job state
 
-```
-Queued ---> Leased ---> Pending ---> Running ---> Succeeded
-              |            |            |     |
-              |            |            |     +--> Failed
-              |            |            |     |
-              |            |            |     +--> Cancelled
-              |            |            |     |
-              |            |            |     +--> Preempted
-              |            |            |
-              |            |            +-------> Failed / Cancelled / Preempted
-              |            |
-              |            +--------------------> Failed / Cancelled
-              |
-              +---------------------------------> Cancelled / Rejected
+```mermaid
+stateDiagram-v2
+    [*] --> Queued: SubmitJob
+    Queued --> Leased: JobRunLeased
+    Leased --> Pending: JobRunAssigned
+    Pending --> Running: JobRunRunning
+    Leased --> Succeeded: JobSucceeded
+    Pending --> Succeeded: JobSucceeded
+    Running --> Succeeded: JobSucceeded
+    Leased --> Failed: JobErrors
+    Pending --> Failed: JobErrors
+    Running --> Failed: JobErrors
+    Pending --> Preempted: JobErrors (JobRunPreemptedError)
+    Running --> Preempted: JobErrors (JobRunPreemptedError)
+    Queued --> Rejected: JobErrors (JobRejected)
+    Queued --> Cancelled: CancelledJob
+    Leased --> Cancelled: CancelledJob
+    Pending --> Cancelled: CancelledJob
+    Running --> Cancelled: CancelledJob
 ```
 
-The scheduler's in-memory job model is a bit richer than the public enum: it tracks flags (queued, failed, succeeded, cancelled, rejected) and timestamps rather than a single state value, and computes the public state on demand. The transitions above are the user-visible ones.
+| From                                | To        | Driven by                                       |
+| ----------------------------------- | --------- | ----------------------------------------------- |
+| (new)                               | Queued    | server publishes `SubmitJob`                    |
+| Queued                              | Leased    | `JobRunLeased`                                  |
+| Leased                              | Pending   | `JobRunAssigned`                                |
+| Pending                             | Running   | `JobRunRunning`                                 |
+| Leased / Pending / Running          | Succeeded | `JobSucceeded`                                  |
+| Leased / Pending / Running          | Failed    | `JobErrors` (Terminal=true, default case)       |
+| Pending / Running                   | Preempted | `JobErrors` with `JobRunPreemptedError` reason  |
+| Queued                              | Rejected  | `JobErrors` with `JobRejected` reason           |
+| Queued / Leased / Pending / Running | Cancelled | `CancelledJob`                                  |
 
 ### Run state
 
-```
-Leased ---> Pending ---> Running ---> Succeeded
-   |           |             |    |
-   |           |             |    +--> Failed
-   |           |             |    |
-   |           |             |    +--> Preempted
-   |           |             |    |
-   |           |             |    +--> Cancelled
-   |           |             |
-   |           |             +--------> Failed / Preempted / Cancelled
-   |           |
-   |           +----------------------> Failed / LeaseReturned / UnableToSchedule
-   |
-   +----------------------------------> LeaseReturned / LeaseExpired
+```mermaid
+stateDiagram-v2
+    [*] --> Leased: JobRunLeased
+    Leased --> Pending: JobRunAssigned
+    Pending --> Running: JobRunRunning
+    Running --> Succeeded: JobRunSucceeded
+    Running --> Failed: JobRunErrors (terminal, non-lease, non-preempt reason)
+    Pending --> Preempted: JobRunPreempted
+    Running --> Preempted: JobRunPreempted
+    Leased --> Cancelled: JobRunCancelled
+    Pending --> Cancelled: JobRunCancelled
+    Running --> Cancelled: JobRunCancelled
+    Pending --> LeaseReturned: JobRunErrors (PodLeaseReturned)
+    Leased --> LeaseExpired: JobRunErrors (LeaseExpired)
+    Pending --> LeaseExpired: JobRunErrors (LeaseExpired)
+    Running --> LeaseExpired: JobRunErrors (LeaseExpired)
 ```
 
-The lookout run-state enum also defines `MaxRunsExceeded` and `Terminated`.
+| From                       | To            | Driven by                                                                                           |
+| -------------------------- | ------------- | --------------------------------------------------------------------------------------------------- |
+| (new)                      | Leased        | `JobRunLeased`                                                                                      |
+| Leased                     | Pending       | `JobRunAssigned`                                                                                    |
+| Pending                    | Running       | `JobRunRunning`                                                                                     |
+| Running                    | Succeeded     | `JobRunSucceeded`                                                                                   |
+| Running                    | Failed        | `JobRunErrors` with any reason except `PodLeaseReturned`, `LeaseExpired`, or `JobRunPreemptedError` |
+| Pending / Running          | Preempted     | `JobRunPreempted`                                                                                   |
+| Leased / Pending / Running | Cancelled     | `JobRunCancelled`                                                                                   |
+| Pending                    | LeaseReturned | `JobRunErrors` (`PodLeaseReturned`)                                                                 |
+| Leased / Pending / Running | LeaseExpired  | `JobRunErrors` (`LeaseExpired`, emitted on stale executor)                                          |
+
+`MaxRunsExceeded`, `UnableToSchedule`, and `Terminated` exist as enum values in the Lookout run-state enum but are not driven by any current emission path. When the scheduler caps retries with a `MaxRunsExceeded` reason, lookout's `JobRunErrors` handler falls into the default case and records the run as `Failed`.
 
 ## Event vocabulary
 
-Three layers of events show up in this system, and conflating them causes confusion.
+A reference for the events used in the flows below.
 
-**Run-level internal events** are emitted by the executor (mostly) and the scheduler (some). They describe what happened to a single run.
+**Run-level internal events** describe what happened to a single run.
 
-- `JobRunLeased`, `JobRunAssigned`, `JobRunRunning`: progress events. Not covered here.
-- `JobRunSucceeded`: the executor observed `PodSucceeded`. Carries resource-usage info collected during the run.
-- `JobRunErrors`: a failure occurred. Holds a discriminated union of reasons (`PodError`, `PodLeaseReturned`, `LeaseExpired`, `MaxRunsExceeded`, `JobRunPreemptedError`, `GangJobUnschedulable`, `JobRejected`, `ReconciliationError`, and others), plus optional `failure_category` and `failure_subcategory` strings assigned by the executor's classifier.
-- `JobRunPreempted`: a run was preempted. Carries the preemption reason text.
-- `JobRunCancelled`: a run was cancelled.
+| Event             | Emitted by              | Carries                                                                                                    |
+| ----------------- | ----------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `JobRunLeased`    | scheduler               | executor ID, node ID, scheduling priority                                                                  |
+| `JobRunAssigned`  | executor                | pod identity (node name, pod number), pool                                                                 |
+| `JobRunRunning`   | executor                | pod identity, pool                                                                                         |
+| `JobRunSucceeded` | executor                | pod identity                                                                                               |
+| `JobRunErrors`    | executor or scheduler   | one or more `Error` values (reason discriminated by oneof) plus optional `failure_category`/`_subcategory` |
+| `JobRunPreempted` | scheduler then executor | preempted run ID, preemption reason text                                                                   |
+| `JobRunCancelled` | scheduler               | run ID, job ID                                                                                             |
 
-**Job-level internal events** are emitted by the scheduler when it concludes the job itself reaches a terminal state, usually one scheduling cycle after the corresponding run-level event lands in the database.
+The `Error.reason` oneof inside `JobRunErrors` has eleven variants: `KubernetesError`, `ContainerError`, `ExecutorError`, `LeaseExpired`, `MaxRunsExceeded`, `PodError`, `PodLeaseReturned`, `JobRunPreemptedError`, `GangJobUnschedulable`, `JobRejected`, `ReconciliationError`.
 
-- `JobSucceeded`: the job's last run succeeded.
-- `JobErrors`: the job has failed terminally (no requeue). Carries one or more `Error` values like `JobRunErrors` does.
-- `CancelledJob`: the job was cancelled.
-- `JobRequeued`: the job's run failed but the scheduler will re-lease it for another attempt.
+**Job-level internal events** are emitted by the scheduler when it concludes the job itself reaches a terminal state or is being requeued, usually one scheduling cycle after the corresponding run-level event lands in the database.
+
+| Event          | Emitted by | Carries                                                                              |
+| -------------- | ---------- | ------------------------------------------------------------------------------------ |
+| `JobSucceeded` | scheduler  | job ID                                                                               |
+| `JobErrors`    | scheduler  | one or more `Error` values, where the reason discriminates Failed/Preempted/Rejected |
+| `CancelledJob` | scheduler  | job ID, cancel reason, cancelling user                                               |
+| `JobRequeued`  | scheduler  | job ID, updated scheduling info, queued version                                      |
 
 **External API events** are what watchers of the event-stream API see. The conversion layer maps internal events to external events. Some internal events have no external counterpart and are silently ignored.
 
@@ -120,43 +195,50 @@ Three layers of events show up in this system, and conflating them causes confus
 | `JobRunSucceeded`          | (none, ignored)                                   | API watchers see success via the job-level `JobSucceeded`.                                                  |
 | `JobRunCancelled`          | (none, ignored)                                   | API watchers see cancellation via the job-level `CancelledJob`.                                             |
 
-The two-layer split has an important consequence: API watchers see the success or failure of a job only after the scheduler has emitted its job-level event, which is one scheduling cycle later than when the run actually finished. Lookout, which consumes the run-level events directly via its own ingester, updates the run-state column promptly and the job-state column with the same lag.
+API watchers see the success or failure of a job only after the scheduler has emitted its job-level event, which is one scheduling cycle later than when the run actually finished. Lookout, which consumes the run-level events directly, updates the run-state column promptly and the job-state column with the same lag.
 
 ## Job succeeded
 
-Run state: `Running` to `Succeeded`. Job state: `Running` to `Succeeded`.
+- **Run state:** `Running` to `Succeeded`.
+- **Job state:** to `Succeeded`, from any non-terminal state.
 
-Two phases.
+Events fired in this flow:
+
+| Event             | Phase | Emitted by | Payload      |
+| ----------------- | ----- | ---------- | ------------ |
+| `JobRunSucceeded` | 1     | executor   | pod identity |
+| `JobSucceeded`    | 2     | scheduler  | job ID       |
 
 Phase 1, observation, the executor:
 
+```mermaid
+sequenceDiagram
+    participant K as Kubelet
+    participant E as Executor
+    participant Sc as Scheduler
+    participant P as Pulsar
+    Note over K: container exits 0
+    K-->>K: sets PodSucceeded
+    K-->>E: pod informer fires
+    E->>Sc: ReportEvents (JobRunSucceeded)
+    Sc->>P: publishes JobRunSucceeded
 ```
-container exits 0
-    |
-    v
-kubelet sets PodSucceeded
-    |
-    v
-executor informer fires
-    |
-    +-> emits JobRunSucceeded   (with resource-usage info)
-```
+
+The scheduler ingester writes `runs.succeeded = true, terminated_timestamp`. The lookout ingester writes the run state.
 
 Phase 2, conclusion, the scheduler:
 
-```
-scheduler ingester writes runs.succeeded = true, succeeded_timestamp
-    |
-    v
-scheduler reconciles jobdb from database
-    |
-    v
-scheduler's cycle sees the run terminal and the job has runs
-    |
-    +-> emits JobSucceeded      (job-level)
+```mermaid
+sequenceDiagram
+    participant Pg as Postgres
+    participant Sc as Scheduler
+    participant P as Pulsar
+    Pg-->>Sc: jobdb reconciles
+    Note over Sc: cycle sees run terminal,<br/>job has runs
+    Sc->>P: publishes JobSucceeded (job-level)
 ```
 
-Downstream: the scheduler ingester marks the job succeeded. The lookout ingester writes both the run state and the job state to its DB. The conversion layer ignores `JobRunSucceeded` and converts `JobSucceeded` to `JobSucceededEvent` for the external API stream.
+The scheduler ingester writes `jobs.succeeded = true`. The lookout ingester writes the job state. The conversion layer ignores `JobRunSucceeded` and converts `JobSucceeded` to `JobSucceededEvent` for the external API stream.
 
 ## Job failed
 
@@ -164,183 +246,175 @@ Two emission paths reach this flow, depending on who detected the failure.
 
 ### Path A: pod reaches terminal phase
 
-Run state: `Running` to `Failed`. Job state: `Running` to `Failed`.
+- **Run state:** `Running` to `Failed`.
+- **Job state:** to `Failed` if terminal, or stays non-terminal if requeued.
 
-Container exits non-zero, or Kubernetes evicts the pod, or the OOM killer fires.
+Events fired in this flow:
 
-```
-container exits non-zero (or k8s evicts)
-    |
-    v
-kubelet sets PodFailed
-    |
-    v
-executor informer fires
-    |
-    +-> executor classifier categorises the failure
-    |
-    +-> emits JobRunErrors      (PodError reason, failure_category, failure_subcategory)
-```
+| Event          | Phase | Emitted by | Payload                                                       |
+| -------------- | ----- | ---------- | ------------------------------------------------------------- |
+| `JobRunErrors` | 1     | executor   | `PodError` reason, `failure_category`, `failure_subcategory`  |
+| `JobErrors`    | 2     | scheduler  | reason copied from the `JobRunErrors`, Terminal=true          |
+| `JobRequeued`  | 2     | scheduler  | (alternative to `JobErrors` when the run is requeue-eligible) |
 
-Then phase 2:
+Phase 1, observation, the executor:
 
-```
-scheduler ingester writes runs.failed = true, terminated_timestamp,
-                          and inserts a row into job_run_errors
-    |
-    v
-scheduler reconciles jobdb
-    |
-    v
-scheduler's cycle: requeue or terminal?
-    |
-    +-> if requeueing: emits JobRequeued, no terminal job-level event
-    +-> if terminal:   emits JobErrors (job-level, Terminal=true)
+```mermaid
+sequenceDiagram
+    participant K as Kubelet
+    participant E as Executor
+    participant Sc as Scheduler
+    participant P as Pulsar
+    Note over K: container exits non-zero<br/>(or k8s evicts)
+    K-->>K: sets PodFailed
+    K-->>E: pod informer fires
+    Note over E: classifier categorises failure
+    E->>Sc: ReportEvents (JobRunErrors with PodError,<br/>failure_category, failure_subcategory)
+    Sc->>P: publishes JobRunErrors
 ```
 
-"Requeue" here is conditional. A failed run is only requeue-eligible if it was *returned*, meaning the run carried a `PodLeaseReturned` error (the executor never successfully ran the pod, typically because the cluster could not honour the lease). Failures with a `PodError` reason (pod ran and exited non-zero, OOM, evicted) are not requeued; the job is marked failed on the next cycle. Returned runs are additionally gated on the per-job `failFast` annotation being unset and the job's attempt count being below the scheduler's `maxAttemptedRuns` cap.
+The scheduler ingester writes `runs.failed = true, terminated_timestamp` and inserts a row into `job_run_errors`. The lookout ingester writes the run state.
 
-Downstream: lookout writes the run state and (when the job-level event arrives) the job state. The conversion layer converts the scheduler's `JobErrors` to `JobFailedEvent` for the API stream. The executor's `JobRunErrors` itself does not produce an external API event for `PodError`-reason failures; it only does so for `LeaseExpired` and `PodLeaseReturned`.
+Phase 2, conclusion, the scheduler:
+
+```mermaid
+sequenceDiagram
+    participant Pg as Postgres
+    participant Sc as Scheduler
+    participant P as Pulsar
+    Pg-->>Sc: jobdb reconciles
+    alt requeue-eligible
+        Sc->>P: publishes JobRequeued
+    else terminal
+        Sc->>P: publishes JobErrors (Terminal=true)
+    end
+```
+
+"Requeue" here is conditional. A failed run is only requeue-eligible if it was *returned*, meaning the run carried a `PodLeaseReturned` error (the executor never successfully ran the pod, typically because the cluster could not honour the lease). Failures with a `PodError` reason are not requeued. The job is marked failed on the next cycle. Returned runs are additionally gated on two configuration knobs: the per-job `armadaproject.io/failFast` annotation must be unset, and the job's attempt count must be below the scheduler-wide `maxAttemptedRuns` cap.
+
+The conversion layer converts the scheduler's job-level `JobErrors` to `JobFailedEvent` for the API stream. The executor's `JobRunErrors` does not produce an external API event for `PodError`-reason failures. It only does so for `LeaseExpired` and `PodLeaseReturned`.
 
 ### Path B: executor's issue handler detects a problem first
 
-The issue handler watches managed pods for known problem patterns: pods stuck pending too long, containers that hit pre-startup error patterns, and similar cases. When it decides a pod is broken, it emits the failure event at detection time, then deletes the pod.
+The issue handler watches managed pods for failure modes that surface before the pod's terminal phase. Its `podIssueType` enum has seven values: `UnableToSchedule`, `StuckStartingUp`, `FailedStartingUp`, `StuckTerminating`, `ActiveDeadlineExceeded`, `ExternallyDeleted`, and `ErrorDuringIssueHandling`. When it decides a pod is broken, it emits the failure event at detection time and then deletes the pod.
 
+Events fired in this flow:
+
+| Event          | Phase | Emitted by | Payload                                                                                                          |
+| -------------- | ----- | ---------- | ---------------------------------------------------------------------------------------------------------------- |
+| `JobRunErrors` | 1     | executor   | `PodError` (or `PodLeaseReturned` for retryable issues) reason, category, subcategory                            |
+| `JobErrors`    | 2     | scheduler  | reason copied from the `JobRunErrors`, Terminal=true                                                             |
+| `JobRequeued`  | 2     | scheduler  | (alternative to `JobErrors` when the issue produced a `PodLeaseReturned` and the run is otherwise eligible)      |
+
+```mermaid
+sequenceDiagram
+    participant E as Executor
+    participant Sc as Scheduler
+    participant P as Pulsar
+    participant K as Kubelet
+    Note over E: issue handler decides pod is broken
+    Note over E: classifier produces category and subcategory
+    E->>Sc: ReportEvents (JobRunErrors with PodError, category, subcategory)
+    Sc->>P: publishes JobRunErrors
+    E-->>K: writes deletion annotation, deletes pod
+    Note over K: pod drains
+    K-->>K: sets PodFailed
+    K-->>E: pod informer fires
+    Note over E: phase-report skipped<br/>(deletion annotation)
 ```
-issue handler decides the pod is broken
-    |
-    +-> classifier produces category and subcategory
-    +-> emits JobRunErrors      (PodError reason, category, subcategory)
-    |
-    v
-executor marks the pod for deletion, issues delete to k8s
-    |
-    v
-pod drains
-    |
-    v
-kubelet sets PodFailed
-    |
-    v
-executor informer fires
-    |
-    +-> phase-report skipped: pod carries deletion-marked annotation
-```
 
-The state reporter skips re-emitting on the terminal-phase tick because the pod is marked for deletion. The downstream effects from there are the same as path A: the scheduler ingester writes the run as failed, the scheduler concludes the job's fate on a later cycle and emits `JobRequeued` or `JobErrors`. The conversion layer converts the latter to `JobFailedEvent`.
+The state reporter skips re-emitting on the terminal-phase tick because the pod is marked for deletion. Downstream from there it matches path A: the scheduler ingester writes the run as failed, the scheduler concludes the job's fate on a later cycle, and the conversion layer surfaces a `JobFailedEvent` if the result was terminal.
 
-The shape of this path differs from path A in timing: `JobRunErrors` is emitted at detection time, not at pod-drain time, so the gap between event-emit and pod-actually-stopped can be tens of seconds for pods with a long graceful shutdown.
+This path differs from path A in timing only. `JobRunErrors` is emitted at detection time, not at pod-drain time. The gap between event emission and the pod actually stopping can be tens of seconds when Kubernetes honours a long `terminationGracePeriodSeconds` before SIGKILL.
 
 ## Job preempted
 
-Run state: `Running` to `Preempted` (the lookout state, driven by `JobRunPreempted`). Job state: terminal `Preempted` once the scheduler concludes.
+- **Run state:** `Pending` or `Running` to `Preempted`.
+- **Job state:** to `Preempted`, once the scheduler emits the job-level `JobErrors` with `JobRunPreemptedError` reason.
 
-This is the busiest flow. It also emits duplicate events to external watchers on every preemption: each preempted run produces two `JobPreemptedEvent` messages on the event-stream API, and a row-overwrite in the scheduler database that loses the scheduler's preemption description.
+Known emission issues are detailed in [Known issues](#known-issues) below.
 
+Events fired in this flow:
+
+| Event             | Phase | Emitted by | Payload                                                                   |
+| ----------------- | ----- | ---------- | ------------------------------------------------------------------------- |
+| `JobRunPreempted` | 1     | scheduler  | preempted run ID, scheduler's preemption reason                           |
+| `JobRunErrors`    | 1     | scheduler  | Terminal=true, `JobRunPreemptedError`, scheduler's reason                 |
+| `JobErrors`       | 1     | scheduler  | Terminal=true, `JobRunPreemptedError` reason (drives Preempted job state) |
+| `JobRunPreempted` | 2     | executor   | (duplicate of the scheduler's, no extra context)                          |
+| `JobRunErrors`    | 2     | executor   | Terminal=true, generic `PodError` with message "Run preempted"            |
+
+```mermaid
+sequenceDiagram
+    participant Sc as Scheduler
+    participant P as Pulsar
+    participant E as Executor
+    participant K as Kubelet
+    Note over Sc: decides to preempt a run
+    Sc->>P: publishes JobRunPreempted (with scheduler's reason)
+    Sc->>P: publishes JobRunErrors (Terminal=true,<br/>JobRunPreemptedError, scheduler's reason)
+    Sc->>P: publishes JobErrors (job-level)
+    Sc->>E: PreemptRuns via lease stream
+    Note over E: preempt processor fires
+    E->>Sc: ReportEvents (JobRunPreempted)
+    Sc->>P: publishes JobRunPreempted (duplicate)
+    E->>Sc: ReportEvents (JobRunErrors,<br/>generic "Run preempted" PodError,<br/>KubernetesReason=AppError)
+    Sc->>P: publishes JobRunErrors (duplicate, generic)
+    E-->>K: writes deletion annotation, deletes pod
+    Note over K: pod drains over<br/>terminationGracePeriodSeconds
+    K-->>K: sets PodFailed
+    K-->>E: pod informer fires
+    Note over E: phase-report skipped<br/>(deletion annotation)
 ```
-scheduler decides to preempt a run
-    |
-    +-> emits JobRunPreempted   (with the scheduler's preemption reason)
-    +-> emits JobRunErrors      (Terminal=true, JobRunPreemptedError, scheduler's reason)
-    +-> emits JobErrors         (job-level)
-    |
-    v
-scheduler sends PreemptRuns to the executor via lease stream
-    |
-    v
-executor's preempt processor fires
-    |
-    +-> emits JobRunPreempted   (a second one)
-    +-> emits JobRunErrors      (a second one, generic "Run preempted" PodError, KubernetesReason=AppError)
-    |
-    v
-executor marks the pod for deletion, issues delete to k8s
-    |
-    v
-pod drains over terminationGracePeriodSeconds
-    |
-    v
-kubelet sets PodFailed
-    |
-    v
-executor informer fires
-    |
-    +-> phase-report skipped: pod carries deletion-marked annotation
-```
 
-Downstream conversion: each `JobRunPreempted` becomes a `JobPreemptedEvent` on the external API, so watchers see two preempted events per preemption. The executor's `JobRunErrors` is silently dropped by the conversion layer (`PodError` reason is not in the run-level handler's whitelist). The scheduler's `JobErrors` becomes the single `JobFailedEvent`.
+Each `JobRunPreempted` becomes a `JobPreemptedEvent` on the external API, so watchers see two preempted events per preemption. The executor's `JobRunErrors` is silently dropped by the conversion layer (`PodError` reason is not in the run-level handler's whitelist). The scheduler's `JobErrors` becomes the single `JobFailedEvent`, with the `JobRunPreemptedError` reason driving the Lookout job state to Preempted rather than Failed.
 
 ### Known issues
 
-Two of them.
+The root cause for both: the scheduler and the executor each emit run-level events for a preemption.
 
-First, `JobRunPreempted` and `JobRunErrors` are each emitted twice: once by the scheduler at decision time, once by the executor when it processes the preempt instruction. External API watchers see two `JobPreemptedEvent` messages per preemption. They do not see two `JobFailedEvent`, because run-level `JobRunErrors` with `PodError` and `JobRunPreemptedError` reasons are both dropped at the conversion layer; only the scheduler's job-level `JobErrors` becomes a `JobFailedEvent`.
+`JobRunPreempted` and `JobRunErrors` are each emitted twice, once by the scheduler at decision time and once by the executor when it processes the preempt instruction. External API watchers see two `JobPreemptedEvent` messages per preemption. They do not see two `JobFailedEvent`, because run-level `JobRunErrors` with `PodError` and `JobRunPreemptedError` reasons are both dropped at the conversion layer. Only the scheduler's job-level `JobErrors` becomes a `JobFailedEvent`.
 
-Second, the scheduler ingester upserts `job_run_errors` keyed on `run_id`. Whichever `JobRunErrors` emission lands second overwrites the first.
+The scheduler ingester upserts `job_run_errors` keyed on `run_id`, so whichever `JobRunErrors` emission lands second overwrites the first. The executor's emission typically arrives second because of the indirection described in [Topology](#topology). The scheduler publishes its `JobRunErrors` to Pulsar at decision time. It also sends a `PreemptRuns` instruction over the lease stream. The executor receives the instruction, runs its preempt processor, produces its own `JobRunErrors`, and sends it back to the scheduler via `ReportEvents`. The scheduler's handler then publishes that to Pulsar. The lease-stream round trip plus the executor's processing plus the `ReportEvents` call plus the second Pulsar publish all happen in series, so the executor's event reaches Pulsar strictly after the scheduler's in typical operation. Pulsar gives ordering only within a single partition for a single producer, so the "typically second" claim is timing not guarantee.
 
-The executor's emission typically arrives second because of the two-transport flow described in [Topology](#topology): the scheduler publishes its `JobRunErrors` to Pulsar immediately upon deciding to preempt, then issues a `PreemptRuns` gRPC message to the executor; the executor only emits its own `JobRunErrors` after receiving that gRPC message and processing it. The gRPC round-trip plus the executor's processing time put its publish strictly after the scheduler's in typical operation. Pulsar does not guarantee a global ordering across publishers, only within a single partition for a single producer, so the "typically second" claim is timing not guarantee.
-
-The executor's `JobRunErrors` is built from a generic helper that produces a `PodError` with the literal text "Run preempted" and a misleading `KubernetesReason: AppError`. When it overwrites the scheduler's row, the specific preemption description (which job caused the eviction, which pool, what fairness violation) is replaced with this generic content. The `MarkRunsFailed` update statement also has no IS NULL guard, so the second emission overwrites `runs.terminated_timestamp` as well.
+The executor's `JobRunErrors` is built from a generic helper that produces a `PodError` with the literal text "Run preempted" and a misleading `KubernetesReason: AppError`. When this overwrites the scheduler's row, the specific preemption description (which job caused the eviction, which pool, what fairness violation) is replaced with the generic content. The `MarkRunsFailed` update statement has no `IS NULL` guard, so the second emission also overwrites `runs.terminated_timestamp`.
 
 The lookout ingester is more defensive: it has an explicit `continue` for `JobRunErrors` with `JobRunPreemptedError` reason, with a comment noting that case is handled by `JobRunPreempted`. So the lookout DB does not develop duplicate rows from that specific reason combo, although it does store the executor's later `PodError`-reason emission.
 
 ## Job cancelled
 
-Run state: `Running` to `Cancelled`. Job state: `Running` to `Cancelled`.
+- **Run state:** any non-terminal state to `Cancelled`.
+- **Job state:** any non-terminal state to `Cancelled`.
 
+Events fired in this flow:
+
+| Event             | Phase | Emitted by | Payload                                       |
+| ----------------- | ----- | ---------- | --------------------------------------------- |
+| `CancelJob`       | input | server     | job ID, cancel reason                         |
+| `JobRunCancelled` | 1     | scheduler  | run ID, job ID (emitted only if a run exists) |
+| `CancelledJob`    | 1     | scheduler  | job ID, cancel reason, cancelling user        |
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant S as Server
+    participant P as Pulsar
+    participant Sc as Scheduler
+    participant E as Executor
+    participant K as Kubelet
+    U->>S: cancel via API
+    S->>P: publishes CancelJob
+    P-->>Sc: scheduler reads in its cycle
+    Note over Sc: if the job has an active run
+    Sc->>P: publishes JobRunCancelled
+    Sc->>P: publishes CancelledJob (job-level)
+    Sc->>E: CancelRuns via lease stream
+    Note over E: remove-runs processor
+    E-->>K: writes deletion annotation, deletes pod
+    Note over K: pod drains
+    K-->>K: sets PodFailed (or PodSucceeded<br/>if cancel raced container exit)
+    K-->>E: pod informer fires
+    Note over E: phase-report skipped<br/>(deletion annotation)
 ```
-user submits cancel via API
-    |
-    v
-server emits CancelJob to Pulsar
-    |
-    v
-scheduler reads it in its cycle
-    |
-    +-> if the job has an active run, emits JobRunCancelled
-    +-> emits CancelledJob      (job-level)
-    |
-    v
-scheduler sends CancelRuns to the executor via lease stream
-    |
-    v
-executor's remove-runs processor marks the pod for deletion
-    and issues delete
-    |
-    v
-pod drains
-    |
-    v
-kubelet sets PodFailed (or PodSucceeded if the cancel raced container exit)
-    |
-    v
-executor informer fires
-    |
-    +-> phase-report skipped: pod is marked for deletion
-```
 
-The executor's cancel path does not emit any events. Cancellation is a clean teardown driven entirely by the scheduler.
-
-Downstream: the lookout ingester writes the run and job as cancelled. The conversion layer ignores `JobRunCancelled` and converts `CancelledJob` to `JobCancelledEvent` for the API stream.
-
-## Summary
-
-Per flow, internal Pulsar events emitted, grouped by run-level (about a single attempt) and job-level (about the job as a whole):
-
-| Flow            | Run-level events                                                                                                      | Job-level events                                                                         |
-| --------------- | --------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| Succeeded       | `JobRunSucceeded` (executor)                                                                                          | `JobSucceeded` (scheduler)                                                               |
-| Failed (path A) | `JobRunErrors` (executor)                                                                                             | `JobErrors` (scheduler, terminal) or `JobRequeued` (scheduler, if returned and eligible) |
-| Failed (path B) | `JobRunErrors` (executor, at detection time)                                                                          | `JobErrors` (scheduler, terminal) or `JobRequeued`                                       |
-| Preempted       | `JobRunPreempted` (scheduler) + `JobRunErrors` (scheduler) + `JobRunPreempted` (executor) + `JobRunErrors` (executor) | `JobErrors` (scheduler)                                                                  |
-| Cancelled       | `JobRunCancelled` (scheduler)                                                                                         | `CancelledJob` (scheduler)                                                               |
-
-And what the external API stream sees, per flow:
-
-| Flow      | External API events                                                                          |
-| --------- | -------------------------------------------------------------------------------------------- |
-| Succeeded | `JobSucceededEvent` (from `JobSucceeded`)                                                    |
-| Failed    | `JobFailedEvent` (from `JobErrors`)                                                          |
-| Preempted | `JobFailedEvent` (from `JobErrors`) and 2x `JobPreemptedEvent` (from both `JobRunPreempted`) |
-| Cancelled | `JobCancelledEvent` (from `CancelledJob`)                                                    |
-
+The executor's cancel path emits no events. Cancellation is a clean teardown driven entirely by the scheduler. The scheduler ingester ignores `JobRunCancelled` (it is in the explicit ignore list) and writes job-level cancellation via `MarkJobsCancelled` from `CancelledJob`. The lookout ingester writes both the run and job state. The conversion layer ignores `JobRunCancelled` and converts `CancelledJob` to `JobCancelledEvent` for the API stream.

--- a/docs/developer/job-lifecycle-events.md
+++ b/docs/developer/job-lifecycle-events.md
@@ -13,7 +13,8 @@
     - [Path A: pod reaches terminal phase](#path-a-pod-reaches-terminal-phase)
     - [Path B: executor's issue handler detects a problem first](#path-b-executors-issue-handler-detects-a-problem-first)
   - [Job preempted](#job-preempted)
-    - [Known issues](#known-issues)
+    - [Scheduler-initiated preemption](#scheduler-initiated-preemption)
+    - [Run reconciliation and the executor/scheduler double emission](#run-reconciliation-and-the-executorscheduler-double-emission)
   - [Job cancelled](#job-cancelled)
 
 Armada's job and run lifecycle is event-driven. This doc covers the architecture, the state machines, the events that drive transitions, and the four terminal flows: succeeded, failed, preempted, cancelled.
@@ -67,19 +68,19 @@ Control-plane components:
 
 Worker-cluster components:
 
-- **Executor.** One per worker cluster, running inside that cluster. Holds an open `LeaseJobRuns` stream and uses `ReportEvents` to send run events back. Creates and watches pods via the local Kubernetes API. Produces `JobRunAssigned`, `JobRunRunning`, `JobRunSucceeded`, and `JobRunErrors` from observed pod state, plus `JobRunPreempted` and `JobRunErrors` from the preempt processor and issue handler when acting on scheduler instructions.
+- **Executor.** One per worker cluster, running inside that cluster. Holds an open `LeaseJobRuns` stream and uses `ReportEvents` to send run events back. Creates and watches pods via the local Kubernetes API. Produces `JobRunAssigned`, `JobRunRunning`, `JobRunSucceeded`, and `JobRunErrors` from observed pod state, plus `JobRunErrors` from its issue handler when a pod fails or disappears. It also has a preempt processor that would emit `JobRunPreempted`, but the scheduler never triggers it (see [Job preempted](#job-preempted)).
 
-Before deleting a pod it owns (cancel, preempt, or detected issue), the executor writes the `deletion_requested` annotation (`domain.MarkedForDeletion`). The state reporter's informer path then skips terminal-phase reporting for annotated pods, preventing a duplicate terminal event for pods the executor is itself killing.
+Before deleting a pod it owns (cancel or detected issue), the executor writes the `deletion_requested` annotation (`domain.MarkedForDeletion`). The state reporter's informer path then skips terminal-phase reporting for annotated pods, preventing a duplicate terminal event for pods the executor is itself killing.
 
 ## Transport and edge cases
 
 A few transport-level behaviours affect how the flows below behave under failure.
 
-**Executor event reporting is buffered, batched, and not retried at the reporter level.** The job-event reporter buffers events in a 1M-slot channel, drains every two seconds or when the batch fills, and sends each batch through one `ReportEvents` call. On failure, per-event callbacks see the error but the reporter itself does not retry. Retries happen one layer up. The state reporter's reconciliation pass re-emits terminal-phase events for pods whose current phase has not been marked reported. The issue handler retries via its in-process `Reported` marker, which is lost on executor restart. The preempt processor retries via the `JobPreemptedAnnotation` pod annotation, which survives restart. Both handlers only set their marker after a successful `Report`, so a failed call gets retried on the next handler tick.
+**Executor event reporting is buffered, batched, and not retried at the reporter level.** The job-event reporter buffers events in a 1M-slot channel, drains every two seconds or when the batch fills, and sends each batch through one `ReportEvents` call. On failure, per-event callbacks see the error but the reporter itself does not retry. Retries happen one layer up. The state reporter's reconciliation pass re-emits terminal-phase events for pods whose current phase has not been marked reported. The issue handler retries via its in-process `Reported` marker, which is lost on executor restart. It sets the marker only after a successful `Report`, so a failed call is retried on the next handler tick. The preempt processor uses a `JobPreemptedAnnotation` pod annotation for the same purpose, but it is dead code in current deployments (see [Job preempted](#job-preempted)).
 
 **Lease expiry is detected by the scheduler from executor heartbeat staleness.** Executors send `LeaseRequest` messages over the `LeaseJobRuns` stream as their heartbeat. The scheduler tracks the last time it heard from each executor. When an executor goes stale (no heartbeat within the scheduler's `executorTimeout`), the next scheduling cycle iterates jobs whose latest run belongs to that executor and emits `JobRunErrors` with a `LeaseExpired` reason for each one. The scheduler cannot distinguish "executor went away" from "stream momentarily lost". It acts on the heartbeat absence either way.
 
-**Pulsar redelivery is effectively idempotent at the ingesters' terminal-state writes.** `MarkRunsSucceeded`, `MarkRunsFailed`, and `MarkRunsPreempted` write timestamps taken from each event's `Created` field. A redelivered event carries the same `Created` value as the original, so a duplicate write produces the same column value. The `job_run_errors` table is upserted on `run_id`, so a redelivered `JobRunErrors` overwrites with identical bytes. `JobRunCancelled` is not written to the runs table at all by the scheduler ingester (it is in the explicit ignore list). Job-level cancellation is tracked separately via `CancelledJob` and `MarkJobsCancelled`. The exception to this idempotence is the preempt flow's double emission described in [Preempted known issues](#known-issues): there the second emission is a different event with different content, not a redelivery.
+**Pulsar redelivery is effectively idempotent at the ingesters' terminal-state writes.** `MarkRunsSucceeded`, `MarkRunsFailed`, and `MarkRunsPreempted` write timestamps taken from each event's `Created` field. A redelivered event carries the same `Created` value as the original, so a duplicate write produces the same column value. The `job_run_errors` table is upserted on `run_id`, so a redelivered `JobRunErrors` overwrites with identical bytes. `JobRunCancelled` is not written to the runs table at all by the scheduler ingester (it is in the explicit ignore list). Job-level cancellation is tracked separately via `CancelledJob` and `MarkJobsCancelled`. The exception to this idempotence is the reconciliation double emission described in [Run reconciliation and the executor/scheduler double emission](#run-reconciliation-and-the-executorscheduler-double-emission), where a separate producer writes a different event with different content, not a redelivery.
 
 ## State machines
 
@@ -332,17 +333,19 @@ This path differs from path A in timing only. `JobRunErrors` is emitted at detec
 - **Run state:** `Pending` or `Running` to `Preempted`.
 - **Job state:** to `Preempted`, once the scheduler emits the job-level `JobErrors` with `JobRunPreemptedError` reason.
 
-Known emission issues are detailed in [Known issues](#known-issues) below.
+Two distinct mechanisms drive a run to `Preempted`. The common one is scheduler-initiated preemption (fair share or priority), described first. A second, experimental one is run reconciliation, which can produce a genuine executor-and-scheduler double emission; see [Run reconciliation and the executor/scheduler double emission](#run-reconciliation-and-the-executorscheduler-double-emission).
 
-Events fired in this flow:
+### Scheduler-initiated preemption
+
+When the scheduling algorithm decides to preempt a run, the scheduler generates all of the preemption events itself, in the same cycle, at decision time (`createEventsForPreemptedJob`). The executor is **not** asked to preempt. The scheduler marks the run failed (which makes it terminal via the generated `runs.terminated` column), and on the next lease request the scheduler finds the run inactive and tells the executor to **cancel** it. The executor's remove-runs processor deletes the pod and emits nothing.
+
+Events fired in this flow (all from the scheduler):
 
 | Event             | Phase | Emitted by | Payload                                                                   |
 | ----------------- | ----- | ---------- | ------------------------------------------------------------------------- |
 | `JobRunPreempted` | 1     | scheduler  | preempted run ID, scheduler's preemption reason                           |
 | `JobRunErrors`    | 1     | scheduler  | Terminal=true, `JobRunPreemptedError`, scheduler's reason                 |
 | `JobErrors`       | 1     | scheduler  | Terminal=true, `JobRunPreemptedError` reason (drives Preempted job state) |
-| `JobRunPreempted` | 2     | executor   | (duplicate of the scheduler's, no extra context)                          |
-| `JobRunErrors`    | 2     | executor   | Terminal=true, generic `PodError` with message "Run preempted"            |
 
 ```mermaid
 sequenceDiagram
@@ -350,16 +353,13 @@ sequenceDiagram
     participant P as Pulsar
     participant E as Executor
     participant K as Kubelet
-    Note over Sc: decides to preempt a run
+    Note over Sc: scheduling cycle decides to preempt a run
     Sc->>P: publishes JobRunPreempted (with scheduler's reason)
     Sc->>P: publishes JobRunErrors (Terminal=true,<br/>JobRunPreemptedError, scheduler's reason)
     Sc->>P: publishes JobErrors (job-level)
-    Sc->>E: PreemptRuns via lease stream
-    Note over E: preempt processor fires
-    E->>Sc: ReportEvents (JobRunPreempted)
-    Sc->>P: publishes JobRunPreempted (duplicate)
-    E->>Sc: ReportEvents (JobRunErrors,<br/>generic "Run preempted" PodError,<br/>KubernetesReason=AppError)
-    Sc->>P: publishes JobRunErrors (duplicate, generic)
+    Note over Sc: marks run failed, run becomes terminal
+    Sc->>E: CancelRuns via lease stream (run is now inactive)
+    Note over E: remove-runs processor (emits nothing)
     E-->>K: writes deletion annotation, deletes pod
     Note over K: pod drains over<br/>terminationGracePeriodSeconds
     K-->>K: sets PodFailed
@@ -367,19 +367,23 @@ sequenceDiagram
     Note over E: phase-report skipped<br/>(deletion annotation)
 ```
 
-Each `JobRunPreempted` becomes a `JobPreemptedEvent` on the external API, so watchers see two preempted events per preemption. The executor's `JobRunErrors` is silently dropped by the conversion layer (`PodError` reason is not in the run-level handler's whitelist). The scheduler's `JobErrors` becomes the single `JobFailedEvent`, with the `JobRunPreemptedError` reason driving the Lookout job state to Preempted rather than Failed.
+The single `JobRunPreempted` becomes one `JobPreemptedEvent` on the external API. The scheduler's run-level `JobRunErrors` (`JobRunPreemptedError` reason) is dropped at the conversion layer. The scheduler's job-level `JobErrors` becomes the single `JobFailedEvent`, with the `JobRunPreemptedError` reason driving the Lookout job state to Preempted rather than Failed.
 
-### Known issues
+The executor does have a preempt processor (`preempt_runs.go`) that would emit its own `JobRunPreempted` and a generic `PodError` ("Run preempted") `JobRunErrors`. It fires only for runs flagged `PreemptionRequested`, which is set only when the scheduler sends a `PreemptRuns` instruction over the lease stream. The scheduler never constructs that message (the lease stream only ever carries `Lease`, `CancelRuns`, and `End`), so this processor is currently dead code. Scheduler-initiated preemption is therefore scheduler-only: no duplicate `JobPreemptedEvent`, no `job_run_errors` overwrite.
 
-The root cause for both: the scheduler and the executor each emit run-level events for a preemption.
+### Run reconciliation and the executor/scheduler double emission
 
-`JobRunPreempted` and `JobRunErrors` are each emitted twice, once by the scheduler at decision time and once by the executor when it processes the preempt instruction. External API watchers see two `JobPreemptedEvent` messages per preemption. They do not see two `JobFailedEvent`, because run-level `JobRunErrors` with `PodError` and `JobRunPreemptedError` reasons are both dropped at the conversion layer. Only the scheduler's job-level `JobErrors` becomes a `JobFailedEvent`.
+A real executor-and-scheduler double emission exists, but it is gated behind the experimental per-pool `ExperimentalRunReconciliation` feature (a `*RunReconciliationConfig` pointer, `nil`/off by default and not set in any shipped config), and it is triggered by node invalidation, not by fair-share preemption.
 
-The scheduler ingester upserts `job_run_errors` keyed on `run_id`, so whichever `JobRunErrors` emission lands second overwrites the first. The executor's emission typically arrives second because of the indirection described in [Topology](#topology). The scheduler publishes its `JobRunErrors` to Pulsar at decision time. It also sends a `PreemptRuns` instruction over the lease stream. The executor receives the instruction, runs its preempt processor, produces its own `JobRunErrors`, and sends it back to the scheduler via `ReportEvents`. The scheduler's handler then publishes that to Pulsar. The lease-stream round trip plus the executor's processing plus the `ReportEvents` call plus the second Pulsar publish all happen in series, so the executor's event reaches Pulsar strictly after the scheduler's in typical operation. Pulsar gives ordering only within a single partition for a single producer, so the "typically second" claim is timing not guarantee.
+When enabled, the scheduler's run-vs-node reconciler (`RunNodeReconciler`) flags a leased run as invalid when its node is no longer reported by any executor (a deleted node; gang jobs only), its node's pool has changed, or its node's reservation has changed. For a preemptible job it then emits the full preemption set (`JobRunPreempted` + run-level `JobRunErrors` with `JobRunPreemptedError` + job-level `JobErrors`); for a non-preemptible job it emits `JobRunErrors`/`JobErrors` with the `ReconciliationError` reason instead.
 
-The executor's `JobRunErrors` is built from a generic helper that produces a `PodError` with the literal text "Run preempted" and a misleading `KubernetesReason: AppError`. When this overwrites the scheduler's row, the specific preemption description (which job caused the eviction, which pool, what fairness violation) is replaced with the generic content. The `MarkRunsFailed` update statement has no `IS NULL` guard, so the second emission also overwrites `runs.terminated_timestamp`.
+The double emission specifically arises in the deleted-node case, where the pod genuinely disappears. The executor's issue handler independently detects that the pod was removed without Armada's deletion annotation, registers an `ExternallyDeleted` issue, and emits its own run-level `JobRunErrors` with a `PodError` reason ("Pod was unexpectedly deleted"). So two producers emit a run-level error for the same run. (Pool-change and reservation-change reconciliation leave the pod healthy, so the executor stays silent and those cases remain scheduler-only.)
 
-The lookout ingester is more defensive: it has an explicit `continue` for `JobRunErrors` with `JobRunPreemptedError` reason, with a comment noting that case is handled by `JobRunPreempted`. So the lookout DB does not develop duplicate rows from that specific reason combo, although it does store the executor's later `PodError`-reason emission.
+- The executor's `PodError` and the scheduler's `JobRunPreemptedError` both upsert `job_run_errors` keyed on `run_id`, so whichever lands second overwrites the first. `MarkRunsFailed` has no `IS NULL` guard, so `runs.terminated_timestamp` is overwritten as well.
+- The executor usually reports first, since it observes the pod loss before the next scheduling cycle runs, so the ordering is executor-then-scheduler. This is timing, not a guarantee.
+- It is a race. If the executor's failure is applied to the scheduler database before the reconciliation cycle runs, the run is already terminal and the reconciler skips it (it only acts on non-terminal leased runs), so no preemption event is produced and the run simply ends up `Failed`.
+
+On the external API this still yields a single `JobPreemptedEvent`, because only the scheduler emits `JobRunPreempted`; the executor's run-level `JobRunErrors` is dropped at the conversion layer. The lookout ingester has an explicit `continue` for `JobRunErrors` with `JobRunPreemptedError` reason (commented as handled by `JobRunPreempted`), but it does store the executor's `PodError`-reason emission.
 
 ## Job cancelled
 

--- a/docs/developer/job-lifecycle-events.md
+++ b/docs/developer/job-lifecycle-events.md
@@ -1,0 +1,346 @@
+# Job lifecycle: states, transitions, and events
+
+Armada's job and run lifecycle is event-driven. This doc covers the state machines and the events that drive transitions between states, for the four terminal flows: succeeded, failed, preempted, cancelled.
+
+For higher-level context on scheduling and preemption mechanics, see [scheduling_and_preempting_jobs.md](../scheduling_and_preempting_jobs.md).
+
+## Topology
+
+Armada is a multi-cluster system. The control plane runs once, centrally. Each worker Kubernetes cluster runs its own executor process that connects the cluster to the control plane.
+
+```
+                                Worker clusters
+                              +-----------------+
+                              | Executor + k8s  |
+                              +-----------------+
++----------------+   gRPC     +-----------------+
+| Control plane  | <--------> | Executor + k8s  |
+| (server,       |   Pulsar   +-----------------+
+|  scheduler,    | <--------> +-----------------+
+|  ingesters)    |            | Executor + k8s  |
++----------------+            +-----------------+
+```
+
+Two transports carry information between the control plane and an executor:
+
+- **Pulsar.** Event bus, persistent log. All lifecycle events flow through Pulsar. Both the control-plane components and the executors publish to and subscribe from Pulsar.
+- **gRPC lease stream.** Bidirectional connection initiated by the executor. The scheduler uses it to push lease, preempt, and cancel instructions to a specific executor; the executor uses it to ack and to request more work.
+
+A consequence relevant to the rest of this doc: a single logical action (for example, preempting a run) can trigger both a Pulsar publication and a gRPC message, and the two paths are not synchronised with each other. The scheduler's Pulsar emission and the executor's subsequent Pulsar emission for the same logical action have no guaranteed ordering relative to each other, only a typical-case ordering driven by the gRPC round trip.
+
+## Cast
+
+A job has at most one active run at a time. A run is one attempt to actually start the pod.
+
+Control-plane components:
+
+- **Server.** Accepts job submissions and cancel requests over its gRPC API. Validates them and publishes the resulting events to Pulsar.
+- **Scheduler.** Owns scheduling decisions. Maintains an in-memory job database (`jobdb`) periodically reconciled from the scheduler Postgres database. Decides which jobs to lease, which to preempt, which to mark terminal. Emits both run-level and job-level decision events to Pulsar. State transitions are computed in the scheduler's cycle from the current run and job flags, then persisted via emitted events that the scheduler ingester writes back to Postgres.
+- **Scheduler ingester.** Consumes events from Pulsar, writes to the scheduler Postgres database. The database is the canonical state store; the scheduler's `jobdb` is a cached view.
+- **Lookout ingester.** Consumes the same events independently, writes to the Lookout Postgres database. Drives what users see in the Lookout UI.
+- **Event ingester.** Consumes events into Redis to back the external event-stream API that external watchers consume.
+- **Conversion layer.** Code inside the API server (the same server that accepts submissions). Translates internal proto events into the external API event vocabulary when serving event-stream requests. Many internal events have no external counterpart.
+
+Worker-cluster components:
+
+- **Executor.** One per worker cluster, running inside that cluster. Holds the gRPC lease stream to the control plane's scheduler. Creates pods in its local Kubernetes API, watches them via a pod informer. Emits run-level observation events to Pulsar.
+
+## State machines
+
+Armada tracks state at two levels: per job and per run. Lookout's enums capture the public-facing state vocabulary, defined in `internal/common/database/lookout/jobstates.go`.
+
+### Job state
+
+```
+Queued ---> Leased ---> Pending ---> Running ---> Succeeded
+              |            |            |     |
+              |            |            |     +--> Failed
+              |            |            |     |
+              |            |            |     +--> Cancelled
+              |            |            |     |
+              |            |            |     +--> Preempted
+              |            |            |
+              |            |            +-------> Failed / Cancelled / Preempted
+              |            |
+              |            +--------------------> Failed / Cancelled
+              |
+              +---------------------------------> Cancelled / Rejected
+```
+
+The scheduler's in-memory job model is a bit richer than the public enum: it tracks flags (queued, failed, succeeded, cancelled, rejected) and timestamps rather than a single state value, and computes the public state on demand. The transitions above are the user-visible ones.
+
+### Run state
+
+```
+Leased ---> Pending ---> Running ---> Succeeded
+   |           |             |    |
+   |           |             |    +--> Failed
+   |           |             |    |
+   |           |             |    +--> Preempted
+   |           |             |    |
+   |           |             |    +--> Cancelled
+   |           |             |
+   |           |             +--------> Failed / Preempted / Cancelled
+   |           |
+   |           +----------------------> Failed / LeaseReturned / UnableToSchedule
+   |
+   +----------------------------------> LeaseReturned / LeaseExpired
+```
+
+The lookout run-state enum also defines `MaxRunsExceeded` and `Terminated`.
+
+## Event vocabulary
+
+Three layers of events show up in this system, and conflating them causes confusion.
+
+**Run-level internal events** are emitted by the executor (mostly) and the scheduler (some). They describe what happened to a single run.
+
+- `JobRunLeased`, `JobRunAssigned`, `JobRunRunning`: progress events. Not covered here.
+- `JobRunSucceeded`: the executor observed `PodSucceeded`. Carries resource-usage info collected during the run.
+- `JobRunErrors`: a failure occurred. Holds a discriminated union of reasons (`PodError`, `PodLeaseReturned`, `LeaseExpired`, `MaxRunsExceeded`, `JobRunPreemptedError`, `GangJobUnschedulable`, `JobRejected`, `ReconciliationError`, and others), plus optional `failure_category` and `failure_subcategory` strings assigned by the executor's classifier.
+- `JobRunPreempted`: a run was preempted. Carries the preemption reason text.
+- `JobRunCancelled`: a run was cancelled.
+
+**Job-level internal events** are emitted by the scheduler when it concludes the job itself reaches a terminal state, usually one scheduling cycle after the corresponding run-level event lands in the database.
+
+- `JobSucceeded`: the job's last run succeeded.
+- `JobErrors`: the job has failed terminally (no requeue). Carries one or more `Error` values like `JobRunErrors` does.
+- `CancelledJob`: the job was cancelled.
+- `JobRequeued`: the job's run failed but the scheduler will re-lease it for another attempt.
+
+**External API events** are what watchers of the event-stream API see. The conversion layer maps internal events to external events. Some internal events have no external counterpart and are silently ignored.
+
+| Internal event             | External event                                    | Notes                                                                                                       |
+| -------------------------- | ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `JobSucceeded` (job-level) | `JobSucceededEvent`                               |                                                                                                             |
+| `JobErrors` (job-level)    | `JobFailedEvent` (for terminal)                   | Carries reason, category, subcategory.                                                                      |
+| `CancelledJob`             | `JobCancelledEvent`                               |                                                                                                             |
+| `JobRunPreempted`          | `JobPreemptedEvent`                               |                                                                                                             |
+| `JobRunErrors`             | `JobLeaseReturnedEvent` or `JobLeaseExpiredEvent` | Only for `PodLeaseReturned` and `LeaseExpired` reasons. All other reasons ignored at the conversion layer.  |
+| `JobRunSucceeded`          | (none, ignored)                                   | API watchers see success via the job-level `JobSucceeded`.                                                  |
+| `JobRunCancelled`          | (none, ignored)                                   | API watchers see cancellation via the job-level `CancelledJob`.                                             |
+
+The two-layer split has an important consequence: API watchers see the success or failure of a job only after the scheduler has emitted its job-level event, which is one scheduling cycle later than when the run actually finished. Lookout, which consumes the run-level events directly via its own ingester, updates the run-state column promptly and the job-state column with the same lag.
+
+## Job succeeded
+
+Run state: `Running` to `Succeeded`. Job state: `Running` to `Succeeded`.
+
+Two phases.
+
+Phase 1, observation, the executor:
+
+```
+container exits 0
+    |
+    v
+kubelet sets PodSucceeded
+    |
+    v
+executor informer fires
+    |
+    +-> emits JobRunSucceeded   (with resource-usage info)
+```
+
+Phase 2, conclusion, the scheduler:
+
+```
+scheduler ingester writes runs.succeeded = true, succeeded_timestamp
+    |
+    v
+scheduler reconciles jobdb from database
+    |
+    v
+scheduler's cycle sees the run terminal and the job has runs
+    |
+    +-> emits JobSucceeded      (job-level)
+```
+
+Downstream: the scheduler ingester marks the job succeeded. The lookout ingester writes both the run state and the job state to its DB. The conversion layer ignores `JobRunSucceeded` and converts `JobSucceeded` to `JobSucceededEvent` for the external API stream.
+
+## Job failed
+
+Two emission paths reach this flow, depending on who detected the failure.
+
+### Path A: pod reaches terminal phase
+
+Run state: `Running` to `Failed`. Job state: `Running` to `Failed`.
+
+Container exits non-zero, or Kubernetes evicts the pod, or the OOM killer fires.
+
+```
+container exits non-zero (or k8s evicts)
+    |
+    v
+kubelet sets PodFailed
+    |
+    v
+executor informer fires
+    |
+    +-> executor classifier categorises the failure
+    |
+    +-> emits JobRunErrors      (PodError reason, failure_category, failure_subcategory)
+```
+
+Then phase 2:
+
+```
+scheduler ingester writes runs.failed = true, terminated_timestamp,
+                          and inserts a row into job_run_errors
+    |
+    v
+scheduler reconciles jobdb
+    |
+    v
+scheduler's cycle: requeue or terminal?
+    |
+    +-> if requeueing: emits JobRequeued, no terminal job-level event
+    +-> if terminal:   emits JobErrors (job-level, Terminal=true)
+```
+
+"Requeue" here is conditional. A failed run is only requeue-eligible if it was *returned*, meaning the run carried a `PodLeaseReturned` error (the executor never successfully ran the pod, typically because the cluster could not honour the lease). Failures with a `PodError` reason (pod ran and exited non-zero, OOM, evicted) are not requeued; the job is marked failed on the next cycle. Returned runs are additionally gated on the per-job `failFast` annotation being unset and the job's attempt count being below the scheduler's `maxAttemptedRuns` cap.
+
+Downstream: lookout writes the run state and (when the job-level event arrives) the job state. The conversion layer converts the scheduler's `JobErrors` to `JobFailedEvent` for the API stream. The executor's `JobRunErrors` itself does not produce an external API event for `PodError`-reason failures; it only does so for `LeaseExpired` and `PodLeaseReturned`.
+
+### Path B: executor's issue handler detects a problem first
+
+The issue handler watches managed pods for known problem patterns: pods stuck pending too long, containers that hit pre-startup error patterns, and similar cases. When it decides a pod is broken, it emits the failure event at detection time, then deletes the pod.
+
+```
+issue handler decides the pod is broken
+    |
+    +-> classifier produces category and subcategory
+    +-> emits JobRunErrors      (PodError reason, category, subcategory)
+    |
+    v
+executor marks the pod for deletion, issues delete to k8s
+    |
+    v
+pod drains
+    |
+    v
+kubelet sets PodFailed
+    |
+    v
+executor informer fires
+    |
+    +-> phase-report skipped: pod carries deletion-marked annotation
+```
+
+The state reporter skips re-emitting on the terminal-phase tick because the pod is marked for deletion. The downstream effects from there are the same as path A: the scheduler ingester writes the run as failed, the scheduler concludes the job's fate on a later cycle and emits `JobRequeued` or `JobErrors`. The conversion layer converts the latter to `JobFailedEvent`.
+
+The shape of this path differs from path A in timing: `JobRunErrors` is emitted at detection time, not at pod-drain time, so the gap between event-emit and pod-actually-stopped can be tens of seconds for pods with a long graceful shutdown.
+
+## Job preempted
+
+Run state: `Running` to `Preempted` (the lookout state, driven by `JobRunPreempted`). Job state: terminal `Preempted` once the scheduler concludes.
+
+This is the busiest flow. It also emits duplicate events to external watchers on every preemption: each preempted run produces two `JobPreemptedEvent` messages on the event-stream API, and a row-overwrite in the scheduler database that loses the scheduler's preemption description.
+
+```
+scheduler decides to preempt a run
+    |
+    +-> emits JobRunPreempted   (with the scheduler's preemption reason)
+    +-> emits JobRunErrors      (Terminal=true, JobRunPreemptedError, scheduler's reason)
+    +-> emits JobErrors         (job-level)
+    |
+    v
+scheduler sends PreemptRuns to the executor via lease stream
+    |
+    v
+executor's preempt processor fires
+    |
+    +-> emits JobRunPreempted   (a second one)
+    +-> emits JobRunErrors      (a second one, generic "Run preempted" PodError, KubernetesReason=AppError)
+    |
+    v
+executor marks the pod for deletion, issues delete to k8s
+    |
+    v
+pod drains over terminationGracePeriodSeconds
+    |
+    v
+kubelet sets PodFailed
+    |
+    v
+executor informer fires
+    |
+    +-> phase-report skipped: pod carries deletion-marked annotation
+```
+
+Downstream conversion: each `JobRunPreempted` becomes a `JobPreemptedEvent` on the external API, so watchers see two preempted events per preemption. The executor's `JobRunErrors` is silently dropped by the conversion layer (`PodError` reason is not in the run-level handler's whitelist). The scheduler's `JobErrors` becomes the single `JobFailedEvent`.
+
+### Known issues
+
+Two of them.
+
+First, `JobRunPreempted` and `JobRunErrors` are each emitted twice: once by the scheduler at decision time, once by the executor when it processes the preempt instruction. External API watchers see two `JobPreemptedEvent` messages per preemption. They do not see two `JobFailedEvent`, because run-level `JobRunErrors` with `PodError` and `JobRunPreemptedError` reasons are both dropped at the conversion layer; only the scheduler's job-level `JobErrors` becomes a `JobFailedEvent`.
+
+Second, the scheduler ingester upserts `job_run_errors` keyed on `run_id`. Whichever `JobRunErrors` emission lands second overwrites the first.
+
+The executor's emission typically arrives second because of the two-transport flow described in [Topology](#topology): the scheduler publishes its `JobRunErrors` to Pulsar immediately upon deciding to preempt, then issues a `PreemptRuns` gRPC message to the executor; the executor only emits its own `JobRunErrors` after receiving that gRPC message and processing it. The gRPC round-trip plus the executor's processing time put its publish strictly after the scheduler's in typical operation. Pulsar does not guarantee a global ordering across publishers, only within a single partition for a single producer, so the "typically second" claim is timing not guarantee.
+
+The executor's `JobRunErrors` is built from a generic helper that produces a `PodError` with the literal text "Run preempted" and a misleading `KubernetesReason: AppError`. When it overwrites the scheduler's row, the specific preemption description (which job caused the eviction, which pool, what fairness violation) is replaced with this generic content. The `MarkRunsFailed` update statement also has no IS NULL guard, so the second emission overwrites `runs.terminated_timestamp` as well.
+
+The lookout ingester is more defensive: it has an explicit `continue` for `JobRunErrors` with `JobRunPreemptedError` reason, with a comment noting that case is handled by `JobRunPreempted`. So the lookout DB does not develop duplicate rows from that specific reason combo, although it does store the executor's later `PodError`-reason emission.
+
+## Job cancelled
+
+Run state: `Running` to `Cancelled`. Job state: `Running` to `Cancelled`.
+
+```
+user submits cancel via API
+    |
+    v
+server emits CancelJob to Pulsar
+    |
+    v
+scheduler reads it in its cycle
+    |
+    +-> if the job has an active run, emits JobRunCancelled
+    +-> emits CancelledJob      (job-level)
+    |
+    v
+scheduler sends CancelRuns to the executor via lease stream
+    |
+    v
+executor's remove-runs processor marks the pod for deletion
+    and issues delete
+    |
+    v
+pod drains
+    |
+    v
+kubelet sets PodFailed (or PodSucceeded if the cancel raced container exit)
+    |
+    v
+executor informer fires
+    |
+    +-> phase-report skipped: pod is marked for deletion
+```
+
+The executor's cancel path does not emit any events. Cancellation is a clean teardown driven entirely by the scheduler.
+
+Downstream: the lookout ingester writes the run and job as cancelled. The conversion layer ignores `JobRunCancelled` and converts `CancelledJob` to `JobCancelledEvent` for the API stream.
+
+## Summary
+
+Per flow, internal Pulsar events emitted, grouped by run-level (about a single attempt) and job-level (about the job as a whole):
+
+| Flow            | Run-level events                                                                                                      | Job-level events                                                                         |
+| --------------- | --------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| Succeeded       | `JobRunSucceeded` (executor)                                                                                          | `JobSucceeded` (scheduler)                                                               |
+| Failed (path A) | `JobRunErrors` (executor)                                                                                             | `JobErrors` (scheduler, terminal) or `JobRequeued` (scheduler, if returned and eligible) |
+| Failed (path B) | `JobRunErrors` (executor, at detection time)                                                                          | `JobErrors` (scheduler, terminal) or `JobRequeued`                                       |
+| Preempted       | `JobRunPreempted` (scheduler) + `JobRunErrors` (scheduler) + `JobRunPreempted` (executor) + `JobRunErrors` (executor) | `JobErrors` (scheduler)                                                                  |
+| Cancelled       | `JobRunCancelled` (scheduler)                                                                                         | `CancelledJob` (scheduler)                                                               |
+
+And what the external API stream sees, per flow:
+
+| Flow      | External API events                                                                          |
+| --------- | -------------------------------------------------------------------------------------------- |
+| Succeeded | `JobSucceededEvent` (from `JobSucceeded`)                                                    |
+| Failed    | `JobFailedEvent` (from `JobErrors`)                                                          |
+| Preempted | `JobFailedEvent` (from `JobErrors`) and 2x `JobPreemptedEvent` (from both `JobRunPreempted`) |
+| Cancelled | `JobCancelledEvent` (from `CancelledJob`)                                                    |
+


### PR DESCRIPTION
Adds a developer reference for the events and state transitions across a job run's lifecycle.

The doc covers the multi-cluster topology and the two transports (Pulsar and the gRPC lease stream) that carry events between the control plane and executors, the job-level and run-level state machines, and the internal proto event vocabulary alongside its mapping to the external API event vocabulary. It then walks through step-by-step flows for the four terminal cases: succeeded, failed (both organic terminal-phase and executor-issue-handler paths), preempted, and cancelled.

The preempt section documents the current double-emission behavior. Each preempted run produces two `JobPreemptedEvent` messages on the external stream and an overwrite in the `job_run_errors` row that replaces the scheduler's preemption description with the executor's generic "Run preempted" text. Operators integrating with the event stream need to know about this.
