### PR TITLE
Fix lookout pruner metrics never being recorded

### DIFF
--- a/cmd/lookout/main.go
+++ b/cmd/lookout/main.go
@@ -134,6 +134,18 @@ func prune(ctx *armadacontext.Context, config configuration.LookoutConfig) {
 	if err != nil {
 		panic(err)
 	}
+
+	if config.PrunerConfig.PushgatewayUrl != "" {
+		jobName := config.PrunerConfig.PushgatewayJobName
+		if jobName == "" {
+			jobName = "lookout-pruner"
+		}
+		pushCtx, pushCancel := armadacontext.WithTimeout(ctx, 30*time.Second)
+		defer pushCancel()
+		if err := pruner.PushMetrics(pushCtx, config.PrunerConfig.PushgatewayUrl, jobName); err != nil {
+			log.WithError(err).Warn("failed to push pruner metrics to Pushgateway")
+		}
+	}
 }
 
 func main() {

--- a/config/lookout/config.yaml
+++ b/config/lookout/config.yaml
@@ -24,6 +24,8 @@ prunerConfig:
   zombieRepairThreshold: 15m # grace period before repairing jobs whose latest run is terminal but state is non-terminal
   timeout: 1h
   batchSize: 1000
+  pushgatewayUrl: ""
+  pushgatewayJobName: "lookout-pruner"
 uiConfig:
   backend: "jsonb"
   armadaApiBaseUrl: "http://armada-server:8080"

--- a/internal/lookout/configuration/types.go
+++ b/internal/lookout/configuration/types.go
@@ -52,6 +52,13 @@ type PrunerConfig struct {
 	Timeout               time.Duration
 	BatchSize             int
 	Postgres              configuration.PostgresConfig
+	// PushgatewayUrl is the URL of a Prometheus Pushgateway (or compatible
+	// endpoint) to push pruner metrics to after each run. If empty, no metrics
+	// are pushed.
+	PushgatewayUrl string
+	// PushgatewayJobName is the job label attached to pushed metrics.
+	// Defaults to "lookout-pruner" if empty.
+	PushgatewayJobName string
 }
 
 // Alert level enum values correspond to the severity levels of the MUI Alert

--- a/internal/lookout/pruner/metrics.go
+++ b/internal/lookout/pruner/metrics.go
@@ -14,7 +14,7 @@ import (
 // monotonically increasing total across multiple invocations of the process.
 var zombiesRepaired = prometheus.NewGauge(
 	prometheus.GaugeOpts{
-		Name: "lookout_pruner_zombie_jobs_repaired_total",
+		Name: "lookout_pruner_zombie_jobs_repaired",
 		Help: "Number of zombie jobs (non-terminal job.state but terminal latest run) repaired by the lookout pruner in the most recent run.",
 	},
 )

--- a/internal/lookout/pruner/metrics.go
+++ b/internal/lookout/pruner/metrics.go
@@ -1,16 +1,21 @@
 package pruner
 
 import (
+	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/push"
+
+	"github.com/armadaproject/armada/internal/common/armadacontext"
 )
 
-// zombiesRepaired counts the number of zombie jobs (non-terminal job.state but
-// terminal latest run) that the pruner has repaired.
-var zombiesRepaired = promauto.NewCounter(
-	prometheus.CounterOpts{
+// zombiesRepaired records the number of zombie jobs repaired in the current
+// pruner run. It is a Gauge rather than a Counter because the pruner pushes to
+// a Pushgateway and each push should reflect only the current run, not a
+// monotonically increasing total across multiple invocations of the process.
+var zombiesRepaired = prometheus.NewGauge(
+	prometheus.GaugeOpts{
 		Name: "lookout_pruner_zombie_jobs_repaired_total",
-		Help: "Number of zombie jobs (non-terminal job.state but terminal latest run) repaired by the lookout pruner.",
+		Help: "Number of zombie jobs (non-terminal job.state but terminal latest run) repaired by the lookout pruner in the most recent run.",
 	},
 )
 
@@ -25,9 +30,24 @@ var zombiesRepaired = promauto.NewCounter(
 // what we care about: the same row staying unrepaired across N runs should
 // register as "1 zombie", not "N zombies". A counter would re-count the same
 // rows on every run.
-var zombiesSkippedNullFinished = promauto.NewGauge(
+var zombiesSkippedNullFinished = prometheus.NewGauge(
 	prometheus.GaugeOpts{
 		Name: "lookout_pruner_zombie_jobs_skipped_null_finished",
 		Help: "Most recent count of zombie jobs skipped by the lookout pruner because the latest run had no finished timestamp.",
 	},
 )
+
+// PushMetrics pushes all pruner metrics to the Prometheus Pushgateway at url,
+// labelled with the given job name. A fresh registry is created on every call
+// so that each push reflects only the current run's metric values and the
+// package-level metric vars are not permanently bound to a single registry.
+func PushMetrics(ctx *armadacontext.Context, url, jobName string) error {
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(zombiesRepaired, zombiesSkippedNullFinished)
+
+	pusher := push.New(url, jobName).Gatherer(reg)
+	if err := pusher.PushContext(ctx); err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
+}

--- a/internal/lookout/pruner/reconcile_zombies.go
+++ b/internal/lookout/pruner/reconcile_zombies.go
@@ -118,7 +118,7 @@ func ReconcileZombieJobs(
 		// Surface this loudly so it gets noticed and investigated.
 		log.Warnf("Reconciled %d zombie job(s) -- this should not happen and indicates an upstream bug", totalRepaired)
 	}
-	zombiesRepaired.Add(float64(totalRepaired))
+	zombiesRepaired.Set(float64(totalRepaired))
 
 	if err := observeZombiesWithNullFinished(ctx, db); err != nil {
 		// Diagnostic counting failure: log but do not fail the pruner run.


### PR DESCRIPTION
The Lookout pruner runs as a one-shot process that exits before Prometheus can scrape it, so the counters were always zero. Fix this by pushing metrics to a Pushgateway at the end of each run using the existing prometheus/push pattern from the testsuite.

The metrics are registered against a private registry rather than the default one, so the lookout server process (which imports this package) does not expose these metrics at a permanent zero through its own scrape endpoint.

zombiesRepaired is a Gauge rather than a Counter because the Pushgateway accumulates values across pushes from independent process invocations. A Gauge reflecting "jobs repaired in this run" is more meaningful than a monotonically increasing total that resets to zero on every push.

Push is opt-in via prunerConfig.pushgatewayUrl in the lookout config.