### PR TITLE
ci: split python format/docs/lint into dedicated 3.12 jobs

### DIFF
--- a/.github/workflows/airflow-operator.yml
+++ b/.github/workflows/airflow-operator.yml
@@ -38,6 +38,25 @@ on:
       - 'third_party/airflow/**'
 
 jobs:
+  # Formatting, linting and docs only need to run once. They are pinned to
+  # Python 3.12 here rather than repeated across every version in the
+  # airflow-tox matrix. The operator pulls armada-client from PyPI, so these
+  # checks need no proto build, Go or Docker.
+  airflow-lint:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install 'tox>=4,<5'
+      - name: Check formatting and lint
+        run: tox -e format-check
+        working-directory: third_party/airflow
+      - name: Verify docs updated if needed
+        run: tox -e docs-check
+        working-directory: third_party/airflow
+
   # Verifies the operator against every supported (Airflow, Python) combination.
   # The airflow-tox job below only resolves Airflow to the top of the range (newest 3.x),
   # so without this grid the 2.x serde / get_current_context paths and the 3.2 airflow.sdk

--- a/.github/workflows/python-client.yml
+++ b/.github/workflows/python-client.yml
@@ -34,6 +34,40 @@ on:
       - './magefiles/python.go'
 
 jobs:
+  # Formatting, linting and docs only need to run once. They are pinned to
+  # Python 3.12 here rather than repeated across every version in the
+  # python-client-tox matrix.
+  python-client-lint:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install 'tox>=4,<5'
+      - name: Setup Docker
+        uses: docker/setup-docker-action@1a6edb0ba9ac496f6850236981f15d8f9a82254d # v5
+        with:
+          daemon-config: '{"features":{"containerd-snapshotter":false}}'
+      - name: Setup Go
+        uses: ./.github/actions/setup-go-cache
+        with:
+          cache-prefix: python-client-lint
+      - name: Install Protoc
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
+        with:
+          version: '23.3'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      # The armada_client package is the generated proto code, so docs autodoc
+      # needs it built before it can import the package.
+      - run: go run github.com/magefile/mage@v1.15.0 -v buildPython
+      - name: Check formatting and lint
+        run: tox -e format
+        working-directory: client/python
+      - name: Verify docs updated if needed
+        run: tox -e docs-check
+        working-directory: client/python
+
   python-client-tox:
     runs-on: ubuntu-22.04
     strategy:

--- a/.github/workflows/python-tests/action.yml
+++ b/.github/workflows/python-tests/action.yml
@@ -1,5 +1,5 @@
-name: "Python tox tests and linting"
-description: "Sets up go environment and runs python tests in tox"
+name: "Python tox tests"
+description: "Sets up go environment and runs python unit tests in tox"
 
 inputs:
   path:
@@ -31,14 +31,9 @@ runs:
     # Generate the proto files for python, required for later steps
     - run: go run github.com/magefile/mage@v1.15.0 -v buildPython
       shell: bash
-    - name: Run tox format environment
-      run: tox -e format
-      shell: bash
-      working-directory: ${{ inputs.path }}
-    - name: Verify docs updated if needed
-      run: tox -e docs-check
-      shell: bash
-      working-directory: ${{ inputs.path }}
+    # Formatting, linting and docs are checked once on Python 3.12 by the
+    # dedicated *-lint jobs, not per matrix version. This action only runs the
+    # version-specific unit tests and wheel build.
     - name: Run tox python ${{ inputs.python-version }} unit tests
       run: tox -e ${{ inputs.tox-env }}
       shell: bash


### PR DESCRIPTION
## Why

The shared `python-tests` composite action ran `tox -e format` and `tox -e docs-check` for **every** matrix Python version (3.10 / 3.12 / 3.14), even though `docs-check` is internally pinned to `python3.12`. The result: the same format and docs checks ran three times per package (client and airflow), wasting CI minutes with no added coverage.

## What

Split formatting, linting and docs into dedicated lint jobs that run **once on Python 3.12**, alongside the existing matrix/integration jobs (each is its own CI check):

- **`python-client-lint`** — `tox -e format` + `tox -e docs-check`. Keeps the proto build (`mage buildPython` + Go/Docker/protoc) because the `armada_client` package *is* generated proto code that docs autodoc imports.
- **`airflow-lint`** — `tox -e format-check` + `tox -e docs-check`. Lightweight: the operator pulls `armada-client` from PyPI, so no proto build, Go or Docker is needed.

The shared composite action (`python-tests/action.yml`) now only runs the version-specific unit tests and wheel build.

### Note: airflow now enforces formatting

The composite action previously called `tox -e format` for airflow, whose `format` env runs `black` in **reformat** mode (no `--check`), so formatting was never actually enforced in CI. The new `airflow-lint` job uses `format-check` (`black --check`), so airflow formatting is now enforced. Verified the current airflow tree is already black-clean, so this does not break the build.

## Verification

- `tox -e format-check` and `tox -e docs-check` for airflow run standalone (verified locally via `uvx tox`).
- All three workflow YAML files parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)