### PR TITLE
Improve the efficiency of updating job prices

### DIFF
--- a/internal/scheduler/pricing/bid_price_service_test.go
+++ b/internal/scheduler/pricing/bid_price_service_test.go
@@ -1,15 +1,19 @@
 package pricing
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 	"k8s.io/apimachinery/pkg/api/resource"
 
+	"github.com/armadaproject/armada/internal/common/armadacontext"
 	schedulerconfiguration "github.com/armadaproject/armada/internal/scheduler/configuration"
 	"github.com/armadaproject/armada/internal/scheduler/internaltypes"
+	"github.com/armadaproject/armada/pkg/api"
 	"github.com/armadaproject/armada/pkg/bidstore"
 )
 
@@ -218,9 +222,11 @@ func TestConvert(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			actual := convert(tc.input, testResourceListFactory)
 
-			// Remove non-deterministic time field before comparison
+			// Remove non-deterministic fields before comparison
 			require.False(t, actual.Timestamp.IsZero(), "timestamp should be set")
 			actual.Timestamp = time.Time{}
+			require.NotEmpty(t, actual.Id, "id should be set")
+			actual.Id = ""
 
 			assert.Equal(t, tc.expected, actual)
 		})
@@ -248,4 +254,38 @@ func CreateRunningBid(p float64) *bidstore.PricingPhaseBid {
 func mustParsePtr(qty string) *resource.Quantity {
 	q := resource.MustParse(qty)
 	return &q
+}
+
+func TestGetBidPrices_SetsId(t *testing.T) {
+	ctx := armadacontext.Background()
+
+	t.Run("LocalBidPriceService", func(t *testing.T) {
+		svc := NewLocalBidPriceService([]string{"pool1"}, &fakeQueueCache{queues: []*api.Queue{{Name: "queue1"}}})
+		snapshot, err := svc.GetBidPrices(ctx)
+		require.NoError(t, err)
+		assert.NotEmpty(t, snapshot.Id)
+	})
+
+	t.Run("ExternalBidPriceService", func(t *testing.T) {
+		svc := NewExternalBidPriceService(&fakeBidRetrieverClient{resp: &bidstore.RetrieveBidsResponse{}}, testResourceListFactory)
+		snapshot, err := svc.GetBidPrices(ctx)
+		require.NoError(t, err)
+		assert.NotEmpty(t, snapshot.Id)
+	})
+}
+
+type fakeQueueCache struct {
+	queues []*api.Queue
+}
+
+func (f *fakeQueueCache) GetAll(_ *armadacontext.Context) ([]*api.Queue, error) {
+	return f.queues, nil
+}
+
+type fakeBidRetrieverClient struct {
+	resp *bidstore.RetrieveBidsResponse
+}
+
+func (f *fakeBidRetrieverClient) RetrieveBids(_ context.Context, _ *bidstore.RetrieveBidsRequest, _ ...grpc.CallOption) (*bidstore.RetrieveBidsResponse, error) {
+	return f.resp, nil
 }

--- a/internal/scheduler/pricing/bid_service.go
+++ b/internal/scheduler/pricing/bid_service.go
@@ -3,6 +3,8 @@ package pricing
 import (
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/armadaproject/armada/internal/common/armadacontext"
 	"github.com/armadaproject/armada/internal/scheduler/internaltypes"
 	"github.com/armadaproject/armada/internal/scheduler/queue"
@@ -31,6 +33,7 @@ func NewLocalBidPriceService(pools []string, queueCache queue.QueueCache) *Local
 
 func (b *LocalBidPriceService) GetBidPrices(ctx *armadacontext.Context) (BidPriceSnapshot, error) {
 	snapshot := BidPriceSnapshot{
+		Id:        uuid.NewString(),
 		Timestamp: time.Now(),
 		Bids:      make(map[PriceKey]map[string]Bid),
 	}
@@ -80,6 +83,7 @@ func (b *ExternalBidPriceService) GetBidPrices(ctx *armadacontext.Context) (BidP
 
 func convert(resp *bidstore.RetrieveBidsResponse, rlf *internaltypes.ResourceListFactory) BidPriceSnapshot {
 	snapshot := BidPriceSnapshot{
+		Id:            uuid.NewString(),
 		Timestamp:     time.Now(),
 		Bids:          make(map[PriceKey]map[string]Bid),
 		ResourceUnits: make(map[string]internaltypes.ResourceList),

--- a/internal/scheduler/pricing/types.go
+++ b/internal/scheduler/pricing/types.go
@@ -1,6 +1,7 @@
 package pricing
 
 import (
+	"maps"
 	"time"
 
 	"github.com/armadaproject/armada/internal/common/armadacontext"
@@ -20,6 +21,10 @@ type PriceKey struct {
 }
 
 type BidPriceSnapshot struct {
+	// Id uniquely identifies this snapshot.
+	// Two snapshots with the same non-empty Id are guaranteed to hold identical Bids and ResourceUnits.
+	// An empty Id means "unidentified" and should never be treated as equal to another.
+	Id            string
 	Timestamp     time.Time
 	Bids          map[PriceKey]map[string]Bid
 	ResourceUnits map[string]internaltypes.ResourceList
@@ -37,4 +42,26 @@ func (s *BidPriceSnapshot) GetPrice(queue string, band bidstore.PriceBand) (map[
 	}
 	price, ok := s.Bids[key]
 	return price, ok
+}
+
+// ChangedPriceKeys returns the set of PriceKeys whose bids differ between the two snapshots.
+// A key is considered changed if it was added, removed, or if its per-pool bids differ.
+func (s *BidPriceSnapshot) ChangedPriceKeys(comparisonSnapshot *BidPriceSnapshot) map[PriceKey]bool {
+	changed := make(map[PriceKey]bool)
+	var comparisonBids map[PriceKey]map[string]Bid
+	if comparisonSnapshot != nil {
+		comparisonBids = comparisonSnapshot.Bids
+	}
+	for key, bids := range s.Bids {
+		if !maps.Equal(comparisonBids[key], bids) {
+			changed[key] = true
+		}
+	}
+	// Report keys that were removed entirely (present previously, gone now).
+	for key := range comparisonBids {
+		if _, ok := s.Bids[key]; !ok {
+			changed[key] = true
+		}
+	}
+	return changed
 }

--- a/internal/scheduler/pricing/types_test.go
+++ b/internal/scheduler/pricing/types_test.go
@@ -1,0 +1,64 @@
+package pricing
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/armadaproject/armada/pkg/bidstore"
+)
+
+func TestChangedPriceKeys(t *testing.T) {
+	keyA := PriceKey{Queue: "queueA", Band: bidstore.PriceBand_PRICE_BAND_A}
+	keyB := PriceKey{Queue: "queueB", Band: bidstore.PriceBand_PRICE_BAND_B}
+
+	bid := func(q, r float64) map[string]Bid {
+		return map[string]Bid{"pool1": {QueuedBid: q, RunningBid: r}}
+	}
+
+	tests := map[string]struct {
+		comparison *BidPriceSnapshot
+		current    *BidPriceSnapshot
+		expected   map[PriceKey]bool
+	}{
+		"nil - everything changed": {
+			comparison: nil,
+			current:    &BidPriceSnapshot{Bids: map[PriceKey]map[string]Bid{keyA: bid(1, 1)}},
+			expected:   map[PriceKey]bool{keyA: true},
+		},
+		"identical - nothing changed": {
+			comparison: &BidPriceSnapshot{Bids: map[PriceKey]map[string]Bid{keyA: bid(1, 1)}},
+			current:    &BidPriceSnapshot{Bids: map[PriceKey]map[string]Bid{keyA: bid(1, 1)}},
+			expected:   map[PriceKey]bool{},
+		},
+		"changed value": {
+			comparison: &BidPriceSnapshot{Bids: map[PriceKey]map[string]Bid{keyA: bid(1, 1)}},
+			current:    &BidPriceSnapshot{Bids: map[PriceKey]map[string]Bid{keyA: bid(2, 2)}},
+			expected:   map[PriceKey]bool{keyA: true},
+		},
+		"added key": {
+			comparison: &BidPriceSnapshot{Bids: map[PriceKey]map[string]Bid{keyA: bid(1, 1)}},
+			current:    &BidPriceSnapshot{Bids: map[PriceKey]map[string]Bid{keyA: bid(1, 1), keyB: bid(1, 1)}},
+			expected:   map[PriceKey]bool{keyB: true},
+		},
+		"removed key is reported as changed": {
+			comparison: &BidPriceSnapshot{Bids: map[PriceKey]map[string]Bid{keyA: bid(1, 1), keyB: bid(1, 1)}},
+			current:    &BidPriceSnapshot{Bids: map[PriceKey]map[string]Bid{keyA: bid(1, 1)}},
+			expected:   map[PriceKey]bool{keyB: true},
+		},
+		"added pool within a key": {
+			comparison: &BidPriceSnapshot{Bids: map[PriceKey]map[string]Bid{keyA: bid(1, 1)}},
+			current: &BidPriceSnapshot{Bids: map[PriceKey]map[string]Bid{keyA: {
+				"pool1": {QueuedBid: 1, RunningBid: 1},
+				"pool2": {QueuedBid: 1, RunningBid: 1},
+			}}},
+			expected: map[PriceKey]bool{keyA: true},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.current.ChangedPriceKeys(tc.comparison))
+		})
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -577,7 +577,7 @@ func (s *Scheduler) updateJobPrices(ctx *armadacontext.Context, txn *jobdb.Txn) 
 			updatedPrice, present := updatedBids.GetPrice(job.Queue(), job.GetPriceBand())
 			if !present {
 				// The key changed but has no price in the new snapshot - for now leave the stale price in place
-				// TODO Decide if we to clear the price for these jobs
+				// TODO Decide if we want to clear the price for these jobs
 				continue
 			}
 			updatedJobs = append(updatedJobs, job.WithBidPrices(updatedPrice))

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -28,7 +28,6 @@ import (
 	schedulercontext "github.com/armadaproject/armada/internal/scheduler/scheduling/context"
 	"github.com/armadaproject/armada/internal/scheduler/scheduling/runner"
 	"github.com/armadaproject/armada/pkg/armadaevents"
-	"github.com/armadaproject/armada/pkg/bidstore"
 )
 
 // Scheduler is the main Armada scheduler.
@@ -534,61 +533,64 @@ func (s *Scheduler) syncState(ctx *armadacontext.Context, initial, fullJobGc boo
 	return jobDbJobs, jsts, newJobsSerial, newRunsSerial, nil
 }
 
-// TODO - This is highly inefficient and will only work if market driven pools are small
-// We should rewrite how bids are stored in an efficient manner
 func (s *Scheduler) updateJobPrices(ctx *armadacontext.Context, txn *jobdb.Txn) error {
 	if len(s.marketDrivenPools) == 0 {
 		return nil
 	}
 
-	jobs := txn.GetAll()
-	jobsByQueue := map[string]map[bidstore.PriceBand][]*jobdb.Job{}
 	updatedBids, err := s.bidPriceProvider.GetBidPrices(ctx)
 	if err != nil {
 		return err
 	}
 
-	hasMarketDrivenPool := func(j *jobdb.Job) bool {
-		for _, pool := range j.Pools() {
-			if slices.Contains(s.marketDrivenPools, pool) {
-				return true
+	// The provider caches the snapshot between refreshes, so most cycles see the same one.
+	// A matching, non-empty Id guarantees identical content, so we can skip all the work.
+	previousSnapshot := txn.GetBidPriceSnapshot()
+	if previousSnapshot != nil && previousSnapshot.Id != "" && previousSnapshot.Id == updatedBids.Id {
+		ctx.Logger().Infof("bid price snapshot %s unchanged, skipping job price update", updatedBids.Id)
+		return nil
+	}
+
+	// Only jobs whose (queue, band) price actually changed need re-pricing.
+	changedKeys := updatedBids.ChangedPriceKeys(previousSnapshot)
+	if len(changedKeys) == 0 {
+		ctx.Logger().Infof("no bid price changes, skipping job price update")
+	} else {
+		hasMarketDrivenPool := func(j *jobdb.Job) bool {
+			for _, pool := range j.Pools() {
+				if slices.Contains(s.marketDrivenPools, pool) {
+					return true
+				}
 			}
+			return false
 		}
-		return false
-	}
 
-	for _, job := range jobs {
-		if _, present := jobsByQueue[job.Queue()]; !present {
-			jobsByQueue[job.Queue()] = map[bidstore.PriceBand][]*jobdb.Job{}
-		}
-		if _, present := jobsByQueue[job.Queue()][job.GetPriceBand()]; !present {
-			jobsByQueue[job.Queue()][job.GetPriceBand()] = []*jobdb.Job{}
-		}
-		if hasMarketDrivenPool(job) {
-			jobsByQueue[job.Queue()][job.GetPriceBand()] = append(jobsByQueue[job.Queue()][job.GetPriceBand()], job)
-		}
-	}
-
-	updatedJobs := make([]*jobdb.Job, 0, len(jobs))
-	for queue := range jobsByQueue {
-		for priceBand, jobs := range jobsByQueue[queue] {
-			updatedPrice, present := updatedBids.GetPrice(queue, priceBand)
-			if !present {
+		jobs := txn.GetAll()
+		updatedJobs := make([]*jobdb.Job, 0)
+		for _, job := range jobs {
+			if !hasMarketDrivenPool(job) {
 				continue
 			}
-
-			// For now always update all jobs, as the jobDb isn't setting them as they come in
-			for _, job := range jobs {
-				job = job.WithBidPrices(updatedPrice)
-				updatedJobs = append(updatedJobs, job)
+			if !changedKeys[pricing.PriceKey{Queue: job.Queue(), Band: job.GetPriceBand()}] {
+				continue
 			}
+			updatedPrice, present := updatedBids.GetPrice(job.Queue(), job.GetPriceBand())
+			if !present {
+				// The key changed but has no price in the new snapshot - for now leave the stale price in place
+				// TODO Decide if we to clear the price for these jobs
+				continue
+			}
+			updatedJobs = append(updatedJobs, job.WithBidPrices(updatedPrice))
+		}
+
+		ctx.Logger().Infof("updating the prices of %d jobs", len(updatedJobs))
+		err = txn.Upsert(updatedJobs)
+		if err != nil {
+			return err
 		}
 	}
-	ctx.Logger().Infof("updating the prices of %d jobs", len(updatedJobs))
-	err = txn.Upsert(updatedJobs)
-	if err != nil {
-		return err
-	}
+
+	ctx.Logger().Infof("updating bid price snapshot (id=%s)", updatedBids.Id)
 	err = txn.SetBidPriceSnapshot(&updatedBids)
 	if err != nil {
 		return err

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1701,7 +1701,6 @@ func TestJobPriceUpdates(t *testing.T) {
 			expectedJobBidPrice:           []float64{0, 0, 0},
 		},
 		"job with no market driven pools": {
-			// No need to set price on job that doesn't belong to market driven pools
 			marketDrivenPools:             []string{testfixtures.TestPool},
 			initialJob:                    jobWithoutMarketDrivenPools,
 			expectedNumberOfProviderCalls: []int{1, 1, 2},
@@ -1709,7 +1708,6 @@ func TestJobPriceUpdates(t *testing.T) {
 			expectedJobBidPrice:           []float64{0, 0, 0},
 		},
 		"non-preemptible queued job": {
-			// No market driven pools, so prices shouldn't be getting updated
 			marketDrivenPools:             []string{testfixtures.TestPool},
 			initialJob:                    queuedJob,
 			expectedNumberOfProviderCalls: []int{1, 1, 2},
@@ -1717,7 +1715,6 @@ func TestJobPriceUpdates(t *testing.T) {
 			expectedJobBidPrice:           []float64{2, 2, 3},
 		},
 		"non-preemptible running job": {
-			// No market driven pools, so prices shouldn't be getting updated
 			marketDrivenPools:             []string{testfixtures.TestPool},
 			initialJob:                    runningJob,
 			expectedNumberOfProviderCalls: []int{1, 1, 2},
@@ -1725,7 +1722,6 @@ func TestJobPriceUpdates(t *testing.T) {
 			expectedJobBidPrice:           []float64{pricing.NonPreemptibleRunningPrice, pricing.NonPreemptibleRunningPrice, pricing.NonPreemptibleRunningPrice},
 		},
 		"non-preemptible queued job with no pricing info": {
-			// No market driven pools, so prices shouldn't be getting updated
 			marketDrivenPools:             []string{testfixtures.TestPool},
 			initialJob:                    queuedJobNoPricingInfo,
 			expectedNumberOfProviderCalls: []int{1, 1, 2},
@@ -1733,7 +1729,6 @@ func TestJobPriceUpdates(t *testing.T) {
 			expectedJobBidPrice:           []float64{0, 0, 0},
 		},
 		"non-preemptible running job with no pricing info": {
-			// No market driven pools, so prices shouldn't be getting updated
 			marketDrivenPools:             []string{testfixtures.TestPool},
 			initialJob:                    runningJobNoPricingInfo,
 			expectedNumberOfProviderCalls: []int{1, 1, 2},
@@ -1741,7 +1736,6 @@ func TestJobPriceUpdates(t *testing.T) {
 			expectedJobBidPrice:           []float64{pricing.NonPreemptibleRunningPrice, pricing.NonPreemptibleRunningPrice, pricing.NonPreemptibleRunningPrice},
 		},
 		"preemptible queued job": {
-			// No market driven pools, so prices shouldn't be getting updated
 			marketDrivenPools:             []string{testfixtures.TestPool},
 			initialJob:                    queuedPreemptibleJob,
 			expectedNumberOfProviderCalls: []int{1, 1, 2},
@@ -1749,7 +1743,6 @@ func TestJobPriceUpdates(t *testing.T) {
 			expectedJobBidPrice:           []float64{2, 2, 3},
 		},
 		"preemptible running job": {
-			// No market driven pools, so prices shouldn't be getting updated
 			marketDrivenPools:             []string{testfixtures.TestPool},
 			initialJob:                    runningPreemptibleJob,
 			expectedNumberOfProviderCalls: []int{1, 1, 2},
@@ -1757,7 +1750,6 @@ func TestJobPriceUpdates(t *testing.T) {
 			expectedJobBidPrice:           []float64{2, 2, 3},
 		},
 		"preemptible queued job - no pricing info": {
-			// No market driven pools, so prices shouldn't be getting updated
 			marketDrivenPools:             []string{testfixtures.TestPool},
 			initialJob:                    queuedPreemptibleJobNoPricingInfo,
 			expectedNumberOfProviderCalls: []int{1, 1, 2},
@@ -1765,7 +1757,6 @@ func TestJobPriceUpdates(t *testing.T) {
 			expectedJobBidPrice:           []float64{0, 0, 0},
 		},
 		"preemptible running job - no pricing info": {
-			// No market driven pools, so prices shouldn't be getting updated
 			marketDrivenPools:             []string{testfixtures.TestPool},
 			initialJob:                    runningPreemptibleJobNoPricingInfo,
 			expectedNumberOfProviderCalls: []int{1, 1, 2},
@@ -1777,17 +1768,20 @@ func TestJobPriceUpdates(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			// Test objects
+			key := pricing.PriceKey{Queue: "testQueue", Band: bidstore.PriceBand_PRICE_BAND_B}
+			bid := func(q, r float64) map[string]pricing.Bid {
+				return map[string]pricing.Bid{"testPool": {QueuedBid: q, RunningBid: r}}
+			}
+			snapshot1 := pricing.BidPriceSnapshot{Id: "1", Bids: map[pricing.PriceKey]map[string]pricing.Bid{key: bid(2, 2)}}
+			snapshot2 := pricing.BidPriceSnapshot{Id: "2", Bids: map[pricing.PriceKey]map[string]pricing.Bid{key: bid(3, 3)}}
+
 			jobDb := testfixtures.NewJobDb(testfixtures.TestResourceListFactory)
 			jobRepo := testJobRepository{numReceivedPartitions: 100}
 			testClock := clock.NewFakeClock(time.Now())
 			schedulingAlgo := &testSchedulingAlgo{}
 			publisher := &testPublisher{}
 			priceProvider := &testBidPriceProvider{
-				pools:  tc.marketDrivenPools,
-				queues: []string{"testQueue"},
-				priceFunc: func(band bidstore.PriceBand) float64 {
-					return float64(band)
-				},
+				currentSnapshot: snapshot1,
 			}
 			clusterRepo := &testExecutorRepository{}
 			leaderController := leaderelection.NewStandaloneLeaderController()
@@ -1842,20 +1836,28 @@ func TestJobPriceUpdates(t *testing.T) {
 			assert.Equal(t, tc.expectedJobBid[0], currentJob.GetAllBidPrices())
 			assert.Equal(t, tc.expectedJobBidPrice[0], currentJob.GetBidPrice(testfixtures.TestPool))
 			assert.Equal(t, priceProvider.numberOfCalls, tc.expectedNumberOfProviderCalls[0])
+			if len(tc.marketDrivenPools) > 0 {
+				assert.Equal(t, jobDb.ReadTxn().GetBidPriceSnapshot().Id, snapshot1.Id)
+			} else {
+				assert.Nil(t, jobDb.ReadTxn().GetBidPriceSnapshot())
+			}
 
 			// invalidate our leadership: we shouldn't update prices
 			leaderController.SetToken(leaderelection.InvalidLeaderToken())
-			priceProvider.priceFunc = func(band bidstore.PriceBand) float64 {
-				return float64(band) + 1
-			}
+			priceProvider.currentSnapshot = snapshot2
 			fireCycle()
 			currentJob = jobDb.ReadTxn().GetById(tc.initialJob.JobID)
 			assert.NotNil(t, currentJob)
 			assert.Equal(t, tc.expectedJobBid[1], currentJob.GetAllBidPrices())
 			assert.Equal(t, tc.expectedJobBidPrice[1], currentJob.GetBidPrice(testfixtures.TestPool))
 			assert.Equal(t, priceProvider.numberOfCalls, tc.expectedNumberOfProviderCalls[1])
+			if len(tc.marketDrivenPools) > 0 {
+				assert.Equal(t, jobDb.ReadTxn().GetBidPriceSnapshot().Id, snapshot1.Id)
+			} else {
+				assert.Nil(t, jobDb.ReadTxn().GetBidPriceSnapshot())
+			}
 
-			// become master again: we shouldn't update prices
+			// become master again: we should update prices
 			leaderController.SetToken(leaderelection.NewLeaderToken())
 			fireCycle()
 			currentJob = jobDb.ReadTxn().GetById(tc.initialJob.JobID)
@@ -1863,6 +1865,11 @@ func TestJobPriceUpdates(t *testing.T) {
 			assert.Equal(t, tc.expectedJobBid[2], currentJob.GetAllBidPrices())
 			assert.Equal(t, tc.expectedJobBidPrice[2], currentJob.GetBidPrice(testfixtures.TestPool))
 			assert.Equal(t, priceProvider.numberOfCalls, tc.expectedNumberOfProviderCalls[2])
+			if len(tc.marketDrivenPools) > 0 {
+				assert.Equal(t, jobDb.ReadTxn().GetBidPriceSnapshot().Id, snapshot2.Id)
+			} else {
+				assert.Nil(t, jobDb.ReadTxn().GetBidPriceSnapshot())
+			}
 
 			cancel()
 		})
@@ -2533,35 +2540,13 @@ func FailedReconciliationResultFromJobs[J *jobdb.Job](jobs []J, reason string) [
 }
 
 type testBidPriceProvider struct {
-	numberOfCalls int
-	pools         []string
-	queues        []string
-	priceFunc     func(band bidstore.PriceBand) float64
+	numberOfCalls   int
+	currentSnapshot pricing.BidPriceSnapshot
 }
 
 func (t *testBidPriceProvider) GetBidPrices(ctx *armadacontext.Context) (pricing.BidPriceSnapshot, error) {
 	t.numberOfCalls++
-	snapshot := pricing.BidPriceSnapshot{
-		Timestamp: time.Now(),
-		Bids:      make(map[pricing.PriceKey]map[string]pricing.Bid),
-	}
-
-	for _, q := range t.queues {
-		for _, band := range bidstore.PriceBandFromShortName {
-			key := pricing.PriceKey{Queue: q, Band: band}
-			bids := make(map[string]pricing.Bid)
-
-			for _, pool := range t.pools {
-				bids[pool] = pricing.Bid{
-					QueuedBid:  t.priceFunc(band),
-					RunningBid: t.priceFunc(band),
-				}
-			}
-
-			snapshot.Bids[key] = bids
-		}
-	}
-	return snapshot, nil
+	return t.currentSnapshot, nil
 }
 
 type testPublisher struct {


### PR DESCRIPTION
Before this PR updating job prices is very inefficient, we'd update the prices of ALL jobs every round if they need it or not
 - Even at modest scale if ~250k jobs, this can take 5-10 seconds

Now the code will only update jobs where prices have changed since the last set of prices
 - Price snapshots have an Id so we can quickly skip if the snapshot has not changed
   - This is the common case, as the snapshot is cached, so often it is simply returning the value we saw last cycle
 - When the snapshot has changed, we check which prices have changed and only update jobs that use those prices

This should mean we go from updating the whole db each cycle to no changes most the time, and targetted updates when prices have changed.
