### PR TITLE
Fix unhandled rejection on the Job Sets page; migrate JobSetsContainer to a functional component

### DIFF
--- a/internal/lookoutui/eslint.config.mjs
+++ b/internal/lookoutui/eslint.config.mjs
@@ -76,6 +76,11 @@ export default tseslint.config(
               "aggregatable",
               "ingester",
 
+              // TanStack Query terminology
+              "refetch",
+              "refetches",
+              "refetching",
+
               // Use the American spelling of these words for consistency with the Armada API
               "reprioritize",
               "reprioritized",

--- a/internal/lookoutui/src/common/utils.tsx
+++ b/internal/lookoutui/src/common/utils.tsx
@@ -1,4 +1,4 @@
-import { Component, FC } from "react"
+import { Component, FC, useRef } from "react"
 
 import { Location, NavigateFunction, Params, useLocation, useNavigate, useParams } from "react-router-dom"
 
@@ -117,6 +117,35 @@ export function withRouter<T extends PropsWithRouter>(Component: FC<T>): FC<Omit
     return <Component {...props} router={{ location, navigate, params }} />
   }
   return ComponentWithRouterProp as FC<Omit<T, "router">>
+}
+
+// Returns a referentially-stable Router whose location, navigate and params always
+// reflect the current render. Use this when passing a router to a service that is
+// instantiated once (e.g. via useMemo with an empty dependency array), so the service
+// reads the live location rather than a snapshot captured at mount.
+export function useStableRouter(): Router {
+  const location = useLocation()
+  const navigate = useNavigate()
+  const params = useParams()
+
+  const ref = useRef<Router>({ location, navigate, params })
+  ref.current.location = location
+  ref.current.navigate = navigate
+  ref.current.params = params
+
+  const stableRouter = useRef<Router>({
+    get location() {
+      return ref.current.location
+    },
+    get navigate() {
+      return ref.current.navigate
+    },
+    get params() {
+      return ref.current.params
+    },
+  })
+
+  return stableRouter.current
 }
 
 export const PlatformCancelReason = "Platform error marked by user"

--- a/internal/lookoutui/src/pages/jobSets/components/CancelJobSetsDialog.tsx
+++ b/internal/lookoutui/src/pages/jobSets/components/CancelJobSetsDialog.tsx
@@ -3,8 +3,9 @@ import { useState } from "react"
 import { Dialog, DialogContent, DialogTitle } from "@mui/material"
 import { ErrorBoundary } from "react-error-boundary"
 
-import { ApiResult, PlatformCancelReason, RequestStatus } from "../../../common/utils"
+import { ApiResult, getErrorMessage, PlatformCancelReason, RequestStatus } from "../../../common/utils"
 import { AlertErrorFallback } from "../../../components/AlertErrorFallback"
+import { useCustomSnackbar } from "../../../components/hooks/useCustomSnackbar"
 import { JobSet } from "../../../models/lookoutModels"
 import { ApiJobState } from "../../../openapi/armada"
 import { CancelJobSetsResponse, useCancelJobSets } from "../../../services/lookout/useCancelJobSets"
@@ -54,6 +55,7 @@ export default function CancelJobSetsDialog(props: CancelJobSetsDialogProps) {
   const statesToCancel = getStatesToCancel(includeQueued, includeRunning)
 
   const cancelJobSetsMutation = useCancelJobSets()
+  const openSnackbar = useCustomSnackbar()
 
   async function cancelJobSets() {
     if (requestStatus === "Loading") {
@@ -62,22 +64,27 @@ export default function CancelJobSetsDialog(props: CancelJobSetsDialogProps) {
 
     setRequestStatus("Loading")
     const reason = isPlatformCancel ? PlatformCancelReason : ""
-    const cancelJobSetsResponse = await cancelJobSetsMutation.mutateAsync({
-      queue: props.queue,
-      jobSets: jobSetsToCancel,
-      states: statesToCancel,
-      reason,
-    })
-    setRequestStatus("Idle")
+    try {
+      const cancelJobSetsResponse = await cancelJobSetsMutation.mutateAsync({
+        queue: props.queue,
+        jobSets: jobSetsToCancel,
+        states: statesToCancel,
+        reason,
+      })
 
-    setResponse(cancelJobSetsResponse)
-    setState("CancelJobSetsResult")
-    if (cancelJobSetsResponse.failedJobSetCancellations.length === 0) {
-      props.onResult("Success")
-    } else if (cancelJobSetsResponse.cancelledJobSets.length === 0) {
-      props.onResult("Failure")
-    } else {
-      props.onResult("Partial success")
+      setResponse(cancelJobSetsResponse)
+      setState("CancelJobSetsResult")
+      if (cancelJobSetsResponse.failedJobSetCancellations.length === 0) {
+        props.onResult("Success")
+      } else if (cancelJobSetsResponse.cancelledJobSets.length === 0) {
+        props.onResult("Failure")
+      } else {
+        props.onResult("Partial success")
+      }
+    } catch (e) {
+      openSnackbar(`Failed to cancel job sets: ${await getErrorMessage(e)}`, "error")
+    } finally {
+      setRequestStatus("Idle")
     }
   }
 

--- a/internal/lookoutui/src/pages/jobSets/components/JobSetsContainer.test.tsx
+++ b/internal/lookoutui/src/pages/jobSets/components/JobSetsContainer.test.tsx
@@ -1,0 +1,131 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { render } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { http, HttpResponse } from "msw"
+import { SnackbarProvider } from "notistack"
+import { createMemoryRouter, RouterProvider } from "react-router-dom"
+import { v4 as uuidV4 } from "uuid"
+import { vi } from "vitest"
+
+import { Job, JobState } from "../../../models/lookoutModels"
+import { JOB_SETS } from "../../../pathnames"
+import { ApiClientsProvider } from "../../../services/apiClients"
+import { MockServer } from "../../../services/lookout/mocks/mockServer"
+
+import JobSetsContainer from "./JobSetsContainer"
+
+const mockServer = new MockServer()
+
+function makeTestJobs(n: number, queue: string, jobSet: string, state: JobState): Job[] {
+  const jobs: Job[] = []
+  for (let i = 0; i < n; i++) {
+    jobs.push({
+      annotations: {},
+      cpu: 1,
+      ephemeralStorage: 8192,
+      gpu: 0,
+      jobId: uuidV4(),
+      jobSet,
+      lastTransitionTime: "2024-01-01T00:00:00Z",
+      memory: 8192,
+      owner: queue,
+      namespace: queue,
+      priority: 1000,
+      priorityClass: "armada-default",
+      queue,
+      runs: [],
+      state,
+      submitted: "2024-01-01T00:00:00Z",
+    })
+  }
+  return jobs
+}
+
+describe("JobSetsContainer", () => {
+  beforeAll(() => {
+    mockServer.listen()
+  })
+
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+    mockServer.reset()
+  })
+
+  afterAll(() => {
+    mockServer.close()
+  })
+
+  const renderComponent = (search: string) => {
+    const testQueryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: 0 },
+      },
+    })
+
+    const element = (
+      <SnackbarProvider maxSnack={10} autoHideDuration={null}>
+        <QueryClientProvider client={testQueryClient}>
+          <ApiClientsProvider>
+            <JobSetsContainer jobSetsAutoRefreshMs={30000} />
+          </ApiClientsProvider>
+        </QueryClientProvider>
+      </SnackbarProvider>
+    )
+
+    const router = createMemoryRouter(
+      [
+        {
+          path: JOB_SETS,
+          element,
+        },
+      ],
+      { initialEntries: [JOB_SETS + search], initialIndex: 0 },
+    )
+
+    return render(<RouterProvider router={router} />)
+  }
+
+  it("renders the job sets table for the queue in the URL", async () => {
+    mockServer.setPostJobsResponse([
+      ...makeTestJobs(2, "queue-1", "job-set-a", JobState.Running),
+      ...makeTestJobs(3, "queue-1", "job-set-b", JobState.Queued),
+    ])
+
+    const { findByLabelText, queryByText } = renderComponent("?queue=queue-1")
+
+    // The "select all" header checkbox only renders when at least one job set has loaded.
+    expect(await findByLabelText("select all job sets")).toBeInTheDocument()
+    expect(queryByText("No job sets found for this queue.")).not.toBeInTheDocument()
+  })
+
+  it("refetches when the active-only filter changes", async () => {
+    // Only finished jobs: visible by default, but excluded once "Active only" is on.
+    mockServer.setPostJobsResponse(makeTestJobs(2, "queue-1", "finished-set", JobState.Succeeded))
+
+    const { findByLabelText, findByText, getByLabelText } = renderComponent("?queue=queue-1")
+
+    expect(await findByLabelText("select all job sets")).toBeInTheDocument()
+
+    await userEvent.click(getByLabelText("Active only"))
+
+    expect(await findByText("No job sets found for this queue.")).toBeInTheDocument()
+  })
+
+  it("surfaces a fetch failure as a snackbar without an unhandled rejection", async () => {
+    const unhandledRejection = vi.fn()
+    window.addEventListener("unhandledrejection", unhandledRejection)
+
+    mockServer.use(http.post("/api/v1/jobGroups", () => HttpResponse.error()))
+
+    const { findByText } = renderComponent("?queue=queue-1")
+
+    expect(await findByText(/Failed to load job sets for queue queue-1/)).toBeInTheDocument()
+    expect(unhandledRejection).not.toHaveBeenCalled()
+
+    window.removeEventListener("unhandledrejection", unhandledRejection)
+  })
+})

--- a/internal/lookoutui/src/pages/jobSets/components/JobSetsContainer.tsx
+++ b/internal/lookoutui/src/pages/jobSets/components/JobSetsContainer.tsx
@@ -1,21 +1,15 @@
-import { Component, FC } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 
 import { ErrorBoundary } from "react-error-boundary"
+import { useLocation, useNavigate, useParams } from "react-router-dom"
 
 import { StandardColumnId } from "../../../common/jobsTableColumns"
-import {
-  ApiResult,
-  debounced,
-  PropsWithRouter,
-  RequestStatus,
-  selectItem,
-  setStateAsync,
-  withRouter,
-} from "../../../common/utils"
+import { ApiResult, RequestStatus, selectItem } from "../../../common/utils"
 import { AlertErrorFallback } from "../../../components/AlertErrorFallback"
-import { GetJobSetsRequest, JobSet, JobSetsOrderByColumn, JobState, Match } from "../../../models/lookoutModels"
+import { useCustomSnackbar } from "../../../components/hooks/useCustomSnackbar"
+import { JobSet, JobSetsOrderByColumn } from "../../../models/lookoutModels"
 import { JOBS } from "../../../pathnames"
-import JobSetsLocalStorageService from "../../../services/JobSetsLocalStorageService"
+import JobSetsLocalStorageService, { JobSetsPrefs } from "../../../services/JobSetsLocalStorageService"
 import JobSetsQueryParamsService from "../../../services/JobSetsQueryParamsService"
 import {
   DEFAULT_PREFERENCES,
@@ -23,382 +17,194 @@ import {
   stringifyQueryParams,
   toQueryStringSafe,
 } from "../../../services/lookout/JobsTablePreferencesService"
-import { useGroupJobs } from "../../../services/lookout/useGroupJobs"
+import { useGetJobSets } from "../../../services/lookout/useGetJobSets"
 
 import CancelJobSetsDialog, { getCancellableJobSets } from "./CancelJobSetsDialog"
 import JobSets from "./JobSets"
 import ReprioritizeJobSetsDialog, { getReprioritizableJobSets } from "./ReprioritizeJobSetsDialog"
 
-interface JobSetsContainerProps extends PropsWithRouter {
-  groupJobs: ReturnType<typeof useGroupJobs>
+export interface JobSetsContainerProps {
   jobSetsAutoRefreshMs: number | undefined
 }
 
-type JobSetsContainerParams = {
-  queue: string
+const DEFAULT_PREFS: JobSetsPrefs = {
+  queue: "",
+  autoRefresh: true,
+  orderByColumn: "submitted",
+  orderByDesc: true,
+  activeOnly: false,
 }
 
-export type JobSetsContainerState = {
-  jobSets: JobSet[]
-  selectedJobSets: Map<string, JobSet>
-  getJobSetsRequestStatus: RequestStatus
-  autoRefresh: boolean
-  lastSelectedIndex: number
-  orderByColumn: JobSetsOrderByColumn
-  orderByDesc: boolean
-  activeOnly: boolean
-  cancelJobSetsIsOpen: boolean
-  reprioritizeJobSetsIsOpen: boolean
-} & JobSetsContainerParams
+export default function JobSetsContainer({ jobSetsAutoRefreshMs }: JobSetsContainerProps) {
+  const location = useLocation()
+  const navigate = useNavigate()
+  const params = useParams()
+  const openSnackbar = useCustomSnackbar()
 
-class JobSetsContainer extends Component<JobSetsContainerProps, JobSetsContainerState> {
-  autoRefreshInterval: NodeJS.Timeout | undefined
-  autoRefreshMs: number | undefined
-  localStorageService: JobSetsLocalStorageService
-  queryParamsService: JobSetsQueryParamsService
+  const localStorageService = useMemo(() => new JobSetsLocalStorageService(), [])
+  const queryParamsService = useMemo(() => new JobSetsQueryParamsService({ location, navigate, params }), [])
 
-  constructor(props: JobSetsContainerProps) {
-    super(props)
+  const [prefs] = useState<JobSetsPrefs>(() => {
+    const initial = { ...DEFAULT_PREFS }
+    localStorageService.updateState(initial)
+    queryParamsService.updateState(initial)
+    return initial
+  })
 
-    this.autoRefreshMs = props.jobSetsAutoRefreshMs
-    this.localStorageService = new JobSetsLocalStorageService()
-    this.queryParamsService = new JobSetsQueryParamsService(this.props.router)
+  const [queue, setQueueState] = useState(prefs.queue)
+  const [orderByColumn, setOrderByColumn] = useState(prefs.orderByColumn)
+  const [orderByDesc, setOrderByDesc] = useState(prefs.orderByDesc)
+  const [activeOnly, setActiveOnly] = useState(prefs.activeOnly)
+  const [autoRefresh, setAutoRefresh] = useState(prefs.autoRefresh)
 
-    this.state = {
-      queue: "",
-      jobSets: [],
-      selectedJobSets: new Map<string, JobSet>(),
-      getJobSetsRequestStatus: "Idle",
-      autoRefresh: true,
-      lastSelectedIndex: 0,
-      cancelJobSetsIsOpen: false,
-      reprioritizeJobSetsIsOpen: false,
-      orderByColumn: "submitted",
-      orderByDesc: true,
-      activeOnly: false,
+  const [selectedJobSets, setSelectedJobSets] = useState<Map<string, JobSet>>(new Map())
+  const [lastSelectedIndex, setLastSelectedIndex] = useState(0)
+  const [cancelJobSetsIsOpen, setCancelJobSetsIsOpen] = useState(false)
+  const [reprioritizeJobSetsIsOpen, setReprioritizeJobSetsIsOpen] = useState(false)
+
+  const { data, error, errorUpdatedAt, isFetching, refetch } = useGetJobSets({
+    queue,
+    activeOnly,
+    orderByColumn,
+    orderByDesc,
+    autoRefresh,
+    autoRefreshMs: jobSetsAutoRefreshMs,
+  })
+  const jobSets = data ?? []
+
+  useEffect(() => {
+    const currentPrefs: JobSetsPrefs = { queue, autoRefresh, orderByColumn, orderByDesc, activeOnly }
+    localStorageService.saveState(currentPrefs)
+    queryParamsService.saveState(currentPrefs)
+  }, [queue, autoRefresh, orderByColumn, orderByDesc, activeOnly, localStorageService, queryParamsService])
+
+  useEffect(() => {
+    if (error !== null) {
+      openSnackbar(`Failed to load job sets for queue ${queue}: ${error}`, "error")
     }
+    // Keyed on errorUpdatedAt (not error) so repeated identical failures, such as
+    // retrying refresh while offline, each surface a fresh snackbar.
+  }, [errorUpdatedAt])
 
-    this.setQueue = this.setQueue.bind(this)
-    this.orderChange = this.orderChange.bind(this)
-    this.activeOnlyChange = this.activeOnlyChange.bind(this)
-    this.selectJobSet = this.selectJobSet.bind(this)
-    this.shiftSelectJobSet = this.shiftSelectJobSet.bind(this)
-    this.deselectAll = this.deselectAll.bind(this)
-    this.selectAll = this.selectAll.bind(this)
+  const deselectAll = useCallback(() => {
+    setSelectedJobSets(new Map())
+    setLastSelectedIndex(0)
+  }, [])
 
-    this.openCancelJobSets = this.openCancelJobSets.bind(this)
-    this.openReprioritizeJobSets = this.openReprioritizeJobSets.bind(this)
-    this.handleApiResult = this.handleApiResult.bind(this)
-
-    this.fetchJobSets = debounced(this.fetchJobSets.bind(this), 100)
-    this.loadJobSets = this.loadJobSets.bind(this)
-    this.toggleAutoRefresh = this.toggleAutoRefresh.bind(this)
-    this.onJobSetStateClick = this.onJobSetStateClick.bind(this)
-  }
-
-  async componentDidMount() {
-    const newState = { ...this.state }
-
-    this.localStorageService.updateState(newState)
-    this.queryParamsService.updateState(newState)
-
-    this.localStorageService.saveState(newState)
-    // queryParamsService.saveState calls navigate, which should only be called in useEffect
-    // actual fix is migrating this component to a functional one with hooks
-    setTimeout(() => this.queryParamsService.saveState(newState))
-
-    await setStateAsync(this, {
-      ...newState,
-    })
-
-    await this.loadJobSets()
-
-    this.tryStartAutoRefresh()
-  }
-
-  componentWillUnmount() {
-    this.stopAutoRefresh()
-  }
-
-  async setQueue(queue: string) {
-    await this.updateState({
-      ...this.state,
-      queue: queue,
-    })
-
-    // Performed separately because debounced
-    await this.loadJobSets()
-  }
-
-  async orderChange(orderByColumn: JobSetsOrderByColumn, orderByDesc: boolean) {
-    await this.updateState({
-      ...this.state,
-      orderByColumn,
-      orderByDesc,
-    })
-    await this.loadJobSets()
-  }
-
-  async activeOnlyChange(activeOnly: boolean) {
-    await this.updateState({
-      ...this.state,
-      activeOnly: activeOnly,
-    })
-
-    await this.loadJobSets()
-  }
-
-  selectJobSet(index: number, selected: boolean) {
-    if (index < 0 || index >= this.state.jobSets.length) {
-      return
-    }
-    const jobSet = this.state.jobSets[index]
-
-    const selectedJobSets = new Map<string, JobSet>(this.state.selectedJobSets)
-    selectItem(jobSet.jobSetId, jobSet, selectedJobSets, selected)
-
-    this.setState({
-      ...this.state,
-      selectedJobSets: selectedJobSets,
-      lastSelectedIndex: index,
-    })
-  }
-
-  shiftSelectJobSet(index: number, selected: boolean) {
-    if (index >= this.state.jobSets.length || index < 0) {
-      return
-    }
-
-    const [start, end] = [this.state.lastSelectedIndex, index].sort((a, b) => a - b)
-
-    const selectedJobSets = new Map<string, JobSet>(this.state.selectedJobSets)
-    for (let i = start; i <= end; i++) {
-      const jobSet = this.state.jobSets[i]
-      selectItem(jobSet.jobSetId, jobSet, selectedJobSets, selected)
-    }
-
-    this.setState({
-      ...this.state,
-      selectedJobSets: selectedJobSets,
-      lastSelectedIndex: index,
-    })
-  }
-
-  deselectAll() {
-    this.setState({
-      ...this.state,
-      selectedJobSets: new Map<string, JobSet>(),
-      lastSelectedIndex: 0,
-    })
-  }
-
-  selectAll() {
+  const selectAll = useCallback(() => {
     const selected = new Map<string, JobSet>()
-    this.state.jobSets.forEach((jobSet) => selected.set(jobSet.jobSetId, jobSet))
+    jobSets.forEach((jobSet) => selected.set(jobSet.jobSetId, jobSet))
+    setSelectedJobSets(selected)
+    setLastSelectedIndex(0)
+  }, [jobSets])
 
-    this.setState({
-      ...this.state,
-      selectedJobSets: selected,
-      lastSelectedIndex: 0,
-    })
-  }
-
-  openCancelJobSets(isOpen: boolean) {
-    this.setState({
-      ...this.state,
-      cancelJobSetsIsOpen: isOpen,
-    })
-  }
-
-  openReprioritizeJobSets(isOpen: boolean) {
-    this.setState({
-      ...this.state,
-      reprioritizeJobSetsIsOpen: isOpen,
-    })
-  }
-
-  handleApiResult(result: ApiResult) {
-    if (result === "Success") {
-      this.deselectAll()
-      return this.loadJobSets()
-    } else if (result === "Partial success") {
-      return this.loadJobSets()
-    }
-  }
-
-  async toggleAutoRefresh(autoRefresh: boolean) {
-    await this.updateState({
-      ...this.state,
-      autoRefresh: autoRefresh,
-    })
-    this.tryStartAutoRefresh()
-  }
-
-  tryStartAutoRefresh() {
-    this.stopAutoRefresh()
-    if (this.state.autoRefresh && this.autoRefreshMs !== undefined) {
-      this.autoRefreshInterval = setInterval(this.loadJobSets, this.autoRefreshMs)
-    }
-  }
-
-  stopAutoRefresh() {
-    if (this.autoRefreshInterval) {
-      clearInterval(this.autoRefreshInterval)
-      this.autoRefreshInterval = undefined
-    }
-  }
-
-  private async onJobSetStateClick(rowIndex: number, state: string) {
-    const jobSet = this.state.jobSets[rowIndex]
-
-    const prefs: JobsTablePreferences = {
-      ...DEFAULT_PREFERENCES,
-      filters: [
-        {
-          id: StandardColumnId.Queue,
-          value: jobSet.queue,
-        },
-        {
-          id: StandardColumnId.State,
-          value: [state],
-        },
-        {
-          id: StandardColumnId.JobSet,
-          value: jobSet.jobSetId,
-        },
-      ],
-    }
-
-    this.props.router.navigate({
-      pathname: JOBS,
-      search: stringifyQueryParams(toQueryStringSafe(prefs)),
-    })
-  }
-
-  private async updateState(updatedState: JobSetsContainerState) {
-    this.localStorageService.saveState(updatedState)
-    this.queryParamsService.saveState(updatedState)
-    await setStateAsync(this, updatedState)
-  }
-
-  private async loadJobSets() {
-    if (this.state.queue === "") {
-      return
-    }
-    await setStateAsync(this, {
-      ...this.state,
-      getJobSetsRequestStatus: "Loading",
-    })
-    const jobSets = await this.fetchJobSets({
-      queue: this.state.queue,
-      orderByColumn: this.state.orderByColumn,
-      orderByDesc: this.state.orderByDesc,
-      activeOnly: this.state.activeOnly,
-    })
-    this.setState({
-      ...this.state,
-      jobSets: jobSets,
-      getJobSetsRequestStatus: "Idle",
-    })
-  }
-
-  private async fetchJobSets(getJobSetsRequest: GetJobSetsRequest): Promise<JobSet[]> {
-    const response = await this.props.groupJobs(
-      [
-        {
-          isAnnotation: false,
-          field: "queue",
-          value: getJobSetsRequest.queue,
-          match: Match.Exact,
-        },
-      ],
-      getJobSetsRequest.activeOnly,
-      {
-        field: getJobSetsRequest.orderByColumn,
-        direction: getJobSetsRequest.orderByDesc ? "DESC" : "ASC",
-      },
-      {
-        field: "jobSet",
-        isAnnotation: false,
-      },
-      ["state", "submitted"],
-      0,
-      0,
-    )
-
-    return response.groups.map((group) => {
-      const state = group.aggregates.state as Record<string, number>
-      return {
-        jobSetId: group.name,
-        queue: getJobSetsRequest.queue,
-        jobsQueued: state[JobState.Queued] || 0,
-        jobsPending: state[JobState.Pending] || 0,
-        jobsRunning: state[JobState.Running] || 0,
-        jobsSucceeded: state[JobState.Succeeded] || 0,
-        jobsFailed: state[JobState.Failed] || 0,
-        jobsCancelled: state[JobState.Cancelled] || 0,
-        latestSubmissionTime: group.aggregates.submitted as string,
+  const selectJobSet = useCallback(
+    (index: number, selected: boolean) => {
+      if (index < 0 || index >= jobSets.length) {
+        return
       }
-    })
-  }
+      const jobSet = jobSets[index]
+      const newSelected = new Map(selectedJobSets)
+      selectItem(jobSet.jobSetId, jobSet, newSelected, selected)
+      setSelectedJobSets(newSelected)
+      setLastSelectedIndex(index)
+    },
+    [jobSets, selectedJobSets],
+  )
 
-  render() {
-    const selectedJobSets = Array.from(this.state.selectedJobSets.values())
-    return (
-      <>
-        <CancelJobSetsDialog
-          isOpen={this.state.cancelJobSetsIsOpen}
-          queue={this.state.queue}
+  const shiftSelectJobSet = useCallback(
+    (index: number, selected: boolean) => {
+      if (index < 0 || index >= jobSets.length) {
+        return
+      }
+      const [start, end] = [lastSelectedIndex, index].sort((a, b) => a - b)
+      const newSelected = new Map(selectedJobSets)
+      for (let i = start; i <= end; i++) {
+        const jobSet = jobSets[i]
+        selectItem(jobSet.jobSetId, jobSet, newSelected, selected)
+      }
+      setSelectedJobSets(newSelected)
+      setLastSelectedIndex(index)
+    },
+    [jobSets, lastSelectedIndex, selectedJobSets],
+  )
+
+  const handleApiResult = useCallback(
+    (result: ApiResult) => {
+      if (result === "Success") {
+        deselectAll()
+        refetch()
+      } else if (result === "Partial success") {
+        refetch()
+      }
+    },
+    [deselectAll, refetch],
+  )
+
+  const onJobSetStateClick = useCallback(
+    (rowIndex: number, state: string) => {
+      const jobSet = jobSets[rowIndex]
+      const prefs: JobsTablePreferences = {
+        ...DEFAULT_PREFERENCES,
+        filters: [
+          { id: StandardColumnId.Queue, value: jobSet.queue },
+          { id: StandardColumnId.State, value: [state] },
+          { id: StandardColumnId.JobSet, value: jobSet.jobSetId },
+        ],
+      }
+      navigate({ pathname: JOBS, search: stringifyQueryParams(toQueryStringSafe(prefs)) })
+    },
+    [jobSets, navigate],
+  )
+
+  const selectedJobSetsArray = Array.from(selectedJobSets.values())
+  const getJobSetsRequestStatus: RequestStatus = isFetching ? "Loading" : "Idle"
+
+  return (
+    <>
+      <CancelJobSetsDialog
+        isOpen={cancelJobSetsIsOpen}
+        queue={queue}
+        selectedJobSets={selectedJobSetsArray}
+        onResult={handleApiResult}
+        onClose={() => setCancelJobSetsIsOpen(false)}
+      />
+      <ReprioritizeJobSetsDialog
+        isOpen={reprioritizeJobSetsIsOpen}
+        queue={queue}
+        selectedJobSets={selectedJobSetsArray}
+        onResult={handleApiResult}
+        onClose={() => setReprioritizeJobSetsIsOpen(false)}
+      />
+      <ErrorBoundary FallbackComponent={AlertErrorFallback}>
+        <JobSets
+          canCancel={getCancellableJobSets(selectedJobSetsArray).length > 0}
+          canReprioritize={getReprioritizableJobSets(selectedJobSetsArray).length > 0}
+          queue={queue}
+          jobSets={jobSets}
           selectedJobSets={selectedJobSets}
-          onResult={this.handleApiResult}
-          onClose={() => this.openCancelJobSets(false)}
+          getJobSetsRequestStatus={getJobSetsRequestStatus}
+          autoRefresh={autoRefresh}
+          orderByColumn={orderByColumn}
+          orderByDesc={orderByDesc}
+          activeOnly={activeOnly}
+          onQueueChange={setQueueState}
+          onOrderChange={(column: JobSetsOrderByColumn, desc: boolean) => {
+            setOrderByColumn(column)
+            setOrderByDesc(desc)
+          }}
+          onActiveOnlyChange={setActiveOnly}
+          onRefresh={() => refetch()}
+          onSelectJobSet={selectJobSet}
+          onShiftSelectJobSet={shiftSelectJobSet}
+          onDeselectAllClick={deselectAll}
+          onSelectAllClick={selectAll}
+          onCancelJobSetsClick={() => setCancelJobSetsIsOpen(true)}
+          onToggleAutoRefresh={jobSetsAutoRefreshMs !== undefined ? setAutoRefresh : undefined}
+          onReprioritizeJobSetsClick={() => setReprioritizeJobSetsIsOpen(true)}
+          onJobSetStateClick={onJobSetStateClick}
         />
-        <ReprioritizeJobSetsDialog
-          isOpen={this.state.reprioritizeJobSetsIsOpen}
-          queue={this.state.queue}
-          selectedJobSets={selectedJobSets}
-          onResult={this.handleApiResult}
-          onClose={() => this.openReprioritizeJobSets(false)}
-        />
-        <ErrorBoundary FallbackComponent={AlertErrorFallback}>
-          <JobSets
-            canCancel={getCancellableJobSets(selectedJobSets).length > 0}
-            canReprioritize={getReprioritizableJobSets(selectedJobSets).length > 0}
-            queue={this.state.queue}
-            jobSets={this.state.jobSets}
-            selectedJobSets={this.state.selectedJobSets}
-            getJobSetsRequestStatus={this.state.getJobSetsRequestStatus}
-            autoRefresh={this.state.autoRefresh}
-            orderByColumn={this.state.orderByColumn}
-            orderByDesc={this.state.orderByDesc}
-            activeOnly={this.state.activeOnly}
-            onQueueChange={this.setQueue}
-            onOrderChange={this.orderChange}
-            onActiveOnlyChange={this.activeOnlyChange}
-            onRefresh={this.loadJobSets}
-            onSelectJobSet={this.selectJobSet}
-            onShiftSelectJobSet={this.shiftSelectJobSet}
-            onDeselectAllClick={this.deselectAll}
-            onSelectAllClick={this.selectAll}
-            onCancelJobSetsClick={() => this.openCancelJobSets(true)}
-            onToggleAutoRefresh={this.autoRefreshMs !== undefined ? this.toggleAutoRefresh : undefined}
-            onReprioritizeJobSetsClick={() => this.openReprioritizeJobSets(true)}
-            onJobSetStateClick={this.onJobSetStateClick}
-          />
-        </ErrorBoundary>
-      </>
-    )
-  }
+      </ErrorBoundary>
+    </>
+  )
 }
-
-const withGroupJobs = <T extends { groupJobs: ReturnType<typeof useGroupJobs> }>(
-  Component: FC<T>,
-): FC<Omit<T, "groupJobs">> => {
-  function ComponentWithGroupJobs(props: T) {
-    const groupJobs = useGroupJobs()
-    return <Component {...props} groupJobs={groupJobs} />
-  }
-  return ComponentWithGroupJobs as FC<Omit<T, "groupJobs">>
-}
-
-export default withGroupJobs(withRouter((props: JobSetsContainerProps) => <JobSetsContainer {...props} />))

--- a/internal/lookoutui/src/pages/jobSets/components/JobSetsContainer.tsx
+++ b/internal/lookoutui/src/pages/jobSets/components/JobSetsContainer.tsx
@@ -1,10 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
 
 import { ErrorBoundary } from "react-error-boundary"
-import { useLocation, useNavigate, useParams } from "react-router-dom"
 
 import { StandardColumnId } from "../../../common/jobsTableColumns"
-import { ApiResult, RequestStatus, selectItem } from "../../../common/utils"
+import { ApiResult, RequestStatus, selectItem, useStableRouter } from "../../../common/utils"
 import { AlertErrorFallback } from "../../../components/AlertErrorFallback"
 import { useCustomSnackbar } from "../../../components/hooks/useCustomSnackbar"
 import { JobSet, JobSetsOrderByColumn } from "../../../models/lookoutModels"
@@ -36,13 +35,11 @@ const DEFAULT_PREFS: JobSetsPrefs = {
 }
 
 export default function JobSetsContainer({ jobSetsAutoRefreshMs }: JobSetsContainerProps) {
-  const location = useLocation()
-  const navigate = useNavigate()
-  const params = useParams()
+  const router = useStableRouter()
   const openSnackbar = useCustomSnackbar()
 
   const localStorageService = useMemo(() => new JobSetsLocalStorageService(), [])
-  const queryParamsService = useMemo(() => new JobSetsQueryParamsService({ location, navigate, params }), [])
+  const queryParamsService = useMemo(() => new JobSetsQueryParamsService(router), [router])
 
   const [prefs] = useState<JobSetsPrefs>(() => {
     const initial = { ...DEFAULT_PREFS }
@@ -152,9 +149,9 @@ export default function JobSetsContainer({ jobSetsAutoRefreshMs }: JobSetsContai
           { id: StandardColumnId.JobSet, value: jobSet.jobSetId },
         ],
       }
-      navigate({ pathname: JOBS, search: stringifyQueryParams(toQueryStringSafe(prefs)) })
+      router.navigate({ pathname: JOBS, search: stringifyQueryParams(toQueryStringSafe(prefs)) })
     },
-    [jobSets, navigate],
+    [jobSets, router],
   )
 
   const selectedJobSetsArray = Array.from(selectedJobSets.values())

--- a/internal/lookoutui/src/pages/jobSets/components/ReprioritizeJobSetsDialog.tsx
+++ b/internal/lookoutui/src/pages/jobSets/components/ReprioritizeJobSetsDialog.tsx
@@ -3,8 +3,9 @@ import { useState } from "react"
 import { Dialog, DialogContent, DialogTitle } from "@mui/material"
 import { ErrorBoundary } from "react-error-boundary"
 
-import { ApiResult, priorityIsValid, RequestStatus } from "../../../common/utils"
+import { ApiResult, getErrorMessage, priorityIsValid, RequestStatus } from "../../../common/utils"
 import { AlertErrorFallback } from "../../../components/AlertErrorFallback"
+import { useCustomSnackbar } from "../../../components/hooks/useCustomSnackbar"
 import { JobSet } from "../../../models/lookoutModels"
 import { ReprioritizeJobSetsResponse, useReprioritizeJobSets } from "../../../services/lookout/useReprioritizeJobSets"
 
@@ -39,6 +40,7 @@ export default function ReprioritizeJobSetsDialog(props: ReprioritizeJobSetsDial
   const jobSetsToReprioritize = getReprioritizableJobSets(props.selectedJobSets)
 
   const reprioritizeJobSetsMutation = useReprioritizeJobSets()
+  const openSnackbar = useCustomSnackbar()
 
   async function reprioritizeJobSets() {
     if (requestStatus == "Loading" || !priorityIsValid(priority)) {
@@ -46,21 +48,26 @@ export default function ReprioritizeJobSetsDialog(props: ReprioritizeJobSetsDial
     }
 
     setRequestStatus("Loading")
-    const reprioritizeJobSetsResponse = await reprioritizeJobSetsMutation.mutateAsync({
-      queue: props.queue,
-      jobSets: jobSetsToReprioritize,
-      newPriority: Number(priority),
-    })
-    setRequestStatus("Idle")
+    try {
+      const reprioritizeJobSetsResponse = await reprioritizeJobSetsMutation.mutateAsync({
+        queue: props.queue,
+        jobSets: jobSetsToReprioritize,
+        newPriority: Number(priority),
+      })
 
-    setResponse(reprioritizeJobSetsResponse)
-    setState("ReprioritizeJobSetsResult")
-    if (reprioritizeJobSetsResponse.failedJobSetReprioritizations.length === 0) {
-      props.onResult("Success")
-    } else if (reprioritizeJobSetsResponse.reprioritizedJobSets.length === 0) {
-      props.onResult("Failure")
-    } else {
-      props.onResult("Partial success")
+      setResponse(reprioritizeJobSetsResponse)
+      setState("ReprioritizeJobSetsResult")
+      if (reprioritizeJobSetsResponse.failedJobSetReprioritizations.length === 0) {
+        props.onResult("Success")
+      } else if (reprioritizeJobSetsResponse.reprioritizedJobSets.length === 0) {
+        props.onResult("Failure")
+      } else {
+        props.onResult("Partial success")
+      }
+    } catch (e) {
+      openSnackbar(`Failed to reprioritize job sets: ${await getErrorMessage(e)}`, "error")
+    } finally {
+      setRequestStatus("Idle")
     }
   }
 

--- a/internal/lookoutui/src/pages/jobs/components/JobsTableContainer.tsx
+++ b/internal/lookoutui/src/pages/jobs/components/JobsTableContainer.tsx
@@ -34,7 +34,6 @@ import {
 } from "@tanstack/react-table"
 import _ from "lodash"
 import { ErrorBoundary } from "react-error-boundary"
-import { useLocation, useNavigate, useParams } from "react-router-dom"
 
 import { buildViewEventData } from "../../../analytics/viewMetadata"
 import {
@@ -62,7 +61,7 @@ import {
 } from "../../../common/jobsTableUtils"
 import { fromRowId, RowId } from "../../../common/reactTableUtils"
 import { EmptyInputError, ParseError } from "../../../common/resourceUtils"
-import { getErrorMessage, waitMs } from "../../../common/utils"
+import { getErrorMessage, useStableRouter, waitMs } from "../../../common/utils"
 import { AlertErrorFallback } from "../../../components/AlertErrorFallback"
 import { useFormatNumberWithUserSettings } from "../../../components/hooks/formatNumberWithUserSettings"
 import {
@@ -121,10 +120,8 @@ export const JobsTableContainer = ({ debug, autoRefreshMs, commandSpecs }: JobsT
   const openSnackbar = useCustomSnackbar()
   const groupJobs = useGroupJobs()
 
-  const location = useLocation()
-  const navigate = useNavigate()
-  const params = useParams()
-  const jobsTablePreferencesService = useMemo(() => new JobsTablePreferencesService({ location, navigate, params }), [])
+  const router = useStableRouter()
+  const jobsTablePreferencesService = useMemo(() => new JobsTablePreferencesService(router), [router])
   const customViewsService = useMemo(() => new CustomViewsService(), [])
   const initialPrefs = useMemo(() => jobsTablePreferencesService.getUserPrefs(), [])
 

--- a/internal/lookoutui/src/services/JobSetsLocalStorageService.ts
+++ b/internal/lookoutui/src/services/JobSetsLocalStorageService.ts
@@ -1,8 +1,15 @@
 import { tryParseJson } from "../common/utils"
 import { isJobSetsOrderByColumn, JobSetsOrderByColumn } from "../models/lookoutModels"
-import { JobSetsContainerState } from "../pages/jobSets/components/JobSetsContainer"
 
 const LOCAL_STORAGE_KEY = "armada_lookout_job_sets_user_settings"
+
+export interface JobSetsPrefs {
+  queue: string
+  autoRefresh: boolean
+  orderByColumn: JobSetsOrderByColumn
+  orderByDesc: boolean
+  activeOnly: boolean
+}
 
 export type JobSetsLocalStorageState = {
   autoRefresh?: boolean
@@ -36,7 +43,7 @@ function convertToLocalStorageState(loadedData: Record<string, unknown>): JobSet
 }
 
 export default class JobSetsLocalStorageService {
-  saveState(state: JobSetsContainerState) {
+  saveState(state: JobSetsPrefs) {
     const localStorageState = {
       autoRefresh: state.autoRefresh,
       queue: state.queue,
@@ -47,7 +54,7 @@ export default class JobSetsLocalStorageService {
     localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(localStorageState))
   }
 
-  updateState(state: JobSetsContainerState) {
+  updateState(state: JobSetsPrefs) {
     const stateJson = localStorage.getItem(LOCAL_STORAGE_KEY)
     if (stateJson == undefined) {
       return

--- a/internal/lookoutui/src/services/JobSetsQueryParamsService.ts
+++ b/internal/lookoutui/src/services/JobSetsQueryParamsService.ts
@@ -2,7 +2,8 @@ import queryString, { ParseOptions, StringifyOptions } from "query-string"
 
 import { Router } from "../common/utils"
 import { JobSetsOrderByColumn } from "../models/lookoutModels"
-import { JobSetsContainerState } from "../pages/jobSets/components/JobSetsContainer"
+
+import { type JobSetsPrefs } from "./JobSetsLocalStorageService"
 
 const QUERY_STRING_OPTIONS: ParseOptions | StringifyOptions = {
   arrayFormat: "comma",
@@ -20,7 +21,7 @@ type JobSetsQueryParams = {
 export default class JobSetsQueryParamsService {
   constructor(private router: Router) {}
 
-  saveState(state: JobSetsContainerState) {
+  saveState(state: JobSetsPrefs) {
     const params = queryString.parse(this.router.location.search, QUERY_STRING_OPTIONS) as Record<any, any>
 
     if (state.queue) {
@@ -36,7 +37,7 @@ export default class JobSetsQueryParamsService {
     })
   }
 
-  updateState(state: JobSetsContainerState) {
+  updateState(state: JobSetsPrefs) {
     const params = queryString.parse(this.router.location.search, QUERY_STRING_OPTIONS) as JobSetsQueryParams
 
     if (params.queue) state.queue = params.queue

--- a/internal/lookoutui/src/services/lookout/mocks/mockServer.ts
+++ b/internal/lookoutui/src/services/lookout/mocks/mockServer.ts
@@ -1,4 +1,4 @@
-import { http, HttpResponse, PathParams } from "msw"
+import { http, HttpResponse, PathParams, RequestHandler } from "msw"
 import { setupServer, SetupServerApi } from "msw/node"
 
 import { compareValues, getActiveJobSets, mergeFilters } from "../../../common/fakeJobsUtils"
@@ -128,6 +128,10 @@ export class MockServer {
 
   close() {
     return this.server.close()
+  }
+
+  use(...handlers: RequestHandler[]) {
+    return this.server.use(...handlers)
   }
 
   setGetQueuesResponse(queueNames: string[]) {

--- a/internal/lookoutui/src/services/lookout/useGetJobSets.ts
+++ b/internal/lookoutui/src/services/lookout/useGetJobSets.ts
@@ -1,0 +1,58 @@
+import { useQuery } from "@tanstack/react-query"
+
+import { JobSet, JobSetsOrderByColumn, JobState, Match } from "../../models/lookoutModels"
+
+import { useGroupJobs } from "./useGroupJobs"
+
+export interface UseGetJobSetsParams {
+  queue: string
+  activeOnly: boolean
+  orderByColumn: JobSetsOrderByColumn
+  orderByDesc: boolean
+  autoRefresh: boolean
+  autoRefreshMs: number | undefined
+}
+
+export const useGetJobSets = ({
+  queue,
+  activeOnly,
+  orderByColumn,
+  orderByDesc,
+  autoRefresh,
+  autoRefreshMs,
+}: UseGetJobSetsParams) => {
+  const groupJobs = useGroupJobs()
+
+  return useQuery<JobSet[], string>({
+    queryKey: ["getJobSets", queue, activeOnly, orderByColumn, orderByDesc],
+    queryFn: async ({ signal }) => {
+      const response = await groupJobs(
+        [{ isAnnotation: false, field: "queue", value: queue, match: Match.Exact }],
+        activeOnly,
+        { field: orderByColumn, direction: orderByDesc ? "DESC" : "ASC" },
+        { field: "jobSet", isAnnotation: false },
+        ["state", "submitted"],
+        0,
+        0,
+        signal,
+      )
+
+      return response.groups.map((group) => {
+        const state = group.aggregates.state as Record<string, number>
+        return {
+          jobSetId: group.name,
+          queue,
+          jobsQueued: state[JobState.Queued] || 0,
+          jobsPending: state[JobState.Pending] || 0,
+          jobsRunning: state[JobState.Running] || 0,
+          jobsSucceeded: state[JobState.Succeeded] || 0,
+          jobsFailed: state[JobState.Failed] || 0,
+          jobsCancelled: state[JobState.Cancelled] || 0,
+          latestSubmissionTime: group.aggregates.submitted as string,
+        }
+      })
+    },
+    enabled: Boolean(queue),
+    refetchInterval: autoRefresh && autoRefreshMs !== undefined ? autoRefreshMs : false,
+  })
+}


### PR DESCRIPTION
Our monitoring picked up a runtime error on the Job Sets page:

> UnhandledRejection: Non-Error promise rejection captured with value: TypeError: Failed to fetch

`JobSetsContainer` was a class component that fetched data via an async `loadJobSets()` method. That method had no error handling and was wired into `setInterval` (auto-refresh), a refresh button, and a result callback. None of these handle a rejected promise. When a fetch failed at the network level, the rejection went unhandled.

This PR migrates `JobSetsContainer` from a class component to a functional component using hooks and TanStack Query. TanStack Query now owns the fetch promise lifecycle, so an app-managed promise can no longer reject unhandled, and loading/error state is reactive.

User-facing behaviour (queue selection, ordering, active-only filter, auto-refresh, cancel/reprioritize dialogs) is unchanged.