### PR TITLE
Add a log message for when a issue is registered in executor

### DIFF
--- a/internal/executor/service/pod_issue_handler.go
+++ b/internal/executor/service/pod_issue_handler.go
@@ -184,7 +184,14 @@ func (p *PodIssueHandler) registerIssue(issue *runIssue) (bool, error) {
 	}
 	_, exists := p.knownPodIssues[issue.RunId]
 	if !exists {
-		log.Infof("Issue for job %s run %s is registered", issue.JobId, issue.RunId)
+		description := "unknown issue type"
+		if issue.PodIssue != nil {
+			description = fmt.Sprintf("pod issue - type %d - %s", issue.PodIssue.Type, issue.PodIssue.Message)
+		} else if issue.ReconciliationIssue != nil {
+			description = "reconciliation issue"
+		}
+
+		log.Infof("Issue for job %s run %s is registered - %s", issue.JobId, issue.RunId, description)
 		p.knownPodIssues[issue.RunId] = issue
 		return true, nil
 	} else {
@@ -290,7 +297,7 @@ func (p *PodIssueHandler) detectPodIssues(allManagedPods []*v1.Pod) {
 					podIssueType = UnableToSchedule
 				}
 
-				log.Warnf("Found issue with pod %s in namespace %s: %s", pod.Name, pod.Namespace, message)
+				log.Infof("Found issue with pod %s in namespace %s: %s", pod.Name, pod.Namespace, message)
 
 				issue := &podIssue{
 					OriginalPodState: pod.DeepCopy(),


### PR DESCRIPTION
Not all paths that register issues log what issue was detected making it hard to debug after the fact

Now we log the issue as it is registered with some details


