### PR TITLE
Fix cross-partition duplicate job rows in Lookout ingester (experimental hot/cold)

### DIFF
--- a/internal/lookoutingester/lookoutdb/insertion.go
+++ b/internal/lookoutingester/lookoutdb/insertion.go
@@ -345,7 +345,27 @@ func (l *LookoutDb) CreateJobsBatch(ctx *armadacontext.Context, instructions []*
 						priority_class,
 						annotations,
 					    external_job_uri
-					) SELECT * from %s
+					)
+					SELECT
+						tmp.job_id,
+						tmp.queue,
+						tmp.owner,
+						tmp.namespace,
+						tmp.jobset,
+						tmp.cpu,
+						tmp.memory,
+						tmp.ephemeral_storage,
+						tmp.gpu,
+						tmp.priority,
+						tmp.submitted,
+						tmp.state,
+						tmp.last_transition_time,
+						tmp.last_transition_time_seconds,
+						tmp.priority_class,
+						tmp.annotations,
+						tmp.external_job_uri
+					FROM %s AS tmp
+					WHERE NOT EXISTS (SELECT 1 FROM job j WHERE j.job_id = tmp.job_id)
 					ON CONFLICT DO NOTHING`, tmpTable),
 			)
 			if err != nil {
@@ -393,7 +413,8 @@ func (l *LookoutDb) CreateJobsScalar(ctx *armadacontext.Context, instructions []
 			annotations,
             external_job_uri
 		)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
+		SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17
+		WHERE NOT EXISTS (SELECT 1 FROM job j WHERE j.job_id = $1::varchar)
 		ON CONFLICT DO NOTHING`
 	for _, i := range instructions {
 		if ctx.Err() != nil {

--- a/internal/lookoutingester/lookoutdb/insertion_hotcold_test.go
+++ b/internal/lookoutingester/lookoutdb/insertion_hotcold_test.go
@@ -380,3 +380,75 @@ func TestHotCold_ConflatedTerminalUpdatesProduceSingleTerminatedRow(t *testing.T
 	})
 	require.NoError(t, err)
 }
+
+// TestHotCold_CreateSuppressedWhenJobExistsInOtherPartition guards against the
+// cross-partition duplicate that caused job_terminated_pkey violations: a
+// create must not add a second row when a row for the same job_id already
+// exists in a different partition. Without the WHERE NOT EXISTS guard in
+// CreateJobs, the untargeted ON CONFLICT DO NOTHING only checks the destination
+// (active) partition and would insert a duplicate routed there.
+func TestHotCold_CreateSuppressedWhenJobExistsInOtherPartition(t *testing.T) {
+	err := withLookoutHCDb(func(db *pgxpool.Pool) error {
+		ldb := NewLookoutDb(db, fatalErrors, m, 10, 10)
+
+		// A row for the job already exists in job_terminated (e.g. from an
+		// out-of-order or replayed terminal event).
+		_, err := db.Exec(armadacontext.Background(),
+			`INSERT INTO job (job_id, queue, owner, jobset, cpu, memory, ephemeral_storage, gpu,
+				priority, submitted, state, last_transition_time, last_transition_time_seconds,
+				duplicate, annotations)
+			 VALUES ($1, 'q', 'o', 'js', 1, 1, 1, 0, 0, $2, $3, $2, $4, false, '{}'::jsonb)`,
+			JobId, finishedTime, lookout.JobSucceededOrdinal, finishedTime.Unix())
+		require.NoError(t, err)
+		assert.Equal(t, 1, countInPartition(t, db, "job_terminated", JobId))
+
+		// Creating the job (active initial state) must be suppressed rather than
+		// routed into job_active as a second row for the same job_id.
+		require.NoError(t, ldb.CreateJobs(armadacontext.Background(),
+			[]*model.CreateJobInstruction{makeCreateJobInstruction(JobId)}))
+
+		assert.Equal(t, 0, countInPartition(t, db, "job_active", JobId))
+		var totalInParent int
+		require.NoError(t, db.QueryRow(armadacontext.Background(),
+			"SELECT count(*) FROM job WHERE job_id = $1", JobId).Scan(&totalInParent))
+		assert.Equal(t, 1, totalInParent, "create must not add a duplicate row across partitions")
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+// TestHotCold_CreateSuppressedWhenJobExistsInSamePartition covers the
+// same-partition variant of the duplicate bug: a create routed to job_active
+// must be suppressed when another active-state row for the same job_id already
+// exists there (e.g. a Queued create arriving after a Leased row is present).
+func TestHotCold_CreateSuppressedWhenJobExistsInSamePartition(t *testing.T) {
+	err := withLookoutHCDb(func(db *pgxpool.Pool) error {
+		ldb := NewLookoutDb(db, fatalErrors, m, 10, 10)
+
+		// An active-state row (Leased) already exists in job_active.
+		_, err := db.Exec(armadacontext.Background(),
+			`INSERT INTO job (job_id, queue, owner, jobset, cpu, memory, ephemeral_storage, gpu,
+				priority, submitted, state, last_transition_time, last_transition_time_seconds,
+				duplicate, annotations)
+			 VALUES ($1, 'q', 'o', 'js', 1, 1, 1, 0, 0, $2, $3, $2, $4, false, '{}'::jsonb)`,
+			JobId, updateTime, lookout.JobLeasedOrdinal, updateTime.Unix())
+		require.NoError(t, err)
+		assert.Equal(t, 1, countInPartition(t, db, "job_active", JobId))
+
+		// Creating the job (Queued) must not add a second active-partition row.
+		require.NoError(t, ldb.CreateJobs(armadacontext.Background(),
+			[]*model.CreateJobInstruction{makeCreateJobInstruction(JobId)}))
+
+		var totalInParent int
+		require.NoError(t, db.QueryRow(armadacontext.Background(),
+			"SELECT count(*) FROM job WHERE job_id = $1", JobId).Scan(&totalInParent))
+		assert.Equal(t, 1, totalInParent, "create must not add a duplicate row in the same partition")
+
+		var state int32
+		require.NoError(t, db.QueryRow(armadacontext.Background(),
+			"SELECT state FROM job WHERE job_id = $1", JobId).Scan(&state))
+		assert.Equal(t, int32(lookout.JobLeasedOrdinal), state, "existing row must be preserved unchanged")
+		return nil
+	})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
In the experimental hot-cold schema, the `job` table is LIST-partitioned on state with a composite primary key `(job_id, state)`, so `job_id` uniqueness is only enforced within a single partition. `CreateJobs` used an untargeted `ON CONFLICT DO NOTHING`, which only checks the partition the insert routes to.

When a row for the same `job_id` already existed elsewhere, the create was not suppressed and a second row was written. This was observed both across partitions (an active create alongside an existing terminal row) and within the active partition (a Queued create alongside an existing Leased row). A later update that moved a row into the terminated partition then collided with `job_terminated_pkey` (which the ingester classified as retryable and retried to exhaustion).

This commit guards both create paths with `WHERE NOT EXISTS` against the parent job table so a duplicate `job_id` is never written regardless of which partition the existing row lives in. This leaves the high-frequency update path untouched and is a no-op on the non-partitioned schema, where `job_id` is already globally unique.