### PR TITLE
Delete failed pods matching a Delete-action category so retries can reuse the name

### DIFF
--- a/internal/common/errormatch/doc.go
+++ b/internal/common/errormatch/doc.go
@@ -8,6 +8,6 @@
 // Condition constants ([ConditionOOMKilled], [ConditionEvicted],
 // [ConditionDeadlineExceeded]) and the [KnownConditions] map are provided
 // for config validation. Non-pod conditions ([ConditionPreempted],
-// [ConditionLeaseReturned]) are also defined here for use by the retry
-// engine but are not included in [KnownConditions].
+// [ConditionLeaseReturned], [ConditionLeaseExpired], [ConditionAppError]) are also defined here
+// for use by the retry engine but are not included in [KnownConditions].
 package errormatch

--- a/internal/common/errormatch/types.go
+++ b/internal/common/errormatch/types.go
@@ -30,10 +30,14 @@ const (
 
 // Condition constants for non-pod error types (used by the retry engine).
 // These are not observable from Kubernetes pod status, so the executor
-// categorizer cannot match them.
+// categorizer cannot match them. ConditionAppError is the catch-all for
+// a PodError whose KubernetesReason is AppError (i.e. container failed
+// without a recognised pod-level reason).
 const (
 	ConditionPreempted     = "Preempted"
 	ConditionLeaseReturned = "LeaseReturned"
+	ConditionLeaseExpired  = "LeaseExpired"
+	ConditionAppError      = "AppError"
 )
 
 // KnownConditions is the set of condition strings accepted by the executor

--- a/internal/executor/categorizer/classifier.go
+++ b/internal/executor/categorizer/classifier.go
@@ -18,8 +18,9 @@ import (
 const maxCategoryNameLen = 63
 
 type category struct {
-	name  string
-	rules []rule
+	name   string
+	action PodFailureAction
+	rules  []rule
 }
 
 type rule struct {
@@ -39,6 +40,9 @@ type ClassifyResult struct {
 	// Hint is operator-supplied user-facing copy attached to the matching rule.
 	// Use AppendHint to attach it to the failure message before emitting events.
 	Hint string
+	// Action is the pod disposition: Delete only when the matched category
+	// explicitly configures it, otherwise Retain.
+	Action PodFailureAction
 }
 
 // AppendHint returns the message with this result's hint appended after a blank
@@ -85,7 +89,14 @@ func NewClassifier(config ErrorCategoriesConfig) (*Classifier, error) {
 		if len(cfg.Rules) == 0 {
 			return nil, fmt.Errorf("category %q must have at least one rule", cfg.Name)
 		}
-		cat := category{name: cfg.Name}
+		action := cfg.Action
+		if action == "" {
+			action = PodFailureActionRetain
+		}
+		if err := validateAction(action); err != nil {
+			return nil, fmt.Errorf("category %q: %w", cfg.Name, err)
+		}
+		cat := category{name: cfg.Name, action: action}
 		for i, r := range cfg.Rules {
 			built, err := buildRule(r)
 			if err != nil {
@@ -100,6 +111,16 @@ func NewClassifier(config ErrorCategoriesConfig) (*Classifier, error) {
 		defaultSubcategory: config.DefaultSubcategory,
 		categories:         categories,
 	}, nil
+}
+
+// validateAction rejects a category action that is neither Retain nor Delete.
+func validateAction(a PodFailureAction) error {
+	switch a {
+	case PodFailureActionRetain, PodFailureActionDelete:
+		return nil
+	default:
+		return fmt.Errorf("invalid action %q: must be %q or %q", a, PodFailureActionDelete, PodFailureActionRetain)
+	}
 }
 
 func buildRule(cfg CategoryRule) (rule, error) {
@@ -198,7 +219,7 @@ func (c *Classifier) ClassifyPodError(pod *v1.Pod, podErrorMessage string) Class
 // Rules are evaluated in config order; the first matching rule wins.
 func (c *Classifier) classify(pod *v1.Pod, podErrorMessage string) ClassifyResult {
 	if c == nil || pod == nil {
-		return ClassifyResult{}
+		return ClassifyResult{Action: PodFailureActionRetain}
 	}
 	containers := failedContainers(pod)
 	podReason := pod.Status.Reason
@@ -209,11 +230,11 @@ func (c *Classifier) classify(pod *v1.Pod, podErrorMessage string) ClassifyResul
 			matched := ruleMatches(r, containers, podReason, podErrorMessage)
 			metrics.RecordRuleEvaluationDuration(cat.name, r.subcategory, time.Since(start))
 			if matched {
-				return ClassifyResult{Category: cat.name, Subcategory: r.subcategory, Hint: r.hint}
+				return ClassifyResult{Category: cat.name, Subcategory: r.subcategory, Hint: r.hint, Action: cat.action}
 			}
 		}
 	}
-	return ClassifyResult{Category: c.defaultCategory, Subcategory: c.defaultSubcategory}
+	return ClassifyResult{Category: c.defaultCategory, Subcategory: c.defaultSubcategory, Action: PodFailureActionRetain}
 }
 
 // ruleMatches evaluates a single rule. Container-level matchers honor the

--- a/internal/executor/categorizer/classifier_test.go
+++ b/internal/executor/categorizer/classifier_test.go
@@ -20,7 +20,18 @@ func TestClassify(t *testing.T) {
 		podErrorMessage     string
 		expectedCategory    string
 		expectedSubcategory string
+		expectedAction      PodFailureAction
 	}{
+		"action propagates from the matched category": {
+			config: ErrorCategoriesConfig{Categories: []CategoryConfig{
+				{Name: "infra", Action: PodFailureActionDelete, Rules: []CategoryRule{
+					{OnExitCodes: &errormatch.ExitCodeMatcher{Operator: errormatch.ExitCodeOperatorIn, Values: []int32{42}}},
+				}},
+			}},
+			pod:              podWithTerminatedContainer(42, "Error", ""),
+			expectedCategory: "infra",
+			expectedAction:   PodFailureActionDelete,
+		},
 		"OOM condition matches": {
 			config: ErrorCategoriesConfig{Categories: []CategoryConfig{
 				{Name: "oom", Rules: []CategoryRule{
@@ -375,6 +386,11 @@ func TestClassify(t *testing.T) {
 			}
 			assert.Equal(t, tc.expectedCategory, result.Category)
 			assert.Equal(t, tc.expectedSubcategory, result.Subcategory)
+			expectedAction := tc.expectedAction
+			if expectedAction == "" {
+				expectedAction = PodFailureActionRetain
+			}
+			assert.Equal(t, expectedAction, result.Action)
 		})
 	}
 }
@@ -443,6 +459,14 @@ func TestNewClassifier_ValidationErrors(t *testing.T) {
 				}},
 			}},
 			errContains: "unknown condition",
+		},
+		"invalid category action": {
+			config: ErrorCategoriesConfig{Categories: []CategoryConfig{
+				{Name: "bad", Action: "Remove", Rules: []CategoryRule{
+					{OnExitCodes: &errormatch.ExitCodeMatcher{Operator: errormatch.ExitCodeOperatorIn, Values: []int32{1}}},
+				}},
+			}},
+			errContains: "invalid action",
 		},
 		"invalid exit code operator": {
 			config: ErrorCategoriesConfig{Categories: []CategoryConfig{

--- a/internal/executor/categorizer/types.go
+++ b/internal/executor/categorizer/types.go
@@ -22,7 +22,25 @@ type ErrorCategoriesConfig struct {
 type CategoryConfig struct {
 	Name  string         `yaml:"name"`
 	Rules []CategoryRule `yaml:"rules"`
+	// Action is what the executor does with a failed pod in this category.
+	// Empty (the default) means Retain.
+	Action PodFailureAction `yaml:"action"`
 }
+
+// PodFailureAction is the executor's disposition of a failed pod in a category.
+type PodFailureAction string
+
+const (
+	// PodFailureActionRetain keeps the failed pod in place until normal GC, so
+	// its logs remain available for debugging.
+	PodFailureActionRetain PodFailureAction = "Retain"
+	// PodFailureActionDelete deletes the failed pod and reports the failure
+	// once the pod is gone, freeing the pod name for a retry of the same job.
+	// Whether the job is retried stays with the scheduler's retry policy.
+	// Intended for narrow infrastructure-failure categories replacing failed
+	// pod checks, not for broad categories like user errors.
+	PodFailureActionDelete PodFailureAction = "Delete"
+)
 
 // CategoryRule defines a single matching condition. Exactly one matcher must
 // be set per rule (validated by NewClassifier). Rules within a category are OR'd.

--- a/internal/executor/service/job_state_reporter.go
+++ b/internal/executor/service/job_state_reporter.go
@@ -101,7 +101,7 @@ func (stateReporter *JobStateReporter) reportCurrentStatus(pod *v1.Pod) {
 			// Pod already being handled by issue handler
 			return
 		}
-		issueAdded, err := stateReporter.podIssueHandler.DetectAndRegisterFailedPodIssue(pod)
+		issueAdded, err := stateReporter.podIssueHandler.DetectAndRegisterIssuesForFailedPod(pod)
 		if issueAdded {
 			// Pod already being handled by issue handler
 			return

--- a/internal/executor/service/job_state_reporter_test.go
+++ b/internal/executor/service/job_state_reporter_test.go
@@ -159,21 +159,19 @@ func TestJobStateReporter_HandlesFailedPod_WithRetryableError(t *testing.T) {
 	after := copyWithUpdatedPhase(before, v1.PodFailed)
 
 	// Does not send event if issue handler detects an issue
-	jobStateReporter.podIssueHandler = &stubIssueHandler{detectAndRegisterFailedPodIssueResult: true, detectAndRegisterFailedPodIssueError: nil}
+	jobStateReporter.podIssueHandler = &stubIssueHandler{detectResult: true}
 	jobStateReporter.reportStatusUpdate(before, after)
 	assert.Len(t, eventReporter.GetReceivedEvents(), 0)
 
 	// Does not send event if issue handler already knows of issue for run
 	jobStateReporter.podIssueHandler = &stubIssueHandler{
-		runIdsWithIssues:                      map[string]bool{util.ExtractJobRunId(after): true},
-		detectAndRegisterFailedPodIssueResult: false,
-		detectAndRegisterFailedPodIssueError:  nil,
+		runIdsWithIssues: map[string]bool{util.ExtractJobRunId(after): true},
 	}
 	jobStateReporter.reportStatusUpdate(before, after)
 	assert.Len(t, eventReporter.GetReceivedEvents(), 0)
 
 	// Does send event if issue handler errors
-	jobStateReporter.podIssueHandler = &stubIssueHandler{detectAndRegisterFailedPodIssueResult: false, detectAndRegisterFailedPodIssueError: fmt.Errorf("error")}
+	jobStateReporter.podIssueHandler = &stubIssueHandler{detectError: fmt.Errorf("error")}
 	jobStateReporter.reportStatusUpdate(before, after)
 	assert.Len(t, eventReporter.GetReceivedEvents(), 1)
 	assertExpectedEvents(t, before, eventReporter.GetReceivedEvents(), reflect.TypeOf(&armadaevents.EventSequence_Event_JobRunErrors{}))
@@ -264,12 +262,17 @@ func makeFailedPodWithExitCode(t *testing.T, exitCode int32) *v1.Pod {
 	return pod
 }
 
-func classifierForExitCode(t *testing.T, category, subcategory string, exitCode int32) *categorizer.Classifier {
+func classifierForExitCode(t *testing.T, category, subcategory string, exitCode int32, deleteOnFailure bool) *categorizer.Classifier {
 	t.Helper()
+	action := categorizer.PodFailureActionRetain
+	if deleteOnFailure {
+		action = categorizer.PodFailureActionDelete
+	}
 	c, err := categorizer.NewClassifier(categorizer.ErrorCategoriesConfig{
 		Categories: []categorizer.CategoryConfig{
 			{
-				Name: category,
+				Name:   category,
+				Action: action,
 				Rules: []categorizer.CategoryRule{
 					{
 						OnExitCodes: &errormatch.ExitCodeMatcher{
@@ -295,7 +298,7 @@ func classifierForExitCode(t *testing.T, category, subcategory string, exitCode 
 // so waiting for it through the locked accessor orders the assertions after
 // everything the handler did.
 func TestJobStateReporter_PodFailed_EmitsJobFailedEventWhenClassifierMatches(t *testing.T) {
-	classifier := classifierForExitCode(t, "jsr-emit-cat", "jsr-emit-sub", 42)
+	classifier := classifierForExitCode(t, "jsr-emit-cat", "jsr-emit-sub", 42, false)
 	_, _, eventReporter, fakeClusterContext := setUpJobStateReporterTestWithClassifier(t, classifier, &stubIssueHandler{})
 
 	pod := makeFailedPodWithExitCode(t, 42)
@@ -309,54 +312,76 @@ func TestJobStateReporter_PodFailed_EmitsJobFailedEventWhenClassifierMatches(t *
 	assertExpectedEvents(t, pod, eventReporter.GetReceivedEvents(), reflect.TypeOf(&armadaevents.EventSequence_Event_JobRunErrors{}))
 }
 
-func TestJobStateReporter_PodFailed_SuppressesEmissionWhenRetryableIssueRegistered(t *testing.T) {
-	classifier := classifierForExitCode(t, "jsr-retryable-cat", "jsr-retryable-sub", 42)
-	stateReporter, _, eventReporter, fakeClusterContext := setUpJobStateReporterTestWithClassifier(
-		t, classifier,
-		&stubIssueHandler{detectAndRegisterFailedPodIssueResult: true},
-	)
+// A failed pod normally results in the reporter emitting the terminal failed
+// event. Each case is one condition that must suppress that emission (the
+// issue handler taking or already owning the run, the event reporter failing)
+// or must not (no classifier, a detection error).
+func TestJobStateReporter_PodFailed_EmissionGating(t *testing.T) {
+	tests := map[string]struct {
+		issueHandler           *stubIssueHandler
+		classifier             func(t *testing.T) *categorizer.Classifier
+		errorOnReport          bool
+		runOwnedByIssueHandler bool
+		expectedEvents         int
+	}{
+		"issue registered by the issue handler": {
+			issueHandler:   &stubIssueHandler{detectResult: true},
+			expectedEvents: 0,
+		},
+		"run already owned by the issue handler": {
+			issueHandler:           &stubIssueHandler{},
+			runOwnedByIssueHandler: true,
+			expectedEvents:         0,
+		},
 
-	pod := makeFailedPodWithExitCode(t, 42)
-	addPod(t, fakeClusterContext, pod)
-	stateReporter.reportCurrentStatus(pod)
+		"reporter errors drop the event": {
+			issueHandler:   &stubIssueHandler{},
+			errorOnReport:  true,
+			expectedEvents: 0,
+		},
+		"nil classifier still emits": {
+			issueHandler:   &stubIssueHandler{},
+			expectedEvents: 1,
+		},
+		"detection error falls through to normal emission": {
+			issueHandler:   &stubIssueHandler{detectError: fmt.Errorf("events unavailable")},
+			expectedEvents: 1,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var classifier *categorizer.Classifier
+			if tc.classifier != nil {
+				classifier = tc.classifier(t)
+			}
+			stateReporter, _, eventReporter, fakeClusterContext := setUpJobStateReporterTestWithClassifier(t, classifier, tc.issueHandler)
+			eventReporter.ErrorOnReport = tc.errorOnReport
 
-	assert.Len(t, eventReporter.GetReceivedEvents(), 0, "retryable issue path emits ReturnLease, not JobFailed")
+			// Reporting marks the pod as reported via its annotations, so a
+			// pod shared across cases would suppress later cases' events.
+			pod := makeFailedPodWithExitCode(t, 42)
+			if tc.runOwnedByIssueHandler {
+				tc.issueHandler.runIdsWithIssues = map[string]bool{util.ExtractJobRunId(pod): true}
+			}
+			addPod(t, fakeClusterContext, pod)
+			stateReporter.reportCurrentStatus(pod)
+
+			assert.Len(t, eventReporter.GetReceivedEvents(), tc.expectedEvents)
+		})
+	}
 }
 
-func TestJobStateReporter_PodFailed_SuppressesEmissionWhenIssueAlreadyExists(t *testing.T) {
-	classifier := classifierForExitCode(t, "jsr-existing-cat", "jsr-existing-sub", 42)
-	pod := makeFailedPodWithExitCode(t, 42)
-	stateReporter, _, eventReporter, fakeClusterContext := setUpJobStateReporterTestWithClassifier(
-		t, classifier,
-		&stubIssueHandler{runIdsWithIssues: map[string]bool{util.ExtractJobRunId(pod): true}},
-	)
-
-	addPod(t, fakeClusterContext, pod)
-	stateReporter.reportCurrentStatus(pod)
-
-	assert.Len(t, eventReporter.GetReceivedEvents(), 0, "run already owned by issue handler - no direct emission from this path")
-}
-
-func TestJobStateReporter_PodFailed_DropsEventWhenReporterErrors(t *testing.T) {
-	classifier := classifierForExitCode(t, "jsr-report-error-cat", "jsr-report-error-sub", 42)
-	stateReporter, _, eventReporter, fakeClusterContext := setUpJobStateReporterTestWithClassifier(t, classifier, &stubIssueHandler{})
-	eventReporter.ErrorOnReport = true
+func TestJobStateReporter_PodFailed_KeepsPodWhenActionRetain(t *testing.T) {
+	classifier := classifierForExitCode(t, "jsr-keep-cat", "jsr-keep-sub", 42, false)
+	stateReporter, _, _, fakeClusterContext := setUpJobStateReporterTestWithClassifier(t, classifier, &stubIssueHandler{})
 
 	pod := makeFailedPodWithExitCode(t, 42)
 	addPod(t, fakeClusterContext, pod)
 	stateReporter.reportCurrentStatus(pod)
 
-	assert.Len(t, eventReporter.GetReceivedEvents(), 0, "event is dropped when reporter errors - counter increment is gated behind successful emission")
-}
-
-func TestJobStateReporter_PodFailed_EmitsEventWithEmptyCategoryWhenClassifierIsNil(t *testing.T) {
-	stateReporter, _, eventReporter, fakeClusterContext := setUpJobStateReporterTestWithClassifier(t, nil, &stubIssueHandler{})
-
-	pod := makeFailedPodWithExitCode(t, 42)
-	addPod(t, fakeClusterContext, pod)
-	stateReporter.reportCurrentStatus(pod)
-
-	assert.Len(t, eventReporter.GetReceivedEvents(), 1, "event still emitted with empty category/subcategory when classification is disabled")
+	assert.Contains(t, fakeClusterContext.Pods, util.ExtractJobId(pod),
+		"a Retain-action failed pod is left in place for debugging")
+	assertExpectedAnnotations(t, pod, fakeClusterContext)
 }
 
 func assertExpectedEvents(t *testing.T, pod *v1.Pod, messages []reporter.EventMessage, expectedType reflect.Type) {
@@ -380,9 +405,9 @@ func assertExpectedAnnotations(t *testing.T, pod *v1.Pod, clusterContext *fakeco
 }
 
 type stubIssueHandler struct {
-	runIdsWithIssues                      map[string]bool
-	detectAndRegisterFailedPodIssueResult bool
-	detectAndRegisterFailedPodIssueError  error
+	runIdsWithIssues map[string]bool
+	detectResult     bool
+	detectError      error
 }
 
 func (s *stubIssueHandler) HasIssue(runId string) bool {
@@ -390,8 +415,8 @@ func (s *stubIssueHandler) HasIssue(runId string) bool {
 	return exists
 }
 
-func (s *stubIssueHandler) DetectAndRegisterFailedPodIssue(pod *v1.Pod) (bool, error) {
-	return s.detectAndRegisterFailedPodIssueResult, s.detectAndRegisterFailedPodIssueError
+func (s *stubIssueHandler) DetectAndRegisterIssuesForFailedPod(pod *v1.Pod) (bool, error) {
+	return s.detectResult, s.detectError
 }
 
 func copyWithUpdatedPhase(pod *v1.Pod, newPhase v1.PodPhase) *v1.Pod {

--- a/internal/executor/service/pod_issue_handler.go
+++ b/internal/executor/service/pod_issue_handler.go
@@ -34,9 +34,13 @@ const (
 	ExternallyDeleted
 	ErrorDuringIssueHandling
 	FailedStartingUp
+	DeleteActionFailure
 )
 
 type podIssue struct {
+	// Classification and DetectionTime are set for DeleteActionFailure issues.
+	Classification categorizer.ClassifyResult
+	DetectionTime  time.Time
 	// A copy of the pod when an issue was detected
 	OriginalPodState  *v1.Pod
 	Message           string
@@ -67,7 +71,7 @@ type runIssue struct {
 
 type IssueHandler interface {
 	HasIssue(runId string) bool
-	DetectAndRegisterFailedPodIssue(pod *v1.Pod) (bool, error)
+	DetectAndRegisterIssuesForFailedPod(pod *v1.Pod) (bool, error)
 }
 
 type PodIssueHandler struct {
@@ -170,6 +174,53 @@ func (p *PodIssueHandler) DetectAndRegisterFailedPodIssue(pod *v1.Pod) (bool, er
 	} else {
 		return false, nil
 	}
+}
+
+// DetectAndRegisterIssuesForFailedPod runs the failed pod detections in
+// precedence order: the failed pod checks keep first claim on every pod while
+// they are being deprecated in favour of categories, then the category delete
+// action is considered.
+func (p *PodIssueHandler) DetectAndRegisterIssuesForFailedPod(pod *v1.Pod) (bool, error) {
+	issueAdded, err := p.DetectAndRegisterFailedPodIssue(pod)
+	if issueAdded || err != nil {
+		return issueAdded, err
+	}
+	return p.DetectAndRegisterDeleteActionIssue(pod)
+}
+
+// DetectAndRegisterDeleteActionIssue registers an issue for a failed pod whose
+// matched category has action Delete.
+func (p *PodIssueHandler) DetectAndRegisterDeleteActionIssue(pod *v1.Pod) (bool, error) {
+	if !util.IsManagedPod(pod) || pod.Status.Phase != v1.PodFailed {
+		return false, nil
+	}
+	classification := p.classifier.ClassifyContainerError(pod)
+	if classification.Action != categorizer.PodFailureActionDelete {
+		return false, nil
+	}
+	podEvents, err := p.clusterContext.GetPodEvents(pod)
+	if err != nil {
+		// The debug message is best effort, the delete-first ordering is not.
+		// Register without the events rather than let the caller report the
+		// failure while the pod still holds its name.
+		log.Warnf("Failed retrieving pod events for pod %s: %v", pod.Name, err)
+		podEvents = nil
+	}
+	return p.registerIssue(&runIssue{
+		JobId: util.ExtractJobId(pod),
+		RunId: util.ExtractJobRunId(pod),
+		PodIssue: &podIssue{
+			OriginalPodState: pod.DeepCopy(),
+			Message:          util.ExtractPodFailedReason(pod),
+			DebugMessage:     reporter.CreateDebugMessage(podEvents),
+			Retryable:        false,
+			Type:             DeleteActionFailure,
+			Cause:            util.ExtractPodFailureCause(pod),
+			Classification:   classification,
+			DetectionTime:    p.clock.Now(),
+		},
+		Reported: false,
+	})
 }
 
 func (p *PodIssueHandler) registerIssue(issue *runIssue) (bool, error) {
@@ -386,6 +437,11 @@ func (p *PodIssueHandler) handlePodIssue(issue *issue) {
 		return
 	}
 
+	if issue.RunIssue.PodIssue.Type == DeleteActionFailure {
+		p.handleDeleteActionFailure(issue)
+		return
+	}
+
 	if issue.RunIssue.PodIssue.Retryable {
 		p.handleRetryableJobIssue(issue)
 	} else {
@@ -464,6 +520,76 @@ func internalSubcategoryForPodIssueType(t podIssueType) string {
 	default:
 		return ""
 	}
+}
+
+// handleDeleteActionFailure deletes a failed pod whose category action is
+// Delete and reports the terminal categorized failure only once the pod is
+// confirmed gone from the cluster. The report is what triggers a scheduler
+// retry, so this ordering guarantees the retry can never collide with the old
+// pod's name. A pod that cannot be deleted within stuckTerminatingPodExpiry is
+// instead failed terminally as an internal stuck-terminating error, which is
+// safer than leaving the job invisible forever. The issue stays registered
+// until the pod is actually gone, so the report fires exactly once and the
+// lingering pod cannot be re-detected as a fresh failure.
+func (p *PodIssueHandler) handleDeleteActionFailure(issue *issue) {
+	podIssue := issue.RunIssue.PodIssue
+
+	if issue.CurrentPodState == nil {
+		if !issue.RunIssue.Reported {
+			p.reportDeleteActionFailure(issue, podIssue.Classification.Category, podIssue.Classification.Subcategory,
+				podIssue.Classification.AppendHint(podIssue.Message))
+		}
+		if issue.RunIssue.Reported {
+			p.markIssuesResolved(issue.RunIssue)
+		}
+		return
+	}
+
+	if !issue.RunIssue.Reported {
+		deleteStartedAt := podIssue.DetectionTime
+		if issue.CurrentPodState.DeletionTimestamp != nil {
+			deleteStartedAt = issue.CurrentPodState.DeletionTimestamp.Time
+		}
+		if deleteStartedAt.Add(p.stuckTerminatingPodExpiry).Before(p.clock.Now()) {
+			p.reportDeleteActionFailure(issue, errormatch.CategoryInternal, errormatch.SubcategoryStuckTerminating,
+				podIssue.Message+"\n\nThe failed pod could not be deleted, so the job is failed rather than retried.")
+		}
+	}
+
+	err := p.clusterContext.DeletePodWithCondition(issue.CurrentPodState, func(pod *v1.Pod) bool {
+		return pod.Status.Phase == v1.PodFailed
+	}, true)
+	if err != nil {
+		log.Errorf("Failed to delete failed pod of job %s because %s", issue.RunIssue.JobId, err)
+		return
+	}
+	podIssue.DeletionRequested = true
+}
+
+func (p *PodIssueHandler) reportDeleteActionFailure(issue *issue, category string, subcategory string, message string) {
+	podIssue := issue.RunIssue.PodIssue
+	clusterId := p.clusterContext.GetClusterId()
+	failedEvent, err := reporter.CreateJobFailedEvent(
+		podIssue.OriginalPodState,
+		message,
+		podIssue.Cause,
+		podIssue.DebugMessage,
+		util.ExtractFailedPodContainerStatuses(podIssue.OriginalPodState, clusterId),
+		clusterId,
+		category,
+		subcategory,
+	)
+	if err != nil {
+		log.Errorf("Failed to create failed event for job %s because %s", issue.RunIssue.JobId, err)
+		return
+	}
+	err = p.eventReporter.Report([]reporter.EventMessage{{Event: failedEvent, JobRunId: issue.RunIssue.RunId}})
+	if err != nil {
+		log.Errorf("Failed to report failed event for job %s because %s", issue.RunIssue.JobId, err)
+		return
+	}
+	metrics.RecordJobFailure(category, subcategory)
+	p.markIssueReported(issue.RunIssue)
 }
 
 // For retryable issues we must:

--- a/internal/executor/service/pod_issue_handler_test.go
+++ b/internal/executor/service/pod_issue_handler_test.go
@@ -808,3 +808,236 @@ func TestInternalSubcategoryForPodIssueType(t *testing.T) {
 		assert.Equal(t, want, internalSubcategoryForPodIssueType(issueType))
 	}
 }
+
+func TestDetectAndRegisterDeleteActionIssue(t *testing.T) {
+	tests := map[string]struct {
+		deleteAction     bool
+		phase            v1.PodPhase
+		podEventsErr     bool
+		expectRegistered bool
+	}{
+		"failed pod in a delete-action category":  {deleteAction: true, phase: v1.PodFailed, expectRegistered: true},
+		"failed pod in a retain category":         {deleteAction: false, phase: v1.PodFailed, expectRegistered: false},
+		"running pod in a delete-action category": {deleteAction: true, phase: v1.PodRunning, expectRegistered: false},
+		"pod events unavailable still registers":  {deleteAction: true, phase: v1.PodFailed, podEventsErr: true, expectRegistered: true},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			classifier := classifierForExitCode(t, "pih-del-cat", "pih-del-sub", 42, tc.deleteAction)
+			podIssueService, _, fakeClusterContext, _, err := setupTestComponentsWithClassifier([]*job.RunState{}, classifier)
+			require.NoError(t, err)
+			pod := makeFailedPodWithExitCode(t, 42)
+			pod.Status.Phase = tc.phase
+			addPod(t, fakeClusterContext, pod)
+			if tc.podEventsErr {
+				fakeClusterContext.GetPodEventsErr = fmt.Errorf("events unavailable")
+			}
+
+			registered, err := podIssueService.DetectAndRegisterDeleteActionIssue(pod)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectRegistered, registered)
+			assert.Equal(t, tc.expectRegistered, podIssueService.HasIssue(util.ExtractJobRunId(pod)))
+		})
+	}
+}
+
+func TestPodIssueService_DeleteAction_FailedPodChecksKeepPrecedence(t *testing.T) {
+	// The pod matches both systems: its status message matches the failed pod
+	// checker and its Evicted condition matches a delete-action category.
+	classifier, err := categorizer.NewClassifier(categorizer.ErrorCategoriesConfig{
+		Categories: []categorizer.CategoryConfig{
+			{
+				Name:   "pih-evicted",
+				Action: categorizer.PodFailureActionDelete,
+				Rules:  []categorizer.CategoryRule{{OnConditions: []string{errormatch.ConditionEvicted}}},
+			},
+		},
+	})
+	require.NoError(t, err)
+	podIssueService, _, fakeClusterContext, eventsReporter, err := setupTestComponentsWithClassifier([]*job.RunState{}, classifier)
+	require.NoError(t, err)
+	pod := makeTestPod(v1.PodStatus{
+		Phase:   v1.PodFailed,
+		Reason:  errormatch.ConditionEvicted,
+		Message: retryableFailedPodStatusMessage,
+	})
+	addPod(t, fakeClusterContext, pod)
+
+	registered, err := podIssueService.DetectAndRegisterIssuesForFailedPod(pod)
+	require.NoError(t, err)
+	require.True(t, registered)
+
+	podIssueService.HandlePodIssues()
+	podIssueService.HandlePodIssues()
+	events := eventsReporter.GetReceivedEvents()
+	require.Len(t, events, 1)
+	require.Len(t, events[0].Event.Events, 1)
+	returnedEvent, ok := events[0].Event.Events[0].Event.(*armadaevents.EventSequence_Event_JobRunErrors)
+	require.True(t, ok)
+	require.Len(t, returnedEvent.JobRunErrors.Errors, 1)
+	assert.NotNil(t, returnedEvent.JobRunErrors.Errors[0].GetPodLeaseReturned(),
+		"the run must take the lease-return path, not the categorized terminal path")
+}
+
+type failingDeleteClusterContext struct {
+	*fakecontext.SyncFakeClusterContext
+	allowDeletes bool
+}
+
+func (c *failingDeleteClusterContext) DeletePodWithCondition(pod *v1.Pod, condition func(pod *v1.Pod) bool, pessimistic bool) error {
+	if c.allowDeletes {
+		return c.SyncFakeClusterContext.DeletePodWithCondition(pod, condition, pessimistic)
+	}
+	return fmt.Errorf("simulated delete failure")
+}
+
+func TestPodIssueService_DeleteAction_PreservesFailureCause(t *testing.T) {
+	classifier, err := categorizer.NewClassifier(categorizer.ErrorCategoriesConfig{
+		Categories: []categorizer.CategoryConfig{
+			{
+				Name:   "pih-evicted",
+				Action: categorizer.PodFailureActionDelete,
+				Rules:  []categorizer.CategoryRule{{OnConditions: []string{errormatch.ConditionEvicted}}},
+			},
+		},
+	})
+	require.NoError(t, err)
+	podIssueService, _, fakeClusterContext, eventsReporter, err := setupTestComponentsWithClassifier([]*job.RunState{}, classifier)
+	require.NoError(t, err)
+	pod := makeTestPod(v1.PodStatus{Phase: v1.PodFailed, Reason: errormatch.ConditionEvicted})
+	addPod(t, fakeClusterContext, pod)
+	registered, err := podIssueService.DetectAndRegisterDeleteActionIssue(pod)
+	require.NoError(t, err)
+	require.True(t, registered)
+
+	podIssueService.HandlePodIssues()
+	podIssueService.HandlePodIssues()
+
+	events := eventsReporter.GetReceivedEvents()
+	require.Len(t, events, 1)
+	failedEvent, ok := events[0].Event.Events[0].Event.(*armadaevents.EventSequence_Event_JobRunErrors)
+	require.True(t, ok)
+	require.Len(t, failedEvent.JobRunErrors.Errors, 1)
+	podError := failedEvent.JobRunErrors.Errors[0].GetPodError()
+	require.NotNil(t, podError)
+	assert.Equal(t, armadaevents.KubernetesReason_Evicted, podError.KubernetesReason,
+		"the reported cause must be the pod's real failure reason, not a generic app error")
+}
+
+// Each case drives HandlePodIssues through a sequence of cycles for a failed
+// pod in a delete-action category and asserts the observable state after each.
+func TestPodIssueService_DeleteActionLifecycle(t *testing.T) {
+	type cycle struct {
+		advanceTo      time.Duration // clock offset from the start, applied before the cycle
+		allowDeletes   bool
+		reporterErr    bool
+		expectPodGone  bool
+		expectEvents   int
+		expectResolved bool
+	}
+	tests := map[string]struct {
+		deleteFails       bool
+		cycles            []cycle
+		expectCategory    string
+		expectSubcategory string
+		expectMessage     string
+	}{
+		"deletes the pod first, reports the categorized failure once it is gone": {
+			cycles: []cycle{
+				{expectPodGone: true, expectEvents: 0},
+				{expectPodGone: true, expectEvents: 1, expectResolved: true},
+			},
+			expectCategory:    "pih-del-cat",
+			expectSubcategory: "pih-del-sub",
+		},
+		"a failed report is retried until delivered": {
+			cycles: []cycle{
+				{reporterErr: true, expectPodGone: true, expectEvents: 0},
+				{reporterErr: true, expectPodGone: true, expectEvents: 0},
+				{expectPodGone: true, expectEvents: 1, expectResolved: true},
+			},
+			expectCategory:    "pih-del-cat",
+			expectSubcategory: "pih-del-sub",
+		},
+		// A pod that cannot be deleted within stuckTerminatingPodExpiry is
+		// failed terminally as an internal stuck-terminating error instead of
+		// staying invisible forever. The issue must stay registered while the
+		// pod exists (resolving would let the reporter re-detect the pod and
+		// report it again), and once the delete finally succeeds it resolves
+		// without a second event.
+		"an undeletable pod is failed terminally once, then resolves when the delete succeeds": {
+			deleteFails: true,
+			cycles: []cycle{
+				{expectEvents: 0},
+				{advanceTo: 4 * time.Minute, expectEvents: 1},
+				{advanceTo: 8 * time.Minute, expectEvents: 1},
+				{advanceTo: 8 * time.Minute, expectEvents: 1},
+				{allowDeletes: true, expectPodGone: true, expectEvents: 1},
+				{allowDeletes: true, expectPodGone: true, expectEvents: 1, expectResolved: true},
+			},
+			expectCategory:    errormatch.CategoryInternal,
+			expectSubcategory: errormatch.SubcategoryStuckTerminating,
+			expectMessage:     "could not be deleted",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			classifier := classifierForExitCode(t, "pih-del-cat", "pih-del-sub", 42, true)
+			var clusterContext context.ClusterContext = fakecontext.NewSyncFakeClusterContext()
+			var failingContext *failingDeleteClusterContext
+			if tc.deleteFails {
+				failingContext = &failingDeleteClusterContext{SyncFakeClusterContext: fakecontext.NewSyncFakeClusterContext()}
+				clusterContext = failingContext
+			}
+			eventsReporter := mocks.NewFakeEventReporter()
+			podIssueService, err := NewPodIssuerHandler(
+				job.NewJobRunStateStoreWithInitialState([]*job.RunState{}),
+				clusterContext,
+				eventsReporter,
+				configuration.StateChecksConfiguration{
+					DeadlineForSubmittedPodConsideredMissing: time.Minute * 15,
+					DeadlineForActivePodConsideredMissing:    time.Minute * 5,
+				},
+				makePendingPodChecker(),
+				makeFailedPodChecker(),
+				time.Minute*3,
+				classifier,
+			)
+			require.NoError(t, err)
+			baseTime := time.Now()
+			fakeClock := clock.NewFakeClock(baseTime)
+			podIssueService.clock = fakeClock
+			pod := makeFailedPodWithExitCode(t, 42)
+			addPod(t, clusterContext, pod)
+			runId := util.ExtractJobRunId(pod)
+			registered, err := podIssueService.DetectAndRegisterDeleteActionIssue(pod)
+			require.NoError(t, err)
+			require.True(t, registered)
+
+			for i, c := range tc.cycles {
+				fakeClock.SetTime(baseTime.Add(c.advanceTo))
+				if failingContext != nil {
+					failingContext.allowDeletes = c.allowDeletes
+				}
+				eventsReporter.ErrorOnReport = c.reporterErr
+				podIssueService.HandlePodIssues()
+
+				assert.Equal(t, !c.expectPodGone, len(getActivePods(t, clusterContext)) == 1, "cycle %d: pod presence", i)
+				assert.Len(t, eventsReporter.GetReceivedEvents(), c.expectEvents, "cycle %d: events", i)
+				assert.Equal(t, !c.expectResolved, podIssueService.HasIssue(runId), "cycle %d: issue state", i)
+			}
+
+			events := eventsReporter.GetReceivedEvents()
+			require.NotEmpty(t, events)
+			failedEvent, ok := events[0].Event.Events[0].Event.(*armadaevents.EventSequence_Event_JobRunErrors)
+			require.True(t, ok)
+			jobError := failedEvent.JobRunErrors.Errors[0]
+			assert.True(t, jobError.Terminal)
+			assert.Equal(t, tc.expectCategory, jobError.FailureCategory)
+			assert.Equal(t, tc.expectSubcategory, jobError.FailureSubcategory)
+			if tc.expectMessage != "" {
+				assert.Contains(t, jobError.GetPodError().GetMessage(), tc.expectMessage)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds an `action` field to executor failure categories, with two values: `Retain` (the default, today's behaviour: a failed pod is kept for debugging) and `Delete`. A failed pod whose matched category has `action: Delete` is deleted so a scheduler retry of the same job can reuse the deterministic pod name without colliding with its predecessor.

Delete-action pods are handled by the pod issue handler, the same machinery that runs failed pod checks. The state reporter registers an issue instead of emitting the terminal event itself, and the issue handler's periodic loop then deletes the pod, waits until the informer confirms it is gone, and only then reports the terminal event with the pod's failure category and subcategory. Because that report is what triggers a scheduler retry, the retry can never race the deletion: the pod name is free before the scheduler learns of the failure. A failed delete or a failed report is retried every cycle from the issue's pod snapshot.

Failed pod checks are not altered. The checker, its detection function, and both existing issue handlers have zero changes; the new detection runs only after the checker declines a pod, so checks keep first claim on everything they match today. This is deliberate: the intended use of `action: Delete` is to replace failed pod checks one at a time, by removing a check from `failedChecks` and adding an equivalent category with `action: Delete` plus a scheduler retry policy for that category. Each migration is config-only and reversible by restoring the check. The checks themselves are only removed once every check has been migrated and validated.

Two operational notes. A `Delete` category without a matching scheduler retry policy turns those failures terminal instead of retried, so the executor and scheduler config must change together when migrating a check. And the mechanism is sized for check-replacement volume, which is operator-curated infrastructure failures; `action: Delete` is not intended for broad categories such as user errors.

It also adds two `errormatch` conditions, `LeaseExpired` and `AppError`, used by the classifier to categorise the corresponding pod failures.
