### PR TITLE
Bump airflow Dockerfile base to 3.1 to match armada_airflow constraint

### DIFF
--- a/developer/airflow/Dockerfile
+++ b/developer/airflow/Dockerfile
@@ -1,4 +1,4 @@
-FROM apache/airflow:2.7.0-python3.10
+FROM apache/airflow:3.1.0-python3.11
 
 RUN umask 0002; \
     mkdir -p /home/airflow/client

--- a/developer/airflow/docker-compose.yaml
+++ b/developer/airflow/docker-compose.yaml
@@ -56,14 +56,11 @@ x-airflow-common:
     &airflow-common-env
     AIRFLOW__CORE__EXECUTOR: CeleryExecutor
     AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@airflow-postgres/airflow
-    # For backward compatibility, with Airflow <2.3
-    AIRFLOW__CORE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@airflow-postgres/airflow
     AIRFLOW__CELERY__RESULT_BACKEND: db+postgresql://airflow:airflow@airflow-postgres/airflow
     AIRFLOW__CELERY__BROKER_URL: redis://:@airflow-redis:6379/0
     AIRFLOW__CORE__FERNET_KEY: ''
     AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: 'true'
     AIRFLOW__CORE__LOAD_EXAMPLES: 'true'
-    AIRFLOW__API__AUTH_BACKENDS: 'airflow.api.auth.backend.basic_auth,airflow.api.auth.backend.session'
     AIRFLOW__WEBSERVER__WEB_SERVER_PORT: ${AIRFLOW_WEBSERVER_PORT}
     # yamllint disable rule:line-length
     # Use simple http server on scheduler for health checks


### PR DESCRIPTION
`mage airflow` and `mage Teste2eAirflow` build their image from `apache/airflow:2.7.0-python3.10`, but `third_party/airflow/pyproject.toml` was updated in #4826 to allow `apache-airflow>=2.6.3,<3.2.0` (so the Armada operator supports Airflow 3.x). The Dockerfile base was never bumped to match.

The mismatch causes `pip install -e /home/airflow/airflow` inside the container to hang on dependency resolution: pip sees Airflow 2.7.0 already installed and a wide constraint range allowing 3.x, then spends forever checking every transitive dependency for compatibility. On a clean Docker cache the build takes 20+ minutes and often stalls indefinitely.

Bumping the base image to `apache/airflow:3.1.0-python3.11` matches what `armada_airflow` actually targets and brings the build down to under a minute (verified locally). There are still a couple of resolver warnings about `types-protobuf` and `opentelemetry-sdk` from Airflow's provider packages, but those are warnings, not errors, and the image builds and tags successfully.
