### PR TITLE
Fix a bug in async runner causing job state to get corrupted

### DIFF
--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1308,23 +1308,36 @@ func TestScheduler_NonLeaderAdvancesCursors(t *testing.T) {
 
 func TestScheduler_AsyncRunner(t *testing.T) {
 	tests := map[string]struct {
-		initialJob    *jobdb.Job
-		jobToSchedule string
-		scheduleErr   error
+		initialJob             *jobdb.Job
+		jobToSchedule          string
+		shouldUpdateInitialJob bool
+		scheduleErr            error
 	}{
 		"schedules a job": {
 			initialJob:    queuedJob,
 			jobToSchedule: queuedJob.Id(),
+		},
+		"schedules a job - job updated during scheduling": {
+			initialJob:             queuedJob,
+			jobToSchedule:          queuedJob.Id(),
+			shouldUpdateInitialJob: true,
 		},
 		"handles error": {
 			initialJob:    queuedJob,
 			jobToSchedule: queuedJob.Id(),
 			scheduleErr:   errors.New("scheduling error"),
 		},
+		"handles error - job updated during scheduling": {
+			initialJob:             queuedJob,
+			jobToSchedule:          queuedJob.Id(),
+			shouldUpdateInitialJob: true,
+			scheduleErr:            errors.New("scheduling error"),
+		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			updatedPriority := queuedJob.Priority() + 100
 			jobRepo := &testJobRepository{}
 			testClock := clock.NewFakeClock(time.Now())
 			clusterRepo := &testExecutorRepository{
@@ -1385,9 +1398,22 @@ func TestScheduler_AsyncRunner(t *testing.T) {
 				return asyncRunner.GetCurrentState() == runner.ResultReady
 			}, 2*time.Second, 5*time.Millisecond, "expected the async runner to have result")
 
+			// Update the job before we merge in the async result,
+			//  so we can validate these updates are still present after the async state merging
+			if tc.shouldUpdateInitialJob {
+				updateTxn := sched.jobDb.WriteTxn()
+				require.NoError(t, updateTxn.Upsert([]*jobdb.Job{updateTxn.GetById(queuedJob.Id()).WithPriority(updatedPriority)}))
+				updateTxn.Commit()
+			}
+
 			// Second cycle: consumes the pending result
 			schedulingAttempted, err = sched.cycle(ctx, false, sched.leaderController.GetToken(), true, 2)
 			assert.True(t, schedulingAttempted)
+
+			if tc.shouldUpdateInitialJob {
+				updatedJob := jobDb.ReadTxn().GetById(queuedJob.Id())
+				assert.Equal(t, updatedPriority, updatedJob.Priority())
+			}
 
 			if tc.scheduleErr != nil {
 				assert.Error(t, err)

--- a/internal/scheduler/scheduling/runner/async.go
+++ b/internal/scheduler/scheduling/runner/async.go
@@ -484,11 +484,15 @@ func markJobScheduled(currentJob *jobdb.Job, jctx *schedulercontext.JobSchedulin
 	if newRun == nil {
 		return nil, errors.Errorf("scheduled job %s has no associated run", jctx.JobId)
 	}
+	scheduledAtPriority := newRun.ScheduledAtPriority()
+	if scheduledAtPriority == nil {
+		return nil, errors.Errorf("scheduled job %s run has no associated scheduled priority", jctx.JobId)
+	}
 
 	currentJob = currentJob.
 		WithQueuedVersion(currentJob.QueuedVersion()+1).
 		WithQueued(false).
-		WithNewRun(newRun.Executor(), newRun.NodeId(), newRun.NodeName(), newRun.Pool(), *newRun.ScheduledAtPriority())
+		WithNewRun(newRun.Executor(), newRun.NodeId(), newRun.NodeName(), newRun.Pool(), *scheduledAtPriority)
 	return currentJob, nil
 }
 

--- a/internal/scheduler/scheduling/runner/async.go
+++ b/internal/scheduler/scheduling/runner/async.go
@@ -3,7 +3,9 @@ package runner
 import (
 	"context"
 	"sync"
+	"time"
 
+	"github.com/pkg/errors"
 	"k8s.io/utils/clock"
 
 	"github.com/armadaproject/armada/internal/common/armadacontext"
@@ -312,7 +314,10 @@ func (r *AsyncSchedulingRunner) reconcile(ctx *armadacontext.Context, txn *jobdb
 		}
 
 		if poolResult.ReconciliationResult != nil {
-			r.updateReconciliationResult(ctx, txn, poolResult)
+			err := r.updateReconciliationResult(ctx, txn, poolResult)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -329,6 +334,11 @@ func (r *AsyncSchedulingRunner) updateScheduledJobs(ctx *armadacontext.Context, 
 	for _, scheduledJob := range nonGangJobs {
 		currentJob := txn.GetById(scheduledJob.JobId)
 		if isQueuedJobActionable(currentJob) {
+			updatedCurrentJob, err := markJobScheduled(currentJob, scheduledJob)
+			if err != nil {
+				return err
+			}
+			scheduledJob.Job = updatedCurrentJob
 			scheduledJobs = append(scheduledJobs, scheduledJob)
 		} else {
 			_, err := poolResult.SchedulingResult.SchedulingContext.RemoveJob(scheduledJob)
@@ -342,6 +352,7 @@ func (r *AsyncSchedulingRunner) updateScheduledJobs(ctx *armadacontext.Context, 
 	// We must unschedule the whole gang if any are not actionable
 	type gangJobInfo struct {
 		scheduledJctx *schedulercontext.JobSchedulingContext
+		currentJob    *jobdb.Job
 		isActionable  bool
 	}
 
@@ -352,7 +363,7 @@ func (r *AsyncSchedulingRunner) updateScheduledJobs(ctx *armadacontext.Context, 
 		if _, exists := gangs[key]; !exists {
 			gangs[key] = make([]*gangJobInfo, 0, scheduledJob.Job.GetGangInfo().Cardinality())
 		}
-		gangs[key] = append(gangs[key], &gangJobInfo{scheduledJctx: scheduledJob, isActionable: isQueuedJobActionable(currentJob)})
+		gangs[key] = append(gangs[key], &gangJobInfo{scheduledJctx: scheduledJob, currentJob: currentJob, isActionable: isQueuedJobActionable(currentJob)})
 	}
 
 	for key, gang := range gangs {
@@ -368,6 +379,11 @@ func (r *AsyncSchedulingRunner) updateScheduledJobs(ctx *armadacontext.Context, 
 		allActionable := slices.AllFunc(gang, func(jobInfo *gangJobInfo) bool { return jobInfo.isActionable })
 		if allActionable {
 			for _, jobInfo := range gang {
+				updatedCurrentJob, err := markJobScheduled(jobInfo.currentJob, jobInfo.scheduledJctx)
+				if err != nil {
+					return err
+				}
+				jobInfo.scheduledJctx.Job = updatedCurrentJob
 				scheduledJobs = append(scheduledJobs, jobInfo.scheduledJctx)
 			}
 		} else {
@@ -400,6 +416,11 @@ func (r *AsyncSchedulingRunner) updatePreemptedJobs(ctx *armadacontext.Context, 
 	for _, preemptedJob := range poolResult.SchedulingResult.PreemptedJobs {
 		currentJob := txn.GetById(preemptedJob.JobId)
 		if isJobActionable(currentJob) {
+			updatedCurrentJob, err := markJobPreempted(currentJob, r.clock.Now())
+			if err != nil {
+				return err
+			}
+			preemptedJob.Job = updatedCurrentJob
 			preemptedJobs = append(preemptedJobs, preemptedJob)
 		} else {
 			_, err := poolResult.SchedulingResult.SchedulingContext.RemoveJob(preemptedJob)
@@ -415,11 +436,16 @@ func (r *AsyncSchedulingRunner) updatePreemptedJobs(ctx *armadacontext.Context, 
 	return nil
 }
 
-func (r *AsyncSchedulingRunner) updateReconciliationResult(ctx *armadacontext.Context, txn *jobdb.Txn, poolResult *scheduling.PoolSchedulingResult) {
+func (r *AsyncSchedulingRunner) updateReconciliationResult(ctx *armadacontext.Context, txn *jobdb.Txn, poolResult *scheduling.PoolSchedulingResult) error {
 	preemptedJobs := make([]*scheduling.FailedReconciliationResult, 0, len(poolResult.ReconciliationResult.PreemptedJobs))
 	for _, preemptedJob := range poolResult.ReconciliationResult.PreemptedJobs {
 		currentJob := txn.GetById(preemptedJob.Job.Id())
 		if isJobActionable(currentJob) {
+			updatedJob, err := markJobFailedReconciliation(currentJob, r.clock.Now())
+			if err != nil {
+				return err
+			}
+			preemptedJob.Job = updatedJob
 			preemptedJobs = append(preemptedJobs, preemptedJob)
 		}
 	}
@@ -431,12 +457,18 @@ func (r *AsyncSchedulingRunner) updateReconciliationResult(ctx *armadacontext.Co
 	for _, failedJob := range poolResult.ReconciliationResult.FailedJobs {
 		currentJob := txn.GetById(failedJob.Job.Id())
 		if isJobActionable(currentJob) {
+			updatedJob, err := markJobFailedReconciliation(currentJob, r.clock.Now())
+			if err != nil {
+				return err
+			}
+			failedJob.Job = updatedJob
 			failedJobs = append(failedJobs, failedJob)
 		}
 	}
 	ctx.Infof("scheduler result reconciler removed %d jobs that would have been failed by reconciler on pool %s",
 		len(poolResult.ReconciliationResult.FailedJobs)-len(failedJobs), poolResult.Name)
 	poolResult.ReconciliationResult.FailedJobs = failedJobs
+	return nil
 }
 
 func isQueuedJobActionable(job *jobdb.Job) bool {
@@ -445,6 +477,43 @@ func isQueuedJobActionable(job *jobdb.Job) bool {
 
 func isJobActionable(job *jobdb.Job) bool {
 	return job != nil && !job.InTerminalState()
+}
+
+func markJobScheduled(currentJob *jobdb.Job, jctx *schedulercontext.JobSchedulingContext) (*jobdb.Job, error) {
+	newRun := jctx.Job.LatestRun()
+	if newRun == nil {
+		return nil, errors.Errorf("scheduled job %s has no associated run", jctx.JobId)
+	}
+
+	currentJob = currentJob.
+		WithQueuedVersion(currentJob.QueuedVersion()+1).
+		WithQueued(false).
+		WithNewRun(newRun.Executor(), newRun.NodeId(), newRun.NodeName(), newRun.Pool(), *newRun.ScheduledAtPriority())
+	return currentJob, nil
+}
+
+func markJobPreempted(currentJob *jobdb.Job, now time.Time) (*jobdb.Job, error) {
+	currentRun := currentJob.LatestRun()
+	if currentRun == nil {
+		return nil, errors.Errorf("attempting to preempt job %s with no associated runs", currentJob.Id())
+	}
+	currentRun = currentRun.WithFailed(true).WithPreemptedTime(&now)
+	currentJob = currentJob.WithUpdatedRun(currentRun).WithQueued(false).WithFailed(true)
+	return currentJob, nil
+}
+
+func markJobFailedReconciliation(currentJob *jobdb.Job, now time.Time) (*jobdb.Job, error) {
+	currentRun := currentJob.LatestRun()
+	if currentRun == nil {
+		return nil, errors.Errorf("attempting to fail reconciliation for job %s with no associated runs", currentJob.Id())
+	}
+
+	if currentJob.PriorityClass().Preemptible {
+		currentRun = currentRun.WithPreemptedTime(&now)
+	}
+	currentJob = currentJob.WithQueued(false).WithFailed(true)
+	currentJob = currentJob.WithUpdatedRun(currentRun.WithFailed(true))
+	return currentJob, nil
 }
 
 type gangKey struct {

--- a/internal/scheduler/scheduling/runner/async_test.go
+++ b/internal/scheduler/scheduling/runner/async_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/armadaproject/armada/internal/common/armadacontext"
 	"github.com/armadaproject/armada/internal/scheduler/internaltypes"
 	"github.com/armadaproject/armada/internal/scheduler/jobdb"
+	"github.com/armadaproject/armada/internal/scheduler/pricing"
 	"github.com/armadaproject/armada/internal/scheduler/scheduling"
 	schedulercontext "github.com/armadaproject/armada/internal/scheduler/scheduling/context"
 	"github.com/armadaproject/armada/internal/scheduler/scheduling/fairness"
@@ -410,6 +411,124 @@ func TestGetSchedulerResult_Reconciliation_ReconciliationResult(t *testing.T) {
 	}
 }
 
+const updatedBid = 42.5
+const updatedPriority = uint32(1150)
+
+func setKnownJobUpdates(job *jobdb.Job) *jobdb.Job {
+	return job.
+		WithPriority(updatedPriority).
+		WithBidPrices(map[string]pricing.Bid{
+			reconcileTestPool: {RunningBid: updatedBid, QueuedBid: updatedBid},
+		})
+}
+
+func assertJobHasKnownUpdates(t *testing.T, job *jobdb.Job) {
+	bidPrices := job.GetAllBidPrices()
+	require.Equal(t, updatedBid, bidPrices[reconcileTestPool].RunningBid)
+	require.Equal(t, updatedBid, bidPrices[reconcileTestPool].QueuedBid)
+	require.Equal(t, updatedPriority, job.Priority())
+}
+
+func TestReconcile_ScheduledJob_PreservesCurrentJobUpdates(t *testing.T) {
+	scheduledJob := testfixtures.Test1Cpu4GiJob(testfixtures.TestQueue, testfixtures.TestDefaultPriorityClass).WithQueued(true)
+	poolResult := scheduledPoolResult(t, []*jobdb.Job{scheduledJob})
+	originalResultJob := poolResult.SchedulingResult.ScheduledJobs[0].Job
+
+	// The current version of the job is still queued but has newer data.
+	currentJob := setKnownJobUpdates(scheduledJob)
+	txn := txnWithJobs(currentJob)
+
+	result := getSchedulerResultFromAsyncRunner(t, poolResult, txn)
+
+	require.Len(t, result.PoolResults, 1)
+	require.Len(t, result.PoolResults[0].SchedulingResult.ScheduledJobs, 1)
+	resultScheduledJob := result.PoolResults[0].SchedulingResult.ScheduledJobs[0].Job
+
+	// Current-version updates are preserved.
+	assertJobHasKnownUpdates(t, resultScheduledJob)
+
+	// Scheduling decision is applied.
+	assert.False(t, resultScheduledJob.Queued(), "scheduled job should be dequeued")
+	assert.Equal(t, scheduledJob.QueuedVersion()+1, resultScheduledJob.QueuedVersion(), "queued version should be bumped")
+	require.NotNil(t, resultScheduledJob.LatestRun())
+	assert.Equal(t, resultScheduledJob.LatestRun().Executor(), originalResultJob.LatestRun().Executor())
+	assert.Equal(t, resultScheduledJob.LatestRun().NodeId(), originalResultJob.LatestRun().NodeId())
+	assert.Equal(t, resultScheduledJob.LatestRun().NodeName(), originalResultJob.LatestRun().NodeName())
+	assert.Equal(t, resultScheduledJob.LatestRun().ScheduledAtPriority(), originalResultJob.LatestRun().ScheduledAtPriority())
+}
+
+func TestReconcile_PreemptedJob_PreservesCurrentJobUpdates(t *testing.T) {
+	preemptedJob := testfixtures.Test1Cpu4GiJob(testfixtures.TestQueue, testfixtures.TestDefaultPriorityClass).
+		WithQueued(false).WithNewRun("executor", "node", "node", reconcileTestPool, 0)
+	jctx := schedulercontext.JobSchedulingContextFromJob(preemptedJob)
+	poolResult := &scheduling.PoolSchedulingResult{
+		SchedulingResult: &scheduling.SchedulingResult{
+			PreemptedJobs:     []*schedulercontext.JobSchedulingContext{jctx},
+			SchedulingContext: createSctx(t, nil, []*jobdb.Job{preemptedJob}),
+			AdditionalSchedulingInfo: &scheduling.SchedulingInformation{
+				EvictorResult: &scheduling.EvictorResult{
+					EvictedJctxsByJobId: map[string]*schedulercontext.JobSchedulingContext{preemptedJob.Id(): jctx},
+				},
+			},
+		},
+	}
+
+	// The current version of the job is still leased but has newer data.
+	currentJob := setKnownJobUpdates(preemptedJob)
+	txn := txnWithJobs(currentJob)
+
+	result := getSchedulerResultFromAsyncRunner(t, poolResult, txn)
+
+	require.Len(t, result.PoolResults, 1)
+	require.Len(t, result.PoolResults[0].SchedulingResult.PreemptedJobs, 1)
+	resultPreemptedJob := result.PoolResults[0].SchedulingResult.PreemptedJobs[0].Job
+
+	// Current-version updates are preserved.
+	assertJobHasKnownUpdates(t, resultPreemptedJob)
+
+	// Preemption decision is applied.
+	assert.True(t, resultPreemptedJob.Failed())
+	require.NotNil(t, resultPreemptedJob.LatestRun())
+	assert.True(t, resultPreemptedJob.LatestRun().Failed())
+	assert.NotNil(t, resultPreemptedJob.LatestRun().PreemptedTime())
+}
+
+func TestReconcile_ReconciliationJob_PreservesCurrentJobUpdates(t *testing.T) {
+	failedJob := testfixtures.Test1Cpu4GiJob(testfixtures.TestQueue, testfixtures.TestDefaultPriorityClass).
+		WithQueued(false).WithNewRun("executor", "node", "node", reconcileTestPool, 0)
+	preemptedJob := testfixtures.Test1Cpu4GiJob(testfixtures.TestQueue, testfixtures.PriorityClass6Preemptible).
+		WithQueued(false).WithNewRun("executor", "node", "node", reconcileTestPool, 0)
+	poolResult := &scheduling.PoolSchedulingResult{
+		ReconciliationResult: &scheduling.ReconciliationResult{
+			FailedJobs:    []*scheduling.FailedReconciliationResult{{Job: failedJob, Reason: "failed"}},
+			PreemptedJobs: []*scheduling.FailedReconciliationResult{{Job: preemptedJob, Reason: "preempted"}},
+		},
+	}
+
+	currentFailed := setKnownJobUpdates(failedJob)
+	currentPreempted := setKnownJobUpdates(preemptedJob)
+	txn := txnWithJobs(currentFailed, currentPreempted)
+
+	result := getSchedulerResultFromAsyncRunner(t, poolResult, txn)
+
+	require.Len(t, result.PoolResults, 1)
+	require.Len(t, result.PoolResults[0].ReconciliationResult.FailedJobs, 1)
+	require.Len(t, result.PoolResults[0].ReconciliationResult.PreemptedJobs, 1)
+
+	for _, returnedJob := range []*jobdb.Job{
+		result.PoolResults[0].ReconciliationResult.FailedJobs[0].Job,
+		result.PoolResults[0].ReconciliationResult.PreemptedJobs[0].Job,
+	} {
+		assertJobHasKnownUpdates(t, returnedJob)
+		assert.True(t, returnedJob.Failed())
+		require.NotNil(t, returnedJob.LatestRun())
+		assert.True(t, returnedJob.LatestRun().Failed())
+		if returnedJob.Id() == preemptedJob.Id() {
+			assert.NotNil(t, returnedJob.LatestRun().PreemptedTime())
+		}
+	}
+}
+
 func TestReconcile_PoolWithNilSchedulingResult(t *testing.T) {
 	failedJob := testfixtures.Test1Cpu4GiJob(testfixtures.TestQueue, testfixtures.TestDefaultPriorityClass)
 	algoResult := &scheduling.PoolSchedulingResult{
@@ -511,15 +630,30 @@ func createSctx(t *testing.T, scheduledJobs []*jobdb.Job, preemptedJobs []*jobdb
 }
 
 // scheduledPoolResult builds a PoolSchedulingResult with the given jobs marked
-// as scheduled, backed by a fresh SchedulingContext containing them.
+// as scheduled, backed by a fresh SchedulingContext containing them. The jobs in
+// the result carry a new run and are dequeued, mirroring how scheduling_algo
+// mutates jobs it schedules.
 func scheduledPoolResult(t *testing.T, scheduledJobs []*jobdb.Job) *scheduling.PoolSchedulingResult {
 	t.Helper()
+	resultJobs := make([]*jobdb.Job, len(scheduledJobs))
+	for i, job := range scheduledJobs {
+		resultJobs[i] = asScheduled(job)
+	}
 	return &scheduling.PoolSchedulingResult{
 		SchedulingResult: &scheduling.SchedulingResult{
-			ScheduledJobs:     jctxsFor(scheduledJobs...),
+			ScheduledJobs:     jctxsFor(resultJobs...),
 			SchedulingContext: createSctx(t, scheduledJobs, nil),
 		},
 	}
+}
+
+// asScheduled returns a copy of job as it would look after being scheduled:
+// dequeued, queued-version bumped, with a new run attached.
+func asScheduled(job *jobdb.Job) *jobdb.Job {
+	return job.
+		WithQueuedVersion(job.QueuedVersion()+1).
+		WithQueued(false).
+		WithNewRun("executor", "nodeId", "node", reconcileTestPool, 0)
 }
 
 // txnWithJobs returns a jobDb txn containing the given jobs.

--- a/internal/scheduler/scheduling/runner/async_test.go
+++ b/internal/scheduler/scheduling/runner/async_test.go
@@ -411,8 +411,10 @@ func TestGetSchedulerResult_Reconciliation_ReconciliationResult(t *testing.T) {
 	}
 }
 
-const updatedBid = 42.5
-const updatedPriority = uint32(1150)
+const (
+	updatedBid      = 42.5
+	updatedPriority = uint32(1150)
+)
 
 func setKnownJobUpdates(job *jobdb.Job) *jobdb.Job {
 	return job.


### PR DESCRIPTION
When we consume the async runners result, we combine the current state with the result of the async runner.

The issue is we'd upsert job state in the async runner to mark them scheduled/preempted
 - However these versions of the jobs could be out of date meaning they'd drop state changes that had happened on the main thread(priority/job prices etc)

Now instead the async runner:
 - Gets the jobs current state
 - Updates it with the relevant changes (mark it as preempted/scheduled etc)
 - Upsert that into the jobdb

This ensures that we only add changes on top of the current state, rather than inadvertently removing state changes that happened between async scheduling_algo starting and us reconciling the result back into the current state

In future we will:
 - Make both runners simply return the state changes they want to happen
 - Have scheduler.go apply these state changes to the current state

This has 2 advantages:
 - It avoids bugs like these
 - It means the only code changing current state is scheduler.go, keeping the model simpler to reason about
