### PR TITLE
Fix preempted job metrics

### DIFF
--- a/internal/scheduler/metrics/cycle_metrics.go
+++ b/internal/scheduler/metrics/cycle_metrics.go
@@ -702,11 +702,16 @@ func (m *cycleMetrics) ReportSchedulerResult(ctx *armadacontext.Context, result 
 			}
 
 			for _, jobCtx := range schedulingResult.PreemptedJobs {
+				if jobCtx.Job == nil && jobCtx.Job.LatestRun() == nil {
+					log.Errorf("could not report preempted job metrics for job %s as it was missing run information", jobCtx.JobId)
+					continue
+				}
 				preemptionType := defaultType
 				if jobCtx.PreemptionType != "" {
 					preemptionType = string(jobCtx.PreemptionType)
 				}
-				m.preemptedJobs.WithLabelValues(pool, jobCtx.Job.Queue(), jobCtx.Job.PriorityClassName(), preemptionType).Inc()
+				runPool := jobCtx.Job.LatestRun().Pool()
+				m.preemptedJobs.WithLabelValues(runPool, jobCtx.Job.Queue(), jobCtx.Job.PriorityClassName(), preemptionType).Inc()
 			}
 		}
 	}

--- a/internal/scheduler/metrics/cycle_metrics.go
+++ b/internal/scheduler/metrics/cycle_metrics.go
@@ -702,7 +702,7 @@ func (m *cycleMetrics) ReportSchedulerResult(ctx *armadacontext.Context, result 
 			}
 
 			for _, jobCtx := range schedulingResult.PreemptedJobs {
-				if jobCtx.Job == nil && jobCtx.Job.LatestRun() == nil {
+				if jobCtx.Job == nil || jobCtx.Job.LatestRun() == nil {
 					log.Errorf("could not report preempted job metrics for job %s as it was missing run information", jobCtx.JobId)
 					continue
 				}


### PR DESCRIPTION
Jobs scheduled "away" cross-pool were incorrectly being reported preempted against the pool they were scheduled away on
 - This was confusing as pool here is supposed to refer to which pool had the preemption rather than did the preemption

Now correctly set pool to be the pool of the job that was preempted rather than the pool that did the preemption

