### PR TITLE
Free disk space in integration test jobs to avoid exhausting small CI runners

### DIFF
--- a/.github/workflows/airflow-operator.yml
+++ b/.github/workflows/airflow-operator.yml
@@ -117,6 +117,15 @@ jobs:
       DOCKER_BUILDX_BUILDER: "builder"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      # Some ubuntu-22.04 runners only have ~17GB free on the root disk, which is
+      # less than this job's ~19.5GB peak usage. Remove unused preinstalled
+      # toolchains to make room.
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: false
+          large-packages: false
+          swap-storage: false
       - name: Setup Docker
         uses: docker/setup-docker-action@1a6edb0ba9ac496f6850236981f15d8f9a82254d # v5
         with:
@@ -142,3 +151,8 @@ jobs:
           version: '23.3'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - run: go run github.com/magefile/mage@v1.15.0 -v teste2eAirflow
+      - name: Disk usage report
+        if: always()
+        run: |
+          df -h /
+          docker system df || true

--- a/.github/workflows/python-client.yml
+++ b/.github/workflows/python-client.yml
@@ -74,6 +74,15 @@ jobs:
       DOCKER_BUILDX_BUILDER: "builder"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      # Some ubuntu-22.04 runners only have ~17GB free on the root disk, which is
+      # less than this job's ~19.5GB peak usage. Remove unused preinstalled
+      # toolchains to make room.
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: false
+          large-packages: false
+          swap-storage: false
       - name: Setup Docker
         uses: docker/setup-docker-action@1a6edb0ba9ac496f6850236981f15d8f9a82254d # v5
         with:
@@ -99,3 +108,8 @@ jobs:
           version: '23.3'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - run: go run github.com/magefile/mage@v1.15.0 -v teste2epython
+      - name: Disk usage report
+        if: always()
+        run: |
+          df -h /
+          docker system df || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
       # Free disk space to prevent "no space left on device" during Docker builds.
       # This runs on every build since GitHub runners are ephemeral.
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@v1.3.1
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           tool-cache: false
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,6 +81,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      # Some ubuntu-22.04 runners only have ~17GB free on the root disk, which is
+      # less than this job's ~19.5GB peak usage. Remove unused preinstalled
+      # toolchains to make room.
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: false
+          large-packages: false
+          swap-storage: false
+
       - name: Setup Docker
         uses: docker/setup-docker-action@1a6edb0ba9ac496f6850236981f15d8f9a82254d # v5
         with:
@@ -91,9 +101,6 @@ jobs:
 
       - name: Install Docker Buildx
         run: docker buildx install
-
-      - name: Free some disk space
-        run: docker image prune -af
 
       - name: Setup Go
         uses: ./.github/actions/setup-go-cache
@@ -129,6 +136,12 @@ jobs:
           path: |
             ./logs/
           if-no-files-found: error
+
+      - name: Disk usage report
+        if: always()
+        run: |
+          df -h /
+          docker system df || true
 
   go-mod-up-to-date:
     name: Golang Mod Up To Date


### PR DESCRIPTION
The integration test jobs (airflow-integration-tests, python-client-integration-tests, go-integration-tests) intermittently fail with "No space left on device". When it happens the runner worker itself often dies while writing its own logs, so the job ends without a useful error. Example: https://github.com/armadaproject/armada/actions/runs/27219588532/job/80370576772

The root cause is that the hosted ubuntu-22.04 pool is heterogeneous. Most runners have a 146GB root disk with about 89GB free at job start, but some have a 73GB disk with only about 17GB free. These jobs peak at roughly 19.5GB of disk (armada images, the kind node's storage, pulsar, go caches, goreleaser dist). 17GB is not enough, so a job fails whenever it happens to land on a small runner. That lottery is why the failures look flaky.

The fix is to run `jlumbroso/free-disk-space` at the start of those three jobs, the same action release.yml already uses. It deletes the preinstalled Android, .NET and Haskell toolchains, which these jobs never touch, freeing 19GiB in about 20 seconds. On a small runner that lifts free space from 17GB to 36GB, nearly double what the job needs. With large-packages enabled the action would free another 4.6GiB, but it spends over a minute in apt-get remove, so I left that off. It can be enabled later if the job footprint grows.

## Benchmarks

Numbers from 11 jobs on my fork: [27239244450](https://github.com/dejanzele/armada/actions/runs/27239244450), [27262717892](https://github.com/dejanzele/armada/actions/runs/27262717892), [27263370317](https://github.com/dejanzele/armada/actions/runs/27263370317).

| Runner disk | Fix | Free space at job start | Outcome |
|---|---|---|---|
| 73GB | without | 17GB | fails: disk hits 100% during setup, pulsar cannot start |
| 73GB | with | 36GB | passes the full airflow e2e, never drops below 16.5GB free |
| 146GB | either | 89GB | always passes, with or without the fix |

Small runners are assigned rarely (1 of 9 jobs in my runs), so to benchmark the 73GB rows reliably I also reproduced that flavor on a large runner by filling the disk with a ballast file until free space matched a small runner exactly. The ballasted runs behave the same as the genuine small runner: without the fix they fail with the identical signature, with the fix they pass.

Cost: about 20 seconds added to each of the three jobs.

Also in this change:

- removed the "Free some disk space" step (docker image prune -af) from go-integration-tests, it only reclaimed a couple of GB of preinstalled images and is superseded by the new step
- added a "Disk usage report" step (df and docker system df, if: always()) at the end of each integration job so headroom stays visible in future runs
- pinned the existing free-disk-space usage in release.yml to the same commit SHA the new steps use

Note: the python-client-tox (3.14) failure on this PR is pre-existing, it fails identically on master (run [27233290830](https://github.com/armadaproject/armada/actions/runs/27233290830)) since the 3.14 matrix cell was added. This PR does not touch the tox jobs.