### PR TITLE
Bump mage to 1.17.2 everywhere, guard dev:up against old mage versions, and fix localdev doc drift

### DIFF
--- a/.github/workflows/airflow-operator-release-to-pypi.yml
+++ b/.github/workflows/airflow-operator-release-to-pypi.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           version: '23.3'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: go run github.com/magefile/mage@v1.15.0 -v airflowOperator
+      - run: go run github.com/magefile/mage@v1.17.2 -v airflowOperator
       - uses: ./.github/workflows/python-tests
         with:
           python-version: '3.10'

--- a/.github/workflows/airflow-operator.yml
+++ b/.github/workflows/airflow-operator.yml
@@ -92,7 +92,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       # Generates the armada_client proto code (typings, *_pb2) that the operator imports.
       # Without this the local client install is incomplete and the tests fail to collect.
-      - run: go run github.com/magefile/mage@v1.15.0 -v buildPython
+      - run: go run github.com/magefile/mage@v1.17.2 -v buildPython
       - name: Run operator tests against Airflow ${{ matrix.airflow }}
         run: third_party/airflow/scripts/run-tests.sh ${{ matrix.airflow }} ${{ matrix.python }}
 
@@ -119,7 +119,7 @@ jobs:
         with:
           version: '23.3'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: go run github.com/magefile/mage@v1.15.0 -v airflowOperator
+      - run: go run github.com/magefile/mage@v1.17.2 -v airflowOperator
       - uses: ./.github/workflows/python-tests
         with:
           python-version: ${{ matrix.python }}
@@ -163,13 +163,13 @@ jobs:
           # Manually create folders to ensure perms are correct.
           mkdir -p .kube/internal
           mkdir -p .kube/external
-          go run github.com/magefile/mage@v1.15.0 -v dev:full
+          go run github.com/magefile/mage@v1.17.2 -v dev:full
       - name: Install Protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
         with:
           version: '23.3'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: go run github.com/magefile/mage@v1.15.0 -v teste2eAirflow
+      - run: go run github.com/magefile/mage@v1.17.2 -v teste2eAirflow
       - name: Disk usage report
         if: always()
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Pack dotnet clients
         env:
           RELEASE_TAG: ${{ steps.create-release-tag.outputs.release_tag }}
-        run: go run github.com/magefile/mage@v1.15.0 -v packNuget
+        run: go run github.com/magefile/mage@v1.17.2 -v packNuget
 
       - name: Save nupkg artifacts
         uses: actions/upload-artifact@v6

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -53,7 +53,7 @@ jobs:
         cache-tools: true
 
     - name: Mage Proto
-      run: go run github.com/magefile/mage@v1.15.0 -v proto
+      run: go run github.com/magefile/mage@v1.17.2 -v proto
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/python-client.yml
+++ b/.github/workflows/python-client.yml
@@ -60,7 +60,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       # The armada_client package is the generated proto code, so docs autodoc
       # needs it built before it can import the package.
-      - run: go run github.com/magefile/mage@v1.15.0 -v buildPython
+      - run: go run github.com/magefile/mage@v1.17.2 -v buildPython
       - name: Check formatting and lint
         run: tox -e format
         working-directory: client/python
@@ -135,13 +135,13 @@ jobs:
           # Manually create folders to ensure perms are correct.
           mkdir -p .kube/internal
           mkdir -p .kube/external
-          go run github.com/magefile/mage@v1.15.0 -v dev:full
+          go run github.com/magefile/mage@v1.17.2 -v dev:full
       - name: Install Protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
         with:
           version: '23.3'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: go run github.com/magefile/mage@v1.15.0 -v teste2epython
+      - run: go run github.com/magefile/mage@v1.17.2 -v teste2epython
       - name: Disk usage report
         if: always()
         run: |

--- a/.github/workflows/python-tests/action.yml
+++ b/.github/workflows/python-tests/action.yml
@@ -29,7 +29,7 @@ runs:
         version: '23.3'
         repo-token: ${{ inputs.github-token }}
     # Generate the proto files for python, required for later steps
-    - run: go run github.com/magefile/mage@v1.15.0 -v buildPython
+    - run: go run github.com/magefile/mage@v1.17.2 -v buildPython
       shell: bash
     # Formatting, linting and docs are checked once on Python 3.12 by the
     # dedicated *-lint jobs, not per matrix version. This action only runs the

--- a/.github/workflows/rust-client-release-to-crates.yml
+++ b/.github/workflows/rust-client-release-to-crates.yml
@@ -42,7 +42,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Bootstrap proto dependencies
-        run: go run github.com/magefile/mage@v1.15.0 -v BootstrapProto
+        run: go run github.com/magefile/mage@v1.17.2 -v BootstrapProto
 
       - name: Check formatting
         run: cargo fmt --manifest-path client/rust/Cargo.toml -- --check

--- a/.github/workflows/rust-client.yml
+++ b/.github/workflows/rust-client.yml
@@ -64,7 +64,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Bootstrap proto dependencies
-        run: go run github.com/magefile/mage@v1.15.0 -v BootstrapProto
+        run: go run github.com/magefile/mage@v1.17.2 -v BootstrapProto
 
       - name: Check formatting
         if: matrix.toolchain == 'stable'

--- a/.github/workflows/scala-client-release-to-maven.yml
+++ b/.github/workflows/scala-client-release-to-maven.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Bootstrap Proto files
         run: |
-          go run github.com/magefile/mage@v1.15.0 -v BootstrapProto
+          go run github.com/magefile/mage@v1.17.2 -v BootstrapProto
 
       - name: Setup JDK
         uses: actions/setup-java@v5

--- a/.github/workflows/scala-client.yml
+++ b/.github/workflows/scala-client.yml
@@ -67,7 +67,7 @@ jobs:
           git diff
         shell: bash
       - name: Bootstrap Proto files
-        run: go run github.com/magefile/mage@v1.15.0 -v BootstrapProto
+        run: go run github.com/magefile/mage@v1.17.2 -v BootstrapProto
         shell: bash
       - name: Fetch mvn dependencies
         working-directory: client/scala/armada-scala-client

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Unit Tests
         id: unit_test
-        run: go run github.com/magefile/mage@v1.15.0 -v tests
+        run: go run github.com/magefile/mage@v1.17.2 -v tests
 
       - name: Upload Test Reports Artifacts
         if: always()
@@ -109,10 +109,10 @@ jobs:
           cache-tools: true
 
       - name: Setup Integration Tests
-        run: go run github.com/magefile/mage@v1.15.0 -v dev:full
+        run: go run github.com/magefile/mage@v1.17.2 -v dev:full
 
       - name: Run Integration Tests
-        run: go run github.com/magefile/mage@v1.15.0 -v testsuite
+        run: go run github.com/magefile/mage@v1.17.2 -v testsuite
 
       - name: Upload JUnit Report Artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
@@ -209,8 +209,8 @@ jobs:
       #             since it's possible for this to fail without any go changes being made.
       - name: Validate no changes in generated proto files
         run: |
-          go run github.com/magefile/mage@v1.15.0 -v proto
-          go run github.com/magefile/mage@v1.15.0 -v dotnet
+          go run github.com/magefile/mage@v1.17.2 -v proto
+          go run github.com/magefile/mage@v1.17.2 -v dotnet
 
           changed=$(git status -s -uno | wc -l)
 
@@ -250,7 +250,7 @@ jobs:
 
       - name: Validate no changes in generated SQL files
         run: |
-          go run github.com/magefile/mage@v1.15.0 -v sql
+          go run github.com/magefile/mage@v1.17.2 -v sql
 
           changed=$(git status -s -uno | wc -l)
 

--- a/README.md
+++ b/README.md
@@ -65,134 +65,20 @@ Or download it from the [GitHub Release](https://github.com/armadaproject/armada
 
 ## Local Development
 
-### Local Development with Goreman
-
-[Goreman](https://github.com/mattn/goreman) is a Go-based clone of [Foreman](https://github.com/ddollar/foreman) that manages Procfile-based applications,
-allowing you to run multiple processes with a single command. Components are built from source and run on the host, so iteration is fast and debuggers attach directly.
-
-Start Armada with one command:
+Armada runs locally via [goreman](https://github.com/mattn/goreman): the dependencies (redis, postgres, pulsar) run in containers, and the Armada components run as host processes built from source, so iteration is fast and debuggers attach directly.
 
 ```shell
-mage dev:up                 # no-auth
-mage dev:up auth            # OIDC via keycloak
-mage dev:up fake-executor   # no Kubernetes cluster needed
-mage dev:up hot-cold        # parallel Hot/Cold Lookout stack
+mage kind                     # one-time: local Kubernetes cluster for the executor (skip for fake-executor)
+export KUBECONFIG=.kube/external/config
+
+mage dev:up no-auth           # default
+mage dev:up auth              # OIDC via keycloak
+mage dev:up fake-executor     # no Kubernetes cluster needed
+mage dev:up hot-cold          # parallel Hot/Cold Lookout stack
+mage dev:down                 # stop the dependency containers
 ```
 
-`mage dev:up` installs `goreman` to `./bin/` if missing, brings up redis/postgres/pulsar via `_local/compose/stack.yaml`, runs `_local/scripts/init.sh` to create databases and apply migrations, then runs `goreman` with the chosen procfile in the foreground. Ctrl+C stops everything cleanly. Image versions for the dependencies can be overridden via `REDIS_IMAGE`, `POSTGRES_IMAGE`, `PULSAR_IMAGE`, `KEYCLOAK_IMAGE`.
-
-To stop the dependency containers afterwards:
-
-```shell
-mage dev:down
-```
-
-### Local Development with Authentication
-
-`mage dev:up auth` brings up the auth flow: Keycloak is added to the dependency containers, the auth-flavoured procfile starts the components, and you can talk to Armada with OIDC:
-
-```shell
-armadactl --config _local/.armadactl.yaml --context auth-oidc get queues
-```
-
-#### Authentication Configuration
-
-The auth profile configures:
-
-- **Keycloak**: OIDC provider running on <http://localhost:8180> with pre-configured realm, users, and clients
-- **Users**: `admin/admin` (admin group), `user/password` (users group) for both OIDC and basic auth
-- **Service accounts**: Executor and Scheduler use OIDC Client Credentials flow for service-to-service authentication
-- **APIs**: Server, Lookout, and Binoculars APIs are secured with OIDC and basic auth
-- **Web UIs**: Lookout UI uses OIDC for user authentication
-- **armadactl**: Supports multiple authentication flows - OIDC PKCE flow (`auth-oidc`), OIDC Device flow (`auth-oidc-device`), OIDC Password flow (`auth-oidc-password`), and basic auth (`auth-basic`)
-
-All components support both OIDC and basic auth for convenience.
-
-### Local Development with Fake Executor
-
-For testing Armada without a real Kubernetes cluster, use the fake executor that simulates a Kubernetes environment:
-
-```shell
-mage dev:up fake-executor
-```
-
-The fake executor simulates:
-
-- 2 virtual nodes with 8 CPUs and 32Gi memory each
-- Pod lifecycle management without actual container execution
-- Resource allocation and job state transitions
-
-This is useful for:
-
-- Testing Armada's scheduling logic
-- Development when Kubernetes is not available
-- Integration testing of job flows
-
-### Available Compose Profiles
-
-The compose file `_local/compose/stack.yaml` supports two profiles:
-
-| Profile  | Brings up                                  |
-| -------- | ------------------------------------------ |
-| (none)   | Dependencies only: redis, postgres, pulsar |
-| `auth`   | Adds keycloak (OIDC provider)              |
-
-For Apache Airflow, use the separate compose file: `docker compose -f _local/airflow/docker-compose.yaml up -d`.
-
-### Available Procfiles
-
-All Procfiles are located in `_local/procfiles/`:
-
-| Procfile                 | Description                                       |
-| ------------------------ | ------------------------------------------------- |
-| `no-auth.Procfile`       | Standard setup without authentication             |
-| `auth.Procfile`          | Standard setup with OIDC authentication           |
-| `fake-executor.Procfile` | Uses fake executor for testing without Kubernetes |
-
-Restart individual processes with `goreman restart <component>` (e.g., `goreman restart server`).
-
-### Service Ports
-
-Run `goreman run status` to check the status of the processes (running processes are prefixed with `*`):
-
-```shell
-$ goreman run status
-*server
-*scheduler
-*scheduleringester
-*eventingester
-*executor
-*lookout
-*lookoutingester
-*binoculars
-*lookoutui
-```
-
-Goreman exposes services on the following ports:
-
-| Service                    | Port  | Description         |
-| -------------------------- | ----- | ------------------- |
-| Server gRPC                | 50051 | Armada gRPC API     |
-| Server HTTP                | 8081  | REST API & Health   |
-| Server Metrics             | 9000  | Prometheus metrics  |
-| Scheduler gRPC             | 50052 | Scheduler API       |
-| Scheduler Metrics          | 9001  | Prometheus metrics  |
-| Scheduler Ingester Metrics | 9006  | Prometheus metrics  |
-| Lookout UI                 | 3000  | Frontend dev server |
-| Lookout Metrics            | 9003  | Prometheus metrics  |
-| Lookout Ingester Metrics   | 9005  | Prometheus metrics  |
-| Executor Metrics           | 9002  | Prometheus metrics  |
-| Event Ingester Metrics     | 9004  | Prometheus metrics  |
-| Executor HTTP              | 8082  | Executor HTTP       |
-| Binoculars HTTP            | 8084  | Binoculars HTTP     |
-| Binoculars gRPC            | 50053 | Binoculars gRPC     |
-| Binoculars Metrics         | 9007  | Prometheus metrics  |
-| Redis                      | 6379  | Cache & events      |
-| PostgreSQL                 | 5432  | Database            |
-| Pulsar                     | 6650  | Message broker      |
-| OTEL Collector gRPC        | 4317  | OTLP ingest         |
-| OTEL Collector HTTP        | 4318  | OTLP ingest         |
-| Jaeger UI                  | 16686 | Trace visualization |
+See the [developer guide](docs/developer_guide.md) for the full localdev reference (profiles, procfiles, service ports, authentication, debugging) and [_local/README.md](_local/README.md) for the directory layout.
 
 ## Documentation
 

--- a/_local/README.md
+++ b/_local/README.md
@@ -1,0 +1,18 @@
+# _local
+
+Everything the local dev stack uses. `mage dev:up <profiles>` wires these pieces together. For how to use the stack (profiles, procfiles, service ports, authentication, debugging), see the [developer guide](../docs/developer_guide.md).
+
+| Path                      | Purpose                                                                                                                                                   |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `<component>/config.yaml` | Per-component config for host-run processes (server, scheduler, scheduleringester, eventingester, executor, fakeexecutor, lookout, lookoutingester, lookouthc, lookouthcingester, binoculars) |
+| `compose/stack.yaml`      | Dependency containers: redis, postgres, pulsar, plus keycloak (`auth` profile) and prometheus (`prometheus` profile)                                      |
+| `compose/full.yaml`       | Fully containerized Armada stack, used by `mage dev:full` and CI                                                                                          |
+| `compose/postgres-init.sql` | Creates the scheduler and lookout databases when the postgres container first initialises                                                               |
+| `procfiles/`              | Goreman procfiles: `no-auth`, `auth`, `fake-executor`, each with a `-dap` (Delve debug) variant                                                           |
+| `scripts/`                | `init.sh` (migrations + priority classes) and helpers for port conflicts, dlv readiness, and pre-building components                                      |
+| `kind/`                   | Kind cluster config for running a real executor locally                                                                                                  |
+| `keycloak/`               | Keycloak realm import for the `auth` profile                                                                                                             |
+| `airflow/`                | Separate docker compose ecosystem for the Airflow operator e2e tests                                                                                     |
+| `prometheus.yml`          | Scrape config for the `prometheus` compose profile                                                                                                       |
+| `.armadactl.yaml`         | Example armadactl config with contexts for all supported auth flows                                                                                      |
+| `readiness-job.yaml`      | Smoke-test job CI submits to verify Armada is accepting jobs                                                                                              |

--- a/_local/compose/stack.yaml
+++ b/_local/compose/stack.yaml
@@ -5,24 +5,24 @@ name: armada
 # Profiles:
 #   (none)         deps only: redis, postgres, pulsar
 #   auth           adds keycloak (OIDC provider)
+#   prometheus     adds prometheus (scrapes the host-run components)
 #
 # Usage:
 #   docker compose -f _local/compose/stack.yaml up -d
 #   docker compose -f _local/compose/stack.yaml --profile auth up -d
 #
-# Container-mode profiles for the Armada components themselves (full Armada stack,
-# fakeexecutor variant) are intentionally not in this PR. The component configs
-# under _local/<component>/config.yaml use localhost for inter-service hosts
-# because they're tuned for the goreman host-network flow; mounting them into
-# containers would crash-loop. A follow-up PR will add those profiles with the
-# right env-var host overrides or a generated container-mode config.
+# This file runs only the dependencies. The component configs under
+# _local/<component>/config.yaml use localhost for inter-service hosts because
+# they're tuned for the goreman host-process flow; mounting them into containers
+# would crash-loop. The fully containerized stack lives in _local/compose/full.yaml
+# and is started with `mage dev:full`.
 #
 # Airflow is a separate ecosystem with its own postgres + redis. Bring it up via:
 #   docker compose -f _local/airflow/docker-compose.yaml up -d
 # (this is what `mage Teste2eAirflow` does internally.)
 #
 # Image versions are overridable via env vars (REDIS_IMAGE, POSTGRES_IMAGE, PULSAR_IMAGE,
-# KEYCLOAK_IMAGE).
+# KEYCLOAK_IMAGE, PROMETHEUS_IMAGE).
 
 services:
   # =========================================================

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -2,20 +2,23 @@
 
 - [Developer guide](#developer-guide)
     - [Quickstart](#quickstart)
-    - [Dealing with Arm and Windows problems](#dealing-with-arm-and-windows-problems)
     - [Armada design docs](#armada-design-docs)
     - [Other developer docs](#other-developer-docs)
     - [Pre-requisites](#pre-requisites)
     - [Using `mage`](#using-mage)
     - [Setting up the local dev stack](#setting-up-the-local-dev-stack)
-    - [Debugging error: port 6443 is already in use after running `mage dev:full`](#debugging-error-port-6443-is-already-in-use-after-running-mage-devfull)
-        - [Identifying the conflict](#identifying-the-conflict)
+        - [Authentication (auth profile)](#authentication-auth-profile)
+        - [Fake executor](#fake-executor)
+        - [Compose profiles](#compose-profiles)
+        - [Procfiles](#procfiles)
+        - [Service ports](#service-ports)
         - [Testing if the local dev stack is working](#testing-if-the-local-dev-stack-is-working)
         - [Running the UI](#running-the-ui)
-        - [Choosing components to run](#choosing-components-to-run)
+    - [Debugging error: port 6443 is already in use after running `mage dev:full`](#debugging-error-port-6443-is-already-in-use-after-running-mage-devfull)
+        - [Identifying the conflict](#identifying-the-conflict)
     - [Debugging](#debugging)
     - [GoLand run configurations](#goland-run-configurations)
-    - [VS Code debug configurations](#vs-code-debug-configurations)
+    - [VS Code Run and Debug configurations](#vs-code-run-and-debug-configurations)
         - [Other debugging methods](#other-debugging-methods)
 
 This document is intended for developers who want to contribute to the project. It contains information about the project structure, how to build the project and how to run the tests.
@@ -59,7 +62,7 @@ Before you can start using Armada, you first need to install the following items
 
 - [`Go`](https://go.dev/doc/install) (version 1.26 or later)
 - `gcc` (for Windows, [see `tdm-gcc`](https://jmeubank.github.io/tdm-gcc/))
-- [`mage`](https://magefile.org/)
+- [`mage`](https://magefile.org/) (version 1.16 or later) - optional, every target also runs as `go run github.com/magefile/mage@v1.17.2 <target>`, which is how CI invokes mage
 - [`docker`](https://docs.docker.com/get-docker/)
 - [`kubectl`](https://kubernetes.io/docs/tasks/tools/#kubectl)
 - [`protoc`](https://github.com/protocolbuffers/protobuf/releases)
@@ -71,21 +74,126 @@ Before you can start using Armada, you first need to install the following items
 
 ## Setting up the local dev stack
 
-The local dev stack provides a reliable and extendable way to install Armada as a developer. It runs the following steps:
+There are two ways to run Armada locally:
 
-- bootstrap the required tools from [tools.yaml](https://github.com/armadaproject/armada/blob/master/tools.yaml)
-- create a local Kubernetes cluster using [kind](https://kind.sigs.k8s.io/)
-- start the dependencies of Armada, including Pulsar, Redis, and Postgres.
+- `mage dev:up <profiles>` - runs the dependencies (Pulsar, Redis, Postgres) in containers and the Armada components as host processes via goreman. The profile argument is required: `mage dev:up no-auth` is the standard setup, `mage dev:up auth` adds OIDC, and `mage dev:up fake-executor` runs without a Kubernetes cluster.
+- `mage dev:full` - runs the full Armada stack in containers (deps + all components) against a [kind](https://kind.sigs.k8s.io/) cluster.
+
+Two smaller targets support these: `mage dev:deps` runs only the dependency containers, and `mage dev:migrate` re-applies the database migrations.
+
+`dev:up` installs `goreman` to `./bin/` if missing, brings up redis/postgres/pulsar via `_local/compose/stack.yaml`, runs `_local/scripts/init.sh` to create databases and apply migrations, then runs `goreman` with the chosen procfile in the foreground. Ctrl+C stops everything cleanly, and `mage dev:down` removes the dependency containers. Image versions for the dependencies can be overridden via `REDIS_IMAGE`, `POSTGRES_IMAGE`, `PULSAR_IMAGE`, `KEYCLOAK_IMAGE`.
+
+The `no-auth` and `auth` profiles run a real executor, which needs a Kubernetes cluster. Create one with `mage kind`, which writes its kubeconfig to `.kube/external/config`, and start the stack with `KUBECONFIG=.kube/external/config mage dev:up no-auth`. Without `KUBECONFIG` set, the executor falls back to your default kubeconfig and connects to whatever cluster that selects. Use the `fake-executor` profile if you do not want a cluster at all.
+
+The profile argument is required and is a comma-separated list of tokens: `no-auth`, `auth`, `fake-executor`, and `hot-cold` pick the procfile, and any other token (for example `prometheus`) is passed to docker compose as a `--profile` flag. The optional `-dap` flag starts every component under a headless [Delve](https://github.com/go-delve/delve) DAP server so your editor can attach a debugger, e.g. `mage dev:up auth,prometheus -dap`.
+
+If `mage dev:up no-auth` reports `Unknown target`, your mage binary is too old for optional flags (`mage checkDeps` verifies this). Upgrade it, or use `go run github.com/magefile/mage@v1.17.2 <target>`, which also works without installing mage at all.
+
+For the layout of the `_local` directory itself, see [_local/README.md](https://github.com/armadaproject/armada/blob/master/_local/README.md).
 
 **Note:** If you edit a proto file, you also need to run `mage proto` to regenerate the Go code.
 
-It has the following options to customise further steps:
-
-- `mage dev:full` - runs the full Armada stack in containers (deps + all components) against a Kind cluster
-- `mage dev:up [profile]` - runs deps in containers and Armada components as host processes via goreman; profile is `no-auth` (default), `auth`, `hot-cold`, or `fake-executor`
-- `mage dev:deps` - runs only the dependency containers (redis, postgres, pulsar)
-
 We use `mage dev:full` to test the CI pipeline. You should therefore use it to test changes to the core components of Armada.
+
+### Authentication (auth profile)
+
+`mage dev:up auth` brings up the auth flow: Keycloak is added to the dependency containers, the auth-flavoured procfile starts the components, and you can talk to Armada with OIDC:
+
+```shell
+armadactl --config _local/.armadactl.yaml --context auth-oidc get queues
+```
+
+The auth profile configures:
+
+- **Keycloak**: OIDC provider running on <http://localhost:8180> with pre-configured realm, users, and clients
+- **Users**: `admin/admin` (admin group), `user/password` (users group) for both OIDC and basic auth
+- **Service accounts**: Executor and Scheduler use OIDC Client Credentials flow for service-to-service authentication
+- **APIs**: Server, Lookout, and Binoculars APIs are secured with OIDC and basic auth
+- **Web UIs**: Lookout UI uses OIDC for user authentication
+- **armadactl**: Supports multiple authentication flows - OIDC PKCE flow (`auth-oidc`), OIDC Device flow (`auth-oidc-device`), OIDC Password flow (`auth-oidc-password`), and basic auth (`auth-basic`)
+
+All components support both OIDC and basic auth for convenience.
+
+### Fake executor
+
+For testing Armada without a real Kubernetes cluster, `mage dev:up fake-executor` runs an executor that simulates a Kubernetes environment: 2 virtual nodes with 8 CPUs and 32Gi memory each, pod lifecycle management without actual container execution, and resource allocation and job state transitions. This is useful for testing scheduling logic and job flows when Kubernetes is not available.
+
+### Compose profiles
+
+The compose file `_local/compose/stack.yaml` supports the following profiles:
+
+| Profile      | Brings up                                  |
+| ------------ | ------------------------------------------ |
+| (none)       | Dependencies only: redis, postgres, pulsar |
+| `auth`       | Adds keycloak (OIDC provider)              |
+| `prometheus` | Adds prometheus (scrapes local components) |
+
+For Apache Airflow, use the separate compose file: `docker compose -f _local/airflow/docker-compose.yaml up -d`.
+
+### Procfiles
+
+All Procfiles are located in `_local/procfiles/`:
+
+| Procfile                 | Description                                       |
+| ------------------------ | ------------------------------------------------- |
+| `no-auth.Procfile`       | Standard setup without authentication             |
+| `auth.Procfile`          | Standard setup with OIDC authentication           |
+| `fake-executor.Procfile` | Uses fake executor for testing without Kubernetes |
+| `hot-cold.Procfile`      | Runs the parallel hot/cold Lookout stack          |
+
+Each profile also has a `-dap` variant, described under [Debugging](#debugging). Restart individual processes with `goreman restart <component>` (e.g., `goreman restart server`).
+
+### Service ports
+
+Run `goreman run status` to check the status of the processes (running processes are prefixed with `*`). Goreman exposes services on the following ports:
+
+| Service                    | Port  | Description                       |
+| -------------------------- | ----- | --------------------------------- |
+| Server gRPC                | 50051 | Armada gRPC API                   |
+| Server HTTP                | 8081  | REST API & Health                 |
+| Server Metrics             | 9009  | Prometheus metrics                |
+| Scheduler gRPC             | 50052 | Scheduler API                     |
+| Scheduler HTTP             | 8080  | Scheduler HTTP                    |
+| Scheduler Metrics          | 9001  | Prometheus metrics                |
+| Scheduler Ingester Metrics | 9006  | Prometheus metrics                |
+| Lookout API                | 8089  | Lookout REST API                  |
+| Lookout UI                 | 3000  | Frontend dev server               |
+| Lookout Metrics            | 9003  | Prometheus metrics                |
+| Lookout Ingester Metrics   | 9005  | Prometheus metrics                |
+| Executor Metrics           | 9002  | Prometheus metrics                |
+| Event Ingester Metrics     | 9004  | Prometheus metrics                |
+| Executor HTTP              | 8082  | Executor HTTP                     |
+| Binoculars HTTP            | 8084  | Binoculars HTTP                   |
+| Binoculars gRPC            | 50053 | Binoculars gRPC                   |
+| Binoculars Metrics         | 9007  | Prometheus metrics                |
+| Redis                      | 6379  | Cache & events                    |
+| PostgreSQL                 | 5432  | Database                          |
+| Pulsar                     | 6650  | Message broker                    |
+| Pulsar Admin               | 8090  | Pulsar REST admin API             |
+| Keycloak                   | 8180  | OIDC provider (`auth` profile)    |
+| Prometheus                 | 9090  | Metrics UI (`prometheus` profile) |
+
+### Testing if the local dev stack is working
+
+Running `mage testsuite` runs the full test suite against the local dev stack. You should therefore use this to test changes to the core components of Armada.
+
+You can also run the same commands yourself:
+
+```bash
+go run cmd/armadactl/main.go create queue e2e-test-queue
+
+# To enable Ingress tests to pass
+export ARMADA_EXECUTOR_INGRESS_URL="http://localhost"
+export ARMADA_EXECUTOR_INGRESS_PORT=5001
+
+go run cmd/testsuite/main.go test --tests "testsuite/testcases/basic/*" --junit junit.xml
+```
+
+### Running the UI
+
+In the goreman flow (`dev:up`), the `lookoutui` process runs the Vite dev server with hot reload on http://localhost:3000. In the containerized flow (`mage dev:full`), the UI is built with `mage ui` and served by lookout on http://localhost:8089.
+
+For more information, [see the UI Developer Guide](./developer/developing-locally.md).
 
 ## Debugging error: port 6443 is already in use after running `mage dev:full`
 
@@ -112,42 +220,16 @@ Before making any changes, identify which port is causing the conflict. Port 644
 
     You are not limited to using port 6444. You can choose any available port that doesn't conflict with other services on your system. Select a port that suits your system configuration.
 
-### Testing if the local dev stack is working
-
-Running `mage testsuite` runs the full test suite against the local dev stack. You should therefore use this to test changes to the core components of Armada.
-
-You can also run the same commands yourself:
-
-```bash
-go run cmd/armadactl/main.go create queue e2e-test-queue
-
-# To enable Ingress tests to pass
-export ARMADA_EXECUTOR_INGRESS_URL="http://localhost"
-export ARMADA_EXECUTOR_INGRESS_PORT=5001
-
-go run cmd/testsuite/main.go test --tests "testsuite/testcases/basic/*" --junit junit.xml
-```
-
-### Running the UI
-
-In the local dev stack, the UI is built separately with `mage ui`. To access it, open http://localhost:8089 in your browser.
-
-For more information, [see the UI Developer Guide](./developer/developing-locally.md).
-
-### Choosing components to run
-
-You can set the `ARMADA_COMPONENTS` environment variable to choose which components to run. It is a comma-separated list of components to run. For example, to run only the server and executor, run:
-
-```bash
-export ARMADA_COMPONENTS="server,executor"
-```
-
 ## Debugging
 
-The goreman-based flow (`mage dev:up`) builds each component with debug flags (`-gcflags="all=-N -l"`)
+The goreman-based flow (`dev:up`) builds each component with debug flags (`-gcflags="all=-N -l"`)
 and runs them as host processes, so you can attach a debugger to any component directly. Bring up the
-dependencies and components with `mage dev:up`, then attach your debugger (Delve, VS Code, or GoLand) to
+dependencies and components with `mage dev:up no-auth`, then attach your debugger (Delve, VS Code, or GoLand) to
 the running process you want to inspect. Each component reads `_local/<component>/config.yaml`.
+
+Alternatively, the `-dap` flag (e.g. `mage dev:up no-auth -dap`) selects the `-dap` procfile variant,
+which starts each component under a headless Delve DAP server (ports 2345-2352) that an editor debugger can
+connect to. The VS Code tasks in `.vscode/tasks.json` use this flow.
 
 ## GoLand run configurations
 

--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3
 	github.com/jackc/pgx/v5 v5.8.0
 	github.com/jessevdk/go-flags v1.6.1
-	github.com/magefile/mage v1.15.0
+	github.com/magefile/mage v1.17.2
 	github.com/minio/highwayhash v1.0.3
 	github.com/openconfig/goyang v1.6.3
 	github.com/prometheus/client_model v0.6.2

--- a/go.sum
+++ b/go.sum
@@ -802,8 +802,8 @@ github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQ
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
-github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
-github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
+github.com/magefile/mage v1.17.2 h1:fyXVu1eadI8Ap1HCCNgEhJ5McIWiYhLR8uol64ZZc40=
+github.com/magefile/mage v1.17.2/go.mod h1:Yj51kqllmsgFpvvSzgrZPK9WtluG3kUhFaBUVLo4feA=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
 github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/mailru/easyjson v0.9.1 h1:LbtsOm5WAswyWbvTEOqhypdPeZzHavpZx96/n553mR8=

--- a/magefiles/dev.go
+++ b/magefiles/dev.go
@@ -30,20 +30,26 @@ const (
 // Up brings up dependencies and runs Armada components via goreman with the chosen profile.
 //
 // profiles is a comma-separated list of tokens:
-//   - "auth"          – enables OIDC (Keycloak); sets goreman profile to "auth" and uses the auth compose profile
-//   - "fake-executor" – no Kubernetes needed; sets goreman profile to "fake-executor"
-//   - anything else   – forwarded as a docker-compose --profile flag for extra services
+//   - "no-auth"       - the default profile
+//   - "auth"          - enables OIDC (Keycloak); sets goreman profile to "auth" and uses the auth compose profile
+//   - "fake-executor" - no Kubernetes needed; sets goreman profile to "fake-executor"
+//   - "hot-cold"      - runs the hot-cold scheduler setup
+//   - anything else   - forwarded as a docker-compose --profile flag for extra services
 //
-// dap may be "-dap" to append "-dap" to the procfile name, or omitted.
+// The optional -dap flag selects the "-dap" procfile variant, which starts each component
+// under dlv in headless DAP mode so an editor debugger can attach.
+//
+// Optional flags need mage 1.16+ and older mage versions silently hide this target.
+// `go run github.com/magefile/mage@v1.17.2 dev:up ...` runs a known-good version
+// (the same pin the CI workflows use).
 //
 // Examples:
 //
-//	mage dev:up ""                        # no-auth
+//	mage dev:up no-auth                   # default
 //	mage dev:up auth                      # OIDC
-//	mage dev:up fake-executor -debug      # fake executor + debug procfile
+//	mage dev:up fake-executor -dap        # fake executor + dap procfile
 //	mage dev:up auth,myservice            # auth + extra compose profile "myservice"
-//	mage dev:up hot-cold                  # hot-cold
-//	mage dev:up "" -dap                 # no-auth + dap procfile
+//	mage dev:up hot-cold                  # hot-cold scheduler setup
 func (Dev) Up(profiles string, dap *bool) error {
 	var (
 		profile         = "no-auth"
@@ -52,13 +58,13 @@ func (Dev) Up(profiles string, dap *bool) error {
 
 	for _, token := range strings.Split(profiles, ",") {
 		token = strings.TrimSpace(token)
-		if token == "" {
+		if token == "" || token == "no-auth" {
 			continue
 		}
 		switch token {
 		case "auth", "fake-executor", "hot-cold":
 			if profile != "no-auth" {
-				fmt.Printf("warning: ignoring %q — profile already set to %q; only one of auth/fake-executor/hot-cold may be used\n", token, profile)
+				fmt.Printf("warning: ignoring %q - profile already set to %q; only one of auth/fake-executor/hot-cold may be used\n", token, profile)
 			} else {
 				profile = token
 			}

--- a/magefiles/main.go
+++ b/magefiles/main.go
@@ -3,15 +3,45 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
 
+	semver "github.com/Masterminds/semver/v3"
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/yaml"
 )
+
+const MAGE_VERSION_CONSTRAINT = ">= 1.16.0"
+
+// mageCheck verifies that any mage binary on PATH is new enough to register targets with
+// optional arguments (a mage 1.16 feature). Older mage silently hides such targets, so
+// `mage dev:up` fails with "Unknown target" before any magefile code runs. This check
+// cannot intercept that failure, but it explains it after the fact.
+func mageCheck() error {
+	if _, err := exec.LookPath("mage"); err != nil {
+		// No binary installed: targets are run via `go run github.com/magefile/mage@<version>`,
+		// which picks the version explicitly.
+		return nil
+	}
+	out, err := sh.Output("mage", "-version")
+	if err != nil {
+		return errors.Errorf("error running version cmd: %v", err)
+	}
+	// Output starts with "Mage Build Tool 1.17.2" (some builds prefix the version with "v").
+	fields := strings.Fields(out)
+	if len(fields) < 4 {
+		return errors.Errorf("unexpected version cmd output: %s", out)
+	}
+	version, err := semver.NewVersion(strings.TrimPrefix(fields[3], "v"))
+	if err != nil {
+		return errors.Errorf("error parsing version: %v", err)
+	}
+	return constraintCheck(version, MAGE_VERSION_CONSTRAINT, "mage")
+}
 
 // BootstrapTools installs all tools needed tobuild and release Armada.
 // For the list of tools this will install, see tools.yaml in the root directory
@@ -103,6 +133,7 @@ func CheckDeps() error {
 	}{
 		{"docker", dockerCheck},
 		{"go", goCheck},
+		{"mage", mageCheck},
 		{"kind", kindCheck},
 		{"kubectl", kubectlCheck},
 		{"protoc", protocCheck},


### PR DESCRIPTION
`mage dev:up` looks broken on older mage binaries. The target takes an optional `-dap` flag through a pointer argument (`dap *bool`), and optional arguments only exist since mage v1.16. An older mage (for example the 1.15.0 that Homebrew shipped through 2023) does not reject the signature. It silently skips the target during parsing, with a message that only appears under `mage -debug`. The result is that `dev:up` vanishes from `mage -l` and every documented command fails with `Unknown target specified: "dev:up"`, which reads like a bug in the magefile rather than a stale local tool.

The magefile cannot intercept that failure, because an old mage never registers the target in the first place. So this PR adds three layers instead:

- The mage pin is bumped from v1.15.0 to v1.17.2 everywhere it exists: in go.mod (the magefiles import the mage library) and in the 21 CI workflow invocations of `go run github.com/magefile/mage@<version>`. Anyone without a new enough mage binary can use that same form: `go run github.com/magefile/mage@v1.17.2 <target>`.
- `mage checkDeps` now checks the mage binary on PATH against `>= 1.16.0`, using the same semver-constraint helper as the other tool checks. Verified that checkDeps itself still runs under mage 1.15 (it takes no optional arguments), so it can explain the problem on exactly the machines that have it.
- The localdev docs say what the `Unknown target` failure means and point at both remedies.

Two small fixes in dev.go: the `no-auth` token is now treated as the default profile instead of being forwarded to docker compose as a bogus `--profile no-auth` flag (the VS Code tasks pass `no-auth` explicitly), and the doc comment examples now match the real CLI (the stale `-debug` becomes `-dap`, and `mage dev:up no-auth` replaces `mage dev:up ""`).

The localdev documentation is also restructured. The main README's Local Development section is now a short quick start (the four `mage dev:*` commands) plus links onward. The full reference (how `dev:up` works, profile tokens, the auth profile details, the fake executor, compose profiles, procfiles, and the service ports table) moved into the local dev stack section of `docs/developer_guide.md`, mostly verbatim; nothing was dropped. A new `_local/README.md` describes the directory layout: what each subdirectory and file in `_local` is for.

Doc corrections made while cross-referencing against the magefile (now mostly living in `docs/developer_guide.md`):

- All `dev:up` examples include the required profile argument (`mage dev:up no-auth`); the previously documented bare `mage dev:up` never worked on any mage version because mage has no optional positional arguments.
- Ports: the Server Metrics row said 9000 but `_local/server/config.yaml` sets 9009. Added rows for Scheduler HTTP (8080), Lookout API (8089), Pulsar admin (8090), Keycloak (8180, `auth` profile) and Prometheus (9090, `prometheus` profile).
- The compose profiles table lists the `prometheus` profile, the procfiles section documents the `-dap` variants, and the `dev:deps`, `dev:migrate`, `dev:full` and `dev:fullDown` targets are covered.
- `docs/developer_guide.md`: the "Setting up the local dev stack" section described the old localdev flow (bootstrapping tools.yaml, creating a kind cluster), which `dev:up` does not do. It now describes the goreman and containerized flows accurately and links to `_local/README.md`. The UI section says which port belongs to which flow: 3000 for the Vite dev server under goreman, 8089 for lookout under `dev:full`. The debugging section documents the `-dap` flag, and the prerequisites note the mage version and the `go run github.com/magefile/mage@v1.17.2` alternative.
- The default and auth profiles run a real executor, which needs a Kubernetes cluster, but no doc said so: only the VS Code tasks knew to run `mage kind` first, and without `KUBECONFIG` the executor falls back to the default kubeconfig and connects to whatever cluster that selects. The README quick start and the developer guide now say to run `mage kind` and set `KUBECONFIG=.kube/external/config`.
- The guide's "Testing if the local dev stack is working" and "Running the UI" sections were nested under the "port 6443" troubleshooting section, where a newcomer would not look. They are now subsections of "Setting up the local dev stack", and the guide's table of contents is regenerated (it listed a section that no longer exists and missed the current ones).
- `_local/compose/stack.yaml`: the header comment said container-mode profiles were "intentionally not in this PR" with a follow-up planned. That follow-up shipped as `full.yaml`, so the comment now points there, and the profile and image override lists include prometheus.

Removed:

- README ports table rows for OTEL Collector gRPC (4317), OTEL Collector HTTP (4318) and Jaeger UI (16686). No otel-collector or jaeger service exists anywhere in `_local`, so the rows described services you cannot reach.
- The "Choosing components to run" section in `docs/developer_guide.md`. `ARMADA_COMPONENTS` has no remaining references in the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

