### PR TITLE
fix(airflow): cancel jobs only when task in terminal state (#490)

### DIFF
--- a/third_party/airflow/armada/triggers.py
+++ b/third_party/airflow/armada/triggers.py
@@ -12,6 +12,13 @@ from ._compat import AIRFLOW_V_3_0_PLUS, deserialize
 from .hooks import ArmadaHook
 from .utils import log_exceptions, xcom_pull_for_ti
 
+# Terminal task states in which a lingering Armada job must be cancelled on
+# trigger cleanup. Any other state (notably DEFERRED) means the triggerer is
+# handing off the trigger, not that the task finished, so the job is left alone.
+CANCEL_JOBS_WHEN_TASK_IN_STATE: frozenset[TaskInstanceState] = frozenset(
+    {TaskInstanceState.SUCCESS, TaskInstanceState.FAILED}
+)
+
 
 class ArmadaPollJobTrigger(BaseTrigger):
     __version__: ClassVar[int] = 1
@@ -73,15 +80,17 @@ class ArmadaPollJobTrigger(BaseTrigger):
 
     async def _should_cancel_job(self) -> bool:
         """
-        Cancel the Armada job only when the task is no longer DEFERRED.
+        Cancel the Armada job only when the task has reached a terminal state.
 
-        A task that is still DEFERRED on trigger exit means the triggerer
-        is restarting / handing off the trigger, not that the user killed
-        the task — cancelling in that case would kill a perfectly healthy
-        job. Morally equivalent to KubernetesPodTrigger.safe_to_cancel().
+        A task that is not in a terminal state on trigger exit (most importantly
+        DEFERRED) means the triggerer is restarting / handing off the trigger,
+        not that the task has finished — cancelling in that case would kill a
+        perfectly healthy job. Morally equivalent to
+        KubernetesPodTrigger.safe_to_cancel().
         """
         try:
             state = await self._get_task_state()
+            self.log.info("Task state during cleanup: %s", state)
         except Exception:
             self.log.warning(
                 "Could not determine task state during cleanup; "
@@ -89,7 +98,7 @@ class ArmadaPollJobTrigger(BaseTrigger):
                 exc_info=True,
             )
             raise
-        return state != TaskInstanceState.DEFERRED
+        return state in CANCEL_JOBS_WHEN_TASK_IN_STATE
 
     async def _get_task_state(self) -> Any:
         if not AIRFLOW_V_3_0_PLUS:

--- a/third_party/airflow/pyproject.toml
+++ b/third_party/airflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "armada_airflow"
-version = "1.1.0"
+version = "1.1.1"
 description = "Armada Airflow Operator"
 readme='README.md'
 authors = [{name = "Armada-GROSS", email = "armada@armadaproject.io"}]

--- a/third_party/airflow/test/unit/test_triggers.py
+++ b/third_party/airflow/test/unit/test_triggers.py
@@ -5,7 +5,7 @@ import pytest
 from airflow.utils.state import TaskInstanceState
 from armada._compat import deserialize, serialize
 from armada.model import GrpcChannelArgs, RunningJobContext
-from armada.triggers import ArmadaPollJobTrigger
+from armada.triggers import CANCEL_JOBS_WHEN_TASK_IN_STATE, ArmadaPollJobTrigger
 from armada_client.typings import JobState
 from pendulum import DateTime
 
@@ -58,8 +58,9 @@ def _make_trigger_with_task_state(state: TaskInstanceState) -> ArmadaPollJobTrig
 
 
 @pytest.mark.asyncio
-async def test_cancels_running_job_when_task_is_cancelled():
-    trigger = _make_trigger_with_task_state(TaskInstanceState.SUCCESS)
+@pytest.mark.parametrize("state", sorted(CANCEL_JOBS_WHEN_TASK_IN_STATE))
+async def test_cancels_running_job_when_task_in_terminal_state(state):
+    trigger = _make_trigger_with_task_state(state)
     job_ctx = RunningJobContext(
         "queue", "job-1", "job-set", DateTime.utcnow(), "cluster"
     )
@@ -68,22 +69,16 @@ async def test_cancels_running_job_when_task_is_cancelled():
     hook.context_from_xcom.return_value = job_ctx
 
     with (
-        patch.object(
-            ArmadaPollJobTrigger,
-            "_get_task_state",
-            return_value=TaskInstanceState.SUCCESS,
-        ),
+        patch.object(ArmadaPollJobTrigger, "_get_task_state", return_value=state),
         patch.object(
             ArmadaPollJobTrigger,
             "hook",
             new_callable=lambda: property(lambda self: hook),
         ),
     ):
-        await trigger.on_kill()
         await trigger.cleanup()
 
-    assert hook.cancel_job.call_count == 2
-    hook.cancel_job.assert_called_with(job_ctx)
+    hook.cancel_job.assert_called_once_with(job_ctx)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Replace the `state != DEFERRED` check in the poll-job trigger cleanup with an explicit allow-list of terminal task states (CANCEL_JOBS_WHEN_TASK_IN_STATE = {SUCCESS, FAILED}). 

Parametrize the cancellation unit test over the same constant.
