### PR TITLE
Classify retryable pod failures on the lease-return path

### DIFF
--- a/internal/executor/metrics/metrics.go
+++ b/internal/executor/metrics/metrics.go
@@ -17,7 +17,9 @@ const (
 var jobFailureCategoryTotal = promauto.NewCounterVec(
 	prometheus.CounterOpts{
 		Name: ArmadaExecutorMetricsPrefix + "job_failure_category_total",
-		Help: "Total number of job failures by failure category and subcategory",
+		Help: "Total number of job run failures by failure category and subcategory. " +
+			"Includes retryable failures whose lease is returned for rescheduling, " +
+			"so a single job can contribute multiple increments.",
 	},
 	[]string{failureCategoryLabel, failureSubcategoryLabel},
 )
@@ -38,8 +40,9 @@ var jobFailureRuleEvaluationDurationSeconds = promauto.NewHistogramVec(
 )
 
 // RecordJobFailure increments the per-category failure counter. Should be
-// called from paths that commit to emitting a JobFailedEvent — retryable
-// pod issues that emit a ReturnLease instead must not call this.
+// called only after the failure event (JobFailedEvent, or ReturnLease for
+// retryable pod issues) has been successfully reported, so failed sends do
+// not inflate the counter.
 //
 // An empty category indicates no classification happened (e.g. the feature
 // flag is off or the classifier is nil); in that case no metric is emitted.

--- a/internal/executor/reporter/event.go
+++ b/internal/executor/reporter/event.go
@@ -320,7 +320,12 @@ func CreateMinimalJobFailedEvent(jobId string, runId string, jobSet string, queu
 	return sequence, nil
 }
 
-func CreateReturnLeaseEvent(pod *v1.Pod, reason string, debugMessage string, clusterId string, runAttempted bool) (*armadaevents.EventSequence, error) {
+// CreateReturnLeaseEvent builds the lease-return error event for a run the scheduler should retry.
+// failureCategory and failureSubcategory carry the pod error classification when the caller has
+// one; empty strings mean the failure was not classified and leave the fields unset.
+func CreateReturnLeaseEvent(pod *v1.Pod, reason string, debugMessage string, clusterId string, runAttempted bool,
+	failureCategory string, failureSubcategory string,
+) (*armadaevents.EventSequence, error) {
 	sequence := createEmptySequence(pod)
 	jobId, runId, err := extractIds(pod)
 	if err != nil {
@@ -335,7 +340,9 @@ func CreateReturnLeaseEvent(pod *v1.Pod, reason string, debugMessage string, clu
 				JobId: jobId,
 				Errors: []*armadaevents.Error{
 					{
-						Terminal: true, // EventMessage_LeaseReturned indicates a pod could not be scheduled.
+						Terminal:           true, // EventMessage_LeaseReturned indicates a pod could not be scheduled.
+						FailureCategory:    failureCategory,
+						FailureSubcategory: failureSubcategory,
 						Reason: &armadaevents.Error_PodLeaseReturned{
 							PodLeaseReturned: &armadaevents.PodLeaseReturned{
 								ObjectMeta: &armadaevents.ObjectMeta{

--- a/internal/executor/service/cluster_allocation.go
+++ b/internal/executor/service/cluster_allocation.go
@@ -118,7 +118,8 @@ func (allocationService *ClusterAllocationService) processFailedJobSubmissions(f
 }
 
 func (allocationService *ClusterAllocationService) sendReturnLeaseEvent(details *job.FailedSubmissionDetails, message string) error {
-	returnLeaseEvent, err := reporter.CreateReturnLeaseEvent(details.Pod, message, "", allocationService.clusterId.GetClusterId(), true)
+	// Submission failures happen before the pod ran, so there is no pod error to classify.
+	returnLeaseEvent, err := reporter.CreateReturnLeaseEvent(details.Pod, message, "", allocationService.clusterId.GetClusterId(), true, "", "")
 	if err != nil {
 		return fmt.Errorf("failed to create return lease event %s", err)
 	}

--- a/internal/executor/service/pod_issue_handler.go
+++ b/internal/executor/service/pod_issue_handler.go
@@ -593,7 +593,7 @@ func (p *PodIssueHandler) reportDeleteActionFailure(issue *issue, category strin
 }
 
 // For retryable issues we must:
-//   - Report JobReturnLeaseEvent
+//   - Report JobReturnLeaseEvent, carrying the pod error classification when a rule matches
 //
 // If the pod becomes Running/Completed/Failed in the middle of being deleted - swap this issue to a nonRetryableIssue where it will be Failed
 func (p *PodIssueHandler) handleRetryableJobIssue(issue *issue) {
@@ -633,13 +633,16 @@ func (p *PodIssueHandler) handleRetryableJobIssue(issue *issue) {
 		// When we have our own internal state - we don't need to wait for the pod deletion to complete
 		// We can just mark is to delete in our state and return the lease
 		jobRunAttempted := issue.RunIssue.PodIssue.Type != UnableToSchedule
+		result := p.classifier.ClassifyPodError(issue.RunIssue.PodIssue.OriginalPodState, issue.RunIssue.PodIssue.Message)
 
 		returnLeaseEvent, err := reporter.CreateReturnLeaseEvent(
 			issue.RunIssue.PodIssue.OriginalPodState,
-			issue.RunIssue.PodIssue.Message,
+			result.AppendHint(issue.RunIssue.PodIssue.Message),
 			issue.RunIssue.PodIssue.DebugMessage,
 			p.clusterContext.GetClusterId(),
 			jobRunAttempted,
+			result.Category,
+			result.Subcategory,
 		)
 		if err != nil {
 			log.Errorf("Failed to create return lease event for job %s because %s", issue.RunIssue.JobId, err)
@@ -651,6 +654,8 @@ func (p *PodIssueHandler) handleRetryableJobIssue(issue *issue) {
 			log.Errorf("Failed to return lease for job %s because %s", issue.RunIssue.JobId, err)
 			return
 		}
+		// Record only after a successful Report so failed sends do not inflate the counter.
+		metrics.RecordJobFailure(result.Category, result.Subcategory)
 		p.markIssuesResolved(issue.RunIssue)
 	}
 }

--- a/internal/executor/service/pod_issue_handler_test.go
+++ b/internal/executor/service/pod_issue_handler_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
@@ -379,31 +380,6 @@ func TestPodIssueService_DeletesPodAndReportsFailed_IfExceedsActiveDeadline(t *t
 	}
 }
 
-func TestPodIssueService_DeletesPodAndReportsLeaseReturned_IfRetryableStuckPod(t *testing.T) {
-	podIssueService, _, fakeClusterContext, eventsReporter, err := setupTestComponents([]*job.RunState{})
-	require.NoError(t, err)
-	retryableStuckPod := makeRetryableStuckPod()
-	addPod(t, fakeClusterContext, retryableStuckPod)
-	addPodEvents(fakeClusterContext, retryableStuckPod, []*v1.Event{{Message: "Some other message", Type: "Warning"}})
-
-	podIssueService.HandlePodIssues()
-
-	// Deletes pod
-	remainingActivePods := getActivePods(t, fakeClusterContext)
-	assert.Equal(t, []*v1.Pod{}, remainingActivePods)
-
-	// Reset events
-	eventsReporter.ReceivedEvents = []reporter.EventMessage{}
-	podIssueService.HandlePodIssues()
-
-	assert.Len(t, eventsReporter.ReceivedEvents[0].Event.Events, 1)
-	returnedEvent, ok := eventsReporter.ReceivedEvents[0].Event.Events[0].Event.(*armadaevents.EventSequence_Event_JobRunErrors)
-	assert.True(t, ok)
-	assert.Len(t, returnedEvent.JobRunErrors.Errors, 1)
-	assert.True(t, returnedEvent.JobRunErrors.Errors[0].GetPodLeaseReturned() != nil)
-	assert.Contains(t, returnedEvent.JobRunErrors.Errors[0].GetPodLeaseReturned().DebugMessage, "Some other message")
-}
-
 func TestPodIssueService_DeletesPodAndReportsFailed_IfRetryableStuckPodStartsUpAfterDeletionCalled(t *testing.T) {
 	podIssueService, _, fakeClusterContext, eventsReporter, err := setupTestComponents([]*job.RunState{})
 	require.NoError(t, err)
@@ -602,8 +578,8 @@ func podErrorClassifier(t *testing.T, category, subcategory, pattern, hint strin
 }
 
 // The metric counter itself is tested in the metrics package. These tests
-// cover the emission gating for the non-retryable issue path: only a
-// successful Report call should have led to a counter increment.
+// cover the emission gating for the non-retryable and retryable issue paths:
+// only a successful Report call should have led to a counter increment.
 
 func TestPodIssueService_EmitsFailedEventWhenClassifierMatches(t *testing.T) {
 	classifier := conditionClassifier(t, "pih-success-cat", "pih-success-sub", errormatch.ConditionOOMKilled)
@@ -651,6 +627,139 @@ func TestPodIssueService_EmitsEventWithEmptyCategoryWhenClassifierIsNil(t *testi
 	podIssueService.HandlePodIssues()
 
 	assert.Len(t, eventReporter.ReceivedEvents, 1, "event still emitted with empty category/subcategory when classification is disabled")
+}
+
+func TestPodIssueService_RetryableIssue_LeaseReturnClassification(t *testing.T) {
+	hint := "Check the image reference and registry availability"
+	tests := map[string]struct {
+		classifier        *categorizer.Classifier
+		expectCategory    string
+		expectSubcategory string
+		expectHint        string
+	}{
+		"matching rule sets category and records failure": {
+			classifier:        podErrorClassifier(t, "pih-retry-cat", "pih-retry-sub", "Unable to start pod", hint),
+			expectCategory:    "pih-retry-cat",
+			expectSubcategory: "pih-retry-sub",
+			expectHint:        hint,
+		},
+		"nil classifier leaves category empty": {},
+		"no matching rule leaves category empty": {
+			classifier: podErrorClassifier(t, "pih-retry-nomatch-cat", "pih-retry-nomatch-sub", "pattern that never matches", ""),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			podIssueService, _, fakeClusterContext, eventReporter, err := setupTestComponentsWithClassifier([]*job.RunState{}, tc.classifier)
+			require.NoError(t, err)
+			counterBefore := failureCounterValue(t, tc.expectCategory, tc.expectSubcategory)
+			familyTotalBefore := failureCounterFamilyTotal(t)
+
+			retryableStuckPod := makeRetryableStuckPod()
+			addPod(t, fakeClusterContext, retryableStuckPod)
+			addPodEvents(fakeClusterContext, retryableStuckPod, []*v1.Event{{Message: "Some other message", Type: "Warning"}})
+
+			// First pass deletes the pod, second pass emits the lease return.
+			podIssueService.HandlePodIssues()
+			assert.Equal(t, []*v1.Pod{}, getActivePods(t, fakeClusterContext))
+			podIssueService.HandlePodIssues()
+
+			require.Len(t, eventReporter.ReceivedEvents, 1)
+			returnedEvent, ok := eventReporter.ReceivedEvents[0].Event.Events[0].Event.(*armadaevents.EventSequence_Event_JobRunErrors)
+			require.True(t, ok)
+			leaseReturnError := returnedEvent.JobRunErrors.Errors[0]
+			require.NotNil(t, leaseReturnError.GetPodLeaseReturned())
+			assert.Contains(t, leaseReturnError.GetPodLeaseReturned().DebugMessage, "Some other message")
+			assert.Equal(t, tc.expectCategory, leaseReturnError.GetFailureCategory())
+			assert.Equal(t, tc.expectSubcategory, leaseReturnError.GetFailureSubcategory())
+
+			message := leaseReturnError.GetPodLeaseReturned().Message
+			rawIdx := strings.Index(message, "Unable to start pod")
+			require.GreaterOrEqual(t, rawIdx, 0, "raw error must appear in message")
+			if tc.expectHint != "" {
+				hintIdx := strings.Index(message, tc.expectHint)
+				require.GreaterOrEqual(t, hintIdx, 0, "hint must appear in message")
+				assert.Greater(t, hintIdx, rawIdx, "hint must come after raw error")
+			}
+
+			if tc.expectCategory != "" {
+				assert.Equal(t, counterBefore+1, failureCounterValue(t, tc.expectCategory, tc.expectSubcategory))
+			} else {
+				assert.Equal(t, familyTotalBefore, failureCounterFamilyTotal(t), "unclassified lease return must not record a failure")
+			}
+		})
+	}
+}
+
+func TestPodIssueService_RetryableIssue_NoRecordWhenReportFails(t *testing.T) {
+	category, subcategory := "pih-retry-report-fail-cat", "pih-retry-report-fail-sub"
+	classifier := podErrorClassifier(t, category, subcategory, "Unable to start pod", "")
+	podIssueService, _, fakeClusterContext, eventReporter, err := setupTestComponentsWithClassifier([]*job.RunState{}, classifier)
+	require.NoError(t, err)
+	counterBefore := failureCounterValue(t, category, subcategory)
+
+	retryableStuckPod := makeRetryableStuckPod()
+	addPod(t, fakeClusterContext, retryableStuckPod)
+
+	podIssueService.HandlePodIssues()
+	eventReporter.ErrorOnReport = true
+	podIssueService.HandlePodIssues()
+
+	assert.Len(t, eventReporter.ReceivedEvents, 0)
+	assert.Equal(t, counterBefore, failureCounterValue(t, category, subcategory), "failed sends must not increment the counter")
+
+	// The issue stays registered, so a later pass reports and records.
+	eventReporter.ErrorOnReport = false
+	podIssueService.HandlePodIssues()
+
+	require.Len(t, eventReporter.ReceivedEvents, 1)
+	recoveredEvent, ok := eventReporter.ReceivedEvents[0].Event.Events[0].Event.(*armadaevents.EventSequence_Event_JobRunErrors)
+	require.True(t, ok)
+	assert.Equal(t, category, recoveredEvent.JobRunErrors.Errors[0].GetFailureCategory())
+	assert.Equal(t, counterBefore+1, failureCounterValue(t, category, subcategory))
+}
+
+// failureCounterValue reads the executor job failure counter for the given
+// label pair from the default prometheus registry, returning 0 when the
+// labelled child does not exist yet.
+func failureCounterValue(t *testing.T, category string, subcategory string) float64 {
+	t.Helper()
+	families, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+	for _, family := range families {
+		if family.GetName() != "armada_executor_job_failure_category_total" {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			labels := map[string]string{}
+			for _, label := range metric.GetLabel() {
+				labels[label.GetName()] = label.GetValue()
+			}
+			if labels["failure_category"] == category && labels["failure_subcategory"] == subcategory {
+				return metric.GetCounter().GetValue()
+			}
+		}
+	}
+	return 0
+}
+
+// failureCounterFamilyTotal sums the executor job failure counter across all
+// label pairs, so tests can assert that no increment happened at all.
+func failureCounterFamilyTotal(t *testing.T) float64 {
+	t.Helper()
+	families, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+	total := float64(0)
+	for _, family := range families {
+		if family.GetName() != "armada_executor_job_failure_category_total" {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			total += metric.GetCounter().GetValue()
+		}
+	}
+	return total
 }
 
 func createRunState(jobId string, runId string, phase job.RunPhase) *job.RunState {


### PR DESCRIPTION
The executor only classifies terminal pod failures. When a pod issue is retryable, the lease is returned with an unclassified error: `FailureCategory`/`FailureSubcategory` stay empty and the failure counter never increments. The failures operators most commonly configure to retry (image-pull backoff, mount failures) are therefore never classified, even with matching `onPodError` rules.

This mirrors the terminal path on the retryable path. `handleRetryableJobIssue` classifies the pod error, `CreateReturnLeaseEvent` sets the category fields on the emitted `Error` (the fields live on the shared `Error` message, so no schema change), the matched rule's hint is appended to the message, and the counter is recorded only after the event is successfully reported. The submission-failure caller passes empty categories since no pod ran.

Behavior changes to be aware of:

- `armada_executor_job_failure_category_total` now also counts retryable failures whose lease is returned, so a single job can contribute several increments across retries. The help text says this.
- The Lookout ingester persists classification for any terminal error, so lease-returned runs now carry `failure_category`/`failure_subcategory` in Lookout.
- When a job later fails with max-runs-exceeded, the scheduler's `job_error_classification_by_{queue,node}` metrics read the category off the stored run error, restoring coverage the `trackedErrorRegexes` scheme had before #4980.

Preemption and the terminal non-retryable path are unchanged.

Validated end to end on the containerized local stack (images from this branch, executor against a kind cluster): a job with a nonexistent image and a matching `onPodError` rule produced a classified lease return, exactly one counter increment after the successful report, the classification and hint on the run in Lookout, and category-labelled scheduler classification metrics when the job terminally failed.

Deliberately not bundled, for maintainer discussion: the scheduler metrics label with `category`/`subcategory` while the executor metric uses `failure_category`/`failure_subcategory`. Unifying them would break existing dashboards and recording rules.
