### PR TITLE
Use more efficient jobdb index when expiring jobs

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -1102,8 +1102,7 @@ func (s *Scheduler) expireJobsIfNecessary(ctx *armadacontext.Context, txn *jobdb
 
 	events := make([]*armadaevents.EventSequence, 0)
 
-	// TODO: this is inefficient. We should create a iterator of the jobs running on the affected executors
-	jobs := txn.GetAll()
+	jobs := txn.GetAllLeasedJobs()
 
 	for _, job := range jobs {
 


### PR DESCRIPTION
If an executor stops communicating with the scheduler for long enough it becomes stale, at which point we fail all the jobs on it

However we try to find the jobs on the executor by looking through all jobs - which is inefficient as we may have millions of jobs queued

Using GetAllLeasedJobs is more efficient, as we'll only need to fail current leased jobs
 - Only leased jobs are associated with an executor

