### PR TITLE
Upgrade python client and airflow operator to work with python3.10, 3.12, 3.14 (#484)

### DIFF
--- a/.github/workflows/airflow-operator.yml
+++ b/.github/workflows/airflow-operator.yml
@@ -41,10 +41,10 @@ jobs:
   # Verifies the operator against every supported (Airflow, Python) combination.
   # The airflow-tox job below only resolves Airflow to the top of the range (newest 3.x),
   # so without this grid the 2.x serde / get_current_context paths and the 3.2 airflow.sdk
-  # serde path would never be exercised in CI. Each supported Airflow (2.10, 3.1, 3.2) runs
-  # against each supported Python (3.10, 3.12, 3.14); all are valid per upstream metadata.
-  # The versions are in the matrix so they appear in the check name (e.g.
-  # "airflow-compat (2.10.5, 3.12)").
+  # serde path would never be exercised in CI. Python 3.14 is only supported upstream by
+  # Airflow 3.2+ (Airflow 2.10.x and 3.1.x cap at Python 3.12), so those (airflow, 3.14)
+  # cells are excluded — they would otherwise fail at dependency install. The versions are
+  # in the matrix so they appear in the check name (e.g. "airflow-compat (2.10.5, 3.12)").
   airflow-compat:
     runs-on: ubuntu-22.04
     strategy:
@@ -52,6 +52,11 @@ jobs:
       matrix:
         airflow: ['2.10.5', '3.1.8', '3.2.1']
         python: ['3.10', '3.12', '3.14']
+        exclude:
+          - airflow: '2.10.5'
+            python: '3.14'
+          - airflow: '3.1.8'
+            python: '3.14'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-python@v5

--- a/.github/workflows/airflow-operator.yml
+++ b/.github/workflows/airflow-operator.yml
@@ -42,7 +42,7 @@ jobs:
   # The airflow-tox job below only resolves Airflow to the top of the range (newest 3.x),
   # so without this grid the 2.x serde / get_current_context paths and the 3.2 airflow.sdk
   # serde path would never be exercised in CI. Each supported Airflow (2.10, 3.1, 3.2) runs
-  # against each supported Python (3.10, 3.11, 3.12); all are valid per upstream metadata.
+  # against each supported Python (3.10, 3.12, 3.14); all are valid per upstream metadata.
   # The versions are in the matrix so they appear in the check name (e.g.
   # "airflow-compat (2.10.5, 3.12)").
   airflow-compat:
@@ -51,7 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         airflow: ['2.10.5', '3.1.8', '3.2.1']
-        python: ['3.10', '3.11', '3.12']
+        python: ['3.10', '3.12', '3.14']
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-python@v5
@@ -76,14 +76,14 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python: [ '3.10', '3.11', '3.12' ]
+        python: [ '3.10', '3.12', '3.14' ]
         include:
           - tox-env: 'py310'
             python: '3.10'
-          - tox-env: 'py311'
-            python: '3.11'
           - tox-env: 'py312'
             python: '3.12'
+          - tox-env: 'py314'
+            python: '3.14'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Go

--- a/.github/workflows/python-client-release-to-pypi.yml
+++ b/.github/workflows/python-client-release-to-pypi.yml
@@ -19,8 +19,8 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: ./.github/workflows/python-tests
         with:
-          python-version: '3.9'
-          tox-env: 'py39'
+          python-version: '3.10'
+          tox-env: 'py310'
           path: 'client/python'
           github-token: ${{secrets.GITHUB_TOKEN}}
       - name: Publish package to PyPI

--- a/.github/workflows/python-client.yml
+++ b/.github/workflows/python-client.yml
@@ -39,16 +39,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
+        python-version: [ '3.10', '3.12', '3.14' ]
         include:
-          - tox-env: 'py39'
-            python-version: '3.9'
           - tox-env: 'py310'
             python-version: '3.10'
-          - tox-env: 'py311'
-            python-version: '3.11'
           - tox-env: 'py312'
             python-version: '3.12'
+          - tox-env: 'py314'
+            python-version: '3.14'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Docker

--- a/.github/workflows/python-tests/action.yml
+++ b/.github/workflows/python-tests/action.yml
@@ -21,7 +21,7 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
     # Tox to run tests; build to build the wheel after tests pass
-    - run: pip install tox==3.27.1 build twine
+    - run: pip install 'tox>=4,<5' build twine
       shell: bash
     - name: Install Protoc
       uses: arduino/setup-protoc@v3

--- a/build/python-client/Dockerfile
+++ b/build/python-client/Dockerfile
@@ -1,5 +1,5 @@
 ARG PLATFORM=x86_64
-ARG BASE_IMAGE=python:3.9-slim-bookworm
+ARG BASE_IMAGE=python:3.10-slim-bookworm
 FROM --platform=$PLATFORM ${BASE_IMAGE}
 
 RUN mkdir /proto

--- a/client/python/CONTRIBUTING.md
+++ b/client/python/CONTRIBUTING.md
@@ -35,7 +35,7 @@ Unit tests, auto-formatting, and formatting checks are all run using `tox` as an
 of virtual environments which allow testing under multiple python versions and install conditions.
 
 The following commands should be run, and passing, at this point:
-- `tox -e py39` will run unit tests with your default python 3.9 environment
+- `tox -e py310` will run unit tests with your default python 3.10 environment
 - `tox -e format` will ensure formatting is compliant with linting tools and code formatters in use.
 
 ### Create a branch and work on your contribution

--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "armada_client"
-version = "0.4.14"
+version = "0.5.0"
 description = "Armada gRPC API python client"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = ["grpcio==1.76.0", "grpcio-tools==1.76.0", "mypy-protobuf>=3.6.0", "protobuf>=6.32.1" ]
 license = { text = "Apache Software License" }
 authors = [{ name = "G-Research Open Source Software", email = "armada@armadaproject.io" }]
@@ -12,7 +12,7 @@ authors = [{ name = "G-Research Open Source Software", email = "armada@armadapro
 format = ["black>=23.7.0", "flake8>=7.0.0", "pylint>=2.17.5"]
 # note(JayF): sphinx-jekyll-builder was broken by sphinx-markdown-builder 0.6 -- so pin to 0.5.5
 docs = ["sphinx==7.1.2", "sphinx-jekyll-builder==0.3.0", "sphinx-toolbox==3.2.0b1", "sphinx-markdown-builder==0.5.5"]
-test = ["pytest==7.3.1", "coverage==6.5.0", "pytest-asyncio==0.21.1"]
+test = ["pytest==9.0.3", "coverage==7.14.1", "pytest-asyncio==1.4.0"]
 
 [build-system]
 requires = ["setuptools"]

--- a/client/python/tox.ini
+++ b/client/python/tox.ini
@@ -2,10 +2,9 @@
 isolated_build = true
 envlist =
     format
-    py39
     py310
-    py311
     py312
+    py314
 
 [testenv]
 extras = test
@@ -40,7 +39,7 @@ commands =
 
 [testenv:format]
 extras = format
-whitelist_externals =
+allowlist_externals =
     black
     flake8
 commands =
@@ -51,7 +50,7 @@ commands =
 
 [testenv:format-code]
 extras = format
-whitelist_externals =
+allowlist_externals =
     black
     flake8
 commands =

--- a/third_party/airflow/pyproject.toml
+++ b/third_party/airflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "armada_airflow"
-version = "1.0.16"
+version = "1.1.0"
 description = "Armada Airflow Operator"
 readme='README.md'
 authors = [{name = "Armada-GROSS", email = "armada@armadaproject.io"}]
@@ -25,8 +25,8 @@ classifiers=[
 
 [project.optional-dependencies]
 format = ["black>=24.0.0", "flake8>=7.0.0", "pylint>=2.17.5"]
-test = ["pytest==7.3.1", "coverage==6.5.0", "pytest-asyncio==0.21.1",
-  "pytest-mock>=3.14.0"]
+test = ["pytest==9.0.3", "coverage==7.14.1", "pytest-asyncio==1.4.0",
+  "pytest-mock>=3.15.1"]
 # note(JayF): sphinx-jekyll-builder was broken by sphinx-markdown-builder 0.6 -- so pin to 0.5.5
 docs = ["sphinx==7.1.2", "sphinx-jekyll-builder==0.3.0", "sphinx-toolbox==3.2.0b1", "sphinx-markdown-builder==0.5.5"]
 
@@ -41,7 +41,7 @@ include = ["armada_airflow*"]
 
 [tool.black]
 line-length = 88
-target-version = ['py310', 'py311', 'py312']
+target-version = ['py310', 'py312', 'py314']
 include = '''
 /(
     armada

--- a/third_party/airflow/scripts/run-tests.sh
+++ b/third_party/airflow/scripts/run-tests.sh
@@ -37,6 +37,21 @@ PYTHON_VERSION="$2"
 OPERATOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CLIENT_DIR="$(cd "${OPERATOR_DIR}/../.." && pwd)/client/python"
 
+# Some (airflow, python) pairs need overrides because Airflow doesn't publish a
+# constraints file for that python version:
+#   airflow 3.1.x has no constraints-3.14.txt — keep python 3.14 but pin transitive
+#     deps using constraints-3.13.txt.
+#   airflow 2.10.5 has no constraints-3.14.txt — keep python 3.14 but pin transitive
+#     deps using constraints-3.12.txt.
+CONSTRAINTS_PYTHON="${PYTHON_VERSION}"
+if [[ "${AIRFLOW_VERSION}" == 3.1.* && "${PYTHON_VERSION}" == "3.14" ]]; then
+  echo "==> airflow ${AIRFLOW_VERSION} has no constraints-3.14: using constraints-3.13"
+  CONSTRAINTS_PYTHON="3.13"
+elif [[ "${AIRFLOW_VERSION}" == "2.10.5" && "${PYTHON_VERSION}" == "3.14" ]]; then
+  echo "==> airflow ${AIRFLOW_VERSION} has no constraints-3.14: using constraints-3.12"
+  CONSTRAINTS_PYTHON="3.12"
+fi
+
 PYTHON_BIN="${PYTHON_BIN:-python${PYTHON_VERSION}}"
 if ! command -v "${PYTHON_BIN}" >/dev/null 2>&1; then
   echo "error: ${PYTHON_BIN} not found on PATH; set PYTHON_BIN to a Python ${PYTHON_VERSION} interpreter" >&2
@@ -45,7 +60,7 @@ fi
 
 # Airflow publishes one constraints file per (airflow version, python version); it pins the
 # exact transitive deps that version was released and tested against.
-CONSTRAINTS_URL="https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-${PYTHON_VERSION}.txt"
+CONSTRAINTS_URL="https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-${CONSTRAINTS_PYTHON}.txt"
 
 # If the caller did not supply VENV_DIR, create the venv inside our own temp dir and remove
 # that whole temp dir on exit. If the caller did supply VENV_DIR, only remove the venv

--- a/third_party/airflow/scripts/run-tests.sh
+++ b/third_party/airflow/scripts/run-tests.sh
@@ -37,21 +37,6 @@ PYTHON_VERSION="$2"
 OPERATOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CLIENT_DIR="$(cd "${OPERATOR_DIR}/../.." && pwd)/client/python"
 
-# Some (airflow, python) pairs need overrides because Airflow doesn't publish a
-# constraints file for that python version:
-#   airflow 3.1.x has no constraints-3.14.txt — keep python 3.14 but pin transitive
-#     deps using constraints-3.13.txt.
-#   airflow 2.10.5 has no constraints-3.14.txt — keep python 3.14 but pin transitive
-#     deps using constraints-3.12.txt.
-CONSTRAINTS_PYTHON="${PYTHON_VERSION}"
-if [[ "${AIRFLOW_VERSION}" == 3.1.* && "${PYTHON_VERSION}" == "3.14" ]]; then
-  echo "==> airflow ${AIRFLOW_VERSION} has no constraints-3.14: using constraints-3.13"
-  CONSTRAINTS_PYTHON="3.13"
-elif [[ "${AIRFLOW_VERSION}" == "2.10.5" && "${PYTHON_VERSION}" == "3.14" ]]; then
-  echo "==> airflow ${AIRFLOW_VERSION} has no constraints-3.14: using constraints-3.12"
-  CONSTRAINTS_PYTHON="3.12"
-fi
-
 PYTHON_BIN="${PYTHON_BIN:-python${PYTHON_VERSION}}"
 if ! command -v "${PYTHON_BIN}" >/dev/null 2>&1; then
   echo "error: ${PYTHON_BIN} not found on PATH; set PYTHON_BIN to a Python ${PYTHON_VERSION} interpreter" >&2
@@ -60,7 +45,7 @@ fi
 
 # Airflow publishes one constraints file per (airflow version, python version); it pins the
 # exact transitive deps that version was released and tested against.
-CONSTRAINTS_URL="https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-${CONSTRAINTS_PYTHON}.txt"
+CONSTRAINTS_URL="https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-${PYTHON_VERSION}.txt"
 
 # If the caller did not supply VENV_DIR, create the venv inside our own temp dir and remove
 # that whole temp dir on exit. If the caller did supply VENV_DIR, only remove the venv

--- a/third_party/airflow/tox.ini
+++ b/third_party/airflow/tox.ini
@@ -2,9 +2,9 @@
 isolated_build = true
 envlist =
     format
-    py38
-    py39
     py310
+    py312
+    py314
 
 [testenv]
 extras = test


### PR DESCRIPTION
- We're deprecating support for python 3.8 - 3.9 - as they have been end of life for year and a half.
- Explicitly testing for python 3.14.