### PR TITLE
Add UnscheduleJob and RemoveJob to sctx/qctx

### DIFF
--- a/internal/scheduler/scheduling/context/queue.go
+++ b/internal/scheduler/scheduling/context/queue.go
@@ -274,17 +274,17 @@ func (qctx *QueueSchedulingContext) UnscheduleJob(jctx *JobSchedulingContext) bo
 	if scheduledInThisRound {
 		qctx.ScheduledResourcesByPriorityClass[pcName] = qctx.ScheduledResourcesByPriorityClass[pcName].Subtract(rl)
 		delete(qctx.SuccessfulJobSchedulingContexts, jobId)
-		qctx.AllocatedByPriorityClass[pcName] = qctx.AllocatedByPriorityClass[pcName].Subtract(jctx.Job.AllResourceRequirements())
-		qctx.Allocated = qctx.Allocated.Subtract(jctx.Job.AllResourceRequirements())
+		qctx.AllocatedByPriorityClass[pcName] = qctx.AllocatedByPriorityClass[pcName].Subtract(rl)
+		qctx.Allocated = qctx.Allocated.Subtract(rl)
 		if existingJctx.Billable {
-			qctx.BillableResource = qctx.BillableResource.Subtract(existingJctx.Job.AllResourceRequirements())
+			qctx.BillableResource = qctx.BillableResource.Subtract(rl)
 		}
 	}
 
 	return scheduledInThisRound
 }
 
-func (qctx *QueueSchedulingContext) RemoveJob(jctx *JobSchedulingContext) (bool, bool, bool, error) {
+func (qctx *QueueSchedulingContext) RemoveJob(jctx *JobSchedulingContext) (bool, bool, bool) {
 	jobId := jctx.Job.Id()
 
 	pcName := jctx.Job.PriorityClassName()
@@ -295,10 +295,10 @@ func (qctx *QueueSchedulingContext) RemoveJob(jctx *JobSchedulingContext) (bool,
 	existingJctx, rescheduledThisRound := qctx.RescheduledJobSchedulingContexts[jobId]
 	if rescheduledThisRound {
 		delete(qctx.RescheduledJobSchedulingContexts, jobId)
-		qctx.AllocatedByPriorityClass[pcName] = qctx.AllocatedByPriorityClass[pcName].Subtract(jctx.Job.AllResourceRequirements())
-		qctx.Allocated = qctx.Allocated.Subtract(jctx.Job.AllResourceRequirements())
+		qctx.AllocatedByPriorityClass[pcName] = qctx.AllocatedByPriorityClass[pcName].Subtract(rl)
+		qctx.Allocated = qctx.Allocated.Subtract(rl)
 		if existingJctx.Billable {
-			qctx.BillableResource = qctx.BillableResource.Subtract(existingJctx.Job.AllResourceRequirements())
+			qctx.BillableResource = qctx.BillableResource.Subtract(rl)
 		}
 	}
 
@@ -314,9 +314,9 @@ func (qctx *QueueSchedulingContext) RemoveJob(jctx *JobSchedulingContext) (bool,
 		qctx.EvictedResourcesByPriorityClass[pcName] = qctx.EvictedResourcesByPriorityClass[pcName].Subtract(rl)
 	}
 
-	qctx.Demand = qctx.Demand.Subtract(jctx.Job.AllResourceRequirements())
+	qctx.Demand = qctx.Demand.Subtract(rl)
 
-	return scheduledInRound, rescheduledThisRound, evictedThisRound, nil
+	return scheduledInRound, rescheduledThisRound, evictedThisRound
 }
 
 func (qctx *QueueSchedulingContext) preemptJob(jctx *JobSchedulingContext) (bool, error) {

--- a/internal/scheduler/scheduling/context/queue.go
+++ b/internal/scheduler/scheduling/context/queue.go
@@ -264,6 +264,61 @@ func (qctx *QueueSchedulingContext) addJobSchedulingContext(jctx *JobSchedulingC
 	return evictedInThisRound, nil
 }
 
+func (qctx *QueueSchedulingContext) UnscheduleJob(jctx *JobSchedulingContext) bool {
+	jobId := jctx.Job.Id()
+
+	pcName := jctx.Job.PriorityClassName()
+	rl := jctx.Job.AllResourceRequirements()
+
+	existingJctx, scheduledInThisRound := qctx.SuccessfulJobSchedulingContexts[jobId]
+	if scheduledInThisRound {
+		qctx.ScheduledResourcesByPriorityClass[pcName] = qctx.ScheduledResourcesByPriorityClass[pcName].Subtract(rl)
+		delete(qctx.SuccessfulJobSchedulingContexts, jobId)
+		qctx.AllocatedByPriorityClass[pcName] = qctx.AllocatedByPriorityClass[pcName].Subtract(jctx.Job.AllResourceRequirements())
+		qctx.Allocated = qctx.Allocated.Subtract(jctx.Job.AllResourceRequirements())
+		if existingJctx.Billable {
+			qctx.BillableResource = qctx.BillableResource.Subtract(existingJctx.Job.AllResourceRequirements())
+		}
+	}
+
+	return scheduledInThisRound
+}
+
+func (qctx *QueueSchedulingContext) RemoveJob(jctx *JobSchedulingContext) (bool, bool, bool, error) {
+	jobId := jctx.Job.Id()
+
+	pcName := jctx.Job.PriorityClassName()
+	rl := jctx.Job.AllResourceRequirements()
+
+	scheduledInRound := qctx.UnscheduleJob(jctx)
+
+	existingJctx, rescheduledThisRound := qctx.RescheduledJobSchedulingContexts[jobId]
+	if rescheduledThisRound {
+		delete(qctx.RescheduledJobSchedulingContexts, jobId)
+		qctx.AllocatedByPriorityClass[pcName] = qctx.AllocatedByPriorityClass[pcName].Subtract(jctx.Job.AllResourceRequirements())
+		qctx.Allocated = qctx.Allocated.Subtract(jctx.Job.AllResourceRequirements())
+		if existingJctx.Billable {
+			qctx.BillableResource = qctx.BillableResource.Subtract(existingJctx.Job.AllResourceRequirements())
+		}
+	}
+
+	_, preemptedByOptimiserThisRound := qctx.PreemptedByOptimiserJobSchedulingContexts[jobId]
+	if preemptedByOptimiserThisRound {
+		delete(qctx.PreemptedByOptimiserJobSchedulingContexts, jobId)
+		qctx.PreemptedByOptimiserResourceByPriorityClass[pcName] = qctx.PreemptedByOptimiserResourceByPriorityClass[pcName].Subtract(rl)
+	}
+
+	evictedThisRound := qctx.EvictedJobsById[jobId]
+	if evictedThisRound {
+		delete(qctx.EvictedJobsById, jobId)
+		qctx.EvictedResourcesByPriorityClass[pcName] = qctx.EvictedResourcesByPriorityClass[pcName].Subtract(rl)
+	}
+
+	qctx.Demand = qctx.Demand.Subtract(jctx.Job.AllResourceRequirements())
+
+	return scheduledInRound, rescheduledThisRound, evictedThisRound, nil
+}
+
 func (qctx *QueueSchedulingContext) preemptJob(jctx *JobSchedulingContext) (bool, error) {
 	jobId := jctx.Job.Id()
 

--- a/internal/scheduler/scheduling/context/queue_test.go
+++ b/internal/scheduler/scheduling/context/queue_test.go
@@ -113,8 +113,7 @@ func TestQueueSchedulingContext_RemoveJob(t *testing.T) {
 			tc.setup(t, sctx, jctx)
 
 			assert.False(t, qctx.Demand.AllZero())
-			scheduled, rescheduled, evicted, err := qctx.RemoveJob(jctx)
-			require.NoError(t, err)
+			scheduled, rescheduled, evicted := qctx.RemoveJob(jctx)
 
 			assert.Equal(t, tc.expectedScheduled, scheduled)
 			assert.Equal(t, tc.expectedRescheduled, rescheduled)

--- a/internal/scheduler/scheduling/context/queue_test.go
+++ b/internal/scheduler/scheduling/context/queue_test.go
@@ -1,0 +1,144 @@
+package context
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/armadaproject/armada/internal/scheduler/testfixtures"
+)
+
+func TestQueueSchedulingContext_UnscheduleJob(t *testing.T) {
+	tests := map[string]struct {
+		isExistingJob    bool
+		setup            func(t *testing.T, sctx *SchedulingContext, jctx *JobSchedulingContext)
+		expectUnschedule bool
+	}{
+		"scheduled this round": {
+			setup: func(t *testing.T, sctx *SchedulingContext, jctx *JobSchedulingContext) {
+				_, err := sctx.AddJobSchedulingContext(jctx)
+				require.NoError(t, err)
+			},
+			expectUnschedule: true,
+		},
+		"evicted job is not unscheduled": {
+			isExistingJob: true,
+			setup: func(t *testing.T, sctx *SchedulingContext, jctx *JobSchedulingContext) {
+				_, err := sctx.EvictJob(jctx)
+				require.NoError(t, err)
+			},
+			expectUnschedule: false,
+		},
+		// UnscheduleJob only reverts jobs newly scheduled this round
+		"rescheduled job is not unscheduled": {
+			isExistingJob: true,
+			setup: func(t *testing.T, sctx *SchedulingContext, jctx *JobSchedulingContext) {
+				_, err := sctx.EvictJob(jctx)
+				require.NoError(t, err)
+				_, err = sctx.AddJobSchedulingContext(jctx)
+				require.NoError(t, err)
+			},
+			expectUnschedule: false,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			jctx := testSmallCpuJobSchedulingContext("A", testfixtures.TestDefaultPriorityClass)
+			sctx := createSchedulingContext(t, jctx, tc.isExistingJob)
+			qctx := sctx.QueueSchedulingContexts["A"]
+			tc.setup(t, sctx, jctx)
+
+			scheduledInRound := qctx.UnscheduleJob(jctx)
+
+			assert.Equal(t, tc.expectUnschedule, scheduledInRound)
+			_, stillScheduled := qctx.SuccessfulJobSchedulingContexts[jctx.JobId]
+			assert.False(t, stillScheduled, "job should never remain in SuccessfulJobSchedulingContexts")
+			if tc.expectUnschedule {
+				assert.True(t, qctx.Allocated.AllZero())
+				for _, allocated := range qctx.AllocatedByPriorityClass {
+					assert.True(t, allocated.AllZero())
+				}
+			}
+		})
+	}
+}
+
+func TestQueueSchedulingContext_RemoveJob(t *testing.T) {
+	tests := map[string]struct {
+		isExistingJob       bool
+		setup               func(t *testing.T, sctx *SchedulingContext, jctx *JobSchedulingContext)
+		expectedScheduled   bool
+		expectedRescheduled bool
+		expectedEvicted     bool
+	}{
+		"scheduled this round": {
+			setup: func(t *testing.T, sctx *SchedulingContext, jctx *JobSchedulingContext) {
+				_, err := sctx.AddJobSchedulingContext(jctx)
+				require.NoError(t, err)
+			},
+			expectedScheduled: true,
+		},
+		"rescheduled this round": {
+			isExistingJob: true,
+			setup: func(t *testing.T, sctx *SchedulingContext, jctx *JobSchedulingContext) {
+				_, err := sctx.EvictJob(jctx)
+				require.NoError(t, err)
+				_, err = sctx.AddJobSchedulingContext(jctx)
+				require.NoError(t, err)
+			},
+			expectedRescheduled: true,
+		},
+		"evicted this round": {
+			isExistingJob: true,
+			setup: func(t *testing.T, sctx *SchedulingContext, jctx *JobSchedulingContext) {
+				_, err := sctx.EvictJob(jctx)
+				require.NoError(t, err)
+			},
+			expectedEvicted: true,
+		},
+		"optimiser-preempted this round": {
+			isExistingJob: true,
+			setup: func(t *testing.T, sctx *SchedulingContext, jctx *JobSchedulingContext) {
+				_, err := sctx.PreemptJob(jctx)
+				require.NoError(t, err)
+			},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			jctx := testSmallCpuJobSchedulingContext("A", testfixtures.TestDefaultPriorityClass)
+			sctx := createSchedulingContext(t, jctx, tc.isExistingJob)
+			qctx := sctx.QueueSchedulingContexts["A"]
+			tc.setup(t, sctx, jctx)
+
+			assert.False(t, qctx.Demand.AllZero())
+			scheduled, rescheduled, evicted, err := qctx.RemoveJob(jctx)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expectedScheduled, scheduled)
+			assert.Equal(t, tc.expectedRescheduled, rescheduled)
+			assert.Equal(t, tc.expectedEvicted, evicted)
+
+			assert.Empty(t, qctx.SuccessfulJobSchedulingContexts[jctx.JobId])
+			assert.Empty(t, qctx.RescheduledJobSchedulingContexts[jctx.JobId])
+			assert.Empty(t, qctx.PreemptedByOptimiserJobSchedulingContexts[jctx.JobId])
+			assert.Empty(t, qctx.EvictedJobsById[jctx.JobId])
+
+			assert.True(t, qctx.Demand.AllZero())
+			assert.True(t, qctx.Allocated.AllZero())
+			for _, allocated := range qctx.AllocatedByPriorityClass {
+				assert.True(t, allocated.AllZero())
+			}
+			for _, allocated := range qctx.EvictedResourcesByPriorityClass {
+				assert.True(t, allocated.AllZero())
+			}
+			for _, allocated := range qctx.PreemptedByOptimiserResourceByPriorityClass {
+				assert.True(t, allocated.AllZero())
+			}
+			for _, allocated := range qctx.ScheduledResourcesByPriorityClass {
+				assert.True(t, allocated.AllZero())
+			}
+		})
+	}
+}

--- a/internal/scheduler/scheduling/context/scheduling.go
+++ b/internal/scheduler/scheduling/context/scheduling.go
@@ -60,7 +60,7 @@ type SchedulingContext struct {
 	// Used to efficiently generate scheduling keys.
 	SchedulingKeyGenerator *internaltypes.SchedulingKeyGenerator
 	// Record of job scheduling requirements known to be unfeasible.
-	// Used to immediately reject new jobs with identical reqirements.
+	// Used to immediately reject new jobs with identical requirements.
 	// Maps to the JobSchedulingContext of a previous job attempted to schedule with the same key.
 	UnfeasibleSchedulingKeys     map[internaltypes.SchedulingKey]*JobSchedulingContext
 	ExperimentalIndicativeShares map[int]float64
@@ -436,6 +436,54 @@ func (sctx *SchedulingContext) EvictGang(gctx *GangSchedulingContext) (bool, err
 		sctx.NumScheduledGangs--
 	}
 	return allJobsScheduledInThisRound, nil
+}
+
+func (sctx *SchedulingContext) UnscheduleJob(jctx *JobSchedulingContext) error {
+	queue := sctx.resolveQueueName(jctx.Job)
+	qctx, ok := sctx.QueueSchedulingContexts[queue]
+	if !ok {
+		return errors.Errorf("failed unscheduling job %s: no context for queue %s", jctx.JobId, queue)
+	}
+
+	scheduledInThisRound := qctx.UnscheduleJob(jctx)
+	if !scheduledInThisRound {
+		return errors.Errorf("failed unscheduling job %s: job is not marked as scheduled", jctx.JobId)
+	}
+
+	sctx.ScheduledResources = sctx.ScheduledResources.Subtract(jctx.Job.AllResourceRequirements())
+	sctx.NumScheduledJobs--
+	sctx.Allocated = sctx.Allocated.Subtract(jctx.Job.AllResourceRequirements())
+
+	return nil
+}
+
+func (sctx *SchedulingContext) RemoveJob(jctx *JobSchedulingContext) (bool, error) {
+	queue := sctx.resolveQueueName(jctx.Job)
+	qctx, ok := sctx.QueueSchedulingContexts[queue]
+	if !ok {
+		return false, errors.Errorf("failed removing job %s from scheduling context: no context for queue %s", jctx.JobId, queue)
+	}
+
+	scheduledInThisRound, rescheduledInThisRound, evictedInRound, err := qctx.RemoveJob(jctx)
+	if err != nil {
+		return false, err
+	}
+
+	if scheduledInThisRound {
+		sctx.ScheduledResources = sctx.ScheduledResources.Subtract(jctx.Job.AllResourceRequirements())
+		sctx.NumScheduledJobs--
+	}
+
+	if scheduledInThisRound || rescheduledInThisRound {
+		sctx.Allocated = sctx.Allocated.Subtract(jctx.Job.AllResourceRequirements())
+	}
+
+	if evictedInRound {
+		sctx.EvictedResources = sctx.EvictedResources.Subtract(jctx.Job.AllResourceRequirements())
+		sctx.NumEvictedJobs--
+	}
+
+	return scheduledInThisRound, nil
 }
 
 // QueueContextExists returns true if we know about the queue associated with the job. An example of when this can

--- a/internal/scheduler/scheduling/context/scheduling.go
+++ b/internal/scheduler/scheduling/context/scheduling.go
@@ -464,11 +464,7 @@ func (sctx *SchedulingContext) RemoveJob(jctx *JobSchedulingContext) (bool, erro
 		return false, errors.Errorf("failed removing job %s from scheduling context: no context for queue %s", jctx.JobId, queue)
 	}
 
-	scheduledInThisRound, rescheduledInThisRound, evictedInRound, err := qctx.RemoveJob(jctx)
-	if err != nil {
-		return false, err
-	}
-
+	scheduledInThisRound, rescheduledInThisRound, evictedInRound := qctx.RemoveJob(jctx)
 	if scheduledInThisRound {
 		sctx.ScheduledResources = sctx.ScheduledResources.Subtract(jctx.Job.AllResourceRequirements())
 		sctx.NumScheduledJobs--

--- a/internal/scheduler/scheduling/context/scheduling_test.go
+++ b/internal/scheduler/scheduling/context/scheduling_test.go
@@ -540,6 +540,156 @@ func addFloatingResourceRequest(request string, job *jobdb.Job) *jobdb.Job {
 		[]*jobdb.Job{job})[0]
 }
 
+func TestSchedulingContext_UnscheduleJob(t *testing.T) {
+	tests := map[string]struct {
+		isExistingJob bool
+		setup         func(t *testing.T, sctx *SchedulingContext, jctx *JobSchedulingContext)
+		expectError   bool
+	}{
+		"unschedules a job scheduled this round": {
+			setup: func(t *testing.T, sctx *SchedulingContext, jctx *JobSchedulingContext) {
+				_, err := sctx.AddJobSchedulingContext(jctx)
+				require.NoError(t, err)
+			},
+		},
+		"errors if job was not scheduled this round": {
+			setup:       func(t *testing.T, sctx *SchedulingContext, jctx *JobSchedulingContext) {},
+			expectError: true,
+		},
+		// UnscheduleJob only reverts jobs newly scheduled this round
+		"errors for a rescheduled job": {
+			isExistingJob: true,
+			setup: func(t *testing.T, sctx *SchedulingContext, jctx *JobSchedulingContext) {
+				_, err := sctx.EvictJob(jctx)
+				require.NoError(t, err)
+				_, err = sctx.AddJobSchedulingContext(jctx)
+				require.NoError(t, err)
+			},
+			expectError: true,
+		},
+		"errors for an optimiser-preempted job": {
+			isExistingJob: true,
+			setup: func(t *testing.T, sctx *SchedulingContext, jctx *JobSchedulingContext) {
+				_, err := sctx.PreemptJob(jctx)
+				require.NoError(t, err)
+			},
+			expectError: true,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			jctx := testSmallCpuJobSchedulingContext("A", testfixtures.TestDefaultPriorityClass)
+			sctx := createSchedulingContext(t, jctx, tc.isExistingJob)
+			tc.setup(t, sctx, jctx)
+
+			err := sctx.UnscheduleJob(jctx)
+			if tc.expectError {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, 0, sctx.NumScheduledJobs)
+			assert.True(t, sctx.ScheduledResources.AllZero())
+			assert.True(t, sctx.Allocated.AllZero())
+		})
+	}
+}
+
+func TestSchedulingContext_UnscheduleJob_ErrorsIfQueueContextMissing(t *testing.T) {
+	jctx := testSmallCpuJobSchedulingContext("A", testfixtures.TestDefaultPriorityClass)
+	sctx := createSchedulingContext(t, jctx, false)
+	missingQueueJctx := testSmallCpuJobSchedulingContext("unknown", testfixtures.TestDefaultPriorityClass)
+
+	err := sctx.UnscheduleJob(missingQueueJctx)
+	assert.Error(t, err)
+}
+
+func TestSchedulingContext_RemoveJob(t *testing.T) {
+	tests := map[string]struct {
+		isExistingJob     bool
+		setup             func(t *testing.T, sctx *SchedulingContext, jctx *JobSchedulingContext)
+		expectedScheduled bool
+	}{
+		"scheduled this round": {
+			setup: func(t *testing.T, sctx *SchedulingContext, jctx *JobSchedulingContext) {
+				_, err := sctx.AddJobSchedulingContext(jctx)
+				require.NoError(t, err)
+			},
+			expectedScheduled: true,
+		},
+		"rescheduled this round": {
+			isExistingJob: true,
+			setup: func(t *testing.T, sctx *SchedulingContext, jctx *JobSchedulingContext) {
+				_, err := sctx.EvictJob(jctx)
+				require.NoError(t, err)
+				_, err = sctx.AddJobSchedulingContext(jctx)
+				require.NoError(t, err)
+			},
+			expectedScheduled: false,
+		},
+		"optimiser-preempted this round": {
+			isExistingJob: true,
+			setup: func(t *testing.T, sctx *SchedulingContext, jctx *JobSchedulingContext) {
+				_, err := sctx.PreemptJob(jctx)
+				require.NoError(t, err)
+			},
+			expectedScheduled: false,
+		},
+		"evicted this round": {
+			isExistingJob: true,
+			setup: func(t *testing.T, sctx *SchedulingContext, jctx *JobSchedulingContext) {
+				_, err := sctx.EvictJob(jctx)
+				require.NoError(t, err)
+			},
+			expectedScheduled: false,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			jctx := testSmallCpuJobSchedulingContext("A", testfixtures.TestDefaultPriorityClass)
+			sctx := createSchedulingContext(t, jctx, tc.isExistingJob)
+			tc.setup(t, sctx, jctx)
+
+			scheduledInRound, err := sctx.RemoveJob(jctx)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expectedScheduled, scheduledInRound)
+			assert.Equal(t, 0, sctx.NumScheduledJobs)
+			assert.True(t, sctx.ScheduledResources.AllZero())
+			assert.Equal(t, 0, sctx.NumEvictedJobs)
+			assert.True(t, sctx.EvictedResources.AllZero())
+			assert.True(t, sctx.Allocated.AllZero())
+		})
+	}
+}
+
+func TestSchedulingContext_RemoveJob_ErrorsIfQueueContextMissing(t *testing.T) {
+	jctx := testSmallCpuJobSchedulingContext("A", testfixtures.TestDefaultPriorityClass)
+	sctx := createSchedulingContext(t, jctx, false)
+	missingQueueJctx := testSmallCpuJobSchedulingContext("unknown", testfixtures.TestDefaultPriorityClass)
+
+	_, err := sctx.RemoveJob(missingQueueJctx)
+	assert.Error(t, err)
+}
+
+func createSchedulingContext(t *testing.T, jctx *JobSchedulingContext, isJobExisting bool) *SchedulingContext {
+	totalResources := cpu(100)
+	fairnessCostProvider, err := fairness.NewDominantResourceFairness(
+		totalResources, "pool", configuration.SchedulingConfig{DominantResourceFairnessResourcesToConsider: []string{"cpu"}})
+	require.NoError(t, err)
+	sctx := NewSchedulingContext("pool", fairnessCostProvider, nil, totalResources)
+
+	var initialAllocation map[string]internaltypes.ResourceList
+	demand := jctx.Job.AllResourceRequirements()
+	if isJobExisting {
+		rl := jctx.Job.AllResourceRequirements()
+		initialAllocation = map[string]internaltypes.ResourceList{jctx.Job.PriorityClassName(): rl}
+	}
+	err = sctx.AddQueueSchedulingContext(jctx.Job.Queue(), 1.0, 1.0, initialAllocation, demand, demand, internaltypes.ResourceList{}, nil)
+	require.NoError(t, err)
+	return sctx
+}
+
 func testNSmallCpuJobSchedulingContext(queue, priorityClassName string, n int) []*JobSchedulingContext {
 	rv := make([]*JobSchedulingContext, n)
 	for i := 0; i < n; i++ {


### PR DESCRIPTION
 - RemoveJob
   - Make the context completely remove all references to this job (including demand)
 - UnscheduleJob
   - Mark a scheduled job as no longer scheduled - but keep other references intact (i.e demand)

 These functions will be used when we move the scheduling loop to be asynchronous to the main loop
  - It'll need to reconcile what it has scheduled/preempted with the current state
  - If it finds the job it scheduled has already been for example cancelled it needs to remove this job from its context
    - It will therefore use these 2 functions to perform this
    - We need Unschedule for when a gang has been scheduled but only some of its jobs are now terminal - meaning we need to unschedule the other jobs but not remove their demand

