### PR TITLE
Make executor tests race-detector clean

### DIFF
--- a/internal/executor/context/fake/sync_cluster_context.go
+++ b/internal/executor/context/fake/sync_cluster_context.go
@@ -3,6 +3,7 @@ package fake
 import (
 	"errors"
 	"fmt"
+	"sync"
 
 	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
@@ -22,6 +23,7 @@ type SyncFakeClusterContext struct {
 	AnnotationsAdded map[string]map[string]string
 	podEventHandlers []*cache.ResourceEventHandlerFuncs
 	GetPodEventsErr  error
+	rwLock           sync.RWMutex
 }
 
 func NewSyncFakeClusterContext() *SyncFakeClusterContext {
@@ -101,11 +103,27 @@ func (c *SyncFakeClusterContext) DeleteIngress(ingress *networking.Ingress) erro
 }
 
 func (c *SyncFakeClusterContext) SubmitPod(pod *v1.Pod, owner string, ownerGroups []string) (*v1.Pod, error) {
+	c.rwLock.Lock()
+	defer c.rwLock.Unlock()
 	c.Pods[pod.Labels[domain.JobId]] = pod
 	return pod, nil
 }
 
+// GetAnnotationsAdded returns a copy of the recorded annotations, safe to
+// read while a handler goroutine is annotating.
+func (c *SyncFakeClusterContext) GetAnnotationsAdded() map[string]map[string]string {
+	c.rwLock.RLock()
+	defer c.rwLock.RUnlock()
+	snapshot := make(map[string]map[string]string, len(c.AnnotationsAdded))
+	for jobId, annotations := range c.AnnotationsAdded {
+		snapshot[jobId] = util.MergeMaps(map[string]string{}, annotations)
+	}
+	return snapshot
+}
+
 func (c *SyncFakeClusterContext) AddAnnotation(pod *v1.Pod, annotations map[string]string) error {
+	c.rwLock.Lock()
+	defer c.rwLock.Unlock()
 	pod.Annotations = util.MergeMaps(pod.Annotations, annotations)
 	if c.AnnotationsAdded[pod.Labels[domain.JobId]] == nil {
 		c.AnnotationsAdded[pod.Labels[domain.JobId]] = map[string]string{}
@@ -122,6 +140,8 @@ func (c *SyncFakeClusterContext) DeletePodWithCondition(pod *v1.Pod, condition f
 }
 
 func (c *SyncFakeClusterContext) DeletePods(pods []*v1.Pod) {
+	c.rwLock.Lock()
+	defer c.rwLock.Unlock()
 	for _, p := range pods {
 		delete(c.Pods, p.Labels[domain.JobId])
 	}

--- a/internal/executor/reporter/job_event_reporter_test.go
+++ b/internal/executor/reporter/job_event_reporter_test.go
@@ -2,6 +2,7 @@ package reporter
 
 import (
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -92,6 +93,7 @@ func createPod(index int) *v1.Pod {
 
 type FakeEventSender struct {
 	receivedEvents [][]EventMessage
+	mutex          sync.Mutex
 }
 
 func NewFakeEventSender() *FakeEventSender {
@@ -99,14 +101,20 @@ func NewFakeEventSender() *FakeEventSender {
 }
 
 func (eventSender *FakeEventSender) SendEvents(events []EventMessage) error {
+	eventSender.mutex.Lock()
+	defer eventSender.mutex.Unlock()
 	eventSender.receivedEvents = append(eventSender.receivedEvents, events)
 	return nil
 }
 
 func (eventSender *FakeEventSender) GetNumberOfSendEventCalls() int {
+	eventSender.mutex.Lock()
+	defer eventSender.mutex.Unlock()
 	return len(eventSender.receivedEvents)
 }
 
 func (eventSender *FakeEventSender) GetSentEvents(callIndex int) []EventMessage {
+	eventSender.mutex.Lock()
+	defer eventSender.mutex.Unlock()
 	return eventSender.receivedEvents[callIndex]
 }

--- a/internal/executor/reporter/mocks/testfixtures.go
+++ b/internal/executor/reporter/mocks/testfixtures.go
@@ -2,6 +2,7 @@ package mocks
 
 import (
 	"fmt"
+	"sync"
 
 	v1 "k8s.io/api/core/v1"
 
@@ -11,6 +12,7 @@ import (
 type FakeEventReporter struct {
 	ReceivedEvents []reporter.EventMessage
 	ErrorOnReport  bool
+	mutex          sync.Mutex
 }
 
 func NewFakeEventReporter() *FakeEventReporter {
@@ -18,11 +20,23 @@ func NewFakeEventReporter() *FakeEventReporter {
 }
 
 func (f *FakeEventReporter) Report(events []reporter.EventMessage) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
 	if f.ErrorOnReport {
 		return fmt.Errorf("failed to report events")
 	}
 	f.ReceivedEvents = append(f.ReceivedEvents, events...)
 	return nil
+}
+
+// GetReceivedEvents returns a copy of the reported events, safe to read
+// while another goroutine is reporting.
+func (f *FakeEventReporter) GetReceivedEvents() []reporter.EventMessage {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+	events := make([]reporter.EventMessage, len(f.ReceivedEvents))
+	copy(events, f.ReceivedEvents)
+	return events
 }
 
 func (f *FakeEventReporter) QueueEvent(event reporter.EventMessage, callback func(error)) {

--- a/internal/executor/service/job_state_reporter_test.go
+++ b/internal/executor/service/job_state_reporter_test.go
@@ -64,22 +64,21 @@ func TestJobStateReporter_HandlesPodAddEvents(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		_, _, eventReporter, fakeClusterContext := setUpJobStateReporterTest(t)
+		stateReporter, _, eventReporter, fakeClusterContext := setUpJobStateReporterTest(t)
 
 		addPod(t, fakeClusterContext, test.pod)
-		fakeClusterContext.SimulatePodAddEvent(test.pod)
-		time.Sleep(time.Millisecond * 100) // Give time for async routine to process message
+		stateReporter.reportCurrentStatus(test.pod)
 
 		if test.expectEvent {
-			assertExpectedEvents(t, test.pod, eventReporter.ReceivedEvents, test.expectedType)
+			assertExpectedEvents(t, test.pod, eventReporter.GetReceivedEvents(), test.expectedType)
 		} else {
-			assert.Len(t, eventReporter.ReceivedEvents, 0)
+			assert.Len(t, eventReporter.GetReceivedEvents(), 0)
 		}
 
 		if test.expectAnnotation {
 			assertExpectedAnnotations(t, test.pod, fakeClusterContext)
 		} else {
-			assert.Len(t, fakeClusterContext.AnnotationsAdded, 0)
+			assert.Len(t, fakeClusterContext.GetAnnotationsAdded(), 0)
 		}
 	}
 }
@@ -107,48 +106,62 @@ func TestJobStateReporter_HandlesPodUpdateEvents(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		_, _, eventReporter, fakeClusterContext := setUpJobStateReporterTest(t)
+		stateReporter, _, eventReporter, fakeClusterContext := setUpJobStateReporterTest(t)
 
 		before := makeTestPod(v1.PodStatus{Phase: test.before})
 		after := copyWithUpdatedPhase(before, test.after)
 
 		addPod(t, fakeClusterContext, before)
-		fakeClusterContext.SimulateUpdateAddEvent(before, after)
-		time.Sleep(time.Millisecond * 100) // Give time for async routine to process message
+		stateReporter.reportStatusUpdate(before, after)
 
 		if test.expectEvent {
-			assertExpectedEvents(t, before, eventReporter.ReceivedEvents, test.expectedType)
+			assertExpectedEvents(t, before, eventReporter.GetReceivedEvents(), test.expectedType)
 			assertExpectedAnnotations(t, after, fakeClusterContext)
 		} else {
-			assert.Len(t, eventReporter.ReceivedEvents, 0)
-			assert.Len(t, fakeClusterContext.AnnotationsAdded, 0)
+			assert.Len(t, eventReporter.GetReceivedEvents(), 0)
+			assert.Len(t, fakeClusterContext.GetAnnotationsAdded(), 0)
 		}
 	}
 }
 
-func TestJobStateReporter_HandlesPodUpdateEvents_IgnoreUnmanagedPods(t *testing.T) {
+// Drives the update through the registered informer handler, covering the
+// UpdateFunc wiring. The wait works as in the add-handler test above.
+func TestJobStateReporter_PodUpdateEventHandlerReportsAsync(t *testing.T) {
 	_, _, eventReporter, fakeClusterContext := setUpJobStateReporterTest(t)
+
+	before := makeTestPod(v1.PodStatus{Phase: v1.PodPending})
+	after := copyWithUpdatedPhase(before, v1.PodRunning)
+	jobId := util.ExtractJobId(after)
+	addPod(t, fakeClusterContext, before)
+	fakeClusterContext.SimulateUpdateAddEvent(before, after)
+
+	assert.Eventually(t, func() bool {
+		return len(fakeClusterContext.GetAnnotationsAdded()[jobId]) > 0
+	}, time.Second, 10*time.Millisecond, "the update handler goroutine must report and annotate the pod")
+	assertExpectedEvents(t, after, eventReporter.GetReceivedEvents(), reflect.TypeOf(&armadaevents.EventSequence_Event_JobRunRunning{}))
+}
+
+func TestJobStateReporter_HandlesPodUpdateEvents_IgnoreUnmanagedPods(t *testing.T) {
+	stateReporter, _, eventReporter, _ := setUpJobStateReporterTest(t)
 
 	before := &v1.Pod{Status: v1.PodStatus{Phase: v1.PodPending}}
 	after := &v1.Pod{Status: v1.PodStatus{Phase: v1.PodRunning}}
 
-	fakeClusterContext.SimulateUpdateAddEvent(before, after)
-	time.Sleep(time.Millisecond * 100) // Give time for async routine to process message
+	stateReporter.reportStatusUpdate(before, after)
 
-	assert.Len(t, eventReporter.ReceivedEvents, 0)
+	assert.Len(t, eventReporter.GetReceivedEvents(), 0)
 }
 
 func TestJobStateReporter_HandlesFailedPod_WithRetryableError(t *testing.T) {
-	jobStateReporter, _, eventReporter, fakeClusterContext := setUpJobStateReporterTest(t)
+	jobStateReporter, _, eventReporter, _ := setUpJobStateReporterTest(t)
 
 	before := makeTestPod(v1.PodStatus{Phase: v1.PodRunning})
 	after := copyWithUpdatedPhase(before, v1.PodFailed)
 
 	// Does not send event if issue handler detects an issue
 	jobStateReporter.podIssueHandler = &stubIssueHandler{detectAndRegisterFailedPodIssueResult: true, detectAndRegisterFailedPodIssueError: nil}
-	fakeClusterContext.SimulateUpdateAddEvent(before, after)
-	time.Sleep(time.Millisecond * 100) // Give time for async routine to process message
-	assert.Len(t, eventReporter.ReceivedEvents, 0)
+	jobStateReporter.reportStatusUpdate(before, after)
+	assert.Len(t, eventReporter.GetReceivedEvents(), 0)
 
 	// Does not send event if issue handler already knows of issue for run
 	jobStateReporter.podIssueHandler = &stubIssueHandler{
@@ -156,16 +169,14 @@ func TestJobStateReporter_HandlesFailedPod_WithRetryableError(t *testing.T) {
 		detectAndRegisterFailedPodIssueResult: false,
 		detectAndRegisterFailedPodIssueError:  nil,
 	}
-	fakeClusterContext.SimulateUpdateAddEvent(before, after)
-	time.Sleep(time.Millisecond * 100) // Give time for async routine to process message
-	assert.Len(t, eventReporter.ReceivedEvents, 0)
+	jobStateReporter.reportStatusUpdate(before, after)
+	assert.Len(t, eventReporter.GetReceivedEvents(), 0)
 
 	// Does send event if issue handler errors
 	jobStateReporter.podIssueHandler = &stubIssueHandler{detectAndRegisterFailedPodIssueResult: false, detectAndRegisterFailedPodIssueError: fmt.Errorf("error")}
-	fakeClusterContext.SimulateUpdateAddEvent(before, after)
-	time.Sleep(time.Millisecond * 100) // Give time for async routine to process message
-	assert.Len(t, eventReporter.ReceivedEvents, 1)
-	assertExpectedEvents(t, before, eventReporter.ReceivedEvents, reflect.TypeOf(&armadaevents.EventSequence_Event_JobRunErrors{}))
+	jobStateReporter.reportStatusUpdate(before, after)
+	assert.Len(t, eventReporter.GetReceivedEvents(), 1)
+	assertExpectedEvents(t, before, eventReporter.GetReceivedEvents(), reflect.TypeOf(&armadaevents.EventSequence_Event_JobRunErrors{}))
 }
 
 func setUpJobStateReporterTest(t *testing.T) (*JobStateReporter, *stubIssueHandler, *mocks.FakeEventReporter, *fakecontext.SyncFakeClusterContext) {
@@ -226,70 +237,73 @@ func classifierForExitCode(t *testing.T, category, subcategory string, exitCode 
 // These tests cover the emission gating that governs when the counter is
 // advanced: a JobFailedEvent must be emitted (not a ReturnLease or a no-op).
 
+// Drives the pod event through the registered informer handler, covering the
+// AddFunc wiring. The state annotation is the handler goroutine's final write,
+// so waiting for it through the locked accessor orders the assertions after
+// everything the handler did.
 func TestJobStateReporter_PodFailed_EmitsJobFailedEventWhenClassifierMatches(t *testing.T) {
 	classifier := classifierForExitCode(t, "jsr-emit-cat", "jsr-emit-sub", 42)
 	_, _, eventReporter, fakeClusterContext := setUpJobStateReporterTestWithClassifier(t, classifier, &stubIssueHandler{})
 
 	pod := makeFailedPodWithExitCode(t, 42)
+	jobId := util.ExtractJobId(pod)
 	addPod(t, fakeClusterContext, pod)
 	fakeClusterContext.SimulatePodAddEvent(pod)
-	time.Sleep(time.Millisecond * 100)
 
-	assert.Len(t, eventReporter.ReceivedEvents, 1)
+	assert.Eventually(t, func() bool {
+		return len(fakeClusterContext.GetAnnotationsAdded()[jobId]) > 0
+	}, time.Second, 10*time.Millisecond, "the handler goroutine must report and annotate the failed pod")
+	assertExpectedEvents(t, pod, eventReporter.GetReceivedEvents(), reflect.TypeOf(&armadaevents.EventSequence_Event_JobRunErrors{}))
 }
 
 func TestJobStateReporter_PodFailed_SuppressesEmissionWhenRetryableIssueRegistered(t *testing.T) {
 	classifier := classifierForExitCode(t, "jsr-retryable-cat", "jsr-retryable-sub", 42)
-	_, _, eventReporter, fakeClusterContext := setUpJobStateReporterTestWithClassifier(
+	stateReporter, _, eventReporter, fakeClusterContext := setUpJobStateReporterTestWithClassifier(
 		t, classifier,
 		&stubIssueHandler{detectAndRegisterFailedPodIssueResult: true},
 	)
 
 	pod := makeFailedPodWithExitCode(t, 42)
 	addPod(t, fakeClusterContext, pod)
-	fakeClusterContext.SimulatePodAddEvent(pod)
-	time.Sleep(time.Millisecond * 100)
+	stateReporter.reportCurrentStatus(pod)
 
-	assert.Len(t, eventReporter.ReceivedEvents, 0, "retryable issue path emits ReturnLease, not JobFailed")
+	assert.Len(t, eventReporter.GetReceivedEvents(), 0, "retryable issue path emits ReturnLease, not JobFailed")
 }
 
 func TestJobStateReporter_PodFailed_SuppressesEmissionWhenIssueAlreadyExists(t *testing.T) {
 	classifier := classifierForExitCode(t, "jsr-existing-cat", "jsr-existing-sub", 42)
 	pod := makeFailedPodWithExitCode(t, 42)
-	_, _, eventReporter, fakeClusterContext := setUpJobStateReporterTestWithClassifier(
+	stateReporter, _, eventReporter, fakeClusterContext := setUpJobStateReporterTestWithClassifier(
 		t, classifier,
 		&stubIssueHandler{runIdsWithIssues: map[string]bool{util.ExtractJobRunId(pod): true}},
 	)
 
 	addPod(t, fakeClusterContext, pod)
-	fakeClusterContext.SimulatePodAddEvent(pod)
-	time.Sleep(time.Millisecond * 100)
+	stateReporter.reportCurrentStatus(pod)
 
-	assert.Len(t, eventReporter.ReceivedEvents, 0, "run already owned by issue handler - no direct emission from this path")
+	assert.Len(t, eventReporter.GetReceivedEvents(), 0, "run already owned by issue handler - no direct emission from this path")
 }
 
 func TestJobStateReporter_PodFailed_DropsEventWhenReporterErrors(t *testing.T) {
 	classifier := classifierForExitCode(t, "jsr-report-error-cat", "jsr-report-error-sub", 42)
-	_, _, eventReporter, fakeClusterContext := setUpJobStateReporterTestWithClassifier(t, classifier, &stubIssueHandler{})
+	stateReporter, _, eventReporter, fakeClusterContext := setUpJobStateReporterTestWithClassifier(t, classifier, &stubIssueHandler{})
 	eventReporter.ErrorOnReport = true
 
 	pod := makeFailedPodWithExitCode(t, 42)
 	addPod(t, fakeClusterContext, pod)
-	fakeClusterContext.SimulatePodAddEvent(pod)
-	time.Sleep(time.Millisecond * 100)
+	stateReporter.reportCurrentStatus(pod)
 
-	assert.Len(t, eventReporter.ReceivedEvents, 0, "event is dropped when reporter errors - counter increment is gated behind successful emission")
+	assert.Len(t, eventReporter.GetReceivedEvents(), 0, "event is dropped when reporter errors - counter increment is gated behind successful emission")
 }
 
 func TestJobStateReporter_PodFailed_EmitsEventWithEmptyCategoryWhenClassifierIsNil(t *testing.T) {
-	_, _, eventReporter, fakeClusterContext := setUpJobStateReporterTestWithClassifier(t, nil, &stubIssueHandler{})
+	stateReporter, _, eventReporter, fakeClusterContext := setUpJobStateReporterTestWithClassifier(t, nil, &stubIssueHandler{})
 
 	pod := makeFailedPodWithExitCode(t, 42)
 	addPod(t, fakeClusterContext, pod)
-	fakeClusterContext.SimulatePodAddEvent(pod)
-	time.Sleep(time.Millisecond * 100)
+	stateReporter.reportCurrentStatus(pod)
 
-	assert.Len(t, eventReporter.ReceivedEvents, 1, "event still emitted with empty category/subcategory when classification is disabled")
+	assert.Len(t, eventReporter.GetReceivedEvents(), 1, "event still emitted with empty category/subcategory when classification is disabled")
 }
 
 func assertExpectedEvents(t *testing.T, pod *v1.Pod, messages []reporter.EventMessage, expectedType reflect.Type) {
@@ -306,7 +320,7 @@ func assertExpectedEvents(t *testing.T, pod *v1.Pod, messages []reporter.EventMe
 }
 
 func assertExpectedAnnotations(t *testing.T, pod *v1.Pod, clusterContext *fakecontext.SyncFakeClusterContext) {
-	jobAnnotations := clusterContext.AnnotationsAdded[util.ExtractJobId(pod)]
+	jobAnnotations := clusterContext.GetAnnotationsAdded()[util.ExtractJobId(pod)]
 	assert.Len(t, jobAnnotations, 1)
 	_, exists := jobAnnotations[string(pod.Status.Phase)]
 	assert.True(t, exists)


### PR DESCRIPTION
Running the executor test suite with the Go race detector currently reports 24 data-race warnings, all in test code. The races come from two patterns: test fakes whose maps and slices are written from the goroutines the production code spawns, and tests that wait for those goroutines with a fixed `time.Sleep`, which establishes no happens-before relationship with the assertions that follow.

This change makes the executor packages race-detector clean without touching production code. `SyncFakeClusterContext`, `FakeEventReporter`, and `FakeEventSender` get the locking their concurrent use requires, plus snapshot accessors (`GetAnnotationsAdded`, `GetReceivedEvents`) for reads that previously touched the maps directly. The `JobStateReporter` tests that drove pod events through the informer handler and slept now call `reportCurrentStatus` and `reportStatusUpdate` directly, which is synchronous and deterministic. One test per informer handler still drives through the registered `AddFunc` and `UpdateFunc` to keep the wiring covered. Those two wait on the state annotation through the locked accessor: the annotation is the handler goroutine's final write, so the wait orders the assertions after everything the handler did.

`go test ./internal/executor/... -race` reports zero warnings after this change. CI does not currently run the race detector, which is how these accumulated silently. Adding `-race` to the unit test job would keep it fixed permanently and is worth considering as a follow-up.

This overlaps with #4999 in the job state reporter test file, so whichever of the two merges second will need a small rebase there. The PRs are otherwise independent.
