### PR TITLE
Populate bid pricing details on job creation

### DIFF
--- a/internal/scheduler/jobdb/comparison_test.go
+++ b/internal/scheduler/jobdb/comparison_test.go
@@ -53,7 +53,7 @@ func TestJobPriorityComparer(t *testing.T) {
 		},
 		"Running jobs come before queued jobs": {
 			a:        &Job{id: "a", priority: 1},
-			b:        (&Job{id: "b", priority: 2, jobDb: NewJobDb(map[string]types.PriorityClass{"foo": {}}, "foo", stringinterner.New(1), testResourceListFactory)}).WithNewRun("", "", "", "", 0),
+			b:        (&Job{id: "b", priority: 2, jobDb: NewJobDb(map[string]types.PriorityClass{"foo": {}}, "foo", stringinterner.New(1), testResourceListFactory, nil)}).WithNewRun("", "", "", "", 0),
 			expected: 1,
 		},
 		"Running jobs are ordered third by runtime": {
@@ -128,7 +128,7 @@ func TestMarketJobPriorityComparer(t *testing.T) {
 			a: &Job{id: "a", priorityClass: types.PriorityClass{Priority: 2, Preemptible: true}},
 			b: (&Job{
 				id: "b", priorityClass: types.PriorityClass{Priority: 1, Preemptible: true}, bidPricesPool: bidPricesB,
-				jobDb: NewJobDb(map[string]types.PriorityClass{"foo": {}}, "foo", stringinterner.New(1), testResourceListFactory),
+				jobDb: NewJobDb(map[string]types.PriorityClass{"foo": {}}, "foo", stringinterner.New(1), testResourceListFactory, nil),
 			}).WithNewRun("", "", "", "", 0),
 			currentPool: "a",
 			expected:    -1,
@@ -137,7 +137,7 @@ func TestMarketJobPriorityComparer(t *testing.T) {
 			a: &Job{id: "a", priorityClass: types.PriorityClass{Priority: 1, Preemptible: true}, bidPricesPool: bidPricesA},
 			b: (&Job{
 				id: "b", priorityClass: types.PriorityClass{Priority: 1, Preemptible: true}, bidPricesPool: bidPricesB,
-				jobDb: NewJobDb(map[string]types.PriorityClass{"foo": {}}, "foo", stringinterner.New(1), testResourceListFactory),
+				jobDb: NewJobDb(map[string]types.PriorityClass{"foo": {}}, "foo", stringinterner.New(1), testResourceListFactory, nil),
 			}).WithNewRun("", "", "", "", 0),
 			currentPool: "b",
 			expected:    -1,
@@ -146,7 +146,7 @@ func TestMarketJobPriorityComparer(t *testing.T) {
 			a: &Job{id: "a", priorityClass: types.PriorityClass{Priority: 1, Preemptible: true}, bidPricesPool: bidPricesA},
 			b: (&Job{
 				id: "b", priorityClass: types.PriorityClass{Priority: 1, Preemptible: true}, bidPricesPool: bidPricesA,
-				jobDb: NewJobDb(map[string]types.PriorityClass{"foo": {}}, "foo", stringinterner.New(1), testResourceListFactory),
+				jobDb: NewJobDb(map[string]types.PriorityClass{"foo": {}}, "foo", stringinterner.New(1), testResourceListFactory, nil),
 			}).WithNewRun("", "", "", "", 0),
 			currentPool: "a",
 			expected:    1,

--- a/internal/scheduler/jobdb/job_run_test.go
+++ b/internal/scheduler/jobdb/job_run_test.go
@@ -38,6 +38,7 @@ var (
 		SchedulingKeyGenerator,
 		stringinterner.New(1024),
 		makeTestResourceListFactory(),
+		nil,
 	)
 	scheduledAtPriority = int32(5)
 	testPreemptReason   = "test preempt reason"

--- a/internal/scheduler/jobdb/jobdb.go
+++ b/internal/scheduler/jobdb/jobdb.go
@@ -14,6 +14,8 @@ import (
 	resource "k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/clock"
 
+	"github.com/armadaproject/armada/internal/scheduler/pricing"
+
 	log "github.com/armadaproject/armada/internal/common/logging"
 	armadaresource "github.com/armadaproject/armada/internal/common/resource"
 	"github.com/armadaproject/armada/internal/common/stringinterner"
@@ -91,6 +93,8 @@ type JobDb struct {
 	// Used to make efficient ResourceList types.
 	resourceListFactory  *internaltypes.ResourceListFactory
 	respectNodePodLimits bool
+	// Provides bid prices allowing bid prices to be set at job creation time. Optional; if nil, prices are not set at creation.
+	priceProvider pricing.PriceProvider
 }
 
 // IDProvider is an interface used to mock run id  generation for tests.
@@ -109,6 +113,7 @@ func NewJobDb(priorityClasses map[string]types.PriorityClass,
 	defaultPriorityClassName string,
 	stringInterner *stringinterner.StringInterner,
 	resourceListFactory *internaltypes.ResourceListFactory,
+	priceProvider pricing.PriceProvider,
 ) *JobDb {
 	return NewJobDbWithSchedulingKeyGenerator(
 		priorityClasses,
@@ -116,6 +121,7 @@ func NewJobDb(priorityClasses map[string]types.PriorityClass,
 		internaltypes.NewSchedulingKeyGenerator(),
 		stringInterner,
 		resourceListFactory,
+		priceProvider,
 	)
 }
 
@@ -125,6 +131,7 @@ func NewJobDbWithSchedulingKeyGenerator(
 	skg *internaltypes.SchedulingKeyGenerator,
 	stringInterner *stringinterner.StringInterner,
 	resourceListFactory *internaltypes.ResourceListFactory,
+	priceProvider pricing.PriceProvider,
 ) *JobDb {
 	defaultPriorityClass, ok := priorityClasses[defaultPriorityClassName]
 	if !ok {
@@ -150,6 +157,7 @@ func NewJobDbWithSchedulingKeyGenerator(
 		clock:                  clock.RealClock{},
 		uuidProvider:           RealUUIDProvider{},
 		resourceListFactory:    resourceListFactory,
+		priceProvider:          priceProvider,
 	}
 }
 
@@ -182,6 +190,7 @@ func (jobDb *JobDb) Clone() *JobDb {
 		stringInterner:         jobDb.stringInterner,
 		resourceListFactory:    jobDb.resourceListFactory,
 		respectNodePodLimits:   jobDb.respectNodePodLimits,
+		priceProvider:          jobDb.priceProvider,
 	}
 }
 
@@ -217,6 +226,11 @@ func (jobDb *JobDb) NewJob(
 		pb = bidstore.PriceBand(priceBand)
 	}
 
+	prices := map[string]pricing.Bid{}
+	if jobDb.priceProvider != nil {
+		prices, _ = jobDb.priceProvider.GetPrice(queue, pb)
+	}
+
 	gangInfo, err := GangInfoFromMinimalJob(schedulingInfo)
 	if err != nil {
 		log.Errorf("failed creating gang info for job %s", jobId)
@@ -246,6 +260,7 @@ func (jobDb *JobDb) NewJob(
 		pools:                          jobDb.internPools(pools),
 		priceBand:                      pb,
 		gangInfo:                       *gangInfo,
+		bidPricesPool:                  prices,
 	}
 	job.ensureJobSchedulingInfoFieldsInitialised()
 	job.updateReservations()

--- a/internal/scheduler/jobdb/jobdb.go
+++ b/internal/scheduler/jobdb/jobdb.go
@@ -14,14 +14,13 @@ import (
 	resource "k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/clock"
 
-	"github.com/armadaproject/armada/internal/scheduler/pricing"
-
 	log "github.com/armadaproject/armada/internal/common/logging"
 	armadaresource "github.com/armadaproject/armada/internal/common/resource"
 	"github.com/armadaproject/armada/internal/common/stringinterner"
 	"github.com/armadaproject/armada/internal/common/types"
 	"github.com/armadaproject/armada/internal/scheduler/adapters"
 	"github.com/armadaproject/armada/internal/scheduler/internaltypes"
+	"github.com/armadaproject/armada/internal/scheduler/pricing"
 	"github.com/armadaproject/armada/pkg/bidstore"
 )
 

--- a/internal/scheduler/jobdb/jobdb_test.go
+++ b/internal/scheduler/jobdb/jobdb_test.go
@@ -20,8 +20,18 @@ import (
 	"github.com/armadaproject/armada/internal/common/util"
 	schedulerconfiguration "github.com/armadaproject/armada/internal/scheduler/configuration"
 	"github.com/armadaproject/armada/internal/scheduler/internaltypes"
+	"github.com/armadaproject/armada/internal/scheduler/pricing"
 	"github.com/armadaproject/armada/pkg/bidstore"
 )
+
+type stubPriceProvider struct {
+	prices map[pricing.PriceKey]map[string]pricing.Bid
+}
+
+func (s *stubPriceProvider) GetPrice(queue string, band bidstore.PriceBand) (map[string]pricing.Bid, bool) {
+	p, ok := s.prices[pricing.PriceKey{Queue: queue, Band: band}]
+	return p, ok
+}
 
 func NewTestJobDb() *JobDb {
 	return NewJobDb(
@@ -32,6 +42,7 @@ func NewTestJobDb() *JobDb {
 		"foo",
 		stringinterner.New(1024),
 		testResourceListFactory,
+		nil,
 	)
 }
 
@@ -685,6 +696,90 @@ func TestJobDb_GangInfoIsPopulated(t *testing.T) {
 	}
 }
 
+func TestJobDb_NewJob_NilPriceProvider_LeavesBidPricesEmpty(t *testing.T) {
+	jobDb := NewJobDb(
+		map[string]types.PriorityClass{"foo": {}},
+		"foo",
+		stringinterner.New(1024),
+		testResourceListFactory,
+		nil,
+	)
+
+	job, err := jobDb.NewJob(
+		"jobId", "jobSet", "queue-a", 1, jobSchedulingInfo,
+		false, 0, false, false, false, 0, false, []string{"pool-1"},
+		int32(bidstore.PriceBand_PRICE_BAND_A),
+	)
+	require.NoError(t, err)
+	assert.Empty(t, job.GetAllBidPrices())
+}
+
+func TestJobDb_NewJob_PriceProviderPopulatesBidPrices(t *testing.T) {
+	bidsForA := map[string]pricing.Bid{
+		"pool-1": {RunningBid: 10, QueuedBid: 5},
+		"pool-2": {RunningBid: 20, QueuedBid: 8},
+	}
+	bidsForB := map[string]pricing.Bid{
+		"pool-1": {RunningBid: 100, QueuedBid: 50},
+	}
+	provider := &stubPriceProvider{
+		prices: map[pricing.PriceKey]map[string]pricing.Bid{
+			{Queue: "queue-a", Band: bidstore.PriceBand_PRICE_BAND_A}: bidsForA,
+			{Queue: "queue-a", Band: bidstore.PriceBand_PRICE_BAND_B}: bidsForB,
+		},
+	}
+	jobDb := NewJobDb(
+		map[string]types.PriorityClass{"foo": {}},
+		"foo",
+		stringinterner.New(1024),
+		testResourceListFactory,
+		provider,
+	)
+
+	tests := map[string]struct {
+		queue     string
+		priceBand bidstore.PriceBand
+		expected  map[string]pricing.Bid
+	}{
+		"matching queue + band A": {
+			queue:     "queue-a",
+			priceBand: bidstore.PriceBand_PRICE_BAND_A,
+			expected:  bidsForA,
+		},
+		"matching queue + band B": {
+			queue:     "queue-a",
+			priceBand: bidstore.PriceBand_PRICE_BAND_B,
+			expected:  bidsForB,
+		},
+		"unknown queue": {
+			queue:     "queue-other",
+			priceBand: bidstore.PriceBand_PRICE_BAND_A,
+			expected:  nil,
+		},
+		"unknown band for known queue": {
+			queue:     "queue-a",
+			priceBand: bidstore.PriceBand_PRICE_BAND_C,
+			expected:  nil,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			job, err := jobDb.NewJob(
+				util.NewULID(), "jobSet", tc.queue, 1, jobSchedulingInfo,
+				false, 0, false, false, false, 0, false, []string{"pool-1"},
+				int32(tc.priceBand),
+			)
+			require.NoError(t, err)
+			if tc.expected == nil {
+				assert.Empty(t, job.GetAllBidPrices())
+			} else {
+				assert.Equal(t, tc.expected, job.GetAllBidPrices())
+			}
+		})
+	}
+}
+
 func TestJobDb_RespectNodePodLimits_InjectsPodsResource(t *testing.T) {
 	cpuMem := []schedulerconfiguration.ResourceType{
 		{Name: "cpu", Resolution: resource.MustParse("1m")},
@@ -730,7 +825,7 @@ func TestJobDb_RespectNodePodLimits_InjectsPodsResource(t *testing.T) {
 			factory, err := internaltypes.NewResourceListFactory(tc.resourceTypes, nil)
 			require.NoError(t, err)
 
-			jobDb := NewJobDb(map[string]types.PriorityClass{"foo": {}}, "foo", stringinterner.New(1024), factory)
+			jobDb := NewJobDb(map[string]types.PriorityClass{"foo": {}}, "foo", stringinterner.New(1024), factory, nil)
 			jobDb.SetRespectNodePodLimits(tc.respect)
 
 			job, err := jobDb.NewJob("jobId", "jobSet", "queue", 1, tc.schedulingInfo, false, 0, false, false, false, 2, false, []string{}, 0)

--- a/internal/scheduler/nodedb/nodedb_test.go
+++ b/internal/scheduler/nodedb/nodedb_test.go
@@ -252,6 +252,7 @@ func TestNodeBindingEvictionUnbinding_ReleasesPodSlot(t *testing.T) {
 		testfixtures.SchedulingKeyGenerator,
 		stringinterner.New(1024),
 		rlFactory,
+		nil,
 	)
 	jobDb.SetRespectNodePodLimits(true)
 

--- a/internal/scheduler/pricing/price_cache.go
+++ b/internal/scheduler/pricing/price_cache.go
@@ -1,0 +1,49 @@
+package pricing
+
+import (
+	"sync"
+
+	"github.com/armadaproject/armada/internal/common/armadacontext"
+	"github.com/armadaproject/armada/pkg/bidstore"
+)
+
+// PriceCache wraps a BidPriceProvider, caching the most recent snapshot.
+type PriceCache struct {
+	priceProvider  BidPriceProvider
+	snapshotLock   sync.RWMutex
+	latestSnapshot *BidPriceSnapshot
+}
+
+func NewPriceCache(priceProvider BidPriceProvider) *PriceCache {
+	return &PriceCache{priceProvider: priceProvider}
+}
+
+// UpdatePrices fetches fresh prices from the underlying provider and caches the result.
+func (c *PriceCache) UpdatePrices(ctx *armadacontext.Context) error {
+	snapshot, err := c.priceProvider.GetBidPrices(ctx)
+	if err != nil {
+		return err
+	}
+	c.snapshotLock.Lock()
+	defer c.snapshotLock.Unlock()
+	c.latestSnapshot = &snapshot
+	return nil
+}
+
+// GetPrice implements jobdb.PriceProvider, returning the current cached price for the
+// given queue and price band.
+func (c *PriceCache) GetPrice(queue string, band bidstore.PriceBand) (map[string]Bid, bool) {
+	c.snapshotLock.RLock()
+	defer c.snapshotLock.RUnlock()
+	if c.latestSnapshot == nil {
+		return nil, false
+	}
+	return c.latestSnapshot.GetPrice(queue, band)
+}
+
+// CurrentSnapshot returns the cached snapshot, or nil if UpdatePrices has not yet been called.
+func (c *PriceCache) CurrentSnapshot() *BidPriceSnapshot {
+	c.snapshotLock.RLock()
+	defer c.snapshotLock.RUnlock()
+	return c.latestSnapshot
+}

--- a/internal/scheduler/pricing/price_cache_test.go
+++ b/internal/scheduler/pricing/price_cache_test.go
@@ -1,0 +1,143 @@
+package pricing
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/armadaproject/armada/internal/common/armadacontext"
+	"github.com/armadaproject/armada/pkg/bidstore"
+)
+
+type stubBidPriceProvider struct {
+	calls    int
+	snapshot BidPriceSnapshot
+	err      error
+}
+
+func (s *stubBidPriceProvider) GetBidPrices(_ *armadacontext.Context) (BidPriceSnapshot, error) {
+	s.calls += 1
+	return s.snapshot, s.err
+}
+
+func snapshotWith(queue string, band bidstore.PriceBand, bids map[string]Bid) BidPriceSnapshot {
+	return BidPriceSnapshot{
+		Timestamp: time.Unix(0, 0),
+		Bids: map[PriceKey]map[string]Bid{
+			{Queue: queue, Band: band}: bids,
+		},
+	}
+}
+
+func TestPriceCache_GetPrice_BeforeUpdateReturnsNotFound(t *testing.T) {
+	cache := NewPriceCache(&stubBidPriceProvider{})
+
+	prices, ok := cache.GetPrice("queue-a", bidstore.PriceBand_PRICE_BAND_A)
+	assert.False(t, ok)
+	assert.Nil(t, prices)
+	assert.Nil(t, cache.CurrentSnapshot())
+}
+
+func TestPriceCache_GetPrice_ReturnsPriceFromSnapshot(t *testing.T) {
+	bids := map[string]Bid{
+		"pool-1": {RunningBid: 1.0, QueuedBid: 0.5},
+	}
+	provider := &stubBidPriceProvider{
+		snapshot: snapshotWith("queue-a", bidstore.PriceBand_PRICE_BAND_A, bids),
+	}
+	cache := NewPriceCache(provider)
+
+	require.NoError(t, cache.UpdatePrices(armadacontext.Background()))
+
+	call1, ok := cache.GetPrice("queue-a", bidstore.PriceBand_PRICE_BAND_A)
+	require.True(t, ok)
+	assert.Equal(t, bids, call1)
+	assert.Equal(t, provider.calls, 1)
+
+	call2, ok := cache.GetPrice("queue-a", bidstore.PriceBand_PRICE_BAND_A)
+	require.True(t, ok)
+	assert.Equal(t, bids, call2)
+	assert.Equal(t, provider.calls, 1)
+
+	call3, ok := cache.GetPrice("queue-a", bidstore.PriceBand_PRICE_BAND_A)
+	require.True(t, ok)
+	assert.Equal(t, bids, call3)
+	assert.Equal(t, provider.calls, 1)
+}
+
+func TestPriceCache_GetPrice_ReturnsUpdatedPrice_AfterUpdateCall(t *testing.T) {
+	bids := map[string]Bid{
+		"pool-1": {RunningBid: 1.0, QueuedBid: 0.5},
+	}
+	bids2 := map[string]Bid{
+		"pool-1": {RunningBid: 2.0, QueuedBid: 1.0},
+	}
+
+	// Set initial prices in provider
+	provider := &stubBidPriceProvider{
+		snapshot: snapshotWith("queue-a", bidstore.PriceBand_PRICE_BAND_A, bids),
+	}
+	cache := NewPriceCache(provider)
+
+	require.NoError(t, cache.UpdatePrices(armadacontext.Background()))
+
+	price, ok := cache.GetPrice("queue-a", bidstore.PriceBand_PRICE_BAND_A)
+	require.True(t, ok)
+	assert.Equal(t, bids, price)
+	assert.Equal(t, provider.calls, 1)
+	// Update price in provider and request cache update it's prices
+	provider.snapshot = snapshotWith("queue-a", bidstore.PriceBand_PRICE_BAND_A, bids2)
+	require.NoError(t, cache.UpdatePrices(armadacontext.Background()))
+
+	price, ok = cache.GetPrice("queue-a", bidstore.PriceBand_PRICE_BAND_A)
+	require.True(t, ok)
+	assert.Equal(t, bids2, price)
+	assert.Equal(t, provider.calls, 2)
+}
+
+func TestPriceCache_UpdatePrices_PopulatesSnapshot(t *testing.T) {
+	bids := map[string]Bid{
+		"pool-1": {RunningBid: 1.0, QueuedBid: 0.5},
+	}
+	provider := &stubBidPriceProvider{
+		snapshot: snapshotWith("queue-a", bidstore.PriceBand_PRICE_BAND_A, bids),
+	}
+	cache := NewPriceCache(provider)
+
+	require.NoError(t, cache.UpdatePrices(armadacontext.Background()))
+
+	assert.Equal(t, provider.calls, 1)
+	assert.NotNil(t, cache.CurrentSnapshot())
+	assert.Equal(t, cache.CurrentSnapshot(), &provider.snapshot)
+}
+
+func TestPriceCache_GetPrice_UnknownKeyReturnsNotFound(t *testing.T) {
+	provider := &stubBidPriceProvider{
+		snapshot: snapshotWith("queue-a", bidstore.PriceBand_PRICE_BAND_A, map[string]Bid{
+			"pool-1": {RunningBid: 1.0},
+		}),
+	}
+	cache := NewPriceCache(provider)
+	require.NoError(t, cache.UpdatePrices(armadacontext.Background()))
+
+	prices, ok := cache.GetPrice("queue-b", bidstore.PriceBand_PRICE_BAND_A)
+	assert.False(t, ok)
+	assert.Nil(t, prices)
+
+	prices, ok = cache.GetPrice("queue-a", bidstore.PriceBand_PRICE_BAND_B)
+	assert.False(t, ok)
+	assert.Nil(t, prices)
+}
+
+func TestPriceCache_UpdatePrices_PropagatesError(t *testing.T) {
+	wantErr := errors.New("boom")
+	provider := &stubBidPriceProvider{err: wantErr}
+	cache := NewPriceCache(provider)
+
+	err := cache.UpdatePrices(armadacontext.Background())
+	require.ErrorIs(t, err, wantErr)
+	assert.Nil(t, cache.CurrentSnapshot())
+}

--- a/internal/scheduler/pricing/price_provider.go
+++ b/internal/scheduler/pricing/price_provider.go
@@ -1,0 +1,10 @@
+package pricing
+
+import (
+	"github.com/armadaproject/armada/pkg/bidstore"
+)
+
+// PriceProvider provides bid prices for a given queue and price band.
+type PriceProvider interface {
+	GetPrice(queue string, band bidstore.PriceBand) (map[string]Bid, bool)
+}

--- a/internal/scheduler/pricing/price_provider.go
+++ b/internal/scheduler/pricing/price_provider.go
@@ -4,7 +4,6 @@ import (
 	"github.com/armadaproject/armada/pkg/bidstore"
 )
 
-// PriceProvider provides bid prices for a given queue and price band.
 type PriceProvider interface {
 	GetPrice(queue string, band bidstore.PriceBand) (map[string]Bid, bool)
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -86,8 +86,8 @@ type Scheduler struct {
 	// If true, enable scheduler assertions.
 	// In particular, assert that the jobDb is in a valid state at the end of each cycle.
 	enableAssertions bool
-	// Caches the latest bid prices fetched from bidPriceProvider each cycle.
-	// Also implements jobdb.PriceProvider so new jobs get prices at creation time.
+	// Provides bid prices for pricebands / jobs
+	// It is a cache over the actual price provider so calling UpdatePrices is needed for up-to-date prices
 	priceCache *pricing.PriceCache
 	// A list of the pools that are market driven
 	// Used to know which jobs need update when updating job prices

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -11,6 +11,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/utils/clock"
 
+	"github.com/armadaproject/armada/internal/scheduler/pricing"
+
 	"github.com/armadaproject/armada/internal/common/armadacontext"
 	"github.com/armadaproject/armada/internal/common/constants"
 	protoutil "github.com/armadaproject/armada/internal/common/proto"
@@ -21,7 +23,6 @@ import (
 	"github.com/armadaproject/armada/internal/scheduler/kubernetesobjects/affinity"
 	"github.com/armadaproject/armada/internal/scheduler/leader"
 	"github.com/armadaproject/armada/internal/scheduler/metrics"
-	"github.com/armadaproject/armada/internal/scheduler/pricing"
 	"github.com/armadaproject/armada/internal/scheduler/queue"
 	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
 	"github.com/armadaproject/armada/internal/scheduler/scheduling"
@@ -85,8 +86,9 @@ type Scheduler struct {
 	// If true, enable scheduler assertions.
 	// In particular, assert that the jobDb is in a valid state at the end of each cycle.
 	enableAssertions bool
-	// The service which provides up-to-date prices for price bands / jobs
-	bidPriceProvider pricing.BidPriceProvider
+	// Caches the latest bid prices fetched from bidPriceProvider each cycle.
+	// Also implements jobdb.PriceProvider so new jobs get prices at creation time.
+	priceCache *pricing.PriceCache
 	// A list of the pools that are market driven
 	// Used to know which jobs need update when updating job prices
 	marketDrivenPools []string
@@ -110,7 +112,7 @@ func NewScheduler(
 	maxAttemptedRuns uint,
 	nodeIdLabel string,
 	metrics *metrics.Metrics,
-	bidPriceProvider pricing.BidPriceProvider,
+	priceCache *pricing.PriceCache,
 	marketDrivenPools []string,
 	queueCache queue.QueueCache,
 ) (*Scheduler, error) {
@@ -127,7 +129,7 @@ func NewScheduler(
 		cyclePeriod:        cyclePeriod,
 		schedulePeriod:     schedulePeriod,
 		executorTimeout:    executorTimeout,
-		bidPriceProvider:   bidPriceProvider,
+		priceCache:         priceCache,
 		shortJobPenalty:    shortJobPenalty,
 		maxAttemptedRuns:   maxAttemptedRuns,
 		nodeIdLabel:        nodeIdLabel,
@@ -526,12 +528,16 @@ func (s *Scheduler) updateJobPrices(ctx *armadacontext.Context, txn *jobdb.Txn) 
 		return nil, nil
 	}
 
-	jobs := txn.GetAll()
-	jobsByQueue := map[string]map[bidstore.PriceBand][]*jobdb.Job{}
-	updatedBids, err := s.bidPriceProvider.GetBidPrices(ctx)
-	if err != nil {
+	if err := s.priceCache.UpdatePrices(ctx); err != nil {
 		return nil, err
 	}
+	snapshot := s.priceCache.CurrentSnapshot()
+	if snapshot == nil {
+		return nil, nil
+	}
+
+	jobs := txn.GetAll()
+	jobsByQueue := map[string]map[bidstore.PriceBand][]*jobdb.Job{}
 
 	hasMarketDrivenPool := func(j *jobdb.Job) bool {
 		for _, pool := range j.Pools() {
@@ -557,12 +563,10 @@ func (s *Scheduler) updateJobPrices(ctx *armadacontext.Context, txn *jobdb.Txn) 
 	updatedJobs := make([]*jobdb.Job, 0, len(jobs))
 	for queue := range jobsByQueue {
 		for priceBand, jobs := range jobsByQueue[queue] {
-			updatedPrice, present := updatedBids.GetPrice(queue, priceBand)
+			updatedPrice, present := snapshot.GetPrice(queue, priceBand)
 			if !present {
 				continue
 			}
-
-			// For now always update all jobs, as the jobDb isn't setting them as they come in
 			for _, job := range jobs {
 				job = job.WithBidPrices(updatedPrice)
 				updatedJobs = append(updatedJobs, job)
@@ -570,11 +574,11 @@ func (s *Scheduler) updateJobPrices(ctx *armadacontext.Context, txn *jobdb.Txn) 
 		}
 	}
 	ctx.Logger().Infof("updating the prices of %d jobs", len(updatedJobs))
-	err = txn.Upsert(updatedJobs)
+	err := txn.Upsert(updatedJobs)
 	if err != nil {
 		return nil, err
 	}
-	return updatedBids.ResourceUnits, nil
+	return snapshot.ResourceUnits, nil
 }
 
 func (s *Scheduler) createSchedulingInfoWithNodeAntiAffinityForAttemptedRuns(job *jobdb.Job) (*internaltypes.JobSchedulingInfo, error) {

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1038,7 +1038,7 @@ func TestScheduler_TestCycle(t *testing.T) {
 				maxNumberOfAttempts,
 				nodeIdLabel,
 				schedulerMetrics,
-				pricing.NoopBidPriceProvider{},
+				pricing.NewPriceCache(pricing.NoopBidPriceProvider{}),
 				[]string{},
 				queueCache,
 			)
@@ -1205,7 +1205,7 @@ func TestScheduler_PublishFailureRepublishesOnNextCycle(t *testing.T) {
 		maxNumberOfAttempts,
 		nodeIdLabel,
 		schedulerMetrics,
-		pricing.NoopBidPriceProvider{},
+		pricing.NewPriceCache(pricing.NoopBidPriceProvider{}),
 		[]string{},
 		&testQueueCache{},
 	)
@@ -1278,7 +1278,7 @@ func TestScheduler_NonLeaderAdvancesCursors(t *testing.T) {
 		maxNumberOfAttempts,
 		nodeIdLabel,
 		schedulerMetrics,
-		pricing.NoopBidPriceProvider{},
+		pricing.NewPriceCache(pricing.NoopBidPriceProvider{}),
 		[]string{},
 		&testQueueCache{},
 	)
@@ -1384,7 +1384,7 @@ func TestRun(t *testing.T) {
 		maxNumberOfAttempts,
 		nodeIdLabel,
 		schedulerMetrics,
-		pricing.NoopBidPriceProvider{},
+		pricing.NewPriceCache(pricing.NoopBidPriceProvider{}),
 		[]string{},
 		&testQueueCache{},
 	)
@@ -1464,7 +1464,7 @@ func TestJobPriceUpdates(t *testing.T) {
 			marketDrivenPools:             []string{},
 			initialJob:                    queuedJob,
 			expectedNumberOfProviderCalls: []int{0, 0, 0},
-			expectedJobBid:                []map[string]pricing.Bid{nil, nil, nil},
+			expectedJobBid:                []map[string]pricing.Bid{{}, {}, {}},
 			expectedJobBidPrice:           []float64{0, 0, 0},
 		},
 		"job with no market driven pools": {
@@ -1472,7 +1472,7 @@ func TestJobPriceUpdates(t *testing.T) {
 			marketDrivenPools:             []string{testfixtures.TestPool},
 			initialJob:                    jobWithoutMarketDrivenPools,
 			expectedNumberOfProviderCalls: []int{1, 1, 2},
-			expectedJobBid:                []map[string]pricing.Bid{nil, nil, nil},
+			expectedJobBid:                []map[string]pricing.Bid{{}, {}, {}},
 			expectedJobBidPrice:           []float64{0, 0, 0},
 		},
 		"non-preemptible queued job": {
@@ -1496,7 +1496,7 @@ func TestJobPriceUpdates(t *testing.T) {
 			marketDrivenPools:             []string{testfixtures.TestPool},
 			initialJob:                    queuedJobNoPricingInfo,
 			expectedNumberOfProviderCalls: []int{1, 1, 2},
-			expectedJobBid:                []map[string]pricing.Bid{nil, nil, nil},
+			expectedJobBid:                []map[string]pricing.Bid{{}, {}, {}},
 			expectedJobBidPrice:           []float64{0, 0, 0},
 		},
 		"non-preemptible running job with no pricing info": {
@@ -1504,7 +1504,7 @@ func TestJobPriceUpdates(t *testing.T) {
 			marketDrivenPools:             []string{testfixtures.TestPool},
 			initialJob:                    runningJobNoPricingInfo,
 			expectedNumberOfProviderCalls: []int{1, 1, 2},
-			expectedJobBid:                []map[string]pricing.Bid{nil, nil, nil},
+			expectedJobBid:                []map[string]pricing.Bid{{}, {}, {}},
 			expectedJobBidPrice:           []float64{pricing.NonPreemptibleRunningPrice, pricing.NonPreemptibleRunningPrice, pricing.NonPreemptibleRunningPrice},
 		},
 		"preemptible queued job": {
@@ -1528,7 +1528,7 @@ func TestJobPriceUpdates(t *testing.T) {
 			marketDrivenPools:             []string{testfixtures.TestPool},
 			initialJob:                    queuedPreemptibleJobNoPricingInfo,
 			expectedNumberOfProviderCalls: []int{1, 1, 2},
-			expectedJobBid:                []map[string]pricing.Bid{nil, nil, nil},
+			expectedJobBid:                []map[string]pricing.Bid{{}, {}, {}},
 			expectedJobBidPrice:           []float64{0, 0, 0},
 		},
 		"preemptible running job - no pricing info": {
@@ -1536,7 +1536,7 @@ func TestJobPriceUpdates(t *testing.T) {
 			marketDrivenPools:             []string{testfixtures.TestPool},
 			initialJob:                    runningPreemptibleJobNoPricingInfo,
 			expectedNumberOfProviderCalls: []int{1, 1, 2},
-			expectedJobBid:                []map[string]pricing.Bid{nil, nil, nil},
+			expectedJobBid:                []map[string]pricing.Bid{{}, {}, {}},
 			expectedJobBidPrice:           []float64{0, 0, 0},
 		},
 	}
@@ -1576,7 +1576,7 @@ func TestJobPriceUpdates(t *testing.T) {
 				maxNumberOfAttempts,
 				nodeIdLabel,
 				schedulerMetrics,
-				priceProvider,
+				pricing.NewPriceCache(priceProvider),
 				tc.marketDrivenPools,
 				&testQueueCache{},
 			)
@@ -1764,7 +1764,7 @@ func TestScheduler_TestSyncInitialState(t *testing.T) {
 				maxNumberOfAttempts,
 				nodeIdLabel,
 				schedulerMetrics,
-				pricing.NoopBidPriceProvider{},
+				pricing.NewPriceCache(pricing.NoopBidPriceProvider{}),
 				[]string{},
 				&testQueueCache{},
 			)
@@ -1980,7 +1980,7 @@ func TestScheduler_TestSyncState(t *testing.T) {
 				maxNumberOfAttempts,
 				nodeIdLabel,
 				schedulerMetrics,
-				pricing.NoopBidPriceProvider{},
+				pricing.NewPriceCache(pricing.NoopBidPriceProvider{}),
 				[]string{},
 				&testQueueCache{},
 			)
@@ -3240,7 +3240,7 @@ func TestCycleConsistency(t *testing.T) {
 					maxNumberOfAttempts,
 					nodeIdLabel,
 					schedulerMetrics,
-					pricing.NoopBidPriceProvider{},
+					pricing.NewPriceCache(pricing.NoopBidPriceProvider{}),
 					[]string{},
 					&testQueueCache{},
 				)

--- a/internal/scheduler/schedulerapp.go
+++ b/internal/scheduler/schedulerapp.go
@@ -363,11 +363,18 @@ func Run(config schedulerconfig.Configuration) error {
 	if err != nil {
 		return errors.WithMessage(err, "error creating scheduling algo")
 	}
+	priceCache := pricing.NewPriceCache(bidPriceProvider)
+	if len(marketDrivenPools) > 0 {
+		if err := priceCache.UpdatePrices(ctx); err != nil {
+			return errors.WithMessage(err, "error initialising price cache")
+		}
+	}
 	jobDb := jobdb.NewJobDb(
 		config.Scheduling.PriorityClasses,
 		config.Scheduling.DefaultPriorityClassName,
 		stringInterner,
 		resourceListFactory,
+		priceCache,
 	)
 	jobDb.SetRespectNodePodLimits(config.Scheduling.RespectNodePodLimits)
 
@@ -402,7 +409,7 @@ func Run(config schedulerconfig.Configuration) error {
 		config.Scheduling.MaxRetries+1,
 		config.Scheduling.NodeIdLabel,
 		schedulerMetrics,
-		bidPriceProvider,
+		priceCache,
 		marketDrivenPools,
 		queueCache,
 	)

--- a/internal/scheduler/scheduling/market_driven_preempting_queue_scheduler_test.go
+++ b/internal/scheduler/scheduling/market_driven_preempting_queue_scheduler_test.go
@@ -647,7 +647,7 @@ func TestMarketDrivenPreemptingQueueScheduler(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			priorities := types.AllowedPriorities(tc.SchedulingConfig.PriorityClasses)
 
-			jobDb := jobdb.NewJobDb(tc.SchedulingConfig.PriorityClasses, tc.SchedulingConfig.DefaultPriorityClassName, stringinterner.New(1024), testfixtures.TestResourceListFactory)
+			jobDb := jobdb.NewJobDb(tc.SchedulingConfig.PriorityClasses, tc.SchedulingConfig.DefaultPriorityClassName, stringinterner.New(1024), testfixtures.TestResourceListFactory, nil)
 			jobDbTxn := jobDb.WriteTxn()
 
 			// Accounting across scheduling rounds.

--- a/internal/scheduler/scheduling/preempting_queue_scheduler_test.go
+++ b/internal/scheduler/scheduling/preempting_queue_scheduler_test.go
@@ -66,7 +66,7 @@ func TestEvictOversubscribed(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	jobDb := jobdb.NewJobDb(config.PriorityClasses, config.DefaultPriorityClassName, stringInterner, testfixtures.TestResourceListFactory)
+	jobDb := jobdb.NewJobDb(config.PriorityClasses, config.DefaultPriorityClassName, stringInterner, testfixtures.TestResourceListFactory, nil)
 	jobDbTxn := jobDb.WriteTxn()
 	err = jobDbTxn.Upsert(jobs)
 	require.NoError(t, err)
@@ -2046,7 +2046,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			priorities := types.AllowedPriorities(tc.SchedulingConfig.PriorityClasses)
 
-			jobDb := jobdb.NewJobDb(tc.SchedulingConfig.PriorityClasses, tc.SchedulingConfig.DefaultPriorityClassName, stringinterner.New(1024), testfixtures.TestResourceListFactory)
+			jobDb := jobdb.NewJobDb(tc.SchedulingConfig.PriorityClasses, tc.SchedulingConfig.DefaultPriorityClassName, stringinterner.New(1024), testfixtures.TestResourceListFactory, nil)
 			jobDbTxn := jobDb.WriteTxn()
 
 			// Add all the initial jobs, creating runs for them
@@ -2488,7 +2488,7 @@ func BenchmarkPreemptingQueueScheduler(b *testing.B) {
 			}
 			txn.Commit()
 
-			jobDb := jobdb.NewJobDb(tc.SchedulingConfig.PriorityClasses, tc.SchedulingConfig.DefaultPriorityClassName, stringinterner.New(1024), testfixtures.TestResourceListFactory)
+			jobDb := jobdb.NewJobDb(tc.SchedulingConfig.PriorityClasses, tc.SchedulingConfig.DefaultPriorityClassName, stringinterner.New(1024), testfixtures.TestResourceListFactory, nil)
 			jobDbTxn := jobDb.WriteTxn()
 			var queuedJobs []*jobdb.Job
 			for _, jobs := range jobsByQueue {
@@ -2635,7 +2635,7 @@ func TestPreemptingQueueSchedulerTimeouts(t *testing.T) {
 
 		// Queue A: 32 jobs already running on the node
 		runningJobs := testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 32)
-		jobDb := jobdb.NewJobDb(config.PriorityClasses, config.DefaultPriorityClassName, stringInterner, testfixtures.TestResourceListFactory)
+		jobDb := jobdb.NewJobDb(config.PriorityClasses, config.DefaultPriorityClassName, stringInterner, testfixtures.TestResourceListFactory, nil)
 		jobDbTxn := jobDb.WriteTxn()
 		for _, job := range runningJobs {
 			err := jobDbTxn.Upsert([]*jobdb.Job{
@@ -2732,7 +2732,7 @@ func TestPreemptingQueueSchedulerTimeouts(t *testing.T) {
 		require.NoError(t, err)
 
 		jobs := testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 10)
-		jobDb := jobdb.NewJobDb(config.PriorityClasses, config.DefaultPriorityClassName, stringInterner, testfixtures.TestResourceListFactory)
+		jobDb := jobdb.NewJobDb(config.PriorityClasses, config.DefaultPriorityClassName, stringInterner, testfixtures.TestResourceListFactory, nil)
 		jobDbTxn := jobDb.WriteTxn()
 		require.NoError(t, jobDbTxn.Upsert(jobs))
 
@@ -2801,7 +2801,7 @@ func setupGangEvictionTest(t *testing.T, numNodes int) *gangEvictionTestFixture 
 	fairnessCostProvider, err := fairness.NewDominantResourceFairness(totalResources, testfixtures.TestPool, config)
 	require.NoError(t, err)
 
-	jdb := jobdb.NewJobDb(config.PriorityClasses, config.DefaultPriorityClassName, stringInterner, testfixtures.TestResourceListFactory)
+	jdb := jobdb.NewJobDb(config.PriorityClasses, config.DefaultPriorityClassName, stringInterner, testfixtures.TestResourceListFactory, nil)
 	jobDbTxn := jdb.WriteTxn()
 
 	sctx := schedulingcontext.NewSchedulingContext(
@@ -3088,7 +3088,7 @@ func TestPreemptingQueueScheduler_RespectNodePodLimits(t *testing.T) {
 			podsAwareFactory, err := internaltypes.NewResourceListFactory(config.SupportedResourceTypes, nil)
 			require.NoError(t, err)
 
-			jobDb := jobdb.NewJobDb(config.PriorityClasses, config.DefaultPriorityClassName, stringinterner.New(1024), podsAwareFactory)
+			jobDb := jobdb.NewJobDb(config.PriorityClasses, config.DefaultPriorityClassName, stringinterner.New(1024), podsAwareFactory, nil)
 			jobDb.SetRespectNodePodLimits(true)
 
 			nodeFactory := internaltypes.NewNodeFactory(
@@ -3252,7 +3252,7 @@ func testNodeWithTaints(node *internaltypes.Node, taints []v1.Taint) *internalty
 func TestPreemptingQueueScheduler_NonPreemptibleOverPack(t *testing.T) {
 	config := testfixtures.TestSchedulingConfig()
 
-	jobDb := jobdb.NewJobDb(config.PriorityClasses, config.DefaultPriorityClassName, stringinterner.New(1024), testfixtures.TestResourceListFactory)
+	jobDb := jobdb.NewJobDb(config.PriorityClasses, config.DefaultPriorityClassName, stringinterner.New(1024), testfixtures.TestResourceListFactory, nil)
 
 	// 5cpu node small enough that saturation by 5 incumbents is unambiguous.
 	node := testfixtures.TestNode(testfixtures.TestPriorities, map[string]*k8sResource.Quantity{

--- a/internal/scheduler/simulator/simulator.go
+++ b/internal/scheduler/simulator/simulator.go
@@ -147,6 +147,7 @@ func NewSimulator(
 		schedulingConfig.DefaultPriorityClassName,
 		stringinterner.New(1024),
 		resourceListFactory,
+		nil,
 	)
 	jobDb.SetRespectNodePodLimits(schedulingConfig.RespectNodePodLimits)
 	randomSeed := workloadSpec.RandomSeed

--- a/internal/scheduler/testfixtures/testfixtures.go
+++ b/internal/scheduler/testfixtures/testfixtures.go
@@ -155,6 +155,7 @@ func NewJobDb(resourceListFactory *internaltypes.ResourceListFactory) *jobdb.Job
 		SchedulingKeyGenerator,
 		stringinterner.New(1024),
 		resourceListFactory,
+		nil,
 	)
 	// Mock out the clock and uuid provider to ensure consistent ids and timestamps are generated.
 	jobDb.SetClock(NewMockPassiveClock())


### PR DESCRIPTION
Previously we'd only populate the price as part of the scheduler cycle.

This meant newly created jobs would have an empty price until it was populated as part of the scheduler cycle.

This was previously completely fine when scheduling happened synchronously. However we plan to have an async scheduling cycle where we can't guarentee the scheduler cycle will have set the price on the jobs before the scheduling sees the jobs
 - This change should mean at all times the jobs in the jobdb that have the same queue/priceband consistently have the prices set
 - This will mean the async scheduling cycle can safely assume job prices are set

