### PR TITLE
Add e2e testsuite cases for retry policies

### DIFF
--- a/_local/executor/config.yaml
+++ b/_local/executor/config.yaml
@@ -24,10 +24,14 @@ application:
     enabled: true
     defaultCategory: uncategorized
     categories:
+      # The action Delete makes the executor remove the failed pod. A retry
+      # then reuses the name of the pod. The retry/ testcases need this.
       - name: oom
+        action: Delete
         rules:
           - onConditions: ["OOMKilled"]
       - name: user_error
+        action: Delete
         rules:
           - onExitCodes:
               operator: In

--- a/_local/scheduler/config.yaml
+++ b/_local/scheduler/config.yaml
@@ -1,3 +1,6 @@
+# A short refresh keeps the e2e setup fast: the queue and policy caches see
+# a new policy after one period.
+queueRefreshPeriod: 3s
 grpc:
   port: 50052
   tls:
@@ -32,5 +35,8 @@ postgres:
 scheduling:
   indexedNodeLabels:
     - "kubernetes.io/hostname"
+  retryPolicy:
+    enabled: true
+    globalMaxRetries: 5
 metrics:
   port: 9001

--- a/magefiles/ci.go
+++ b/magefiles/ci.go
@@ -14,21 +14,13 @@ import (
 )
 
 func createQueue() error {
-	out, err := runArmadaCtl("create", "queue", "e2e-test-queue")
-	// check if err text contains "already exists" and ignore if it does
-	if err != nil && !strings.Contains(out, "already exists") {
-		fmt.Println(out)
-		return err
-	}
-
-	return nil
+	return runArmadaCtlIgnoreExists("create", "queue", "e2e-test-queue")
 }
 
-// createRetryPolicyAndQueue smoke-tests retry-policy creation and queue
-// attachment against a live server: it creates a policy and a queue bound to
-// it. Driving a retry end to end additionally needs the executor to delete the
-// failed pod so the retry can reuse its name, so no testcase submits to this
-// queue yet.
+// createRetryPolicyAndQueue creates the retry policy and the queue that uses
+// it. The retry/ testcases submit to this queue. The executor config sets the
+// action Delete on the categories that this policy retries. The executor thus
+// removes the failed pod, and the retry reuses the name of the pod.
 func createRetryPolicyAndQueue() error {
 	policyPath, err := writeRetryPolicyFile()
 	if err != nil {
@@ -37,17 +29,24 @@ func createRetryPolicyAndQueue() error {
 	defer os.Remove(policyPath)
 
 	out, err := runArmadaCtl("create", "retry-policy", "-f", policyPath)
-	if err != nil && !strings.Contains(out, "already exists") {
+	if err != nil && strings.Contains(out, "already exists") {
+		// The policy can remain from an earlier run against a live server.
+		// The update makes sure the testcases see the current rules.
+		out, err = runArmadaCtl("update", "retry-policy", "-f", policyPath)
+	}
+	if err != nil {
 		fmt.Println(out)
 		return err
 	}
 
-	out, err = runArmadaCtl("create", "queue", "e2e-retry-queue", "--retry-policies", "e2e-retry-policy")
-	if err != nil && !strings.Contains(out, "already exists") {
-		fmt.Println(out)
+	if err := runArmadaCtlIgnoreExists("create", "queue", "e2e-retry-queue", "--retry-policies", "e2e-retry-policy"); err != nil {
 		return err
 	}
 
+	// The scheduler's queue and policy caches poll on queueRefreshPeriod
+	// (3s in the local config) and do not observe creations. Wait one
+	// period, so the first testcase always finds the policy in the cache.
+	time.Sleep(4 * time.Second)
 	return nil
 }
 
@@ -60,6 +59,12 @@ defaultAction: Fail
 rules:
   - action: Retry
     onCategory: "user_error"
+  - action: Retry
+    onCategory: "oom"
+    mutate:
+      resources:
+        memory:
+          factor: 2.0
 `
 	f, err := os.CreateTemp("", "retry-policy-*.yaml")
 	if err != nil {
@@ -86,7 +91,7 @@ func TestSuite() error {
 	timeTakenTestSuite := time.Now()
 
 	suites := []string{
-		"basic", "categorization", "preemption", "reprioritization", "queue",
+		"basic", "categorization", "retry", "preemption", "reprioritization", "queue",
 		"testsuite/testcases/node/node_cancel_by_name_1x5.yaml",
 		"testsuite/testcases/node/node_preempt_by_name_1x5.yaml",
 	}
@@ -198,6 +203,19 @@ func runArmadaCtl(args ...string) (string, error) {
 	outBytes, err := exec.Command(findOrBuildArmadaCtl(), armadaCtlArgs...).CombinedOutput()
 	out := string(outBytes)
 	return out, err
+}
+
+// runArmadaCtlIgnoreExists runs armadactl and accepts an "already exists"
+// error. A rerun against a live server thus keeps the resource from the
+// earlier run.
+func runArmadaCtlIgnoreExists(args ...string) error {
+	out, err := runArmadaCtl(args...)
+	if err != nil && !strings.Contains(out, "already exists") {
+		fmt.Println(out)
+		return err
+	}
+
+	return nil
 }
 
 // Builds armadactl binary using goreleaser and returns the path.

--- a/testsuite/testcases/retry/default_action_fail.yaml
+++ b/testsuite/testcases/retry/default_action_fail.yaml
@@ -1,0 +1,33 @@
+numBatches: 1
+batchSize: 1
+queue: e2e-retry-queue
+jobs:
+  - priority: 0
+    namespace: default
+    podSpec:
+      terminationGracePeriodSeconds: 0
+      restartPolicy: Never
+      containers:
+        - name: fail-unmatched
+          imagePullPolicy: IfNotPresent
+          image: alpine:3.20.0
+          # Exit code 3 matches no category rule. The executor thus applies the
+          # default category uncategorized. The policy has no rule for that
+          # category, so the scheduler applies the defaultAction Fail.
+          command: ["sh", "-c", "exit 3"]
+          resources:
+            limits:
+              memory: 25Mi
+              cpu: 100m
+            requests:
+              memory: 25Mi
+              cpu: 100m
+---
+timeout: "300s"
+expectedEvents:
+  - submitted:
+  - queued:
+  - leased:
+  - pending:
+  - failed:
+      failureCategory: "uncategorized"

--- a/testsuite/testcases/retry/failfast_no_retry.yaml
+++ b/testsuite/testcases/retry/failfast_no_retry.yaml
@@ -1,0 +1,34 @@
+numBatches: 1
+batchSize: 1
+queue: e2e-retry-queue
+jobs:
+  - priority: 0
+    namespace: default
+    annotations:
+      # The policy retries the user_error category. This annotation opts the
+      # job out, so exit 1 fails the job at the first attempt.
+      armadaproject.io/failFast: "true"
+    podSpec:
+      terminationGracePeriodSeconds: 0
+      restartPolicy: Never
+      containers:
+        - name: fail-fast
+          imagePullPolicy: IfNotPresent
+          image: alpine:3.20.0
+          command: ["sh", "-c", "exit 1"]
+          resources:
+            limits:
+              memory: 25Mi
+              cpu: 100m
+            requests:
+              memory: 25Mi
+              cpu: 100m
+---
+timeout: "300s"
+expectedEvents:
+  - submitted:
+  - queued:
+  - leased:
+  - pending:
+  - failed:
+      failureCategory: "user_error"

--- a/testsuite/testcases/retry/oom_memory_bump.yaml
+++ b/testsuite/testcases/retry/oom_memory_bump.yaml
@@ -1,0 +1,40 @@
+numBatches: 1
+batchSize: 1
+queue: e2e-retry-queue
+jobs:
+  - priority: 0
+    namespace: default
+    podSpec:
+      terminationGracePeriodSeconds: 0
+      restartPolicy: Never
+      containers:
+        - name: oom-then-fit
+          imagePullPolicy: IfNotPresent
+          image: alpine:3.20.0
+          # The sleep makes sure the executor sees the running state before the
+          # container writes data. The 56Mi of tmpfs data exceeds the 40Mi
+          # limit, so Kubernetes OOM-kills the first attempt. The policy
+          # doubles the memory, and the same data fits in the 80Mi of the retry.
+          command: ["sh", "-c", "sleep 3; dd if=/dev/zero of=/dev/shm/fill bs=1M count=56"]
+          resources:
+            limits:
+              memory: 40Mi
+              cpu: 100m
+            requests:
+              memory: 40Mi
+              cpu: 100m
+---
+timeout: "600s"
+expectedEvents:
+  - submitted:
+  - queued:
+  - leased:
+  - pending:
+  - running:
+  - failed:
+      failureCategory: "oom"
+      retryable: true
+  - leased:
+  - pending:
+  - running:
+  - succeeded:

--- a/testsuite/testcases/retry/retry_limit_exceeded.yaml
+++ b/testsuite/testcases/retry/retry_limit_exceeded.yaml
@@ -1,0 +1,40 @@
+numBatches: 1
+batchSize: 1
+queue: e2e-retry-queue
+jobs:
+  - priority: 0
+    namespace: default
+    podSpec:
+      terminationGracePeriodSeconds: 0
+      restartPolicy: Never
+      containers:
+        - name: fail
+          imagePullPolicy: IfNotPresent
+          image: alpine:3.20.0
+          command: ["sh", "-c", "exit 1"]
+          resources:
+            limits:
+              memory: 25Mi
+              cpu: 100m
+            requests:
+              memory: 25Mi
+              cpu: 100m
+---
+timeout: "600s"
+expectedEvents:
+  - submitted:
+  - queued:
+  - leased:
+  - pending:
+  - failed:
+      failureCategory: "user_error"
+      retryable: true
+  - leased:
+  - pending:
+  - failed:
+      failureCategory: "user_error"
+      retryable: true
+  - leased:
+  - pending:
+  - failed:
+      failureCategory: "user_error"


### PR DESCRIPTION
Unit tests cover the retry policy engine (#5001) and its building blocks (#4998, #4999, #5012, #5048, #5049, #5080, #5081). No e2e test drives a retry through a live cluster. This PR adds a `retry/` testsuite with four cases. They exercise the full pipeline: the executor categorizes a failure and deletes the failed pod, and the scheduler retries per the policy.

The cases:

* **Retry limit exceeded**: a job always fails with the `user_error` category. The policy retries it twice (`retryLimit: 2`), then the job fails terminally. The test asserts the full lifecycle sequence: submitted, queued, then leased, pending and a `retryable: true` failure for each attempt, then a terminal failure. A pod-name collision diverts a retry to the lease-return path and breaks this sequence, so the test also proves that pod deletion frees the name.
* **Memory bump**: a job writes 56Mi of tmpfs data against a 40Mi memory limit, and the first attempt fails with OOMKilled. The policy retries `oom` failures with `mutate.resources.memory.factor: 2.0`. The retried pod runs with 80Mi and succeeds. The test asserts the running event on both attempts and the final succeeded event, which validates the mutation through the whole lease pipeline.
* **Default action**: a job exits with a code that matches no category rule. The failure gets the default category, and the job fails terminally with no retry. The event validator compares `retryable` unconditionally, so a retry before the terminal event fails the test.
* **failFast**: a job with the `armadaproject.io/failFast` annotation fails terminally on a queue with a matching Retry rule. The annotation disables the retry engine for that job.

Setup changes: the `_local` executor config sets `action: Delete` on the `oom` and `user_error` categories. The `_local` scheduler config enables the retry engine. The CI policy gains the `oom` rule with the memory factor. The CI setup updates the policy when it already exists, so a rerun against a live server sees the current rules.

This PR does not cover anti-affinity: its event sequence depends on the node count of the cluster, so it is not stable across environments. Unit tests and the scheduler wiring PR cover it.

All four cases pass against a local stack (compose plus kind): 4/4 in 1m4s.