### PR TITLE
Treat cordoned nodes as available in the submit checker

### DIFF
--- a/internal/scheduler/internaltypes/node_factory.go
+++ b/internal/scheduler/internaltypes/node_factory.go
@@ -157,6 +157,51 @@ func (f *NodeFactory) AddTaints(nodes []*Node, extraTaints []v1.Taint) []*Node {
 	return result
 }
 
+// RemoveCordonTaint returns copies of nodes with cordon taints stripped (see IsCordonTaint) and the
+// unschedulable flag cleared. The submit checker uses it so that jobs targeting a node type whose
+// nodes are all cordoned (via `kubectl cordon`, or otherwise reported unschedulable by the executor)
+// stay queued rather than being rejected. See issue #4946.
+//
+// A cordoned node always has the unschedulable flag set (Kubernetes only adds
+// node.kubernetes.io/unschedulable when the node is unschedulable, and the Armada taint is only
+// synthesized for unschedulable nodes), so the flag alone identifies the nodes to fix.
+//
+// Like AddTaints/AddLabels, this rebuilds via CreateNodeAndType so NodeType (used for nodeDb
+// indexing) is recomputed from the reduced taint set and stays consistent.
+func (f *NodeFactory) RemoveCordonTaint(nodes []*Node) []*Node {
+	result := make([]*Node, len(nodes))
+	for i, node := range nodes {
+		if !node.IsUnschedulable() {
+			// Not cordoned. Freshly built node, not yet inserted into a NodeDb, so reuse it as-is.
+			result[i] = node
+			continue
+		}
+		taints := node.GetTaints()
+		nonCordonTaints := make([]v1.Taint, 0, len(taints))
+		for _, taint := range taints {
+			if !IsCordonTaint(taint) {
+				nonCordonTaints = append(nonCordonTaints, taint)
+			}
+		}
+		result[i] = CreateNodeAndType(node.GetId(),
+			node.GetIndex(),
+			node.GetExecutor(),
+			node.GetName(),
+			node.GetPool(),
+			node.GetReportingNodeType(),
+			false,
+			nonCordonTaints,
+			node.GetLabels(),
+			f.indexedTaints,
+			f.indexedNodeLabels,
+			node.GetTotalResources(),
+			node.GetAllocatableResources(),
+			node.AllocatableByPriority,
+		)
+	}
+	return result
+}
+
 func (f *NodeFactory) allocateNodeIndex() uint64 {
 	return f.nodeIndexCounter.Add(1)
 }

--- a/internal/scheduler/internaltypes/unschedulable.go
+++ b/internal/scheduler/internaltypes/unschedulable.go
@@ -16,3 +16,15 @@ func UnschedulableTaint() v1.Taint {
 		Effect: unschedulableTaintEffect,
 	}
 }
+
+// IsCordonTaint reports whether taint marks a node as cordoned, i.e. temporarily not accepting new
+// jobs. This covers both the Armada-synthesized taint (added when a node reports unschedulable=true)
+// and the taint Kubernetes adds automatically on `kubectl cordon` (v1.TaintNodeUnschedulable).
+// A cordon is transient, so feasibility checks (e.g. the submit checker) should ignore these taints.
+//
+// Matching is by key only, not effect. Both cordon taints are always NoSchedule in practice, and for
+// a feasibility check any taint under these keys is transient operational state we want to ignore, so
+// we strip it regardless of effect rather than risk rejecting a job that could run once uncordoned.
+func IsCordonTaint(taint v1.Taint) bool {
+	return taint.Key == unschedulableTaintKey || taint.Key == v1.TaintNodeUnschedulable
+}

--- a/internal/scheduler/submitcheck.go
+++ b/internal/scheduler/submitcheck.go
@@ -154,6 +154,8 @@ func (srv *SubmitChecker) updateExecutors(ctx *armadacontext.Context) error {
 		nodes := nodeFactory.FromSchedulerObjectsExecutors(
 			[]*schedulerobjects.Executor{ex},
 			func(s string) { ctx.Error(s) })
+		// Treat cordoned nodes as available.
+		nodes = nodeFactory.RemoveCordonTaint(nodes)
 		nodesByPool := armadaslices.GroupByFunc(nodes, func(n *internaltypes.Node) string {
 			return n.GetPool()
 		})

--- a/internal/scheduler/submitcheck_test.go
+++ b/internal/scheduler/submitcheck_test.go
@@ -92,6 +92,22 @@ func TestSubmitChecker_CheckJobDbJobs(t *testing.T) {
 				smallJob1.Id(): {isSchedulable: true, pools: []string{"cpu"}},
 			},
 		},
+		"Job schedulable when its only node is cordoned": {
+			executorTimeout: defaultTimeout,
+			executors:       []*schedulerobjects.Executor{Executor(cordon(SmallNode("cpu")))},
+			jobs:            []*jobdb.Job{smallJob1},
+			expectedResult: map[string]schedulingResult{
+				smallJob1.Id(): {isSchedulable: true, pools: []string{"cpu"}},
+			},
+		},
+		"GPU job schedulable when all GPU nodes are cordoned": {
+			executorTimeout: defaultTimeout,
+			executors:       []*schedulerobjects.Executor{Executor(cordon(GpuNode("gpu")))},
+			jobs:            []*jobdb.Job{smallGpuJob},
+			expectedResult: map[string]schedulingResult{
+				smallGpuJob.Id(): {isSchedulable: true, pools: []string{"gpu"}},
+			},
+		},
 		"One job schedulable, jobs not assigned to pools with matching disallowed resources": {
 			executorTimeout: defaultTimeout,
 			executors: []*schedulerobjects.Executor{
@@ -514,6 +530,19 @@ func GpuNode(pool string) *schedulerobjects.Node {
 		},
 	}
 	node.Pool = pool
+	return node
+}
+
+// cordon simulates `kubectl cordon` on a node: it sets the unschedulable flag (which the scheduler
+// turns into the armadaproject.io/unschedulable taint) and adds the Kubernetes-native unschedulable
+// taint that kubectl applies. armadactl executor-level cordoning is unaffected as the submit checker
+// does not read executor settings.
+func cordon(node *schedulerobjects.Node) *schedulerobjects.Node {
+	node.Unschedulable = true
+	node.Taints = append(node.Taints, &v1.Taint{
+		Key:    v1.TaintNodeUnschedulable,
+		Effect: v1.TaintEffectNoSchedule,
+	})
 	return node
 }
 


### PR DESCRIPTION
When every node of a given type is cordoned, for example all the H200 GPU nodes pulled out for maintenance, a job requesting that node type should sit in the queue until the nodes come back. Right now it gets rejected instead.

The submit checker decides whether a job can ever run by trying to fit it onto the nodes it knows about. A cordoned node carries a NoSchedule taint: the `armadaproject.io/unschedulable` taint we add whenever a node reports `Unschedulable`, and on `kubectl cordon` also the `node.kubernetes.io/unschedulable` taint that Kubernetes adds itself. No ordinary job tolerates those taints, so once a node type is fully cordoned the submit checker concludes the job is impossible and fails it with a terminal rejection. There is no second attempt once the nodes are uncordoned.

This change makes the submit checker treat cordoned nodes as available. As it builds its view of each executor's nodes it clears the unschedulable flag and strips the two cordon taints, so a job whose only matching nodes are cordoned stays queued rather than being rejected. Jobs that are genuinely infeasible, asking for a node type that does not exist or for more resource than any single node has, are still rejected, because only the cordon taints are removed and nothing else about the node changes. The scheduler itself is untouched, so cordoned nodes still will not run anything until they are uncordoned. The jobs just wait in the queue until then.

Node cordoning via `kubectl cordon` is the case that was being rejected. Executor-level `armadactl cordon` was already left queued, because the submit checker does not look at executor cordon settings, and this change keeps that behaviour.

Closes #4946.

## How to validate

Create a kind cluster with more than one worker so a node type can be fully cordoned while the cluster stays up. Add extra worker entries to `e2e/setup/kind.yaml`:

```yaml
nodes:
  - role: worker
  - role: worker
  - role: control-plane
    # leave the rest of the control-plane block as-is
```

Bring up the cluster and a local Armada:

```bash
mage kind                                              # create the cluster and write the kubeconfig
docker compose -f _local/docker-compose-deps.yaml up -d
scripts/localdev-init.sh                               # create the databases and run migrations
KUBECONFIG=$(pwd)/.kube/external/config goreman -f _local/procfiles/no-auth.Procfile start
```

Wait until the scheduler logs `Retrieved 1 executors` and the executor logs `Reporting current free resource`, then create a queue and a small job:

```bash
armadactl create queue test-queue

cat > /tmp/job.yaml <<'YAML'
queue: test-queue
jobSetId: cordon-test
jobs:
  - namespace: default
    priority: 1000
    podSpec:
      terminationGracePeriodSeconds: 0
      restartPolicy: Never
      containers:
        - name: sleep
          image: busybox:latest
          command: ["sh", "-c", "sleep 300"]
          resources:
            requests: {cpu: 100m, memory: 128Mi}
            limits: {cpu: 100m, memory: 128Mi}
YAML

armadactl submit /tmp/job.yaml
armadactl watch test-queue cordon-test                 # Queued -> Leased -> Running
```

Now cordon every worker so the pool is fully cordoned, and submit another job:

```bash
kubectl cordon armada-test-worker armada-test-worker2
armadactl submit /tmp/job.yaml
armadactl watch test-queue cordon-test
```

Before this change the new job is failed immediately with a rejection. With this change it stays `Queued`. Uncordon the nodes and it schedules:

```bash
kubectl uncordon armada-test-worker armada-test-worker2
```

The job moves from `Queued` to `Leased` to `Running`.
