### PR TITLE
Add urgency-preemptable resource view to fix urgency preemption over-matching

### DIFF
--- a/internal/scheduler/internaltypes/node.go
+++ b/internal/scheduler/internaltypes/node.go
@@ -55,10 +55,13 @@ type Node struct {
 	// This field is set when inserting the Node into a NodeDb.
 	Keys [][]byte
 
-	AllocatableByPriority map[int32]ResourceList
-	AllocatedByQueue      map[string]ResourceList
-	AllocatedByJobId      map[string]ResourceList
-	EvictedJobRunIds      map[string]bool
+	AllocatableByPriority        map[int32]ResourceList
+	UrgencyPreemptableByPriority map[int32]ResourceList
+	AllocatedByQueue             map[string]ResourceList
+	AllocatedByJobId             map[string]ResourceList
+	EvictedJobRunIds             map[string]bool
+
+	hasUrgencyPreemptableResources bool
 }
 
 func FromSchedulerObjectsNode(node *schedulerobjects.Node,
@@ -176,24 +179,25 @@ func CreateNode(
 ) *Node {
 	reservation := util.GetReservationName(taints)
 	return &Node{
-		id:                    id,
-		nodeType:              nodeType,
-		index:                 index,
-		executor:              executor,
-		name:                  name,
-		pool:                  pool,
-		reportingNodeType:     reportingNodeType,
-		taints:                koTaint.DeepCopyTaints(taints),
-		reservation:           reservation,
-		labels:                deepCopyLabels(labels),
-		unschedulable:         unschedulable,
-		totalResources:        totalResources,
-		allocatableResources:  allocatableResources,
-		AllocatableByPriority: maps.Clone(allocatableByPriority),
-		AllocatedByQueue:      maps.Clone(allocatedByQueue),
-		AllocatedByJobId:      maps.Clone(allocatedByJobId),
-		EvictedJobRunIds:      evictedJobRunIds,
-		Keys:                  keys,
+		id:                           id,
+		nodeType:                     nodeType,
+		index:                        index,
+		executor:                     executor,
+		name:                         name,
+		pool:                         pool,
+		reportingNodeType:            reportingNodeType,
+		taints:                       koTaint.DeepCopyTaints(taints),
+		reservation:                  reservation,
+		labels:                       deepCopyLabels(labels),
+		unschedulable:                unschedulable,
+		totalResources:               totalResources,
+		allocatableResources:         allocatableResources,
+		AllocatableByPriority:        maps.Clone(allocatableByPriority),
+		UrgencyPreemptableByPriority: maps.Clone(allocatableByPriority),
+		AllocatedByQueue:             maps.Clone(allocatedByQueue),
+		AllocatedByJobId:             maps.Clone(allocatedByJobId),
+		EvictedJobRunIds:             evictedJobRunIds,
+		Keys:                         keys,
 	}
 }
 
@@ -282,6 +286,23 @@ func (node *Node) GetAllocatableResources() ResourceList {
 	return node.allocatableResources
 }
 
+func (node *Node) HasUrgencyPreemptableResources() bool {
+	return node.hasUrgencyPreemptableResources
+}
+
+// RecomputeUrgencyPreemptableFlag sets hasUrgencyPreemptableResources to true iff the
+// urgency-preemptable view has more resource available at the highest real priority than
+// at the lowest, i.e. at least one lower-priority job could be urgency-preempted.
+func (node *Node) RecomputeUrgencyPreemptableFlag(realPriorities []int32) {
+	if len(realPriorities) == 0 {
+		node.hasUrgencyPreemptableResources = false
+		return
+	}
+	lowest := node.UrgencyPreemptableByPriority[realPriorities[0]]
+	highest := node.UrgencyPreemptableByPriority[realPriorities[len(realPriorities)-1]]
+	node.hasUrgencyPreemptableResources = !lowest.Equal(highest)
+}
+
 func (node *Node) MarkResourceUnallocatable(unallocatable ResourceList) *Node {
 	result := node.DeepCopyNilKeys()
 
@@ -341,10 +362,13 @@ func (node *Node) DeepCopyNilKeys() *Node {
 		Keys: nil,
 
 		// these maps are mutable but their keys and values are immutable
-		AllocatableByPriority: maps.Clone(node.AllocatableByPriority),
-		AllocatedByQueue:      maps.Clone(node.AllocatedByQueue),
-		AllocatedByJobId:      maps.Clone(node.AllocatedByJobId),
-		EvictedJobRunIds:      maps.Clone(node.EvictedJobRunIds),
+		AllocatableByPriority:        maps.Clone(node.AllocatableByPriority),
+		UrgencyPreemptableByPriority: maps.Clone(node.UrgencyPreemptableByPriority),
+		AllocatedByQueue:             maps.Clone(node.AllocatedByQueue),
+		AllocatedByJobId:             maps.Clone(node.AllocatedByJobId),
+		EvictedJobRunIds:             maps.Clone(node.EvictedJobRunIds),
+
+		hasUrgencyPreemptableResources: node.hasUrgencyPreemptableResources,
 	}
 }
 

--- a/internal/scheduler/internaltypes/node.go
+++ b/internal/scheduler/internaltypes/node.go
@@ -300,6 +300,32 @@ func (node *Node) RecomputeUrgencyPreemptableFlag(realPriorities []int32) {
 	node.hasUrgencyPreemptableResources = !lowest.Equal(highest)
 }
 
+func (node *Node) MarkAllocatedFairShare(priorityCutoff int32, rs ResourceList) {
+	MarkAllocated(node.AllocatableByPriority, priorityCutoff, rs)
+}
+
+func (node *Node) MarkAllocatableFairShare(priorityCutoff int32, rs ResourceList) {
+	MarkAllocatable(node.AllocatableByPriority, priorityCutoff, rs)
+}
+
+func (node *Node) MarkAllocatedUrgency(priorityCutoff int32, rs ResourceList) {
+	MarkAllocated(node.UrgencyPreemptableByPriority, priorityCutoff, rs)
+}
+
+func (node *Node) MarkAllocatableUrgency(priorityCutoff int32, rs ResourceList) {
+	MarkAllocatable(node.UrgencyPreemptableByPriority, priorityCutoff, rs)
+}
+
+func (node *Node) MarkAllocated(priorityCutoff int32, rs ResourceList) {
+	node.MarkAllocatedFairShare(priorityCutoff, rs)
+	node.MarkAllocatedUrgency(priorityCutoff, rs)
+}
+
+func (node *Node) MarkAllocatable(priorityCutoff int32, rs ResourceList) {
+	node.MarkAllocatableFairShare(priorityCutoff, rs)
+	node.MarkAllocatableUrgency(priorityCutoff, rs)
+}
+
 func (node *Node) MarkResourceUnallocatable(unallocatable ResourceList) *Node {
 	result := node.DeepCopyNilKeys()
 

--- a/internal/scheduler/internaltypes/node.go
+++ b/internal/scheduler/internaltypes/node.go
@@ -290,9 +290,6 @@ func (node *Node) HasUrgencyPreemptableResources() bool {
 	return node.hasUrgencyPreemptableResources
 }
 
-// RecomputeUrgencyPreemptableFlag sets hasUrgencyPreemptableResources to true iff the
-// urgency-preemptable view has more resource available at the highest real priority than
-// at the lowest, i.e. at least one lower-priority job could be urgency-preempted.
 func (node *Node) RecomputeUrgencyPreemptableFlag(realPriorities []int32) {
 	if len(realPriorities) == 0 {
 		node.hasUrgencyPreemptableResources = false

--- a/internal/scheduler/internaltypes/node_test.go
+++ b/internal/scheduler/internaltypes/node_test.go
@@ -213,6 +213,55 @@ func TestMarkResourceUnallocatable_ProtectsFromNegativeValues(t *testing.T) {
 	assert.Equal(t, expectedAllocatableByPriority, result.AllocatableByPriority)
 }
 
+func TestUrgencyPreemptableByPriorityInitializedEqualToAllocatable(t *testing.T) {
+	resourceListFactory, err := NewResourceListFactory(
+		[]schedulerconfiguration.ResourceType{
+			{Name: "cpu", Resolution: resource.MustParse("1m")},
+		},
+		nil,
+	)
+	require.Nil(t, err)
+
+	allocatableResources := makeCpuResourceList(resourceListFactory, "10")
+	allocatableByPriority := map[int32]ResourceList{
+		1: makeCpuResourceList(resourceListFactory, "8"),
+		2: makeCpuResourceList(resourceListFactory, "6"),
+	}
+
+	node := createNode(allocatableResources, allocatableByPriority)
+
+	require.NotNil(t, node.UrgencyPreemptableByPriority)
+	require.Equal(t, len(node.AllocatableByPriority), len(node.UrgencyPreemptableByPriority))
+	for p, rl := range node.AllocatableByPriority {
+		require.True(t, rl.Equal(node.UrgencyPreemptableByPriority[p]), "priority %d", p)
+	}
+}
+
+func TestDeepCopyNilKeysClonesUrgencyMap(t *testing.T) {
+	resourceListFactory, err := NewResourceListFactory(
+		[]schedulerconfiguration.ResourceType{
+			{Name: "cpu", Resolution: resource.MustParse("1m")},
+		},
+		nil,
+	)
+	require.Nil(t, err)
+
+	allocatableResources := makeCpuResourceList(resourceListFactory, "10")
+	allocatableByPriority := map[int32]ResourceList{
+		1: makeCpuResourceList(resourceListFactory, "8"),
+		2: makeCpuResourceList(resourceListFactory, "6"),
+	}
+
+	node := createNode(allocatableResources, allocatableByPriority)
+	cp := node.DeepCopyNilKeys()
+	require.NotNil(t, cp.UrgencyPreemptableByPriority)
+	for p := range cp.UrgencyPreemptableByPriority {
+		delete(cp.UrgencyPreemptableByPriority, p)
+		break
+	}
+	require.Equal(t, len(node.AllocatableByPriority), len(node.UrgencyPreemptableByPriority))
+}
+
 func makeCpuResourceList(factory *ResourceListFactory, cpu string) ResourceList {
 	return factory.FromNodeProto(
 		map[string]*resource.Quantity{

--- a/internal/scheduler/nodedb/nodedb.go
+++ b/internal/scheduler/nodedb/nodedb.go
@@ -104,6 +104,14 @@ type NodeDb struct {
 	indexNameByPriority map[int32]string
 	// Map from priority class priority to the index of node.keys corresponding to that priority.
 	keyIndexByPriority map[int32]int
+	// Like indexNameByPriority, but for the sparse urgency-preemptable resource view.
+	urgencyIndexNameByPriority map[int32]string
+	// Like keyIndexByPriority, but for the sparse urgency-preemptable resource view.
+	urgencyKeyIndexByPriority map[int32]int
+	// Number of priorities in nodeDbPriorities; also the size of each key block in node.Keys.
+	numPriorities int
+	// Priority class priorities, ascending, excluding EvictedPriority.
+	realPriorities []int32
 	// Taint keys that to create indexes for.
 	// Should include taints frequently used for scheduling.
 	// Since the NodeDb can efficiently sort out nodes with taints not tolerated
@@ -173,7 +181,7 @@ func NewNodeDb(
 	nodeDbPriorities = append(nodeDbPriorities, types.AllowedPriorities(priorityClasses)...)
 
 	indexedResourceNames := slices.Map(indexedResources, func(v configuration.ResourceType) string { return v.Name })
-	schema, indexNameByPriority, keyIndexByPriority := nodeDbSchema(nodeDbPriorities, indexedResourceNames)
+	schema, indexNameByPriority, keyIndexByPriority, urgencyIndexNameByPriority, urgencyKeyIndexByPriority := nodeDbSchema(nodeDbPriorities, indexedResourceNames)
 	db, err := memdb.NewMemDB(schema)
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -204,21 +212,25 @@ func NewNodeDb(
 	}
 
 	nodeDb := NodeDb{
-		priorityClasses:           priorityClasses,
-		nodeDbPriorities:          nodeDbPriorities,
-		indexedResources:          indexedResourceNames,
-		indexedResourcesSet:       util.StringListToSet(indexedResourceNames),
-		indexedResourceResolution: indexedResourceResolution,
-		indexNameByPriority:       indexNameByPriority,
-		keyIndexByPriority:        keyIndexByPriority,
-		indexedTaints:             util.StringListToSet(indexedTaints),
-		indexedNodeLabels:         util.StringListToSet(indexedNodeLabels),
-		indexedNodeLabelValues:    indexedNodeLabelValues,
-		nodeTypes:                 make(map[uint64]*internaltypes.NodeType),
-		wellKnownNodeTypes:        make(map[string]*configuration.WellKnownNodeType),
-		numNodesByNodeType:        make(map[uint64]int),
-		totalAllocatableResources: resourceListFactory.MakeAllZero(),
-		db:                        db,
+		priorityClasses:            priorityClasses,
+		nodeDbPriorities:           nodeDbPriorities,
+		indexedResources:           indexedResourceNames,
+		indexedResourcesSet:        util.StringListToSet(indexedResourceNames),
+		indexedResourceResolution:  indexedResourceResolution,
+		indexNameByPriority:        indexNameByPriority,
+		keyIndexByPriority:         keyIndexByPriority,
+		urgencyIndexNameByPriority: urgencyIndexNameByPriority,
+		urgencyKeyIndexByPriority:  urgencyKeyIndexByPriority,
+		numPriorities:              len(nodeDbPriorities),
+		realPriorities:             types.AllowedPriorities(priorityClasses),
+		indexedTaints:              util.StringListToSet(indexedTaints),
+		indexedNodeLabels:          util.StringListToSet(indexedNodeLabels),
+		indexedNodeLabelValues:     indexedNodeLabelValues,
+		nodeTypes:                  make(map[uint64]*internaltypes.NodeType),
+		wellKnownNodeTypes:         make(map[string]*configuration.WellKnownNodeType),
+		numNodesByNodeType:         make(map[uint64]int),
+		totalAllocatableResources:  resourceListFactory.MakeAllZero(),
+		db:                         db,
 		// Set the initial capacity (somewhat arbitrarily) to 128 reasons.
 		podRequirementsNotMetReasonStringCache: make(map[uint64]string, 128),
 
@@ -307,6 +319,18 @@ func (nodeDb *NodeDb) IndexedNodeLabelValues(label string) (map[string]struct{},
 
 func (nodeDb *NodeDb) NumNodes() int {
 	return int(nodeDb.numNodes)
+}
+
+func (nodeDb *NodeDb) RealPrioritiesForTest() []int32 {
+	return nodeDb.realPriorities
+}
+
+func (nodeDb *NodeDb) UrgencyIndexNameForTest(p int32) string {
+	return nodeDb.urgencyIndexNameByPriority[p]
+}
+
+func (nodeDb *NodeDb) AllocatableIndexNameForTest(p int32) string {
+	return nodeDb.indexNameByPriority[p]
 }
 
 func (nodeDb *NodeDb) TotalKubernetesResources() internaltypes.ResourceList {
@@ -1163,9 +1187,13 @@ func (nodeDb *NodeDb) Upsert(node *internaltypes.Node) error {
 }
 
 func (nodeDb *NodeDb) UpsertWithTxn(txn *memdb.Txn, node *internaltypes.Node) error {
-	keys := make([][]byte, len(nodeDb.nodeDbPriorities))
+	node.RecomputeUrgencyPreemptableFlag(nodeDb.realPriorities)
+
+	keys := make([][]byte, 2*nodeDb.numPriorities)
 	for i, p := range nodeDb.nodeDbPriorities {
 		keys[i] = nodeDb.nodeDbKey(keys[i], node.GetNodeTypeId(), node.AllocatableByPriority[p], node.GetIndex())
+		urgencyKeyIndex := nodeDb.numPriorities + i
+		keys[urgencyKeyIndex] = nodeDb.nodeDbKey(keys[urgencyKeyIndex], node.GetNodeTypeId(), node.UrgencyPreemptableByPriority[p], node.GetIndex())
 	}
 	node.Keys = keys
 
@@ -1187,6 +1215,10 @@ func (nodeDb *NodeDb) ClearAllocated() error {
 	for node := it.NextNode(); node != nil; node = it.NextNode() {
 		node = node.DeepCopyNilKeys()
 		node.AllocatableByPriority = newAllocatableByPriorityAndResourceType(
+			nodeDb.nodeDbPriorities,
+			node.GetAllocatableResources(),
+		)
+		node.UrgencyPreemptableByPriority = newAllocatableByPriorityAndResourceType(
 			nodeDb.nodeDbPriorities,
 			node.GetAllocatableResources(),
 		)
@@ -1219,26 +1251,31 @@ func (nodeDb *NodeDb) AddEvictedJobSchedulingContextWithTxn(txn *memdb.Txn, inde
 	return nil
 }
 
-func nodeDbSchema(priorities []int32, resources []string) (*memdb.DBSchema, map[int32]string, map[int32]int) {
-	nodesTable, indexNameByPriority, keyIndexByPriority := nodesTableSchema(priorities)
+func nodeDbSchema(priorities []int32, resources []string) (*memdb.DBSchema, map[int32]string, map[int32]int, map[int32]string, map[int32]int) {
+	nodesTable, indexNameByPriority, keyIndexByPriority, urgencyIndexNameByPriority, urgencyKeyIndexByPriority := nodesTableSchema(priorities)
 	evictionsTable := evictionsTableSchema()
 	return &memdb.DBSchema{
 		Tables: map[string]*memdb.TableSchema{
 			nodesTable.Name:     nodesTable,
 			evictionsTable.Name: evictionsTable,
 		},
-	}, indexNameByPriority, keyIndexByPriority
+	}, indexNameByPriority, keyIndexByPriority, urgencyIndexNameByPriority, urgencyKeyIndexByPriority
 }
 
-func nodesTableSchema(priorities []int32) (*memdb.TableSchema, map[int32]string, map[int32]int) {
-	indexes := make(map[string]*memdb.IndexSchema, len(priorities)+1)
+func nodesTableSchema(priorities []int32) (*memdb.TableSchema, map[int32]string, map[int32]int, map[int32]string, map[int32]int) {
+	n := len(priorities)
+	indexes := make(map[string]*memdb.IndexSchema, 2*n+1)
 	indexes["id"] = &memdb.IndexSchema{
 		Name:    "id",
 		Unique:  true,
 		Indexer: createNodeIdIndex(),
 	}
-	indexNameByPriority := make(map[int32]string, len(priorities))
-	keyIndexByPriority := make(map[int32]int, len(priorities))
+
+	indexNameByPriority := make(map[int32]string, n)
+	keyIndexByPriority := make(map[int32]int, n)
+	urgencyIndexNameByPriority := make(map[int32]string, n)
+	urgencyKeyIndexByPriority := make(map[int32]int, n)
+
 	for i, priority := range priorities {
 		name := nodeIndexName(i)
 		indexNameByPriority[priority] = name
@@ -1248,11 +1285,22 @@ func nodesTableSchema(priorities []int32) (*memdb.TableSchema, map[int32]string,
 			Unique:  true,
 			Indexer: &NodeIndex{KeyIndex: i},
 		}
+
+		urgencyKeyIndex := n + i
+		urgencyName := nodeIndexName(urgencyKeyIndex)
+		urgencyIndexNameByPriority[priority] = urgencyName
+		urgencyKeyIndexByPriority[priority] = urgencyKeyIndex
+		indexes[urgencyName] = &memdb.IndexSchema{
+			Name:         urgencyName,
+			Unique:       true,
+			AllowMissing: true,
+			Indexer:      &NodeIndex{KeyIndex: urgencyKeyIndex, Urgency: true},
+		}
 	}
 	return &memdb.TableSchema{
 		Name:    "nodes",
 		Indexes: indexes,
-	}, indexNameByPriority, keyIndexByPriority
+	}, indexNameByPriority, keyIndexByPriority, urgencyIndexNameByPriority, urgencyKeyIndexByPriority
 }
 
 func evictionsTableSchema() *memdb.TableSchema {

--- a/internal/scheduler/nodedb/nodedb.go
+++ b/internal/scheduler/nodedb/nodedb.go
@@ -1017,7 +1017,8 @@ func markAllocatable(allocatableByPriority map[int32]internaltypes.ResourceList,
 }
 
 func (nodeDb *NodeDb) markAllocatedBoth(node *internaltypes.Node, cutoff int32, rs internaltypes.ResourceList) {
-	nodeDb.markAllocatableBoth(node, cutoff, rs.Negate())
+	markAllocated(node.AllocatableByPriority, cutoff, rs)
+	markAllocated(node.UrgencyPreemptableByPriority, cutoff, rs)
 }
 
 func (nodeDb *NodeDb) markAllocatableBoth(node *internaltypes.Node, cutoff int32, rs internaltypes.ResourceList) {
@@ -1026,7 +1027,7 @@ func (nodeDb *NodeDb) markAllocatableBoth(node *internaltypes.Node, cutoff int32
 }
 
 func (nodeDb *NodeDb) markAllocatedRealOnly(node *internaltypes.Node, cutoff int32, rs internaltypes.ResourceList) {
-	markAllocatable(node.AllocatableByPriority, cutoff, rs.Negate())
+	markAllocated(node.AllocatableByPriority, cutoff, rs)
 }
 
 func (nodeDb *NodeDb) markAllocatableRealOnly(node *internaltypes.Node, cutoff int32, rs internaltypes.ResourceList) {

--- a/internal/scheduler/nodedb/nodedb.go
+++ b/internal/scheduler/nodedb/nodedb.go
@@ -482,7 +482,7 @@ func (nodeDb *NodeDb) SelectNodeForJobWithTxn(txn *memdb.Txn, jctx *context.JobS
 		if it, err := txn.Get("nodes", "id", nodeId); err != nil {
 			return nil, errors.WithStack(err)
 		} else {
-			if node, err := nodeDb.selectNodeForPodWithItAtPriority(it, jctx, priority, true); err != nil {
+			if node, err := nodeDb.selectNodeForPodWithItAtPriority(it, jctx, priority, true, false); err != nil {
 				return nil, err
 			} else {
 				jctx.PodSchedulingContext.SchedulingMethod = context.Rescheduled
@@ -631,7 +631,7 @@ func (nodeDb *NodeDb) selectNodeForJobWithTxnAtPriority(
 
 	// Try scheduling at evictedPriority. If this succeeds, no preemption is necessary.
 	pctx.NumExcludedNodesByReason = maps.Clone(numExcludedNodesByReason)
-	if node, err := nodeDb.selectNodeForPodAtPriority(txn, jctx, matchingNodeTypeIds, internaltypes.EvictedPriority); err != nil {
+	if node, err := nodeDb.selectNodeForPodAtPriority(txn, jctx, matchingNodeTypeIds, internaltypes.EvictedPriority, false); err != nil {
 		return nil, err
 	} else if err := assertPodSchedulingContextNode(pctx, node); err != nil {
 		return nil, err
@@ -643,7 +643,7 @@ func (nodeDb *NodeDb) selectNodeForJobWithTxnAtPriority(
 	// Try scheduling at the job priority. If this fails, scheduling is impossible and we return.
 	// This is an optimisation to avoid looking for preemption targets for unschedulable jobs.
 	pctx.NumExcludedNodesByReason = maps.Clone(numExcludedNodesByReason)
-	if node, err := nodeDb.selectNodeForPodAtPriority(txn, jctx, matchingNodeTypeIds, pctx.ScheduledAtPriority); err != nil {
+	if node, err := nodeDb.selectNodeForPodAtPriority(txn, jctx, matchingNodeTypeIds, pctx.ScheduledAtPriority, false); err != nil {
 		return nil, err
 	} else if err := assertPodSchedulingContextNode(pctx, node); err != nil {
 		return nil, err
@@ -723,7 +723,7 @@ func (nodeDb *NodeDb) selectNodeForJobWithUrgencyPreemption(
 		pctx.NumExcludedNodesByReason = maps.Clone(numExcludedNodesByReason)
 
 		// Try to find a node at this priority.
-		if node, err := nodeDb.selectNodeForPodAtPriority(txn, jctx, matchingNodeTypeIds, priority); err != nil {
+		if node, err := nodeDb.selectNodeForPodAtPriority(txn, jctx, matchingNodeTypeIds, priority, true); err != nil {
 			return nil, err
 		} else if err := assertPodSchedulingContextNode(pctx, node); err != nil {
 			return nil, err
@@ -739,18 +739,27 @@ func (nodeDb *NodeDb) selectNodeForPodAtPriority(
 	jctx *context.JobSchedulingContext,
 	matchingNodeTypeIds []uint64,
 	priority int32,
+	urgency bool,
 ) (*internaltypes.Node, error) {
 	indexResourceRequests := make([]int64, len(nodeDb.indexedResources))
 	for i, t := range nodeDb.indexedResources {
 		indexResourceRequests[i] = jctx.KubernetesResourceRequirements.GetRawByNameZeroIfMissing(t)
 	}
-	indexName, ok := nodeDb.indexNameByPriority[priority]
-	if !ok {
-		return nil, errors.Errorf("no index for priority %d; must be in %v", priority, nodeDb.indexNameByPriority)
+
+	indexNameByPriority := nodeDb.indexNameByPriority
+	keyIndexByPriority := nodeDb.keyIndexByPriority
+	if urgency {
+		indexNameByPriority = nodeDb.urgencyIndexNameByPriority
+		keyIndexByPriority = nodeDb.urgencyKeyIndexByPriority
 	}
-	keyIndex, ok := nodeDb.keyIndexByPriority[priority]
+
+	indexName, ok := indexNameByPriority[priority]
 	if !ok {
-		return nil, errors.Errorf("no key index for priority %d; must be in %v", priority, nodeDb.keyIndexByPriority)
+		return nil, errors.Errorf("no index for priority %d; must be in %v", priority, indexNameByPriority)
+	}
+	keyIndex, ok := keyIndexByPriority[priority]
+	if !ok {
+		return nil, errors.Errorf("no key index for priority %d; must be in %v", priority, keyIndexByPriority)
 	}
 	it, err := NewNodeTypesIterator(
 		txn,
@@ -766,7 +775,7 @@ func (nodeDb *NodeDb) selectNodeForPodAtPriority(
 		return nil, err
 	}
 
-	if node, err := nodeDb.selectNodeForPodWithItAtPriority(it, jctx, priority, false); err != nil {
+	if node, err := nodeDb.selectNodeForPodWithItAtPriority(it, jctx, priority, false, urgency); err != nil {
 		return nil, err
 	} else if node != nil {
 		return node, nil
@@ -780,6 +789,7 @@ func (nodeDb *NodeDb) selectNodeForPodWithItAtPriority(
 	jctx *context.JobSchedulingContext,
 	priority int32,
 	onlyCheckDynamicRequirements bool,
+	urgency bool,
 ) (*internaltypes.Node, error) {
 	var selectedNode *internaltypes.Node
 	for obj := it.Next(); obj != nil; obj = it.Next() {
@@ -798,9 +808,13 @@ func (nodeDb *NodeDb) selectNodeForPodWithItAtPriority(
 			// It should be safe as the nodes are also unschedulable, so no new resource should get scheduled there
 			if node.IsUnschedulable() && node.IsOverAllocated() {
 				matches = true
+			} else if urgency {
+				matches, reason = DynamicJobRequirementsMet(node.UrgencyPreemptableByPriority[priority], jctx)
 			} else {
 				matches, reason = DynamicJobRequirementsMet(node.AllocatableByPriority[priority], jctx)
 			}
+		} else if urgency {
+			matches, reason, err = JobRequirementsMetForView(node, node.UrgencyPreemptableByPriority[priority], jctx)
 		} else {
 			matches, reason, err = JobRequirementsMet(node, priority, jctx)
 		}

--- a/internal/scheduler/nodedb/nodedb.go
+++ b/internal/scheduler/nodedb/nodedb.go
@@ -321,18 +321,6 @@ func (nodeDb *NodeDb) NumNodes() int {
 	return int(nodeDb.numNodes)
 }
 
-func (nodeDb *NodeDb) RealPrioritiesForTest() []int32 {
-	return nodeDb.realPriorities
-}
-
-func (nodeDb *NodeDb) UrgencyIndexNameForTest(p int32) string {
-	return nodeDb.urgencyIndexNameByPriority[p]
-}
-
-func (nodeDb *NodeDb) AllocatableIndexNameForTest(p int32) string {
-	return nodeDb.indexNameByPriority[p]
-}
-
 func (nodeDb *NodeDb) TotalKubernetesResources() internaltypes.ResourceList {
 	return nodeDb.totalAllocatableResources
 }

--- a/internal/scheduler/nodedb/nodedb.go
+++ b/internal/scheduler/nodedb/nodedb.go
@@ -960,10 +960,10 @@ func (nodeDb *NodeDb) bindJobToNodeInPlace(node *internaltypes.Node, job *jobdb.
 	}
 
 	if isEvicted {
-		nodeDb.markAllocatedRealOnly(node, priorityCutoffFor(job, priority), requests)
-		nodeDb.markAllocatableRealOnly(node, internaltypes.EvictedPriority, requests)
+		node.MarkAllocatedFairShare(priorityCutoffFor(job, priority), requests)
+		node.MarkAllocatableFairShare(internaltypes.EvictedPriority, requests)
 	} else {
-		nodeDb.markAllocatedBoth(node, priorityCutoffFor(job, priority), requests)
+		node.MarkAllocated(priorityCutoffFor(job, priority), requests)
 	}
 
 	nodeDb.scheduledAtPriorityByJobId[jobId] = priority
@@ -1018,48 +1018,14 @@ func (nodeDb *NodeDb) evictJobFromNodeInPlace(job *jobdb.Job, node *internaltype
 		return errors.Errorf("job %s not mapped to a priority", jobId)
 	}
 	jobRequests := job.KubernetesResourceRequirements()
-	nodeDb.markAllocatableRealOnly(node, priorityCutoffFor(job, priority), jobRequests)
-	nodeDb.markAllocatedRealOnly(node, internaltypes.EvictedPriority, jobRequests)
+	node.MarkAllocatableFairShare(priorityCutoffFor(job, priority), jobRequests)
+	node.MarkAllocatedFairShare(internaltypes.EvictedPriority, jobRequests)
 
 	return nil
 }
 
-func markAllocated(allocatableByPriority map[int32]internaltypes.ResourceList, priorityCutoff int32, rs internaltypes.ResourceList) {
-	markAllocatable(allocatableByPriority, priorityCutoff, rs.Negate())
-}
-
-func markAllocatable(allocatableByPriority map[int32]internaltypes.ResourceList, priorityCutoff int32, rs internaltypes.ResourceList) {
-	priorities := make([]int32, 0, len(allocatableByPriority))
-	for priority := range allocatableByPriority {
-		if priority <= priorityCutoff {
-			priorities = append(priorities, priority)
-		}
-	}
-	for _, priority := range priorities {
-		allocatableByPriority[priority] = allocatableByPriority[priority].Add(rs)
-	}
-}
-
-func (nodeDb *NodeDb) markAllocatedBoth(node *internaltypes.Node, cutoff int32, rs internaltypes.ResourceList) {
-	markAllocated(node.AllocatableByPriority, cutoff, rs)
-	markAllocated(node.UrgencyPreemptableByPriority, cutoff, rs)
-}
-
-func (nodeDb *NodeDb) markAllocatableBoth(node *internaltypes.Node, cutoff int32, rs internaltypes.ResourceList) {
-	markAllocatable(node.AllocatableByPriority, cutoff, rs)
-	markAllocatable(node.UrgencyPreemptableByPriority, cutoff, rs)
-}
-
-func (nodeDb *NodeDb) markAllocatedRealOnly(node *internaltypes.Node, cutoff int32, rs internaltypes.ResourceList) {
-	markAllocated(node.AllocatableByPriority, cutoff, rs)
-}
-
-func (nodeDb *NodeDb) markAllocatableRealOnly(node *internaltypes.Node, cutoff int32, rs internaltypes.ResourceList) {
-	markAllocatable(node.AllocatableByPriority, cutoff, rs)
-}
-
 // nonPreemptibleCutoff is a sentinel value (not a real priority) passed to
-// markAllocated/markAllocatable to deduct at every priority bucket.
+// Node.MarkAllocated*/MarkAllocatable* to deduct at every priority bucket.
 const nonPreemptibleCutoff = math.MaxInt32
 
 // priorityCutoffFor returns the priorityCutoff to use when updating
@@ -1127,10 +1093,10 @@ func (nodeDb *NodeDb) unbindJobFromNodeInPlace(job *jobdb.Job, node *internaltyp
 		return errors.Errorf("job %s not mapped to a priority", jobId)
 	}
 	if isEvicted {
-		nodeDb.markAllocatableRealOnly(node, internaltypes.EvictedPriority, requests)
-		markAllocatable(node.UrgencyPreemptableByPriority, priorityCutoffFor(job, priority), requests)
+		node.MarkAllocatableFairShare(internaltypes.EvictedPriority, requests)
+		node.MarkAllocatableUrgency(priorityCutoffFor(job, priority), requests)
 	} else {
-		nodeDb.markAllocatableBoth(node, priorityCutoffFor(job, priority), requests)
+		node.MarkAllocatable(priorityCutoffFor(job, priority), requests)
 	}
 
 	return nil

--- a/internal/scheduler/nodedb/nodedb.go
+++ b/internal/scheduler/nodedb/nodedb.go
@@ -972,8 +972,6 @@ func (nodeDb *NodeDb) bindJobToNodeInPlace(node *internaltypes.Node, job *jobdb.
 	}
 
 	if isEvicted {
-		// Evicted job re-binding: to the urgency view the job never left, so only the
-		// real allocatable view moves - deduct at EvictedPriority and give back at cutoff.
 		nodeDb.markAllocatedRealOnly(node, priorityCutoffFor(job, priority), requests)
 		nodeDb.markAllocatableRealOnly(node, internaltypes.EvictedPriority, requests)
 	} else {
@@ -1141,8 +1139,6 @@ func (nodeDb *NodeDb) unbindJobFromNodeInPlace(job *jobdb.Job, node *internaltyp
 		return errors.Errorf("job %s not mapped to a priority", jobId)
 	}
 	if isEvicted {
-		// Real view tracks evicted jobs at EvictedPriority; the urgency view never gave
-		// the resource back, so it returns at the job's real priority cutoff.
 		nodeDb.markAllocatableRealOnly(node, internaltypes.EvictedPriority, requests)
 		markAllocatable(node.UrgencyPreemptableByPriority, priorityCutoffFor(job, priority), requests)
 	} else {

--- a/internal/scheduler/nodedb/nodedb.go
+++ b/internal/scheduler/nodedb/nodedb.go
@@ -933,10 +933,13 @@ func (nodeDb *NodeDb) bindJobToNodeInPlace(node *internaltypes.Node, job *jobdb.
 		node.AllocatedByQueue[queue] = allocatedToQueue.Add(requests)
 	}
 
-	allocatable := node.AllocatableByPriority
-	markAllocated(allocatable, priorityCutoffFor(job, priority), requests)
 	if isEvicted {
-		markAllocatable(allocatable, internaltypes.EvictedPriority, requests)
+		// Evicted job re-binding: to the urgency view the job never left, so only the
+		// real allocatable view moves - deduct at EvictedPriority and give back at cutoff.
+		nodeDb.markAllocatedRealOnly(node, priorityCutoffFor(job, priority), requests)
+		nodeDb.markAllocatableRealOnly(node, internaltypes.EvictedPriority, requests)
+	} else {
+		nodeDb.markAllocatedBoth(node, priorityCutoffFor(job, priority), requests)
 	}
 
 	nodeDb.scheduledAtPriorityByJobId[jobId] = priority
@@ -986,14 +989,13 @@ func (nodeDb *NodeDb) evictJobFromNodeInPlace(job *jobdb.Job, node *internaltype
 	}
 	node.EvictedJobRunIds[jobId] = true
 
-	allocatableByPriority := node.AllocatableByPriority
 	priority, ok := nodeDb.GetScheduledAtPriority(jobId)
 	if !ok {
 		return errors.Errorf("job %s not mapped to a priority", jobId)
 	}
 	jobRequests := job.KubernetesResourceRequirements()
-	markAllocatable(allocatableByPriority, priorityCutoffFor(job, priority), jobRequests)
-	markAllocated(allocatableByPriority, internaltypes.EvictedPriority, jobRequests)
+	nodeDb.markAllocatableRealOnly(node, priorityCutoffFor(job, priority), jobRequests)
+	nodeDb.markAllocatedRealOnly(node, internaltypes.EvictedPriority, jobRequests)
 
 	return nil
 }
@@ -1012,6 +1014,23 @@ func markAllocatable(allocatableByPriority map[int32]internaltypes.ResourceList,
 	for _, priority := range priorities {
 		allocatableByPriority[priority] = allocatableByPriority[priority].Add(rs)
 	}
+}
+
+func (nodeDb *NodeDb) markAllocatedBoth(node *internaltypes.Node, cutoff int32, rs internaltypes.ResourceList) {
+	nodeDb.markAllocatableBoth(node, cutoff, rs.Negate())
+}
+
+func (nodeDb *NodeDb) markAllocatableBoth(node *internaltypes.Node, cutoff int32, rs internaltypes.ResourceList) {
+	markAllocatable(node.AllocatableByPriority, cutoff, rs)
+	markAllocatable(node.UrgencyPreemptableByPriority, cutoff, rs)
+}
+
+func (nodeDb *NodeDb) markAllocatedRealOnly(node *internaltypes.Node, cutoff int32, rs internaltypes.ResourceList) {
+	markAllocatable(node.AllocatableByPriority, cutoff, rs.Negate())
+}
+
+func (nodeDb *NodeDb) markAllocatableRealOnly(node *internaltypes.Node, cutoff int32, rs internaltypes.ResourceList) {
+	markAllocatable(node.AllocatableByPriority, cutoff, rs)
 }
 
 // nonPreemptibleCutoff is a sentinel value (not a real priority) passed to
@@ -1078,16 +1097,17 @@ func (nodeDb *NodeDb) unbindJobFromNodeInPlace(job *jobdb.Job, node *internaltyp
 		}
 	}
 
-	allocatable := node.AllocatableByPriority
+	priority, ok := nodeDb.GetScheduledAtPriority(jobId)
+	if !ok {
+		return errors.Errorf("job %s not mapped to a priority", jobId)
+	}
 	if isEvicted {
-		// Evicted jobs are always tracked at EvictedPriority regardless of preemptibility.
-		markAllocatable(allocatable, internaltypes.EvictedPriority, requests)
+		// Real view tracks evicted jobs at EvictedPriority; the urgency view never gave
+		// the resource back, so it returns at the job's real priority cutoff.
+		nodeDb.markAllocatableRealOnly(node, internaltypes.EvictedPriority, requests)
+		markAllocatable(node.UrgencyPreemptableByPriority, priorityCutoffFor(job, priority), requests)
 	} else {
-		priority, ok := nodeDb.GetScheduledAtPriority(jobId)
-		if !ok {
-			return errors.Errorf("job %s not mapped to a priority", jobId)
-		}
-		markAllocatable(allocatable, priorityCutoffFor(job, priority), requests)
+		nodeDb.markAllocatableBoth(node, priorityCutoffFor(job, priority), requests)
 	}
 
 	return nil

--- a/internal/scheduler/nodedb/nodedb_test.go
+++ b/internal/scheduler/nodedb/nodedb_test.go
@@ -1053,6 +1053,60 @@ func TestUrgencySelectionIgnoresFairShareGiveBack(t *testing.T) {
 		"must not match at PriorityClass0's priority, where the fair-share give-back has freed AllocatableByPriority but not UrgencyPreemptableByPriority")
 }
 
+func TestUrgencyFitCheckUsesUrgencyView(t *testing.T) {
+	nodeDb, err := newNodeDbWithNodes(nil)
+	require.NoError(t, err)
+
+	txn := nodeDb.Txn(true)
+	node := testfixtures.Test32CpuNode(testfixtures.TestPriorities)
+	boundJobs := testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 32)
+	require.NoError(t, nodeDb.CreateAndInsertWithJobDbJobsWithTxn(txn, boundJobs, node))
+	txn.Commit()
+
+	node, err = nodeDb.GetNode(node.GetId())
+	require.NoError(t, err)
+
+	evictedNode, err := nodeDb.EvictJobsFromNode(boundJobs, node)
+	require.NoError(t, err)
+
+	txn = nodeDb.Txn(true)
+	require.NoError(t, nodeDb.UpsertWithTxn(txn, evictedNode))
+	txn.Commit()
+
+	p0 := testfixtures.TestPriorityClasses[testfixtures.PriorityClass0].Priority
+	p1 := testfixtures.TestPriorityClasses[testfixtures.PriorityClass1].Priority
+
+	incoming := testfixtures.N1Cpu4GiJobs("B", testfixtures.PriorityClass1, 1)[0]
+	jctx := context.JobSchedulingContextFromJob(incoming)
+	jctx.PodSchedulingContext = &context.PodSchedulingContext{
+		ScheduledAtPriority:      incoming.PriorityClass().Priority,
+		PreemptedAtPriority:      internaltypes.MinPriority,
+		NumExcludedNodesByReason: make(map[string]int),
+	}
+
+	readTxn := nodeDb.Txn(false)
+	defer readTxn.Abort()
+
+	it, err := readTxn.Get("nodes", "id", evictedNode.GetId())
+	require.NoError(t, err)
+	selected, err := nodeDb.selectNodeForPodWithItAtPriority(it, jctx, p0, false, true)
+	require.NoError(t, err)
+	assert.Nil(t, selected, "at p0 the urgency view still counts the 32 evicted jobs, so the node must not fit")
+
+	it2, err := readTxn.Get("nodes", "id", evictedNode.GetId())
+	require.NoError(t, err)
+	selected2, err := nodeDb.selectNodeForPodWithItAtPriority(it2, jctx, p1, false, true)
+	require.NoError(t, err)
+	require.NotNil(t, selected2, "at p1 the urgency view frees the evicted p0 jobs, so the node must fit")
+	assert.Equal(t, evictedNode.GetId(), selected2.GetId())
+
+	it3, err := readTxn.Get("nodes", "id", evictedNode.GetId())
+	require.NoError(t, err)
+	selected3, err := nodeDb.selectNodeForPodWithItAtPriority(it3, jctx, p0, false, false)
+	require.NoError(t, err)
+	require.NotNil(t, selected3, "with urgency=false the fit-check reads AllocatableByPriority, which the give-back already freed at p0")
+}
+
 func TestMatchesConditions(t *testing.T) {
 	cpu0 := resource.MustParse("0")
 	cpu2 := resource.MustParse("2")

--- a/internal/scheduler/nodedb/nodedb_test.go
+++ b/internal/scheduler/nodedb/nodedb_test.go
@@ -233,6 +233,54 @@ func TestNodeBindingEvictionUnbinding(t *testing.T) {
 	assert.Empty(t, unboundNode.EvictedJobRunIds)
 }
 
+func setupNodeDbNodeAndBoundJob(t *testing.T) (*NodeDb, *internaltypes.Node, *jobdb.Job) {
+	t.Helper()
+	node := testfixtures.Test8GpuNode(testfixtures.TestPriorities)
+	nodeDb, err := newNodeDbWithNodes([]*internaltypes.Node{node})
+	require.NoError(t, err)
+	entry, err := nodeDb.GetNode(node.GetId())
+	require.NoError(t, err)
+
+	job := testfixtures.Test1GpuJob("A", testfixtures.PriorityClass0)
+	boundNode, err := nodeDb.BindJobToNode(entry, job, job.PriorityClass().Priority)
+	require.NoError(t, err)
+
+	return nodeDb, boundNode, job
+}
+
+func TestUrgencyMapUnaffectedByEviction(t *testing.T) {
+	nodeDb, node, job := setupNodeDbNodeAndBoundJob(t)
+	priority, ok := nodeDb.GetScheduledAtPriority(job.Id())
+	require.True(t, ok)
+
+	boundUrgency := maps.Clone(node.UrgencyPreemptableByPriority)
+	boundAllocatable := maps.Clone(node.AllocatableByPriority)
+	require.True(t, boundAllocatable[priority].Equal(boundUrgency[priority]),
+		"genuine bind should deduct both maps identically")
+
+	// Evict: real map gives resources back at the job priority; urgency map must NOT.
+	evicted, err := nodeDb.EvictJobsFromNode([]*jobdb.Job{job}, node)
+	require.NoError(t, err)
+	require.True(t, boundUrgency[priority].Equal(evicted.UrgencyPreemptableByPriority[priority]),
+		"urgency map changed on eviction")
+	require.False(t, boundAllocatable[priority].Equal(evicted.AllocatableByPriority[priority]),
+		"allocatable map should give resources back on eviction")
+
+	// Re-bind the evicted job: real map deducts again; urgency map still unchanged.
+	rebound, err := nodeDb.BindJobToNode(evicted, job, priority)
+	require.NoError(t, err)
+	require.True(t, boundUrgency[priority].Equal(rebound.UrgencyPreemptableByPriority[priority]),
+		"urgency map changed on evicted re-bind")
+	require.True(t, boundAllocatable[priority].Equal(rebound.AllocatableByPriority[priority]),
+		"allocatable map should return to bound state on re-bind")
+
+	// Unbind for real: both maps return to the fully-free state.
+	unbound, err := nodeDb.UnbindJobFromNode(job, rebound)
+	require.NoError(t, err)
+	require.True(t, unbound.AllocatableByPriority[priority].Equal(unbound.UrgencyPreemptableByPriority[priority]),
+		"both maps should agree once the node is empty")
+}
+
 // Covers the pods resource path, which TestNodeBindingEvictionUnbinding does not exercise.
 // Bind, evict, and unbind flow resource requirements through KubernetesResourceRequirements,
 // so a regression in pod-slot accounting would surface here even though the cpu/memory/GPU

--- a/internal/scheduler/nodedb/nodedb_test.go
+++ b/internal/scheduler/nodedb/nodedb_test.go
@@ -26,8 +26,28 @@ import (
 )
 
 func TestNodeDbSchema(t *testing.T) {
-	schema, _, _ := nodeDbSchema(testfixtures.TestPriorities, testfixtures.TestResourceNames)
+	schema, _, _, _, _ := nodeDbSchema(testfixtures.TestPriorities, testfixtures.TestResourceNames)
 	assert.NoError(t, schema.Validate())
+}
+
+func TestUrgencyIndexOmitsNodesWithNothingPreemptable(t *testing.T) {
+	nodeDb, err := newNodeDbWithNodes(nil)
+	require.NoError(t, err)
+	node := testfixtures.Test32CpuNode(testfixtures.TestPriorities)
+	require.NoError(t, nodeDb.Upsert(node))
+
+	txn := nodeDb.Txn(false)
+	defer txn.Abort()
+
+	for _, p := range nodeDb.RealPrioritiesForTest() {
+		it, err := txn.Get("nodes", nodeDb.UrgencyIndexNameForTest(p))
+		require.NoError(t, err)
+		require.Nil(t, it.Next(), "urgency index for priority %d should be empty", p)
+	}
+
+	it, err := txn.Get("nodes", nodeDb.AllocatableIndexNameForTest(nodeDb.RealPrioritiesForTest()[0]))
+	require.NoError(t, err)
+	require.NotNil(t, it.Next())
 }
 
 // Test the accounting of total resources across all nodes.

--- a/internal/scheduler/nodedb/nodedb_test.go
+++ b/internal/scheduler/nodedb/nodedb_test.go
@@ -1012,6 +1012,47 @@ func TestPreemptionScheduling(t *testing.T) {
 	}
 }
 
+func TestUrgencySelectionIgnoresFairShareGiveBack(t *testing.T) {
+	nodeDb, err := newNodeDbWithNodes(nil)
+	require.NoError(t, err)
+
+	txn := nodeDb.Txn(true)
+	node := testfixtures.Test32CpuNode(testfixtures.TestPriorities)
+	boundJobs := testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 32)
+	require.NoError(t, nodeDb.CreateAndInsertWithJobDbJobsWithTxn(txn, boundJobs, node))
+	txn.Commit()
+
+	node, err = nodeDb.GetNode(node.GetId())
+	require.NoError(t, err)
+
+	evictedNode, err := nodeDb.EvictJobsFromNode(boundJobs, node)
+	require.NoError(t, err)
+
+	txn = nodeDb.Txn(true)
+	require.NoError(t, nodeDb.UpsertWithTxn(txn, evictedNode))
+	txn.Commit()
+
+	incoming := testfixtures.N1Cpu4GiJobs("B", testfixtures.PriorityClass1, 1)[0]
+	jctx := context.JobSchedulingContextFromJob(incoming)
+	jctx.PodSchedulingContext = &context.PodSchedulingContext{
+		ScheduledAtPriority:      incoming.PriorityClass().Priority,
+		PreemptedAtPriority:      internaltypes.MinPriority,
+		NumExcludedNodesByReason: make(map[string]int),
+	}
+
+	txn = nodeDb.Txn(false)
+	defer txn.Abort()
+	matchingNodeTypeIds, _, err := nodeDb.NodeTypesMatchingJob(jctx)
+	require.NoError(t, err)
+
+	selectedNode, err := nodeDb.selectNodeForJobWithUrgencyPreemption(txn, jctx, matchingNodeTypeIds)
+	require.NoError(t, err)
+	require.NotNil(t, selectedNode, "urgency preemption should find the evicted node by reading the urgency-preemptable view")
+	assert.Equal(t, node.GetId(), selectedNode.GetId())
+	assert.Equal(t, testfixtures.TestPriorityClasses[testfixtures.PriorityClass1].Priority, jctx.PodSchedulingContext.PreemptedAtPriority,
+		"must not match at PriorityClass0's priority, where the fair-share give-back has freed AllocatableByPriority but not UrgencyPreemptableByPriority")
+}
+
 func TestMatchesConditions(t *testing.T) {
 	cpu0 := resource.MustParse("0")
 	cpu2 := resource.MustParse("2")

--- a/internal/scheduler/nodedb/nodedb_test.go
+++ b/internal/scheduler/nodedb/nodedb_test.go
@@ -39,13 +39,13 @@ func TestUrgencyIndexOmitsNodesWithNothingPreemptable(t *testing.T) {
 	txn := nodeDb.Txn(false)
 	defer txn.Abort()
 
-	for _, p := range nodeDb.RealPrioritiesForTest() {
-		it, err := txn.Get("nodes", nodeDb.UrgencyIndexNameForTest(p))
+	for _, p := range nodeDb.realPriorities {
+		it, err := txn.Get("nodes", nodeDb.urgencyIndexNameByPriority[p])
 		require.NoError(t, err)
 		require.Nil(t, it.Next(), "urgency index for priority %d should be empty", p)
 	}
 
-	it, err := txn.Get("nodes", nodeDb.AllocatableIndexNameForTest(nodeDb.RealPrioritiesForTest()[0]))
+	it, err := txn.Get("nodes", nodeDb.indexNameByPriority[nodeDb.realPriorities[0]])
 	require.NoError(t, err)
 	require.NotNil(t, it.Next())
 }

--- a/internal/scheduler/nodedb/nodedb_test.go
+++ b/internal/scheduler/nodedb/nodedb_test.go
@@ -281,6 +281,35 @@ func TestUrgencyMapUnaffectedByEviction(t *testing.T) {
 		"both maps should agree once the node is empty")
 }
 
+// TestUrgencyMapReconciledOnUnbindWhileEvicted covers the unbind-while-evicted branch of
+// unbindJobFromNodeInPlace: unbinding an evicted job must still return its resources to the
+// urgency map, even though the real map already gave them back on eviction.
+func TestUrgencyMapReconciledOnUnbindWhileEvicted(t *testing.T) {
+	rawNode := testfixtures.Test8GpuNode(testfixtures.TestPriorities)
+	nodeDb, err := newNodeDbWithNodes([]*internaltypes.Node{rawNode})
+	require.NoError(t, err)
+	entry, err := nodeDb.GetNode(rawNode.GetId())
+	require.NoError(t, err)
+
+	job := testfixtures.Test1GpuJob("A", testfixtures.PriorityClass0)
+	priority := job.PriorityClass().Priority
+	freeAllocatable := maps.Clone(entry.AllocatableByPriority)
+
+	bound, err := nodeDb.BindJobToNode(entry, job, priority)
+	require.NoError(t, err)
+
+	evicted, err := nodeDb.EvictJobsFromNode([]*jobdb.Job{job}, bound)
+	require.NoError(t, err)
+
+	unbound, err := nodeDb.UnbindJobFromNode(job, evicted)
+	require.NoError(t, err)
+
+	require.True(t, unbound.UrgencyPreemptableByPriority[priority].Equal(unbound.AllocatableByPriority[priority]),
+		"urgency map should reconcile with allocatable map once the evicted job is unbound")
+	require.True(t, unbound.UrgencyPreemptableByPriority[priority].Equal(freeAllocatable[priority]),
+		"urgency map should return to the fully-free state once the evicted job is unbound")
+}
+
 // Covers the pods resource path, which TestNodeBindingEvictionUnbinding does not exercise.
 // Bind, evict, and unbind flow resource requirements through KubernetesResourceRequirements,
 // so a regression in pod-slot accounting would surface here even though the cpu/memory/GPU

--- a/internal/scheduler/nodedb/nodeiteration.go
+++ b/internal/scheduler/nodedb/nodeiteration.go
@@ -50,6 +50,7 @@ func (it *NodesIterator) Next() interface{} {
 // NodeIndex is an index for internaltypes.Node that returns node.NodeDbKeys[KeyIndex].
 type NodeIndex struct {
 	KeyIndex int
+	Urgency  bool
 }
 
 // FromArgs computes the index key from a set of arguments.
@@ -64,6 +65,9 @@ func (index *NodeIndex) FromArgs(args ...interface{}) ([]byte, error) {
 // FromObject extracts the index key from a *Node.
 func (index *NodeIndex) FromObject(raw interface{}) (bool, []byte, error) {
 	node := raw.(*internaltypes.Node)
+	if index.Urgency && !node.HasUrgencyPreemptableResources() {
+		return false, nil, nil
+	}
 	return true, node.Keys[index.KeyIndex], nil
 }
 

--- a/internal/scheduler/nodedb/nodematching.go
+++ b/internal/scheduler/nodedb/nodematching.go
@@ -145,11 +145,18 @@ func NodeTypeJobRequirementsMet(nodeType *internaltypes.NodeType, jctx *schedule
 // If the requirements are not met, it returns the reason why.
 // If the requirements can't be parsed, an error is returned.
 func JobRequirementsMet(node *internaltypes.Node, priority int32, jctx *schedulercontext.JobSchedulingContext) (bool, PodRequirementsNotMetReason, error) {
+	return JobRequirementsMetForView(node, node.AllocatableByPriority[priority], jctx)
+}
+
+// JobRequirementsMetForView is like JobRequirementsMet, but checks dynamic requirements against
+// the given resource view instead of always reading node.AllocatableByPriority. This lets urgency-based
+// preemption check node.UrgencyPreemptableByPriority, which excludes the fair-share eviction give-back.
+func JobRequirementsMetForView(node *internaltypes.Node, allocatable internaltypes.ResourceList, jctx *schedulercontext.JobSchedulingContext) (bool, PodRequirementsNotMetReason, error) {
 	matches, reason, err := StaticJobRequirementsMet(node, jctx)
 	if !matches || err != nil {
 		return matches, reason, err
 	}
-	matches, reason = DynamicJobRequirementsMet(node.AllocatableByPriority[priority], jctx)
+	matches, reason = DynamicJobRequirementsMet(allocatable, jctx)
 	if !matches {
 		return matches, reason, nil
 	}

--- a/internal/scheduler/testfixtures/testfixtures.go
+++ b/internal/scheduler/testfixtures/testfixtures.go
@@ -392,6 +392,7 @@ func WithMaxQueueLookbackConfig(maxQueueLookback uint, config schedulerconfigura
 func WithUsedResourcesNodes(p int32, rl internaltypes.ResourceList, nodes []*internaltypes.Node) []*internaltypes.Node {
 	for _, node := range nodes {
 		internaltypes.MarkAllocated(node.AllocatableByPriority, p, rl)
+		internaltypes.MarkAllocated(node.UrgencyPreemptableByPriority, p, rl)
 	}
 	return nodes
 }

--- a/internal/scheduler/testfixtures/testfixtures.go
+++ b/internal/scheduler/testfixtures/testfixtures.go
@@ -391,8 +391,7 @@ func WithMaxQueueLookbackConfig(maxQueueLookback uint, config schedulerconfigura
 
 func WithUsedResourcesNodes(p int32, rl internaltypes.ResourceList, nodes []*internaltypes.Node) []*internaltypes.Node {
 	for _, node := range nodes {
-		internaltypes.MarkAllocated(node.AllocatableByPriority, p, rl)
-		internaltypes.MarkAllocated(node.UrgencyPreemptableByPriority, p, rl)
+		node.MarkAllocated(p, rl)
 	}
 	return nodes
 }


### PR DESCRIPTION
#### What type of PR is this?

Refactor

#### What this PR does / why we need it

Adds a sparse per-priority "urgency-preemptable" resource view (`UrgencyPreemptableByPriority`) to `internaltypes.Node` and a matching `NodeDb` index, and switches urgency-based node selection (`selectNodeForJobWithUrgencyPreemption`) to read from it instead of `AllocatableByPriority`.

Previously, urgency preemption read the same `AllocatableByPriority` view used for normal scheduling. That view reflects the fair-share give-back applied on eviction (freeing a job's priority-bucket allocation), so an evicted job's resources could look available at its own priority before it has actually been preempted - urgency preemption could match a node at a priority where the give-back had freed capacity that isn't truly free. `UrgencyPreemptableByPriority` is only adjusted for genuine binds/unbinds, not eviction give-backs, so urgency preemption now sees an accurate picture of what a job would actually free. The index stays sparse - nodes with nothing preemptable are excluded entirely.

#### Special notes for your reviewer

- `Node.RecomputeUrgencyPreemptableFlag` runs on every `UpsertWithTxn` to keep the flag `Node.HasUrgencyPreemptableResources()` correct
- `bindJobToNodeInPlace`/`evictJobFromNodeInPlace`/`unbindJobFromNodeInPlace` now route through `markAllocatedBoth`/`markAllocatableBoth` vs. the `*RealOnly` variants depending on whether the mutation is a genuine bind/unbind or an eviction give-back.