### PR TITLE
Enable govet in golangci-lint and fix all findings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,7 @@ linters:
   default: none
   enable:
     - errcheck
+    - govet
     - ineffassign
     - lll
     - misspell

--- a/cmd/armada-load-tester/cmd/loadtest.go
+++ b/cmd/armada-load-tester/cmd/loadtest.go
@@ -82,7 +82,9 @@ var loadtestCmd = &cobra.Command{
 
 		loadTestTimeout := context.Background()
 		if timeout != defaultTimeout {
-			loadTestTimeout, _ = context.WithTimeout(context.Background(), timeout)
+			var cancel context.CancelFunc
+			loadTestTimeout, cancel = context.WithTimeout(context.Background(), timeout)
+			defer cancel()
 		}
 		apiConnectionDetails, err := client.ExtractCommandlineArmadaApiConnectionDetails()
 		if err != nil {

--- a/internal/common/auth/basic_test.go
+++ b/internal/common/auth/basic_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestBasicAuthService(t *testing.T) {
 	service := NewBasicAuthService(map[string]configuration.UserInfo{
-		"root": {"toor", []string{}},
+		"root": {Password: "toor", Groups: []string{}},
 	})
 
 	auth1 := basicPassword("root", "toor")

--- a/internal/common/ingest/topic_delay_monitor_test.go
+++ b/internal/common/ingest/topic_delay_monitor_test.go
@@ -22,7 +22,7 @@ const (
 )
 
 // This is what pulsar returns when there are no message to peek, it doesn't just return an empty list
-var pulsarNotFoundError = rest.Error{messageNotFound, 404}
+var pulsarNotFoundError = rest.Error{Reason: messageNotFound, Code: 404}
 
 func TestInitialise(t *testing.T) {
 	delayMonitor, _, _, _, _ := setupTopicDelayMonitorTest()

--- a/internal/executor/reporter/event_sender_test.go
+++ b/internal/executor/reporter/event_sender_test.go
@@ -107,7 +107,7 @@ func makeTestPod(phase v1.PodPhase) *v1.Pod {
 				domain.JobSetId:          "job-set-id-1",
 				constants.PoolAnnotation: "test-pool",
 			},
-			CreationTimestamp: metav1.Time{time.Now().Add(-10 * time.Minute)},
+			CreationTimestamp: metav1.Time{Time: time.Now().Add(-10 * time.Minute)},
 			UID:               k8sTypes.UID(util.NewULID()),
 		},
 		Spec: v1.PodSpec{

--- a/internal/scheduler/kubernetesobjects/taint/taint_test.go
+++ b/internal/scheduler/kubernetesobjects/taint/taint_test.go
@@ -11,7 +11,7 @@ import (
 
 var testTaints = []v1.Taint{
 	{Key: "key1", Value: "val", Effect: v1.TaintEffectNoSchedule, TimeAdded: nil},
-	{Key: "key2", Value: "val", Effect: v1.TaintEffectNoExecute, TimeAdded: &metav1.Time{time.Now()}},
+	{Key: "key2", Value: "val", Effect: v1.TaintEffectNoExecute, TimeAdded: &metav1.Time{Time: time.Now()}},
 }
 
 func TestDeepCopy(t *testing.T) {

--- a/internal/scheduler/scheduling/fairness/fairness_test.go
+++ b/internal/scheduler/scheduling/fairness/fairness_test.go
@@ -31,7 +31,7 @@ func TestNewDominantResourceFairness_InvalidConfig(t *testing.T) {
 		"must not provide both types of config": {
 			config: configuration.SchedulingConfig{
 				DominantResourceFairnessResourcesToConsider:             []string{"foo", "bar"},
-				ExperimentalDominantResourceFairnessResourcesToConsider: []configuration.DominantResourceFairnessResource{{"foo", 1}, {"bar", 1}},
+				ExperimentalDominantResourceFairnessResourcesToConsider: []configuration.DominantResourceFairnessResource{{Name: "foo", Multiplier: 1}, {Name: "bar", Multiplier: 1}},
 			},
 		},
 		"pool override - invalid combination": {
@@ -40,7 +40,7 @@ func TestNewDominantResourceFairness_InvalidConfig(t *testing.T) {
 				Pools: []configuration.PoolConfig{
 					{
 						Name: poolName,
-						DominantResourceFairnessResourcesToConsider: []configuration.DominantResourceFairnessResource{{"foo", 1}, {"bar", 0.5}},
+						DominantResourceFairnessResourcesToConsider: []configuration.DominantResourceFairnessResource{{Name: "foo", Multiplier: 1}, {Name: "bar", Multiplier: 0.5}},
 					},
 				},
 			},
@@ -121,21 +121,21 @@ func TestDominantResourceFairness(t *testing.T) {
 		},
 		"experimental config": {
 			totalResources: fooBarBaz(rlFactory, "1", "2", "3"),
-			config:         configuration.SchedulingConfig{ExperimentalDominantResourceFairnessResourcesToConsider: []configuration.DominantResourceFairnessResource{{"foo", 1}, {"bar", 1}}},
+			config:         configuration.SchedulingConfig{ExperimentalDominantResourceFairnessResourcesToConsider: []configuration.DominantResourceFairnessResource{{Name: "foo", Multiplier: 1}, {Name: "bar", Multiplier: 1}}},
 			allocation:     fooBarBaz(rlFactory, "0.5", "1.1", "0"),
 			weight:         1.0,
 			expectedCost:   1.1 / 2,
 		},
 		"experimental config defaults multipliers to one": {
 			totalResources: fooBarBaz(rlFactory, "1", "2", "3"),
-			config:         configuration.SchedulingConfig{ExperimentalDominantResourceFairnessResourcesToConsider: []configuration.DominantResourceFairnessResource{{"foo", 0}, {"bar", 0}}},
+			config:         configuration.SchedulingConfig{ExperimentalDominantResourceFairnessResourcesToConsider: []configuration.DominantResourceFairnessResource{{Name: "foo", Multiplier: 0}, {Name: "bar", Multiplier: 0}}},
 			allocation:     fooBarBaz(rlFactory, "0.5", "1.1", "0"),
 			weight:         1.0,
 			expectedCost:   1.1 / 2,
 		},
 		"experimental config non-unit multiplier": {
 			totalResources: fooBarBaz(rlFactory, "1", "2", "3"),
-			config:         configuration.SchedulingConfig{ExperimentalDominantResourceFairnessResourcesToConsider: []configuration.DominantResourceFairnessResource{{"foo", 4}, {"bar", 1}}},
+			config:         configuration.SchedulingConfig{ExperimentalDominantResourceFairnessResourcesToConsider: []configuration.DominantResourceFairnessResource{{Name: "foo", Multiplier: 4}, {Name: "bar", Multiplier: 1}}},
 			allocation:     fooBarBaz(rlFactory, "0.5", "1.1", "0"),
 			weight:         1.0,
 			expectedCost:   2,
@@ -143,11 +143,11 @@ func TestDominantResourceFairness(t *testing.T) {
 		"pool override - experimental config": {
 			totalResources: fooBarBaz(rlFactory, "1", "2", "3"),
 			config: configuration.SchedulingConfig{
-				ExperimentalDominantResourceFairnessResourcesToConsider: []configuration.DominantResourceFairnessResource{{"foo", 1}, {"bar", 1}},
+				ExperimentalDominantResourceFairnessResourcesToConsider: []configuration.DominantResourceFairnessResource{{Name: "foo", Multiplier: 1}, {Name: "bar", Multiplier: 1}},
 				Pools: []configuration.PoolConfig{
 					{
 						Name: poolName,
-						DominantResourceFairnessResourcesToConsider: []configuration.DominantResourceFairnessResource{{"foo", 1}, {"bar", 0.5}},
+						DominantResourceFairnessResourcesToConsider: []configuration.DominantResourceFairnessResource{{Name: "foo", Multiplier: 1}, {Name: "bar", Multiplier: 0.5}},
 					},
 				},
 			},

--- a/internal/scheduler/scheduling/market_driven_preempting_queue_scheduler_test.go
+++ b/internal/scheduler/scheduling/market_driven_preempting_queue_scheduler_test.go
@@ -131,15 +131,9 @@ func TestMarketDrivenPreemptingQueueScheduler(t *testing.T) {
 			Rounds: []SchedulingRound{
 				{
 					JobsByQueue: map[string][]*jobdb.Job{
-						"A": append(
-							testfixtures.N1Cpu4GiJobsWithPriceBand("A", bidstore.PriceBand_PRICE_BAND_A, 21),
-						),
-						"B": append(
-							testfixtures.N1Cpu4GiJobsWithPriceBand("B", bidstore.PriceBand_PRICE_BAND_A, 21),
-						),
-						"C": append(
-							testfixtures.N1Cpu4GiJobsWithPriceBand("C", bidstore.PriceBand_PRICE_BAND_A, 21),
-						),
+						"A": testfixtures.N1Cpu4GiJobsWithPriceBand("A", bidstore.PriceBand_PRICE_BAND_A, 21),
+						"B": testfixtures.N1Cpu4GiJobsWithPriceBand("B", bidstore.PriceBand_PRICE_BAND_A, 21),
+						"C": testfixtures.N1Cpu4GiJobsWithPriceBand("C", bidstore.PriceBand_PRICE_BAND_A, 21),
 					},
 					ExpectedScheduledIndices: map[string][]int{
 						"A": testfixtures.IntRange(0, 10),

--- a/internal/testsuite/eventwatcher/eventwatcher.go
+++ b/internal/testsuite/eventwatcher/eventwatcher.go
@@ -325,9 +325,12 @@ func GetFromIngresses(parent context.Context, C chan *api.EventMessage) error {
 		case msg := <-C:
 			if ingressInfo := msg.GetIngressInfo(); ingressInfo != nil {
 				for _, host := range ingressInfo.IngressAddresses {
-					ctxWithTimeout, _ := context.WithTimeout(ctx, time.Minute)
+					ctxWithTimeout, cancel := context.WithTimeout(ctx, time.Minute)
 					host := host
-					g.Go(func() error { return getFromIngress(ctxWithTimeout, host) })
+					g.Go(func() error {
+						defer cancel()
+						return getFromIngress(ctxWithTimeout, host)
+					})
 				}
 			}
 		}

--- a/pkg/client/submit.go
+++ b/pkg/client/submit.go
@@ -27,7 +27,7 @@ func UpdateQueue(submitClient api.SubmitClient, queue *api.Queue) error {
 func DeleteQueue(submitClient api.SubmitClient, name string) error {
 	ctx, cancel := common.ContextWithDefaultTimeout()
 	defer cancel()
-	_, e := submitClient.DeleteQueue(ctx, &api.QueueDeleteRequest{name})
+	_, e := submitClient.DeleteQueue(ctx, &api.QueueDeleteRequest{Name: name})
 	return e
 }
 


### PR DESCRIPTION
`go vet ./internal/... ./pkg/... ./cmd/...` currently fails on master with 24 findings, and nothing in CI catches that because .golangci.yml enables an explicit linter list that leaves govet out.

This fixes all findings and enables govet in the same PR so the two cannot drift apart:

- Keyed struct literals in fairness_test.go, taint_test.go, event_sender_test.go, basic_test.go, topic_delay_monitor_test.go, and pkg/client/submit.go. The submit.go literal is the only one in non-test code. Behavior is unchanged everywhere.
- Removed three single-argument append wrappers in market_driven_preempting_queue_scheduler_test.go that were no-ops around the slice they wrapped.
- Captured and deferred the discarded context.WithTimeout cancel functions in internal/testsuite/eventwatcher and cmd/armada-load-tester. The eventwatcher one leaked a timer and goroutine per polled ingress for up to a minute. The load-tester one was bounded by process lifetime.

`golangci-lint run` with the new config reports zero issues, using the same v2.9.0 the lint workflow pins.
