### PR TITLE
Populate bid pricing details on job creation

### DIFF
--- a/internal/scheduler/jobdb/jobdb.go
+++ b/internal/scheduler/jobdb/jobdb.go
@@ -20,6 +20,7 @@ import (
 	"github.com/armadaproject/armada/internal/common/types"
 	"github.com/armadaproject/armada/internal/scheduler/adapters"
 	"github.com/armadaproject/armada/internal/scheduler/internaltypes"
+	"github.com/armadaproject/armada/internal/scheduler/pricing"
 	"github.com/armadaproject/armada/pkg/bidstore"
 )
 
@@ -91,6 +92,9 @@ type JobDb struct {
 	// Used to make efficient ResourceList types.
 	resourceListFactory  *internaltypes.ResourceListFactory
 	respectNodePodLimits bool
+	// The current bid price snapshot. Used by NewJob to apply prices to newly created jobs.
+	// Updated through the same WriteTxn → SetBidPriceSnapshot → Commit flow as the rest of the JobDb state.
+	bidPriceSnapshot *pricing.BidPriceSnapshot
 }
 
 // IDProvider is an interface used to mock run id  generation for tests.
@@ -182,6 +186,7 @@ func (jobDb *JobDb) Clone() *JobDb {
 		stringInterner:         jobDb.stringInterner,
 		resourceListFactory:    jobDb.resourceListFactory,
 		respectNodePodLimits:   jobDb.respectNodePodLimits,
+		bidPriceSnapshot:       jobDb.bidPriceSnapshot,
 	}
 }
 
@@ -217,6 +222,14 @@ func (jobDb *JobDb) NewJob(
 		pb = bidstore.PriceBand(priceBand)
 	}
 
+	bidPrices := map[string]pricing.Bid{}
+	if jobDb.bidPriceSnapshot != nil {
+		prices, ok := jobDb.bidPriceSnapshot.GetPrice(queue, pb)
+		if ok {
+			bidPrices = prices
+		}
+	}
+
 	gangInfo, err := GangInfoFromMinimalJob(schedulingInfo)
 	if err != nil {
 		log.Errorf("failed creating gang info for job %s", jobId)
@@ -245,6 +258,7 @@ func (jobDb *JobDb) NewJob(
 		runsById:                       map[string]*JobRun{},
 		pools:                          jobDb.internPools(pools),
 		priceBand:                      pb,
+		bidPricesPool:                  bidPrices,
 		gangInfo:                       *gangInfo,
 	}
 	job.ensureJobSchedulingInfoFieldsInitialised()
@@ -341,6 +355,7 @@ func (jobDb *JobDb) ReadTxn() *Txn {
 		leasedJobs:         jobDb.leasedJobs,
 		terminalJobs:       jobDb.terminalJobs,
 		unvalidatedJobs:    jobDb.unvalidatedJobs,
+		bidPriceSnapshot:   jobDb.bidPriceSnapshot,
 		active:             true,
 		jobDb:              jobDb,
 	}
@@ -363,6 +378,7 @@ func (jobDb *JobDb) WriteTxn() *Txn {
 		leasedJobs:         jobDb.leasedJobs,
 		terminalJobs:       jobDb.terminalJobs,
 		unvalidatedJobs:    jobDb.unvalidatedJobs,
+		bidPriceSnapshot:   jobDb.bidPriceSnapshot,
 		active:             true,
 		jobDb:              jobDb,
 	}
@@ -385,6 +401,7 @@ func (jobDb *JobDb) DryRunTxn() *Txn {
 		leasedJobs:         jobDb.leasedJobs,
 		terminalJobs:       jobDb.terminalJobs,
 		unvalidatedJobs:    jobDb.unvalidatedJobs,
+		bidPriceSnapshot:   jobDb.bidPriceSnapshot,
 		active:             true,
 		jobDb:              jobDb,
 	}
@@ -431,6 +448,9 @@ type Txn struct {
 	terminalJobs *immutable.Set[*Job]
 	// Jobs that require submit checking
 	unvalidatedJobs *immutable.Set[*Job]
+	// The bid price snapshot captured when the txn was opened. Reads return this value (or whatever was
+	// staged via SetBidPriceSnapshot). On Commit, this value is written back to the JobDb.
+	bidPriceSnapshot *pricing.BidPriceSnapshot
 	// The jobDb from which this transaction was created.
 	jobDb *JobDb
 	// Set to false when this transaction is either committed or aborted.
@@ -456,6 +476,7 @@ func (txn *Txn) Commit() {
 	txn.jobDb.leasedJobs = txn.leasedJobs
 	txn.jobDb.terminalJobs = txn.terminalJobs
 	txn.jobDb.unvalidatedJobs = txn.unvalidatedJobs
+	txn.jobDb.bidPriceSnapshot = txn.bidPriceSnapshot
 
 	txn.active = false
 }
@@ -1029,5 +1050,17 @@ func (txn *Txn) checkWritableTransaction() error {
 	if !txn.active {
 		return errors.New("Cannot write using an inactive transaction")
 	}
+	return nil
+}
+
+func (txn *Txn) GetBidPriceSnapshot() *pricing.BidPriceSnapshot {
+	return txn.bidPriceSnapshot
+}
+
+func (txn *Txn) SetBidPriceSnapshot(snapshot *pricing.BidPriceSnapshot) error {
+	if err := txn.checkWritableTransaction(); err != nil {
+		return err
+	}
+	txn.bidPriceSnapshot = snapshot
 	return nil
 }

--- a/internal/scheduler/jobdb/jobdb.go
+++ b/internal/scheduler/jobdb/jobdb.go
@@ -448,8 +448,7 @@ type Txn struct {
 	terminalJobs *immutable.Set[*Job]
 	// Jobs that require submit checking
 	unvalidatedJobs *immutable.Set[*Job]
-	// The bid price snapshot captured when the txn was opened. Reads return this value (or whatever was
-	// staged via SetBidPriceSnapshot). On Commit, this value is written back to the JobDb.
+	// The current snapshot of bid prices - allowing look up of bidding prices on job creation
 	bidPriceSnapshot *pricing.BidPriceSnapshot
 	// The jobDb from which this transaction was created.
 	jobDb *JobDb

--- a/internal/scheduler/jobdb/jobdb.go
+++ b/internal/scheduler/jobdb/jobdb.go
@@ -226,7 +226,7 @@ func (jobDb *JobDb) NewJob(
 	if jobDb.bidPriceSnapshot != nil {
 		prices, ok := jobDb.bidPriceSnapshot.GetPrice(queue, pb)
 		if ok {
-			bidPrices = prices
+			bidPrices = maps.Clone(prices)
 		}
 	}
 

--- a/internal/scheduler/jobdb/jobdb_test.go
+++ b/internal/scheduler/jobdb/jobdb_test.go
@@ -4,6 +4,7 @@ import (
 	"math/rand"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -20,6 +21,7 @@ import (
 	"github.com/armadaproject/armada/internal/common/util"
 	schedulerconfiguration "github.com/armadaproject/armada/internal/scheduler/configuration"
 	"github.com/armadaproject/armada/internal/scheduler/internaltypes"
+	"github.com/armadaproject/armada/internal/scheduler/pricing"
 	"github.com/armadaproject/armada/pkg/bidstore"
 )
 
@@ -1710,5 +1712,139 @@ func newGangJob() *Job {
 		jobSchedulingInfo: gangJobSchedulingInfo,
 		pools:             []string{"pool"},
 		gangInfo:          *gangInfo,
+	}
+}
+
+func TestJobDb_SetBidPriceSnapshot_UpdatedOnCommit(t *testing.T) {
+	jobDb := NewTestJobDb()
+
+	initialReadTxn := jobDb.ReadTxn()
+	assert.Nil(t, initialReadTxn.GetBidPriceSnapshot())
+
+	snapshot := &pricing.BidPriceSnapshot{
+		Timestamp: time.Unix(0, 0),
+		Bids: map[pricing.PriceKey]map[string]pricing.Bid{
+			{Queue: "queue", Band: bidstore.PriceBand_PRICE_BAND_UNSPECIFIED}: {
+				"pool": {QueuedBid: 1, RunningBid: 2},
+			},
+		},
+	}
+
+	writeTxn := jobDb.WriteTxn()
+	require.NoError(t, writeTxn.SetBidPriceSnapshot(snapshot))
+	writeTxn.Commit()
+
+	readTxn := jobDb.ReadTxn()
+	assert.Equal(t, snapshot, readTxn.GetBidPriceSnapshot())
+}
+
+func TestJobDb_SetBidPriceSnapshot_NotUpdatedOnAbort(t *testing.T) {
+	jobDb := NewTestJobDb()
+
+	snapshot := &pricing.BidPriceSnapshot{
+		Bids: map[pricing.PriceKey]map[string]pricing.Bid{
+			{Queue: "queue", Band: bidstore.PriceBand_PRICE_BAND_UNSPECIFIED}: {
+				"pool": {QueuedBid: 1, RunningBid: 2},
+			},
+		},
+	}
+
+	writeTxn := jobDb.WriteTxn()
+	require.NoError(t, writeTxn.SetBidPriceSnapshot(snapshot))
+	writeTxn.Abort()
+
+	readTxn := jobDb.ReadTxn()
+	assert.Nil(t, readTxn.GetBidPriceSnapshot())
+}
+
+func TestJobDb_SetBidPriceSnapshot_ErrOnReadTxn(t *testing.T) {
+	jobDb := NewTestJobDb()
+	readTxn := jobDb.ReadTxn()
+	err := readTxn.SetBidPriceSnapshot(&pricing.BidPriceSnapshot{})
+	assert.Error(t, err)
+}
+
+func TestJobDb_NewJob_PriceProviderPopulatesBidPrices(t *testing.T) {
+	bidsForA := map[string]pricing.Bid{
+		"pool-1": {RunningBid: 10, QueuedBid: 5},
+		"pool-2": {RunningBid: 20, QueuedBid: 8},
+	}
+	bidsForB := map[string]pricing.Bid{
+		"pool-1": {RunningBid: 100, QueuedBid: 50},
+	}
+	snapshot := &pricing.BidPriceSnapshot{
+		Bids: map[pricing.PriceKey]map[string]pricing.Bid{
+			{Queue: "queue-a", Band: bidstore.PriceBand_PRICE_BAND_A}: bidsForA,
+			{Queue: "queue-b", Band: bidstore.PriceBand_PRICE_BAND_B}: bidsForB,
+		},
+	}
+
+	tests := map[string]struct {
+		queue     string
+		priceBand bidstore.PriceBand
+		snapshot  *pricing.BidPriceSnapshot
+		expected  map[string]pricing.Bid
+	}{
+		"matching queue + band A": {
+			queue:     "queue-a",
+			priceBand: bidstore.PriceBand_PRICE_BAND_A,
+			snapshot:  snapshot,
+			expected:  bidsForA,
+		},
+		"matching queue + band B": {
+			queue:     "queue-b",
+			priceBand: bidstore.PriceBand_PRICE_BAND_B,
+			snapshot:  snapshot,
+			expected:  bidsForB,
+		},
+		"unknown queue": {
+			queue:     "queue-other",
+			priceBand: bidstore.PriceBand_PRICE_BAND_A,
+			snapshot:  snapshot,
+			expected:  map[string]pricing.Bid{},
+		},
+		"unknown band for known queue": {
+			queue:     "queue-a",
+			priceBand: bidstore.PriceBand_PRICE_BAND_C,
+			snapshot:  snapshot,
+			expected:  map[string]pricing.Bid{},
+		},
+		"no snapshot set": {
+			queue:     "queue-a",
+			priceBand: bidstore.PriceBand_PRICE_BAND_A,
+			snapshot:  nil,
+			expected:  map[string]pricing.Bid{},
+		},
+		"empty snapshot set": {
+			queue:     "queue-a",
+			priceBand: bidstore.PriceBand_PRICE_BAND_A,
+			snapshot:  &pricing.BidPriceSnapshot{},
+			expected:  map[string]pricing.Bid{},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			jobDb := NewJobDb(
+				map[string]types.PriorityClass{"foo": {}},
+				"foo",
+				stringinterner.New(1024),
+				testResourceListFactory,
+			)
+
+			if tc.snapshot != nil {
+				writeTxn := jobDb.WriteTxn()
+				require.NoError(t, writeTxn.SetBidPriceSnapshot(tc.snapshot))
+				writeTxn.Commit()
+			}
+
+			job, err := jobDb.NewJob(
+				util.NewULID(), "jobSet", tc.queue, 1, jobSchedulingInfo,
+				false, 0, false, false, false, 0, false, []string{"pool-1"},
+				int32(tc.priceBand),
+			)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, job.GetAllBidPrices())
+		})
 	}
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -574,6 +574,10 @@ func (s *Scheduler) updateJobPrices(ctx *armadacontext.Context, txn *jobdb.Txn) 
 	if err != nil {
 		return nil, err
 	}
+	err = txn.SetBidPriceSnapshot(&updatedBids)
+	if err != nil {
+		return nil, err
+	}
 	return updatedBids.ResourceUnits, nil
 }
 

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1464,7 +1464,7 @@ func TestJobPriceUpdates(t *testing.T) {
 			marketDrivenPools:             []string{},
 			initialJob:                    queuedJob,
 			expectedNumberOfProviderCalls: []int{0, 0, 0},
-			expectedJobBid:                []map[string]pricing.Bid{nil, nil, nil},
+			expectedJobBid:                []map[string]pricing.Bid{{}, {}, {}},
 			expectedJobBidPrice:           []float64{0, 0, 0},
 		},
 		"job with no market driven pools": {
@@ -1472,7 +1472,7 @@ func TestJobPriceUpdates(t *testing.T) {
 			marketDrivenPools:             []string{testfixtures.TestPool},
 			initialJob:                    jobWithoutMarketDrivenPools,
 			expectedNumberOfProviderCalls: []int{1, 1, 2},
-			expectedJobBid:                []map[string]pricing.Bid{nil, nil, nil},
+			expectedJobBid:                []map[string]pricing.Bid{{}, {}, {}},
 			expectedJobBidPrice:           []float64{0, 0, 0},
 		},
 		"non-preemptible queued job": {
@@ -1496,7 +1496,7 @@ func TestJobPriceUpdates(t *testing.T) {
 			marketDrivenPools:             []string{testfixtures.TestPool},
 			initialJob:                    queuedJobNoPricingInfo,
 			expectedNumberOfProviderCalls: []int{1, 1, 2},
-			expectedJobBid:                []map[string]pricing.Bid{nil, nil, nil},
+			expectedJobBid:                []map[string]pricing.Bid{{}, {}, {}},
 			expectedJobBidPrice:           []float64{0, 0, 0},
 		},
 		"non-preemptible running job with no pricing info": {
@@ -1504,7 +1504,7 @@ func TestJobPriceUpdates(t *testing.T) {
 			marketDrivenPools:             []string{testfixtures.TestPool},
 			initialJob:                    runningJobNoPricingInfo,
 			expectedNumberOfProviderCalls: []int{1, 1, 2},
-			expectedJobBid:                []map[string]pricing.Bid{nil, nil, nil},
+			expectedJobBid:                []map[string]pricing.Bid{{}, {}, {}},
 			expectedJobBidPrice:           []float64{pricing.NonPreemptibleRunningPrice, pricing.NonPreemptibleRunningPrice, pricing.NonPreemptibleRunningPrice},
 		},
 		"preemptible queued job": {
@@ -1528,7 +1528,7 @@ func TestJobPriceUpdates(t *testing.T) {
 			marketDrivenPools:             []string{testfixtures.TestPool},
 			initialJob:                    queuedPreemptibleJobNoPricingInfo,
 			expectedNumberOfProviderCalls: []int{1, 1, 2},
-			expectedJobBid:                []map[string]pricing.Bid{nil, nil, nil},
+			expectedJobBid:                []map[string]pricing.Bid{{}, {}, {}},
 			expectedJobBidPrice:           []float64{0, 0, 0},
 		},
 		"preemptible running job - no pricing info": {
@@ -1536,7 +1536,7 @@ func TestJobPriceUpdates(t *testing.T) {
 			marketDrivenPools:             []string{testfixtures.TestPool},
 			initialJob:                    runningPreemptibleJobNoPricingInfo,
 			expectedNumberOfProviderCalls: []int{1, 1, 2},
-			expectedJobBid:                []map[string]pricing.Bid{nil, nil, nil},
+			expectedJobBid:                []map[string]pricing.Bid{{}, {}, {}},
 			expectedJobBidPrice:           []float64{0, 0, 0},
 		},
 	}

--- a/internal/scheduler/schedulerapp.go
+++ b/internal/scheduler/schedulerapp.go
@@ -371,6 +371,11 @@ func Run(config schedulerconfig.Configuration) error {
 	)
 	jobDb.SetRespectNodePodLimits(config.Scheduling.RespectNodePodLimits)
 
+	err = populateInitialBidPrices(ctx, bidPriceProvider, jobDb)
+	if err != nil {
+		return err
+	}
+
 	schedulerMetrics, err := metrics.New(
 		config.Metrics.TrackedErrorRegexes,
 		config.Metrics.TrackedResourceNames,
@@ -444,6 +449,23 @@ func Run(config schedulerconfig.Configuration) error {
 	startupCompleteCheck.MarkComplete()
 
 	return g.Wait()
+}
+
+func populateInitialBidPrices(ctx *armadacontext.Context, priceProvider pricing.BidPriceProvider, jobdb *jobdb.JobDb) error {
+	timeout, cancel := armadacontext.WithTimeout(ctx, time.Second*30)
+	defer cancel()
+	initialBidPriceSnapshot, err := priceProvider.GetBidPrices(timeout)
+	if err != nil {
+		return errors.WithMessage(err, "error retrieving initial bid price snapshot")
+	}
+	txn := jobdb.WriteTxn()
+	if err := txn.SetBidPriceSnapshot(&initialBidPriceSnapshot); err != nil {
+		txn.Abort()
+		return errors.WithMessage(err, "error setting initial bid price snapshot on jobDb")
+	}
+	txn.Commit()
+
+	return nil
 }
 
 func createLeaderController(ctx *armadacontext.Context, config schedulerconfig.LeaderConfig) (leader.LeaderController, error) {

--- a/internal/scheduler/schedulerapp.go
+++ b/internal/scheduler/schedulerapp.go
@@ -183,7 +183,7 @@ func Run(config schedulerconfig.Configuration) error {
 			defer cancel()
 			err = bidPriceCache.Initialise(bidPriceProviderInitTimeout)
 			if err != nil {
-				ctx.Errorf("error initialising queue cache - %v", err)
+				return errors.WithMessage(err, "error initialising queue cache")
 			}
 			services = append(services, func() error { return bidPriceCache.Run(ctx) })
 			bidPriceProvider = bidPriceCache

--- a/internal/scheduler/schedulerapp.go
+++ b/internal/scheduler/schedulerapp.go
@@ -183,7 +183,7 @@ func Run(config schedulerconfig.Configuration) error {
 			defer cancel()
 			err = bidPriceCache.Initialise(bidPriceProviderInitTimeout)
 			if err != nil {
-				return errors.WithMessage(err, "error initialising queue cache")
+				return errors.WithMessage(err, "error initialising bid price cache")
 			}
 			services = append(services, func() error { return bidPriceCache.Run(ctx) })
 			bidPriceProvider = bidPriceCache


### PR DESCRIPTION
Previously we'd only populate the price as part of the scheduler cycle.

This meant newly created jobs would have an empty price until it was populated as part of the scheduler cycle.

This was previously completely fine, but we plan to have an async scheduling cycle where we can't guarentee the scheduler cycle will have set the price on the jobs before the scheduling sees the jobs
 - This change should mean at all times the jobs in the jobdb that have the same queue/priceband consistently have the prices set
 - This will mean the async scheduling cycle can safely assume job prices are set

The approach chosen was to simply set a price snapshot on the jobdb, it can then use this to get the price, this approach was chosen because:
 - It is simple
 - It leads the way for if we want to be smarter about what jobs we update on snapshot updates
   - Now we have the previous snapshot used on the jobdb, we could compare the diff and only update jobs impacted by the changes. Which would be far more efficient than now - which simply updates all jobs regardless of if the bids change


