### PR TITLE
Remove resourceUnits from SchedulingAlgo.Schedule

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -352,14 +352,14 @@ func (s *Scheduler) cycle(ctx *armadacontext.Context, updateAll bool, leaderToke
 	// Schedule jobs.
 	if shouldSchedule {
 		start := time.Now()
-		resourceUnits, err := s.updateJobPrices(ctx, txn)
+		err := s.updateJobPrices(ctx, txn)
 		if err != nil {
 			return err
 		}
 		ctx.Logger().Infof("updating job prices in %s", time.Now().Sub(start))
 
 		var result *scheduling.SchedulerResult
-		result, err = s.schedulingAlgo.Schedule(ctx, resourceUnits, txn)
+		result, err = s.schedulingAlgo.Schedule(ctx, txn)
 		if err != nil {
 			return err
 		}
@@ -521,16 +521,16 @@ func (s *Scheduler) syncState(ctx *armadacontext.Context, initial, fullJobGc boo
 
 // TODO - This is highly inefficient and will only work if market driven pools are small
 // We should rewrite how bids are stored in an efficient manner
-func (s *Scheduler) updateJobPrices(ctx *armadacontext.Context, txn *jobdb.Txn) (map[string]internaltypes.ResourceList, error) {
+func (s *Scheduler) updateJobPrices(ctx *armadacontext.Context, txn *jobdb.Txn) error {
 	if len(s.marketDrivenPools) == 0 {
-		return nil, nil
+		return nil
 	}
 
 	jobs := txn.GetAll()
 	jobsByQueue := map[string]map[bidstore.PriceBand][]*jobdb.Job{}
 	updatedBids, err := s.bidPriceProvider.GetBidPrices(ctx)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	hasMarketDrivenPool := func(j *jobdb.Job) bool {
@@ -572,13 +572,13 @@ func (s *Scheduler) updateJobPrices(ctx *armadacontext.Context, txn *jobdb.Txn) 
 	ctx.Logger().Infof("updating the prices of %d jobs", len(updatedJobs))
 	err = txn.Upsert(updatedJobs)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	err = txn.SetBidPriceSnapshot(&updatedBids)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	return updatedBids.ResourceUnits, nil
+	return nil
 }
 
 func (s *Scheduler) createSchedulingInfoWithNodeAntiAffinityForAttemptedRuns(job *jobdb.Job) (*internaltypes.JobSchedulingInfo, error) {

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -2147,7 +2147,7 @@ type testSchedulingAlgo struct {
 	persisted bool
 }
 
-func (t *testSchedulingAlgo) Schedule(_ *armadacontext.Context, _ map[string]internaltypes.ResourceList, txn *jobdb.Txn) (*scheduling.SchedulerResult, error) {
+func (t *testSchedulingAlgo) Schedule(_ *armadacontext.Context, txn *jobdb.Txn) (*scheduling.SchedulerResult, error) {
 	t.numberOfScheduleCalls++
 	if t.shouldError {
 		return &scheduling.SchedulerResult{}, errors.New("error scheduling jobs")

--- a/internal/scheduler/scheduling/scheduling_algo.go
+++ b/internal/scheduler/scheduling/scheduling_algo.go
@@ -38,7 +38,7 @@ import (
 type SchedulingAlgo interface {
 	// Schedule should assign jobs to nodes.
 	// Any jobs that are scheduled should be marked as such in the JobDb using the transaction provided.
-	Schedule(*armadacontext.Context, map[string]internaltypes.ResourceList, *jobdb.Txn) (*SchedulerResult, error)
+	Schedule(*armadacontext.Context, *jobdb.Txn) (*SchedulerResult, error)
 }
 
 // FairSchedulingAlgo is a SchedulingAlgo based on PreemptingQueueScheduler.
@@ -108,7 +108,6 @@ func NewFairSchedulingAlgo(
 // and callers depend on this for metrics reporting.
 func (l *FairSchedulingAlgo) Schedule(
 	ctx *armadacontext.Context,
-	resourceUnits map[string]internaltypes.ResourceList,
 	txn *jobdb.Txn,
 ) (*SchedulerResult, error) {
 	var cancel context.CancelFunc
@@ -153,7 +152,7 @@ func (l *FairSchedulingAlgo) Schedule(
 		if reconciliation.Err() != nil {
 			outcome = reconciliation.Outcome()
 		} else {
-			outcome, schedulingResult, err = l.runPoolSchedulingRound(ctx, pool, resourceUnits, txn, executors)
+			outcome, schedulingResult, err = l.runPoolSchedulingRound(ctx, pool, txn, executors)
 			if err != nil {
 				return nil, err
 			}
@@ -204,7 +203,6 @@ func (l *FairSchedulingAlgo) appendSchedulingDisabledResults(ctx *armadacontext.
 func (l *FairSchedulingAlgo) runPoolSchedulingRound(
 	ctx *armadacontext.Context,
 	pool configuration.PoolConfig,
-	resourceUnits map[string]internaltypes.ResourceList,
 	txn *jobdb.Txn,
 	executors []*schedulerobjects.Executor,
 ) (*PoolSchedulingOutcome, *SchedulingResult, error) {
@@ -250,12 +248,7 @@ func (l *FairSchedulingAlgo) runPoolSchedulingRound(
 	fsctx.nodeDb.SetDisallowedJobResources(pool.ExperimentalUnscheduledResources)
 
 	start := time.Now()
-	resourceUnit, ok := resourceUnits[pool.Name]
-	if !ok {
-		ctx.Warnf("Pool %s has no resource unit defined", pool.Name)
-		resourceUnit = l.resourceListFactory.MakeAllZero()
-	}
-	schedulingResult, sctx, err := l.SchedulePool(ctx, fsctx, pool, resourceUnit)
+	schedulingResult, sctx, err := l.SchedulePool(ctx, fsctx, pool)
 	if err != nil {
 		ctx.Infof("Scheduled on pool %s in %v - failed with error %s", pool.Name, time.Now().Sub(start), err)
 		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
@@ -805,7 +798,6 @@ func (l *FairSchedulingAlgo) SchedulePool(
 	ctx *armadacontext.Context,
 	fsctx *FairSchedulingAlgoContext,
 	pool configuration.PoolConfig,
-	resourceUnit internaltypes.ResourceList,
 ) (*SchedulingResult, *schedulercontext.SchedulingContext, error) {
 	totalResources := fsctx.nodeDb.TotalKubernetesResources()
 	totalResources = totalResources.Add(l.floatingResourceTypes.GetTotalAvailableForPool(pool.Name))
@@ -814,6 +806,20 @@ func (l *FairSchedulingAlgo) SchedulePool(
 
 	if shouldRunOptimiser {
 		defer l.updateOptimiserLastRunTime(pool)
+	}
+
+	resourceUnits := l.resourceListFactory.MakeAllZero()
+	if pool.ExperimentalMarketScheduling != nil && pool.ExperimentalMarketScheduling.Enabled {
+		snapshot := fsctx.Txn.GetBidPriceSnapshot()
+		if snapshot != nil {
+			if poolResourceUnits, ok := snapshot.ResourceUnits[pool.Name]; ok {
+				resourceUnits = poolResourceUnits
+			} else {
+				ctx.Warnf("Pool %s has no resource unit defined", pool.Name)
+			}
+		} else {
+			ctx.Warnf("No price snapshot found when processing pool %s", pool.Name)
+		}
 	}
 
 	// Calculate "Idealised value" on every queue.  This is a metric that is useful on market-driven pools in order
@@ -831,7 +837,7 @@ func (l *FairSchedulingAlgo) SchedulePool(
 		l.floatingResourceTypes,
 		l.schedulingConfig,
 		l.resourceListFactory,
-		resourceUnit,
+		resourceUnits,
 	)
 	if idealisedShareErr != nil {
 		log.WithStacktrace(idealisedShareErr).Warnf("failed to calculated idealised share for pool %s - %s", fsctx.pool, idealisedShareErr)
@@ -893,7 +899,7 @@ func (l *FairSchedulingAlgo) SchedulePool(
 	// We only calculate value for market driven pools
 	marketConfig := l.schedulingConfig.GetMarketConfig(pool.Name)
 	if marketConfig != nil && marketConfig.Enabled {
-		realisedValueByQueue := valueFromSchedulingResult(fsctx.schedulingContext, resourceUnit)
+		realisedValueByQueue := valueFromSchedulingResult(fsctx.schedulingContext, resourceUnits)
 		for qName, qCtx := range fsctx.schedulingContext.QueueSchedulingContexts {
 			qCtx.RealisedValue = realisedValueByQueue[qName]
 		}

--- a/internal/scheduler/scheduling/scheduling_algo_test.go
+++ b/internal/scheduler/scheduling/scheduling_algo_test.go
@@ -70,7 +70,7 @@ func TestSchedule_DisableSchedulingSkipsReconciliation(t *testing.T) {
 	txn := jobDb.WriteTxn()
 	require.NoError(t, txn.Upsert([]*jobdb.Job{job}))
 
-	schedulerResult, err := sch.Schedule(ctx, nil, txn)
+	schedulerResult, err := sch.Schedule(ctx, txn)
 	require.NoError(t, err)
 	require.Len(t, schedulerResult.PoolResults, 1)
 	require.Equal(t, PoolSchedulingTerminationReasonSchedulingDisabled, schedulerResult.PoolResults[0].Outcome.TerminationReason())
@@ -213,7 +213,7 @@ func TestSchedule_PoolFailureIsolation(t *testing.T) {
 				require.NoError(t, txn.Upsert([]*jobdb.Job{job}))
 			}
 
-			schedulerResult, err := sch.Schedule(ctx, nil, txn)
+			schedulerResult, err := sch.Schedule(ctx, txn)
 			if tc.expectError {
 				assert.Error(t, err)
 				assert.Nil(t, schedulerResult)
@@ -977,7 +977,7 @@ func TestSchedule(t *testing.T) {
 			require.NoError(t, err)
 
 			// Run a scheduling round.
-			schedulerResult, err := sch.Schedule(ctx, nil, txn)
+			schedulerResult, err := sch.Schedule(ctx, txn)
 			require.NoError(t, err)
 
 			// Check that the expected preemptions took place.


### PR DESCRIPTION
Resource units come from the BidPriceSnapshot.

The latest BidPriceSnapshot is now stored in the jobdb - meaning it already gets passed to SchedulingAlgo.Schedule via *jobdb.Txn

Now we simply get the resource units from the txn passed to Schedule, removing the need to pass a copy separately

