### PR TITLE
Categorize internal failures with a static failure category

### DIFF
--- a/internal/common/errormatch/types.go
+++ b/internal/common/errormatch/types.go
@@ -44,3 +44,20 @@ var KnownConditions = map[string]bool{
 	ConditionEvicted:          true,
 	ConditionDeadlineExceeded: true,
 }
+
+// CategoryInternal is the failure category for Armada-generated failures.
+// It is hard-coded at the Error-construction site,
+// not assigned by the operator categorizer.
+const CategoryInternal = "internal"
+
+const (
+	SubcategoryJobCreationFailed = "job-creation-failed" // executor failed to build the runnable job from the lease
+	SubcategoryPodMissing        = "pod-missing"         // reconciliation: pod vanished from Kubernetes for an active run
+	SubcategoryLeaseExpired      = "lease-expired"       // run cancelled because its executor went stale or was lost
+	SubcategoryMaxRunsExceeded   = "max-runs-exceeded"   // job exhausted its run attempts
+	SubcategoryJobRejected       = "job-rejected"        // submitcheck or validation rejected the job
+	SubcategoryStuckTerminating  = "stuck-terminating"   // node issue: the pod will not terminate
+	SubcategoryExternallyDeleted = "externally-deleted"  // pod deleted by something other than Armada
+	SubcategoryIssueHandlerError = "issue-handler-error" // pod unexpectedly changed state mid issue-handling
+	SubcategoryActiveDeadline    = "active-deadline"     // pod exceeded its user-set activeDeadlineSeconds
+)

--- a/internal/executor/reporter/event.go
+++ b/internal/executor/reporter/event.go
@@ -209,10 +209,9 @@ func CreateSimpleJobPreemptedEvent(pod *v1.Pod) (*armadaevents.EventSequence, er
 	return sequence, nil
 }
 
-// CreateSimpleJobFailedEvent creates a failed event with no container details and no classification.
-// Use for failures where pod container statuses are unavailable (preemption, submit failures).
-// failure_category/failure_subcategory are left empty, resulting in NULL in the DB.
-// This is intentional: these failures are not classifiable pod errors.
+// CreateSimpleJobFailedEvent creates a failed event with no container details
+// or failure category, for failures where pod container statuses are unavailable
+// (preemption, submit failures).
 func CreateSimpleJobFailedEvent(pod *v1.Pod, reason string, clusterId string, cause armadaevents.KubernetesReason) (*armadaevents.EventSequence, error) {
 	return CreateJobFailedEvent(pod, reason, cause, "", []*armadaevents.ContainerError{}, clusterId, "", "")
 }
@@ -261,7 +260,7 @@ func CreateJobFailedEvent(pod *v1.Pod, reason string, cause armadaevents.Kuberne
 	return sequence, nil
 }
 
-func CreateMinimalJobFailedEvent(jobId string, runId string, jobSet string, queue string, clusterId string, message string) (*armadaevents.EventSequence, error) {
+func CreateMinimalJobFailedEvent(jobId string, runId string, jobSet string, queue string, clusterId string, message string, failureCategory string, failureSubcategory string) (*armadaevents.EventSequence, error) {
 	sequence := &armadaevents.EventSequence{}
 	sequence.Queue = queue
 	sequence.JobSetName = jobSet
@@ -274,7 +273,9 @@ func CreateMinimalJobFailedEvent(jobId string, runId string, jobSet string, queu
 				JobId: jobId,
 				Errors: []*armadaevents.Error{
 					{
-						Terminal: true,
+						Terminal:           true,
+						FailureCategory:    failureCategory,
+						FailureSubcategory: failureSubcategory,
 						Reason: &armadaevents.Error_PodError{
 							PodError: &armadaevents.PodError{
 								ObjectMeta: &armadaevents.ObjectMeta{

--- a/internal/executor/service/job_requester.go
+++ b/internal/executor/service/job_requester.go
@@ -7,6 +7,7 @@ import (
 	"golang.org/x/exp/maps"
 
 	"github.com/armadaproject/armada/internal/common/armadacontext"
+	"github.com/armadaproject/armada/internal/common/errormatch"
 	log "github.com/armadaproject/armada/internal/common/logging"
 	"github.com/armadaproject/armada/internal/common/slices"
 	"github.com/armadaproject/armada/internal/executor/configuration"
@@ -187,6 +188,8 @@ func (r *JobRequester) sendFailedEvent(details *failedJobCreationDetails) error 
 		details.JobRunMeta.Queue,
 		r.clusterId.GetClusterId(),
 		details.Error.Error(),
+		errormatch.CategoryInternal,
+		errormatch.SubcategoryJobCreationFailed,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create job failed events because %s", err)

--- a/internal/executor/service/job_requester_test.go
+++ b/internal/executor/service/job_requester_test.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/armadaproject/armada/internal/common/armadacontext"
+	"github.com/armadaproject/armada/internal/common/errormatch"
 	armadaresource "github.com/armadaproject/armada/internal/common/resource"
 	"github.com/armadaproject/armada/internal/common/util"
 	"github.com/armadaproject/armada/internal/executor/configuration"
@@ -225,6 +226,8 @@ func TestRequestJobsRuns_HandlesPartiallyInvalidLeasedJobs(t *testing.T) {
 	assert.Len(t, failedEvent.JobRunErrors.Errors, 1)
 	assert.NotNil(t, failedEvent.JobRunErrors.Errors[0].GetPodError())
 	assert.Equal(t, failedEvent.JobRunErrors.JobId, jobId)
+	assert.Equal(t, errormatch.CategoryInternal, failedEvent.JobRunErrors.Errors[0].GetFailureCategory())
+	assert.Equal(t, errormatch.SubcategoryJobCreationFailed, failedEvent.JobRunErrors.Errors[0].GetFailureSubcategory())
 
 	allJobRuns := stateStore.GetAll()
 	assert.Len(t, allJobRuns, 1)

--- a/internal/executor/service/pod_issue_handler.go
+++ b/internal/executor/service/pod_issue_handler.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/utils/clock"
 
 	"github.com/armadaproject/armada/internal/common/armadacontext"
+	"github.com/armadaproject/armada/internal/common/errormatch"
 	log "github.com/armadaproject/armada/internal/common/logging"
 	"github.com/armadaproject/armada/internal/executor/categorizer"
 	"github.com/armadaproject/armada/internal/executor/configuration"
@@ -418,11 +419,17 @@ func (p *PodIssueHandler) handleNonRetryableJobIssue(issue *issue) {
 	if !issue.RunIssue.Reported {
 		log.Infof("Handling non-retryable issue detected for job %s run %s", issue.RunIssue.JobId, issue.RunIssue.RunId)
 		podIssue := issue.RunIssue.PodIssue
-
-		result := p.classifier.ClassifyPodError(podIssue.OriginalPodState, podIssue.Message)
 		clusterId := p.clusterContext.GetClusterId()
 
-		message := result.AppendHint(podIssue.Message)
+		var failureCategory, failureSubcategory, message string
+		if sub := internalSubcategoryForPodIssueType(podIssue.Type); sub != "" {
+			failureCategory, failureSubcategory = errormatch.CategoryInternal, sub
+			message = podIssue.Message
+		} else {
+			result := p.classifier.ClassifyPodError(podIssue.OriginalPodState, podIssue.Message)
+			failureCategory, failureSubcategory = result.Category, result.Subcategory
+			message = result.AppendHint(podIssue.Message)
+		}
 
 		failedEvent, err := reporter.CreateJobFailedEvent(
 			podIssue.OriginalPodState,
@@ -431,8 +438,8 @@ func (p *PodIssueHandler) handleNonRetryableJobIssue(issue *issue) {
 			podIssue.DebugMessage,
 			util.ExtractFailedPodContainerStatuses(podIssue.OriginalPodState, clusterId),
 			clusterId,
-			result.Category,
-			result.Subcategory,
+			failureCategory,
+			failureSubcategory,
 		)
 		if err != nil {
 			log.Errorf("Failed to create failed event for job %s because %s", issue.RunIssue.JobId, err)
@@ -445,7 +452,7 @@ func (p *PodIssueHandler) handleNonRetryableJobIssue(issue *issue) {
 		}
 		// Increment only after successful Report so failed sends do not inflate the counter.
 		// RecordJobFailure is a no-op when classification didn't run (empty category).
-		metrics.RecordJobFailure(result.Category, result.Subcategory)
+		metrics.RecordJobFailure(failureCategory, failureSubcategory)
 		p.markIssueReported(issue.RunIssue)
 	}
 
@@ -454,6 +461,25 @@ func (p *PodIssueHandler) handleNonRetryableJobIssue(issue *issue) {
 		issue.RunIssue.PodIssue.DeletionRequested = true
 	} else {
 		p.markIssuesResolved(issue.RunIssue)
+	}
+}
+
+// internalSubcategoryForPodIssueType returns the internal failure subcategory
+// for Armada-detected structural pod issues. It returns "" for StuckStartingUp,
+// UnableToSchedule, and FailedStartingUp, whose cause (e.g. image pull, scheduling)
+// the operator categorizer should attribute instead.
+func internalSubcategoryForPodIssueType(t podIssueType) string {
+	switch t {
+	case StuckTerminating:
+		return errormatch.SubcategoryStuckTerminating
+	case ExternallyDeleted:
+		return errormatch.SubcategoryExternallyDeleted
+	case ErrorDuringIssueHandling:
+		return errormatch.SubcategoryIssueHandlerError
+	case ActiveDeadlineExceeded:
+		return errormatch.SubcategoryActiveDeadline
+	default:
+		return ""
 	}
 }
 
@@ -606,7 +632,9 @@ func (p *PodIssueHandler) handleReconciliationIssue(issue *issue) {
 			currentRunState.Meta.JobSet,
 			currentRunState.Meta.Queue,
 			p.clusterContext.GetClusterId(),
-			fmt.Sprintf("Pod is unexpectedly missing in Kubernetes"),
+			"Pod is unexpectedly missing in Kubernetes",
+			errormatch.CategoryInternal,
+			errormatch.SubcategoryPodMissing,
 		)
 		if err != nil {
 			log.Errorf("failed to create job failed event because %s", err)

--- a/internal/executor/service/pod_issue_handler_test.go
+++ b/internal/executor/service/pod_issue_handler_test.go
@@ -96,9 +96,10 @@ func TestPodIssueService_DeletesPodAndReportsFailed_IfStuckAndUnretryable(t *tes
 	assert.Len(t, failedEvent.JobRunErrors.Errors, 1)
 	assert.Contains(t, failedEvent.JobRunErrors.Errors[0].GetPodError().Message, "unrecoverable problem")
 	assert.Contains(t, failedEvent.JobRunErrors.Errors[0].GetPodError().DebugMessage, "Image pull has failed")
+	assert.NotEqual(t, errormatch.CategoryInternal, failedEvent.JobRunErrors.Errors[0].GetFailureCategory())
 }
 
-func TestPodIssueService_FailureCategorySet_WhenClassifierConfigured(t *testing.T) {
+func TestPodIssueService_StructuralIssueIsInternal_RegardlessOfClassifier(t *testing.T) {
 	classifier, err := categorizer.NewClassifier(categorizer.ErrorCategoriesConfig{
 		Categories: []categorizer.CategoryConfig{
 			{
@@ -111,35 +112,12 @@ func TestPodIssueService_FailureCategorySet_WhenClassifierConfigured(t *testing.
 	})
 	require.NoError(t, err)
 
-	fakeClusterContext := fakecontext.NewSyncFakeClusterContext()
-	eventReporter := mocks.NewFakeEventReporter()
-	runStateStore := job.NewJobRunStateStoreWithInitialState([]*job.RunState{})
-	stateChecksConfig := configuration.StateChecksConfiguration{
-		DeadlineForSubmittedPodConsideredMissing: time.Minute * 15,
-		DeadlineForActivePodConsideredMissing:    time.Minute * 5,
-	}
-
-	podIssueService, err := NewPodIssuerHandler(
-		runStateStore,
-		fakeClusterContext,
-		eventReporter,
-		stateChecksConfig,
-		makePendingPodChecker(),
-		makeFailedPodChecker(),
-		time.Minute*3,
-		classifier,
-	)
+	podIssueService, _, fakeClusterContext, eventReporter, err := setupTestComponentsWithClassifier([]*job.RunState{}, classifier)
 	require.NoError(t, err)
 
-	// Stuck terminating pod with an OOMKilled container - the classifier should match
 	pod := makeTerminatingPod()
 	pod.Status.ContainerStatuses = []v1.ContainerStatus{
-		{
-			Name: "main",
-			State: v1.ContainerState{
-				Terminated: &v1.ContainerStateTerminated{ExitCode: 137, Reason: "OOMKilled"},
-			},
-		},
+		{Name: "main", State: v1.ContainerState{Terminated: &v1.ContainerStateTerminated{ExitCode: 137, Reason: "OOMKilled"}}},
 	}
 	addPod(t, fakeClusterContext, pod)
 
@@ -148,11 +126,8 @@ func TestPodIssueService_FailureCategorySet_WhenClassifierConfigured(t *testing.
 	require.Len(t, eventReporter.ReceivedEvents, 1)
 	failedEvent, ok := eventReporter.ReceivedEvents[0].Event.Events[0].Event.(*armadaevents.EventSequence_Event_JobRunErrors)
 	require.True(t, ok)
-
-	assert.Equal(t, "oom-failure", failedEvent.JobRunErrors.Errors[0].GetFailureCategory())
-	assert.Equal(t, "kernel-oom", failedEvent.JobRunErrors.Errors[0].GetFailureSubcategory())
-	// Verify ContainerErrors are populated (not empty) so retry engine has fallback data
-	assert.NotEmpty(t, failedEvent.JobRunErrors.Errors[0].GetPodError().ContainerErrors)
+	assert.Equal(t, errormatch.CategoryInternal, failedEvent.JobRunErrors.Errors[0].GetFailureCategory())
+	assert.Equal(t, errormatch.SubcategoryStuckTerminating, failedEvent.JobRunErrors.Errors[0].GetFailureSubcategory())
 }
 
 func TestPodIssueService_OnPodErrorClassifies(t *testing.T) {
@@ -175,14 +150,6 @@ func TestPodIssueService_OnPodErrorClassifies(t *testing.T) {
 				return p
 			},
 			expectMessageContains: "no match for platform in manifest",
-		},
-		"active deadline exceeded from executor-side detection": {
-			category:    "user_error",
-			subcategory: "deadline_exceeded",
-			pattern:     "exceeded active deadline",
-			// 10 minutes old with 5 minute deadline -> exceeded.
-			pod:                   func() *v1.Pod { return makePodWithDeadline(time.Now().Add(-time.Minute*10), 300, 0) },
-			expectMessageContains: "exceeded active deadline",
 		},
 	}
 
@@ -402,6 +369,8 @@ func TestPodIssueService_DeletesPodAndReportsFailed_IfExceedsActiveDeadline(t *t
 				assert.True(t, ok)
 				assert.Len(t, failedEvent.JobRunErrors.Errors, 1)
 				assert.Contains(t, failedEvent.JobRunErrors.Errors[0].GetPodError().Message, "exceeded active deadline")
+				assert.Equal(t, errormatch.CategoryInternal, failedEvent.JobRunErrors.Errors[0].GetFailureCategory())
+				assert.Equal(t, errormatch.SubcategoryActiveDeadline, failedEvent.JobRunErrors.Errors[0].GetFailureSubcategory())
 			} else {
 				assert.Equal(t, []*v1.Pod{tc.pod}, remainingActivePods)
 				assert.Len(t, eventsReporter.ReceivedEvents, 0)
@@ -482,6 +451,8 @@ func TestPodIssueService_ReportsFailed_IfDeletedExternally(t *testing.T) {
 	assert.Len(t, failedEvent.JobRunErrors.Errors, 1)
 	assert.True(t, failedEvent.JobRunErrors.Errors[0].GetPodError() != nil)
 	assert.Equal(t, jobId, failedEvent.JobRunErrors.JobId)
+	assert.Equal(t, errormatch.CategoryInternal, failedEvent.JobRunErrors.Errors[0].GetFailureCategory())
+	assert.Equal(t, errormatch.SubcategoryExternallyDeleted, failedEvent.JobRunErrors.Errors[0].GetFailureSubcategory())
 }
 
 func TestPodIssueService_ReportsFailed_IfPodOfActiveRunGoesMissing(t *testing.T) {
@@ -507,6 +478,8 @@ func TestPodIssueService_ReportsFailed_IfPodOfActiveRunGoesMissing(t *testing.T)
 	assert.Len(t, failedEvent.JobRunErrors.Errors, 1)
 	assert.True(t, failedEvent.JobRunErrors.Errors[0].GetPodError() != nil)
 	assert.Equal(t, jobId, failedEvent.JobRunErrors.JobId)
+	assert.Equal(t, errormatch.CategoryInternal, failedEvent.JobRunErrors.Errors[0].GetFailureCategory())
+	assert.Equal(t, errormatch.SubcategoryPodMissing, failedEvent.JobRunErrors.Errors[0].GetFailureSubcategory())
 }
 
 func TestPodIssueService_DoesNothing_IfMissingPodOfActiveRunReturns(t *testing.T) {
@@ -869,5 +842,20 @@ func TestCreateDebugMessage(t *testing.T) {
 				assert.Contains(t, result, tt.events[0].Message)
 			}
 		})
+	}
+}
+
+func TestInternalSubcategoryForPodIssueType(t *testing.T) {
+	tests := map[podIssueType]string{
+		StuckTerminating:         errormatch.SubcategoryStuckTerminating,
+		ExternallyDeleted:        errormatch.SubcategoryExternallyDeleted,
+		ErrorDuringIssueHandling: errormatch.SubcategoryIssueHandlerError,
+		ActiveDeadlineExceeded:   errormatch.SubcategoryActiveDeadline,
+		StuckStartingUp:          "",
+		UnableToSchedule:         "",
+		FailedStartingUp:         "",
+	}
+	for issueType, want := range tests {
+		assert.Equal(t, want, internalSubcategoryForPodIssueType(issueType))
 	}
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/armadaproject/armada/internal/common/armadacontext"
 	"github.com/armadaproject/armada/internal/common/constants"
+	"github.com/armadaproject/armada/internal/common/errormatch"
 	protoutil "github.com/armadaproject/armada/internal/common/proto"
 	armadaslices "github.com/armadaproject/armada/internal/common/slices"
 	"github.com/armadaproject/armada/internal/leaderelection"
@@ -1040,7 +1041,9 @@ func (s *Scheduler) generateUpdateMessagesFromJob(ctx *armadacontext.Context, jo
 					}
 
 					runError = &armadaevents.Error{
-						Terminal: true,
+						Terminal:           true,
+						FailureCategory:    errormatch.CategoryInternal,
+						FailureSubcategory: errormatch.SubcategoryMaxRunsExceeded,
 						Reason: &armadaevents.Error_MaxRunsExceeded{
 							MaxRunsExceeded: &armadaevents.MaxRunsExceeded{
 								Message: errorMessage,
@@ -1133,7 +1136,9 @@ func (s *Scheduler) expireJobsIfNecessary(ctx *armadacontext.Context, txn *jobdb
 			jobsToUpdate = append(jobsToUpdate, job.WithQueued(false).WithFailed(true).WithUpdatedRun(run.WithFailed(true)))
 
 			leaseExpiredError := &armadaevents.Error{
-				Terminal: true,
+				Terminal:           true,
+				FailureCategory:    errormatch.CategoryInternal,
+				FailureSubcategory: errormatch.SubcategoryLeaseExpired,
 				Reason: &armadaevents.Error_LeaseExpired{
 					LeaseExpired: &armadaevents.LeaseExpired{},
 				},
@@ -1243,7 +1248,9 @@ func (s *Scheduler) submitCheck(ctx *armadacontext.Context, txn *jobdb.Txn) ([]*
 					JobId: job.Id(),
 					Errors: []*armadaevents.Error{
 						{
-							Terminal: true,
+							Terminal:           true,
+							FailureCategory:    errormatch.CategoryInternal,
+							FailureSubcategory: errormatch.SubcategoryJobRejected,
 							Reason: &armadaevents.Error_JobRejected{
 								JobRejected: &armadaevents.JobRejected{
 									Message: result.reason,

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/armadaproject/armada/internal/common/armadacontext"
 	"github.com/armadaproject/armada/internal/common/armadaerrors"
 	apiconfig "github.com/armadaproject/armada/internal/common/constants"
+	"github.com/armadaproject/armada/internal/common/errormatch"
 	"github.com/armadaproject/armada/internal/common/ingest/utils"
 	protoutil "github.com/armadaproject/armada/internal/common/proto"
 	"github.com/armadaproject/armada/internal/common/pulsarutils"
@@ -1084,6 +1085,8 @@ func TestScheduler_TestCycle(t *testing.T) {
 			for eventType, m := range outstandingJobEventsByType {
 				assert.Empty(t, m, "%d outstanding eventSequences of type %s", len(m), eventType)
 			}
+
+			assertInternalFailureCategories(t, publisher.eventSequences)
 
 			// assert that the serials are where we expect them to be.
 			// On publish failure the cursor must not advance, so that the next cycle re-fetches
@@ -4032,4 +4035,42 @@ func TestAppendEventSequencesFromPreemptedJobs_NilPreemptingJob(t *testing.T) {
 	assert.NotNil(t, preemptedEvent)
 	assert.Equal(t, preemptedRun.Id(), preemptedEvent.PreemptedRunId)
 	assert.Equal(t, "", preemptedEvent.PreemptingJobId)
+}
+
+// assertInternalFailureCategories checks that each published lease-expired,
+// max-runs-exceeded, and job-rejected error carries the internal category
+// and its matching subcategory.
+func assertInternalFailureCategories(t *testing.T, sequences []*armadaevents.EventSequence) {
+	t.Helper()
+	for _, es := range sequences {
+		for _, event := range es.Events {
+			var runError *armadaevents.Error
+			switch e := event.Event.(type) {
+			case *armadaevents.EventSequence_Event_JobRunErrors:
+				if len(e.JobRunErrors.Errors) > 0 {
+					runError = e.JobRunErrors.Errors[0]
+				}
+			case *armadaevents.EventSequence_Event_JobErrors:
+				if len(e.JobErrors.Errors) > 0 {
+					runError = e.JobErrors.Errors[0]
+				}
+			}
+			if runError == nil {
+				continue
+			}
+			var wantSubcategory string
+			switch runError.Reason.(type) {
+			case *armadaevents.Error_LeaseExpired:
+				wantSubcategory = errormatch.SubcategoryLeaseExpired
+			case *armadaevents.Error_MaxRunsExceeded:
+				wantSubcategory = errormatch.SubcategoryMaxRunsExceeded
+			case *armadaevents.Error_JobRejected:
+				wantSubcategory = errormatch.SubcategoryJobRejected
+			default:
+				continue
+			}
+			assert.Equal(t, errormatch.CategoryInternal, runError.GetFailureCategory())
+			assert.Equal(t, wantSubcategory, runError.GetFailureSubcategory())
+		}
+	}
 }


### PR DESCRIPTION
Armada-generated job-run failures previously carried no `failure_category`/`failure_subcategory`. Only operator-classified pod failures (via the executor categorizer) were tagged, so any dashboard attributing "why did this run end" had a large unlabeled remainder for everything Armada itself decided.

This change stamps the failures Armada itself authors with a static, code-owned category `internal` plus a subcategory naming the cause. The boundary is the source of the error. `internal` covers errors Armada produces from its own logic, where it writes a fixed, self-authored message. Errors where Armada merely relays dynamic external content (the kubelet, the K8s API, the scheduler) are left to the operator categorizer, which attributes them into the operator's own categories (infra, user_error, and so on) using its configured default when no rule matches. An operator never has to match Armada's internal error strings, and the top-level value reads as a triage signal: `internal` means the failure was Armada's own machinery, not the workload.

Stamped `internal`:
- Scheduler: lease expiry, max-runs-exceeded, job rejection.
- Executor: failed job creation, reconciliation pod-missing, and the Armada-detected structural pod issues it authors a fixed message for (stuck-terminating, externally-deleted, active-deadline, issue-handler-error).

For the structural pod issues the categorization is deterministic: the categorizer is not consulted, so a configured rule cannot override `internal`. The only fallback anywhere is the categorizer's own defaultCategory, which applies to the external causes below.

Not stamped `internal`:
- Stuck-starting-up and unschedulable pod issues (image pull, scheduling) run through the operator categorizer, which attributes their external cause.
- Lease returns and failed pod submissions wrap the kubelet or K8s API message. These paths do not run the categorizer yet, so they currently carry no category. Wiring the categorizer into them is follow-up work (see below).
- Preemption is left uncategorized. It is a scheduling action rather than a failure, is metered separately, and does not flow through the failed-run path.

The subcategory vocabulary lives in `internal/common/errormatch` (a dependency-free leaf already holding the sibling condition constants), so both the executor and the scheduler stamp from one shared set without an import cycle.

No proto change, no migration. The change populates the existing `Error.FailureCategory`/`Error.FailureSubcategory` proto fields. One observable metric effect: the executor failure counter `armada_executor_job_failure_category_total` now reports `internal` for the structural pod issues, which previously emitted no category (the counter is a no-op on an empty category). This is intentional.

Where the stamps are visible today:
- Lease expiry, failed job creation, reconciliation pod-missing, and the structural pod issues are `JobRunErrors` and reach the Lookout `job_run.failure_category` / `failure_subcategory` columns.
- Max-runs-exceeded and job-rejected are `JobErrors` (not `JobRunErrors`), so they do not reach the Lookout `job_run` columns. The api event conversion only copies these fields on the `PodError` arm, so they do not reach the api stream either. Their stamps are not observable anywhere today. They are set for construction-site consistency and to be ready when `JobErrors` persistence or the api conversion is extended.

Follow-up (separate PR): an `onPodIssue` structured matcher so operators can categorize the external Armada-detected causes (stuck-starting-up, unschedulable, and optionally the structural ones) into their own categories without regexing Armada's messages, plus running the categorizer on the lease-return and submission paths.
