### PR TITLE
Fix five defects in the scheduler recording rules

### DIFF
--- a/deployment/scheduler/templates/scheduler-prometheusrule.yaml
+++ b/deployment/scheduler/templates/scheduler-prometheusrule.yaml
@@ -23,12 +23,12 @@ spec:
         - record: cluster_category_subCategory:armada_scheduler_failed_jobs
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: sum by (cluster, category, subCategory) (armada_scheduler_error_classification_by_node{namespace="{{ .Release.Namespace }}"})
+          expr: sum by (cluster, category, subcategory) (armada_scheduler_job_error_classification_by_node{namespace="{{ .Release.Namespace }}"})
         # Per-queue failures.
         - record: queue_category_subCategory:armada_scheduler_failed_jobs
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: sum by (queue, category, subCategory) (armada_scheduler_job_error_classification_by_queue{namespace="{{ .Release.Namespace }}"})
+          expr: sum by (queue, category, subcategory) (armada_scheduler_job_error_classification_by_queue{namespace="{{ .Release.Namespace }}"})
         # Per-node successes.
         - record: node:armada_scheduler_succeeded_jobs
           labels:
@@ -38,7 +38,7 @@ spec:
         - record: cluster_category_subCategory:armada_scheduler_succeeded_jobs
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: sum by (cluster, category, subCategory) (armada_scheduler_job_state_counter_by_node{namespace="{{ .Release.Namespace }}", state="succeeded"})
+          expr: sum by (cluster, category, subcategory) (armada_scheduler_job_state_counter_by_node{namespace="{{ .Release.Namespace }}", state="succeeded"})
         # Per-queue successes.
         - record: queue_category_subCategory:armada_scheduler_succeeded_jobs
           labels:
@@ -49,15 +49,15 @@ spec:
         - record: node:armada_scheduler_failed_jobs:increase1m
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: increase(node:armada_scheduler_job_state_counter_by_queue{state="failed",namespace="{{ .Release.Namespace }}"}[1m:])
+          expr: increase(node:armada_scheduler_failed_jobs{namespace="{{ .Release.Namespace }}"}[1m:])
         - record: node:armada_scheduler_failed_jobs:increase10m
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: increase(node:armada_scheduler_job_state_counter_by_queue{state="failed",namespace="{{ .Release.Namespace }}"}[10m:])
+          expr: increase(node:armada_scheduler_failed_jobs{namespace="{{ .Release.Namespace }}"}[10m:])
         - record: node:armada_scheduler_failed_jobs:increase1h
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: increase(node:armada_scheduler_job_state_counter_by_queue{state="failed",namespace="{{ .Release.Namespace }}"}[10m:])
+          expr: increase(node:armada_scheduler_failed_jobs{namespace="{{ .Release.Namespace }}"}[1h:])
         # Per-cluster failures increase.
         - record: cluster_category_subCategory:armada_scheduler_failed_jobs:increase1m
           labels:
@@ -118,11 +118,11 @@ spec:
         - record: queue_category_subCategory:armada_scheduler_succeeded_jobs:increase10m
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: increase(queue_category_subCategory:armada_scheduler_succeeded_jobs{namespace="{{ .Release.Namespace }}"}[1m:])
+          expr: increase(queue_category_subCategory:armada_scheduler_succeeded_jobs{namespace="{{ .Release.Namespace }}"}[10m:])
         - record: queue_category_subCategory:armada_scheduler_succeeded_jobs:increase1h
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: increase(queue_category_subCategory:armada_scheduler_succeeded_jobs{namespace="{{ .Release.Namespace }}"}[1m:])
+          expr: increase(queue_category_subCategory:armada_scheduler_succeeded_jobs{namespace="{{ .Release.Namespace }}"}[1h:])
         # Per-node failure rates.
         - record: node:armada_scheduler_failed_rate_jobs:increase1m
           labels:
@@ -140,26 +140,26 @@ spec:
         - record: cluster_category_subCategory:armada_scheduler_failed_rate_jobs:increase1m
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: sum by(cluster, category, subCategory) (cluster_category_subCategory:armada_scheduler_failed_jobs:increase1m{namespace="{{ .Release.Namespace }}"}) / on(cluster) group_left() ((sum by(cluster) (cluster_category_subCategory:armada_scheduler_failed_jobs:increase1m{namespace="{{ .Release.Namespace }}"})) + (sum by(cluster) (cluster_category_subCategory:armada_scheduler_succeeded_jobs:increase1m{namespace="{{ .Release.Namespace }}"})))
+          expr: sum by(cluster, category, subcategory) (cluster_category_subCategory:armada_scheduler_failed_jobs:increase1m{namespace="{{ .Release.Namespace }}"}) / on(cluster) group_left() ((sum by(cluster) (cluster_category_subCategory:armada_scheduler_failed_jobs:increase1m{namespace="{{ .Release.Namespace }}"})) + (sum by(cluster) (cluster_category_subCategory:armada_scheduler_succeeded_jobs:increase1m{namespace="{{ .Release.Namespace }}"})))
         - record: cluster_category_subCategory:armada_scheduler_failed_rate_jobs:increase10m
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: sum by(cluster, category, subCategory) (cluster_category_subCategory:armada_scheduler_failed_jobs:increase10m{namespace="{{ .Release.Namespace }}"}) / on(cluster) group_left() ((sum by(cluster) (cluster_category_subCategory:armada_scheduler_failed_jobs:increase10m{namespace="{{ .Release.Namespace }}"})) + (sum by(cluster) (cluster_category_subCategory:armada_scheduler_succeeded_jobs:increase10m{namespace="{{ .Release.Namespace }}"})))
+          expr: sum by(cluster, category, subcategory) (cluster_category_subCategory:armada_scheduler_failed_jobs:increase10m{namespace="{{ .Release.Namespace }}"}) / on(cluster) group_left() ((sum by(cluster) (cluster_category_subCategory:armada_scheduler_failed_jobs:increase10m{namespace="{{ .Release.Namespace }}"})) + (sum by(cluster) (cluster_category_subCategory:armada_scheduler_succeeded_jobs:increase10m{namespace="{{ .Release.Namespace }}"})))
         - record: cluster_category_subCategory:armada_scheduler_failed_rate_jobs:increase1h
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: sum by(cluster, category, subCategory) (cluster_category_subCategory:armada_scheduler_failed_jobs:increase1h{namespace="{{ .Release.Namespace }}"}) / on(cluster) group_left() ((sum by(cluster) (cluster_category_subCategory:armada_scheduler_failed_jobs:increase1h{namespace="{{ .Release.Namespace }}"})) + (sum by(cluster) (cluster_category_subCategory:armada_scheduler_succeeded_jobs:increase1h{namespace="{{ .Release.Namespace }}"})))
+          expr: sum by(cluster, category, subcategory) (cluster_category_subCategory:armada_scheduler_failed_jobs:increase1h{namespace="{{ .Release.Namespace }}"}) / on(cluster) group_left() ((sum by(cluster) (cluster_category_subCategory:armada_scheduler_failed_jobs:increase1h{namespace="{{ .Release.Namespace }}"})) + (sum by(cluster) (cluster_category_subCategory:armada_scheduler_succeeded_jobs:increase1h{namespace="{{ .Release.Namespace }}"})))
         # Per-queue failure rates.
         - record: queue_category_subCategory:armada_scheduler_failed_rate_jobs:increase1m
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: sum by(queue, category, subCategory) (queue_category_subCategory:armada_scheduler_failed_jobs:increase1m{namespace="{{ .Release.Namespace }}"}) / on(queue) group_left() ((sum by(queue) (queue_category_subCategory:armada_scheduler_failed_jobs:increase1m{namespace="{{ .Release.Namespace }}"})) + (sum by(queue) (queue_category_subCategory:armada_scheduler_succeeded_jobs:increase1m{namespace="{{ .Release.Namespace }}"})))
+          expr: sum by(queue, category, subcategory) (queue_category_subCategory:armada_scheduler_failed_jobs:increase1m{namespace="{{ .Release.Namespace }}"}) / on(queue) group_left() ((sum by(queue) (queue_category_subCategory:armada_scheduler_failed_jobs:increase1m{namespace="{{ .Release.Namespace }}"})) + (sum by(queue) (queue_category_subCategory:armada_scheduler_succeeded_jobs:increase1m{namespace="{{ .Release.Namespace }}"})))
         - record: queue_category_subCategory:armada_scheduler_failed_rate_jobs:increase10m
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: sum by(queue, category, subCategory) (queue_category_subCategory:armada_scheduler_failed_jobs:increase10m{namespace="{{ .Release.Namespace }}"}) / on(queue) group_left() ((sum by(queue) (queue_category_subCategory:armada_scheduler_failed_jobs:increase10m{namespace="{{ .Release.Namespace }}"})) + (sum by(queue) (queue_category_subCategory:armada_scheduler_succeeded_jobs:increase10m{namespace="{{ .Release.Namespace }}"})))
+          expr: sum by(queue, category, subcategory) (queue_category_subCategory:armada_scheduler_failed_jobs:increase10m{namespace="{{ .Release.Namespace }}"}) / on(queue) group_left() ((sum by(queue) (queue_category_subCategory:armada_scheduler_failed_jobs:increase10m{namespace="{{ .Release.Namespace }}"})) + (sum by(queue) (queue_category_subCategory:armada_scheduler_succeeded_jobs:increase10m{namespace="{{ .Release.Namespace }}"})))
         - record: queue_category_subCategory:armada_scheduler_failed_rate_jobs:increase1h
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: sum by(queue, category, subCategory) (queue_category_subCategory:armada_scheduler_failed_jobs:increase1h{namespace="{{ .Release.Namespace }}"}) / on(queue) group_left() ((sum by(queue) (queue_category_subCategory:armada_scheduler_failed_jobs:increase1h{namespace="{{ .Release.Namespace }}"})) + (sum by(queue) (queue_category_subCategory:armada_scheduler_succeeded_jobs:increase1h{namespace="{{ .Release.Namespace }}"})))
+          expr: sum by(queue, category, subcategory) (queue_category_subCategory:armada_scheduler_failed_jobs:increase1h{namespace="{{ .Release.Namespace }}"}) / on(queue) group_left() ((sum by(queue) (queue_category_subCategory:armada_scheduler_failed_jobs:increase1h{namespace="{{ .Release.Namespace }}"})) + (sum by(queue) (queue_category_subCategory:armada_scheduler_succeeded_jobs:increase1h{namespace="{{ .Release.Namespace }}"})))
 {{- end }}

--- a/deployment/scheduler/templates/scheduler-prometheusrule.yaml
+++ b/deployment/scheduler/templates/scheduler-prometheusrule.yaml
@@ -20,27 +20,29 @@ spec:
             namespace: "{{ .Release.Namespace }}"
           expr: sum by (node) (armada_scheduler_job_state_counter_by_node{namespace="{{ .Release.Namespace }}", state="failed"})
         # Per-cluster failures.
-        - record: cluster_category_subCategory:armada_scheduler_failed_jobs
+        - record: cluster_category_subcategory:armada_scheduler_failed_jobs
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: sum by (cluster, category, subCategory) (armada_scheduler_error_classification_by_node{namespace="{{ .Release.Namespace }}"})
+          expr: sum by (cluster, category, subcategory) (armada_scheduler_job_error_classification_by_node{namespace="{{ .Release.Namespace }}"})
         # Per-queue failures.
-        - record: queue_category_subCategory:armada_scheduler_failed_jobs
+        - record: queue_category_subcategory:armada_scheduler_failed_jobs
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: sum by (queue, category, subCategory) (armada_scheduler_job_error_classification_by_queue{namespace="{{ .Release.Namespace }}"})
+          expr: sum by (queue, category, subcategory) (armada_scheduler_job_error_classification_by_queue{namespace="{{ .Release.Namespace }}"})
         # Per-node successes.
         - record: node:armada_scheduler_succeeded_jobs
           labels:
             namespace: "{{ .Release.Namespace }}"
           expr: sum by (node) (armada_scheduler_job_state_counter_by_node{namespace="{{ .Release.Namespace }}", state="succeeded"})
         # Per-cluster successes.
-        - record: cluster_category_subCategory:armada_scheduler_succeeded_jobs
+        # Not dimensioned by category: the job state counter carries no category or subcategory labels.
+        - record: cluster:armada_scheduler_succeeded_jobs
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: sum by (cluster, category, subCategory) (armada_scheduler_job_state_counter_by_node{namespace="{{ .Release.Namespace }}", state="succeeded"})
+          expr: sum by (cluster) (armada_scheduler_job_state_counter_by_node{namespace="{{ .Release.Namespace }}", state="succeeded"})
         # Per-queue successes.
-        - record: queue_category_subCategory:armada_scheduler_succeeded_jobs
+        # Not dimensioned by category: the job state counter carries no category or subcategory labels.
+        - record: queue:armada_scheduler_succeeded_jobs
           labels:
             namespace: "{{ .Release.Namespace }}"
           expr: sum by (queue) (armada_scheduler_job_state_counter_by_queue{namespace="{{ .Release.Namespace }}", state="succeeded"})
@@ -49,41 +51,41 @@ spec:
         - record: node:armada_scheduler_failed_jobs:increase1m
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: increase(node:armada_scheduler_job_state_counter_by_queue{state="failed",namespace="{{ .Release.Namespace }}"}[1m:])
+          expr: increase(node:armada_scheduler_failed_jobs{namespace="{{ .Release.Namespace }}"}[1m:])
         - record: node:armada_scheduler_failed_jobs:increase10m
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: increase(node:armada_scheduler_job_state_counter_by_queue{state="failed",namespace="{{ .Release.Namespace }}"}[10m:])
+          expr: increase(node:armada_scheduler_failed_jobs{namespace="{{ .Release.Namespace }}"}[10m:])
         - record: node:armada_scheduler_failed_jobs:increase1h
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: increase(node:armada_scheduler_job_state_counter_by_queue{state="failed",namespace="{{ .Release.Namespace }}"}[10m:])
+          expr: increase(node:armada_scheduler_failed_jobs{namespace="{{ .Release.Namespace }}"}[1h:])
         # Per-cluster failures increase.
-        - record: cluster_category_subCategory:armada_scheduler_failed_jobs:increase1m
+        - record: cluster_category_subcategory:armada_scheduler_failed_jobs:increase1m
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: increase(cluster_category_subCategory:armada_scheduler_failed_jobs{namespace="{{ .Release.Namespace }}"}[1m:])
-        - record: cluster_category_subCategory:armada_scheduler_failed_jobs:increase10m
+          expr: increase(cluster_category_subcategory:armada_scheduler_failed_jobs{namespace="{{ .Release.Namespace }}"}[1m:])
+        - record: cluster_category_subcategory:armada_scheduler_failed_jobs:increase10m
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: increase(cluster_category_subCategory:armada_scheduler_failed_jobs{namespace="{{ .Release.Namespace }}"}[10m:])
-        - record: cluster_category_subCategory:armada_scheduler_failed_jobs:increase1h
+          expr: increase(cluster_category_subcategory:armada_scheduler_failed_jobs{namespace="{{ .Release.Namespace }}"}[10m:])
+        - record: cluster_category_subcategory:armada_scheduler_failed_jobs:increase1h
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: increase(cluster_category_subCategory:armada_scheduler_failed_jobs{namespace="{{ .Release.Namespace }}"}[1h:])
+          expr: increase(cluster_category_subcategory:armada_scheduler_failed_jobs{namespace="{{ .Release.Namespace }}"}[1h:])
         # Per-queue failures increase.
-        - record: queue_category_subCategory:armada_scheduler_failed_jobs:increase1m
+        - record: queue_category_subcategory:armada_scheduler_failed_jobs:increase1m
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: increase(queue_category_subCategory:armada_scheduler_failed_jobs{namespace="{{ .Release.Namespace }}"}[1m:])
-        - record: queue_category_subCategory:armada_scheduler_failed_jobs:increase10m
+          expr: increase(queue_category_subcategory:armada_scheduler_failed_jobs{namespace="{{ .Release.Namespace }}"}[1m:])
+        - record: queue_category_subcategory:armada_scheduler_failed_jobs:increase10m
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: increase(queue_category_subCategory:armada_scheduler_failed_jobs{namespace="{{ .Release.Namespace }}"}[10m:])
-        - record: queue_category_subCategory:armada_scheduler_failed_jobs:increase1h
+          expr: increase(queue_category_subcategory:armada_scheduler_failed_jobs{namespace="{{ .Release.Namespace }}"}[10m:])
+        - record: queue_category_subcategory:armada_scheduler_failed_jobs:increase1h
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: increase(queue_category_subCategory:armada_scheduler_failed_jobs{namespace="{{ .Release.Namespace }}"}[1h:])
+          expr: increase(queue_category_subcategory:armada_scheduler_failed_jobs{namespace="{{ .Release.Namespace }}"}[1h:])
         # Per-node successes increase.
         - record: node:armada_scheduler_succeeded_jobs:increase1m
           labels:
@@ -98,31 +100,31 @@ spec:
             namespace: "{{ .Release.Namespace }}"
           expr: increase(node:armada_scheduler_succeeded_jobs{namespace="{{ .Release.Namespace }}"}[1h:])
         # Per-cluster successes increase.
-        - record: cluster_category_subCategory:armada_scheduler_succeeded_jobs:increase1m
+        - record: cluster:armada_scheduler_succeeded_jobs:increase1m
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: increase(cluster_category_subCategory:armada_scheduler_succeeded_jobs{namespace="{{ .Release.Namespace }}"}[1m:])
-        - record: cluster_category_subCategory:armada_scheduler_succeeded_jobs:increase10m
+          expr: increase(cluster:armada_scheduler_succeeded_jobs{namespace="{{ .Release.Namespace }}"}[1m:])
+        - record: cluster:armada_scheduler_succeeded_jobs:increase10m
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: increase(cluster_category_subCategory:armada_scheduler_succeeded_jobs{namespace="{{ .Release.Namespace }}"}[10m:])
-        - record: cluster_category_subCategory:armada_scheduler_succeeded_jobs:increase1h
+          expr: increase(cluster:armada_scheduler_succeeded_jobs{namespace="{{ .Release.Namespace }}"}[10m:])
+        - record: cluster:armada_scheduler_succeeded_jobs:increase1h
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: increase(cluster_category_subCategory:armada_scheduler_succeeded_jobs{namespace="{{ .Release.Namespace }}"}[1h:])
+          expr: increase(cluster:armada_scheduler_succeeded_jobs{namespace="{{ .Release.Namespace }}"}[1h:])
         # Per-queue successes increase.
-        - record: queue_category_subCategory:armada_scheduler_succeeded_jobs:increase1m
+        - record: queue:armada_scheduler_succeeded_jobs:increase1m
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: increase(queue_category_subCategory:armada_scheduler_succeeded_jobs{namespace="{{ .Release.Namespace }}"}[1m:])
-        - record: queue_category_subCategory:armada_scheduler_succeeded_jobs:increase10m
+          expr: increase(queue:armada_scheduler_succeeded_jobs{namespace="{{ .Release.Namespace }}"}[1m:])
+        - record: queue:armada_scheduler_succeeded_jobs:increase10m
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: increase(queue_category_subCategory:armada_scheduler_succeeded_jobs{namespace="{{ .Release.Namespace }}"}[1m:])
-        - record: queue_category_subCategory:armada_scheduler_succeeded_jobs:increase1h
+          expr: increase(queue:armada_scheduler_succeeded_jobs{namespace="{{ .Release.Namespace }}"}[10m:])
+        - record: queue:armada_scheduler_succeeded_jobs:increase1h
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: increase(queue_category_subCategory:armada_scheduler_succeeded_jobs{namespace="{{ .Release.Namespace }}"}[1m:])
+          expr: increase(queue:armada_scheduler_succeeded_jobs{namespace="{{ .Release.Namespace }}"}[1h:])
         # Per-node failure rates.
         - record: node:armada_scheduler_failed_rate_jobs:increase1m
           labels:
@@ -137,29 +139,29 @@ spec:
             namespace: "{{ .Release.Namespace }}"
           expr: sum by(node) (node:armada_scheduler_failed_jobs:increase1h{namespace="{{ .Release.Namespace }}"}) / on(node) group_left() ((sum by(node) (node:armada_scheduler_failed_jobs:increase1h{namespace="{{ .Release.Namespace }}"})) + (sum by(node) (node:armada_scheduler_succeeded_jobs:increase1h{namespace="{{ .Release.Namespace }}"})))
         # Per-cluster failure rates.
-        - record: cluster_category_subCategory:armada_scheduler_failed_rate_jobs:increase1m
+        - record: cluster_category_subcategory:armada_scheduler_failed_rate_jobs:increase1m
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: sum by(cluster, category, subCategory) (cluster_category_subCategory:armada_scheduler_failed_jobs:increase1m{namespace="{{ .Release.Namespace }}"}) / on(cluster) group_left() ((sum by(cluster) (cluster_category_subCategory:armada_scheduler_failed_jobs:increase1m{namespace="{{ .Release.Namespace }}"})) + (sum by(cluster) (cluster_category_subCategory:armada_scheduler_succeeded_jobs:increase1m{namespace="{{ .Release.Namespace }}"})))
-        - record: cluster_category_subCategory:armada_scheduler_failed_rate_jobs:increase10m
+          expr: sum by(cluster, category, subcategory) (cluster_category_subcategory:armada_scheduler_failed_jobs:increase1m{namespace="{{ .Release.Namespace }}"}) / on(cluster) group_left() ((sum by(cluster) (cluster_category_subcategory:armada_scheduler_failed_jobs:increase1m{namespace="{{ .Release.Namespace }}"})) + (sum by(cluster) (cluster:armada_scheduler_succeeded_jobs:increase1m{namespace="{{ .Release.Namespace }}"})))
+        - record: cluster_category_subcategory:armada_scheduler_failed_rate_jobs:increase10m
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: sum by(cluster, category, subCategory) (cluster_category_subCategory:armada_scheduler_failed_jobs:increase10m{namespace="{{ .Release.Namespace }}"}) / on(cluster) group_left() ((sum by(cluster) (cluster_category_subCategory:armada_scheduler_failed_jobs:increase10m{namespace="{{ .Release.Namespace }}"})) + (sum by(cluster) (cluster_category_subCategory:armada_scheduler_succeeded_jobs:increase10m{namespace="{{ .Release.Namespace }}"})))
-        - record: cluster_category_subCategory:armada_scheduler_failed_rate_jobs:increase1h
+          expr: sum by(cluster, category, subcategory) (cluster_category_subcategory:armada_scheduler_failed_jobs:increase10m{namespace="{{ .Release.Namespace }}"}) / on(cluster) group_left() ((sum by(cluster) (cluster_category_subcategory:armada_scheduler_failed_jobs:increase10m{namespace="{{ .Release.Namespace }}"})) + (sum by(cluster) (cluster:armada_scheduler_succeeded_jobs:increase10m{namespace="{{ .Release.Namespace }}"})))
+        - record: cluster_category_subcategory:armada_scheduler_failed_rate_jobs:increase1h
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: sum by(cluster, category, subCategory) (cluster_category_subCategory:armada_scheduler_failed_jobs:increase1h{namespace="{{ .Release.Namespace }}"}) / on(cluster) group_left() ((sum by(cluster) (cluster_category_subCategory:armada_scheduler_failed_jobs:increase1h{namespace="{{ .Release.Namespace }}"})) + (sum by(cluster) (cluster_category_subCategory:armada_scheduler_succeeded_jobs:increase1h{namespace="{{ .Release.Namespace }}"})))
+          expr: sum by(cluster, category, subcategory) (cluster_category_subcategory:armada_scheduler_failed_jobs:increase1h{namespace="{{ .Release.Namespace }}"}) / on(cluster) group_left() ((sum by(cluster) (cluster_category_subcategory:armada_scheduler_failed_jobs:increase1h{namespace="{{ .Release.Namespace }}"})) + (sum by(cluster) (cluster:armada_scheduler_succeeded_jobs:increase1h{namespace="{{ .Release.Namespace }}"})))
         # Per-queue failure rates.
-        - record: queue_category_subCategory:armada_scheduler_failed_rate_jobs:increase1m
+        - record: queue_category_subcategory:armada_scheduler_failed_rate_jobs:increase1m
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: sum by(queue, category, subCategory) (queue_category_subCategory:armada_scheduler_failed_jobs:increase1m{namespace="{{ .Release.Namespace }}"}) / on(queue) group_left() ((sum by(queue) (queue_category_subCategory:armada_scheduler_failed_jobs:increase1m{namespace="{{ .Release.Namespace }}"})) + (sum by(queue) (queue_category_subCategory:armada_scheduler_succeeded_jobs:increase1m{namespace="{{ .Release.Namespace }}"})))
-        - record: queue_category_subCategory:armada_scheduler_failed_rate_jobs:increase10m
+          expr: sum by(queue, category, subcategory) (queue_category_subcategory:armada_scheduler_failed_jobs:increase1m{namespace="{{ .Release.Namespace }}"}) / on(queue) group_left() ((sum by(queue) (queue_category_subcategory:armada_scheduler_failed_jobs:increase1m{namespace="{{ .Release.Namespace }}"})) + (sum by(queue) (queue:armada_scheduler_succeeded_jobs:increase1m{namespace="{{ .Release.Namespace }}"})))
+        - record: queue_category_subcategory:armada_scheduler_failed_rate_jobs:increase10m
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: sum by(queue, category, subCategory) (queue_category_subCategory:armada_scheduler_failed_jobs:increase10m{namespace="{{ .Release.Namespace }}"}) / on(queue) group_left() ((sum by(queue) (queue_category_subCategory:armada_scheduler_failed_jobs:increase10m{namespace="{{ .Release.Namespace }}"})) + (sum by(queue) (queue_category_subCategory:armada_scheduler_succeeded_jobs:increase10m{namespace="{{ .Release.Namespace }}"})))
-        - record: queue_category_subCategory:armada_scheduler_failed_rate_jobs:increase1h
+          expr: sum by(queue, category, subcategory) (queue_category_subcategory:armada_scheduler_failed_jobs:increase10m{namespace="{{ .Release.Namespace }}"}) / on(queue) group_left() ((sum by(queue) (queue_category_subcategory:armada_scheduler_failed_jobs:increase10m{namespace="{{ .Release.Namespace }}"})) + (sum by(queue) (queue:armada_scheduler_succeeded_jobs:increase10m{namespace="{{ .Release.Namespace }}"})))
+        - record: queue_category_subcategory:armada_scheduler_failed_rate_jobs:increase1h
           labels:
             namespace: "{{ .Release.Namespace }}"
-          expr: sum by(queue, category, subCategory) (queue_category_subCategory:armada_scheduler_failed_jobs:increase1h{namespace="{{ .Release.Namespace }}"}) / on(queue) group_left() ((sum by(queue) (queue_category_subCategory:armada_scheduler_failed_jobs:increase1h{namespace="{{ .Release.Namespace }}"})) + (sum by(queue) (queue_category_subCategory:armada_scheduler_succeeded_jobs:increase1h{namespace="{{ .Release.Namespace }}"})))
+          expr: sum by(queue, category, subcategory) (queue_category_subcategory:armada_scheduler_failed_jobs:increase1h{namespace="{{ .Release.Namespace }}"}) / on(queue) group_left() ((sum by(queue) (queue_category_subcategory:armada_scheduler_failed_jobs:increase1h{namespace="{{ .Release.Namespace }}"})) + (sum by(queue) (queue:armada_scheduler_succeeded_jobs:increase1h{namespace="{{ .Release.Namespace }}"})))
 {{- end }}


### PR DESCRIPTION
The scheduler PrometheusRule (`deployment/scheduler/templates/scheduler-prometheusrule.yaml`) has five defects. All five are valid PromQL, so `promtool check rules` reports SUCCESS on the old file and on the new file. This PR edits only that file. The rule count stays at 33.

1. The scheduler exports the labels `category` and `subcategory` (`internal/scheduler/metrics/constants.go:16-17`). The rules aggregated `by (..., subCategory)`. Prometheus ignores a `by` label that matches nothing, so the failed-jobs series never carried a subcategory label. All 43 occurrences of `subCategory` now read `subcategory`, in the `by` clauses and in the record names.
2. `cluster_category_subCategory:armada_scheduler_failed_jobs` read `armada_scheduler_error_classification_by_node`. That metric does not exist. The exported name is `armada_scheduler_job_error_classification_by_node` (`internal/scheduler/metrics/state_metrics.go:101`). The file now references only the four metrics defined at `state_metrics.go:52,59,94,101`.
3. The three `node:armada_scheduler_failed_jobs:increase*` rules read `node:armada_scheduler_job_state_counter_by_queue`. No rule records that series. They now read `node:armada_scheduler_failed_jobs`. The `state="failed"` selector is gone from those three rules, because that recorded series has no `state` label.
4. `node:armada_scheduler_failed_jobs:increase1h` used `[10m:]`. The queue succeeded `increase10m` and `increase1h` rules used `[1m:]`. Each window now matches the rule name.
5. The succeeded-jobs rules derive from `armada_scheduler_job_state_counter_by_{queue,node}`. Those counters carry no `category` or `subcategory` label (`state_metrics.go:50-63`). The new names state what the rules compute. The failure-ratio denominators use the new names. The ratio formula does not change.

This PR renames these record families. Each family includes its `:increase1m`, `:increase10m` and `:increase1h` variants.

- `cluster_category_subCategory:armada_scheduler_failed_jobs` → `cluster_category_subcategory:armada_scheduler_failed_jobs`
- `queue_category_subCategory:armada_scheduler_failed_jobs` → `queue_category_subcategory:armada_scheduler_failed_jobs`
- `cluster_category_subCategory:armada_scheduler_failed_rate_jobs` → `cluster_category_subcategory:armada_scheduler_failed_rate_jobs`
- `queue_category_subCategory:armada_scheduler_failed_rate_jobs` → `queue_category_subcategory:armada_scheduler_failed_rate_jobs`
- `cluster_category_subCategory:armada_scheduler_succeeded_jobs` → `cluster:armada_scheduler_succeeded_jobs`
- `queue_category_subCategory:armada_scheduler_succeeded_jobs` → `queue:armada_scheduler_succeeded_jobs`

The queue failed, queue failed-rate and both succeeded families produced data before this PR (15 series). Consumers that query those names must move to the new names. The cluster failed and cluster failed-rate families were empty, because of defect 2.
