### PR TITLE
Remove X-Mirrored-Request header from Lookout requests

### DIFF
--- a/internal/lookoutui/src/lookoutApiRequestMirror/mirrorLookoutApiRequest.ts
+++ b/internal/lookoutui/src/lookoutApiRequestMirror/mirrorLookoutApiRequest.ts
@@ -46,12 +46,8 @@ export const mirrorLookoutApiRequest = (input: RequestInfo | URL, init: RequestI
 
     const targetUrl = `${mirrorOrigin}${requestUrl.pathname}${requestUrl.search}`
 
-    const headers = new Headers(init?.headers)
-    headers.set("X-Mirrored-Request", "true")
-
     fetch(targetUrl, {
       ...init,
-      headers,
       credentials: "include",
     }).catch(() => undefined)
   } catch {


### PR DESCRIPTION
This header is not accepted by the Lookout API server
