### PR TITLE
Update BidPriceSnapshot.Id to be a uuid rather than string

### DIFF
--- a/internal/scheduler/pricing/bid_price_service_test.go
+++ b/internal/scheduler/pricing/bid_price_service_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -225,8 +226,8 @@ func TestConvert(t *testing.T) {
 			// Remove non-deterministic fields before comparison
 			require.False(t, actual.Timestamp.IsZero(), "timestamp should be set")
 			actual.Timestamp = time.Time{}
-			require.NotEmpty(t, actual.Id, "id should be set")
-			actual.Id = ""
+			require.NotEqual(t, uuid.Nil, actual.Id, "id should be set")
+			actual.Id = uuid.Nil
 
 			assert.Equal(t, tc.expected, actual)
 		})
@@ -263,14 +264,14 @@ func TestGetBidPrices_SetsId(t *testing.T) {
 		svc := NewLocalBidPriceService([]string{"pool1"}, &fakeQueueCache{queues: []*api.Queue{{Name: "queue1"}}})
 		snapshot, err := svc.GetBidPrices(ctx)
 		require.NoError(t, err)
-		assert.NotEmpty(t, snapshot.Id)
+		assert.NotEqual(t, uuid.Nil, snapshot.Id)
 	})
 
 	t.Run("ExternalBidPriceService", func(t *testing.T) {
 		svc := NewExternalBidPriceService(&fakeBidRetrieverClient{resp: &bidstore.RetrieveBidsResponse{}}, testResourceListFactory)
 		snapshot, err := svc.GetBidPrices(ctx)
 		require.NoError(t, err)
-		assert.NotEmpty(t, snapshot.Id)
+		assert.NotEqual(t, uuid.Nil, snapshot.Id)
 	})
 }
 

--- a/internal/scheduler/pricing/bid_service.go
+++ b/internal/scheduler/pricing/bid_service.go
@@ -33,7 +33,7 @@ func NewLocalBidPriceService(pools []string, queueCache queue.QueueCache) *Local
 
 func (b *LocalBidPriceService) GetBidPrices(ctx *armadacontext.Context) (BidPriceSnapshot, error) {
 	snapshot := BidPriceSnapshot{
-		Id:        uuid.NewString(),
+		Id:        uuid.New(),
 		Timestamp: time.Now(),
 		Bids:      make(map[PriceKey]map[string]Bid),
 	}
@@ -83,7 +83,7 @@ func (b *ExternalBidPriceService) GetBidPrices(ctx *armadacontext.Context) (BidP
 
 func convert(resp *bidstore.RetrieveBidsResponse, rlf *internaltypes.ResourceListFactory) BidPriceSnapshot {
 	snapshot := BidPriceSnapshot{
-		Id:            uuid.NewString(),
+		Id:            uuid.New(),
 		Timestamp:     time.Now(),
 		Bids:          make(map[PriceKey]map[string]Bid),
 		ResourceUnits: make(map[string]internaltypes.ResourceList),

--- a/internal/scheduler/pricing/types.go
+++ b/internal/scheduler/pricing/types.go
@@ -4,6 +4,8 @@ import (
 	"maps"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/armadaproject/armada/internal/common/armadacontext"
 	"github.com/armadaproject/armada/internal/scheduler/internaltypes"
 	"github.com/armadaproject/armada/pkg/bidstore"
@@ -22,9 +24,9 @@ type PriceKey struct {
 
 type BidPriceSnapshot struct {
 	// Id uniquely identifies this snapshot.
-	// Two snapshots with the same non-empty Id are guaranteed to hold identical Bids and ResourceUnits.
-	// An empty Id means "unidentified" and should never be treated as equal to another.
-	Id            string
+	// Two snapshots with the same non-nil Id are guaranteed to hold identical Bids and ResourceUnits.
+	// A nil Id (uuid.Nil) means "unidentified" and should never be treated as equal to another.
+	Id            uuid.UUID
 	Timestamp     time.Time
 	Bids          map[PriceKey]map[string]Bid
 	ResourceUnits map[string]internaltypes.ResourceList

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -547,7 +547,7 @@ func (s *Scheduler) updateJobPrices(ctx *armadacontext.Context, txn *jobdb.Txn) 
 	// The provider caches the snapshot between refreshes, so most cycles see the same one.
 	// A matching, non-empty Id guarantees identical content, so we can skip all the work.
 	previousSnapshot := txn.GetBidPriceSnapshot()
-	if previousSnapshot != nil && previousSnapshot.Id != "" && previousSnapshot.Id == updatedBids.Id {
+	if previousSnapshot != nil && previousSnapshot.Id != uuid.Nil && previousSnapshot.Id == updatedBids.Id {
 		ctx.Logger().Infof("bid price snapshot %s unchanged, skipping job price update", updatedBids.Id)
 		return nil
 	}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1775,8 +1775,8 @@ func TestJobPriceUpdates(t *testing.T) {
 			bid := func(q, r float64) map[string]pricing.Bid {
 				return map[string]pricing.Bid{"testPool": {QueuedBid: q, RunningBid: r}}
 			}
-			snapshot1 := pricing.BidPriceSnapshot{Id: "1", Bids: map[pricing.PriceKey]map[string]pricing.Bid{key: bid(2, 2)}}
-			snapshot2 := pricing.BidPriceSnapshot{Id: "2", Bids: map[pricing.PriceKey]map[string]pricing.Bid{key: bid(3, 3)}}
+			snapshot1 := pricing.BidPriceSnapshot{Id: uuid.New(), Bids: map[pricing.PriceKey]map[string]pricing.Bid{key: bid(2, 2)}}
+			snapshot2 := pricing.BidPriceSnapshot{Id: uuid.New(), Bids: map[pricing.PriceKey]map[string]pricing.Bid{key: bid(3, 3)}}
 
 			jobDb := testfixtures.NewJobDb(testfixtures.TestResourceListFactory)
 			jobRepo := testJobRepository{numReceivedPartitions: 100}


### PR DESCRIPTION
Use a typed field to make it clear what we expect in this field, rather than a string with a uuid in it

