### PR TITLE
Replace sleep-based synchronization in executor reporter tests

### DIFF
--- a/internal/executor/reporter/job_event_reporter_test.go
+++ b/internal/executor/reporter/job_event_reporter_test.go
@@ -26,14 +26,15 @@ func TestJobEventReporter_SendsEventImmediately_OnceNumberOfWaitingEventsMatches
 	pod2 := createPod(2)
 
 	jobEventReporter.QueueEvent(EventMessage{createFailedEvent(t, pod1), util.ExtractJobRunId(pod1)}, func(err error) {})
-	time.Sleep(time.Millisecond * 100) // Allow time for async event processing
-	// No calls excepted, as batch size is 2 and only 1 event has been sent
+	waitForQueueDrained(t, jobEventReporter)
+	// Batch size is 2, so a single buffered event must not be sent
 	assert.Equal(t, 0, eventSender.GetNumberOfSendEventCalls())
 
 	jobEventReporter.QueueEvent(EventMessage{createFailedEvent(t, pod2), util.ExtractJobRunId(pod2)}, func(err error) {})
-	time.Sleep(time.Millisecond * 100) // Allow time for async event processing
+	require.Eventually(t, func() bool {
+		return eventSender.GetNumberOfSendEventCalls() == 1
+	}, time.Second, 10*time.Millisecond, "filling the batch must trigger a send")
 
-	assert.Equal(t, 1, eventSender.GetNumberOfSendEventCalls())
 	sentMessages := eventSender.GetSentEvents(0)
 	assert.Len(t, sentMessages, 2)
 }
@@ -43,16 +44,31 @@ func TestJobEventReporter_SendsAllEventsInBuffer_EachBatchTickInterval(t *testin
 	pod1 := createPod(1)
 
 	jobEventReporter.QueueEvent(EventMessage{createFailedEvent(t, pod1), util.ExtractJobRunId(pod1)}, func(err error) {})
-	time.Sleep(time.Millisecond * 100)
+	waitForQueueDrained(t, jobEventReporter)
 	assert.Equal(t, 0, eventSender.GetNumberOfSendEventCalls())
 
-	// Increment time
+	// The queue is drained, so the event sits in the partial batch and the tick
+	// below must flush it. The tick is buffered by the fake clock, so it is not
+	// lost if the reporter is between selects when it fires.
+	require.Eventually(t, testClock.HasWaiters, time.Second, 10*time.Millisecond, "reporter never registered its ticker")
 	testClock.Step(time.Second * 5)
-	time.Sleep(time.Millisecond * 100)
+	require.Eventually(t, func() bool {
+		return eventSender.GetNumberOfSendEventCalls() == 1
+	}, time.Second, 10*time.Millisecond, "the tick must flush the buffered event")
 
-	assert.Equal(t, 1, eventSender.GetNumberOfSendEventCalls())
 	sentMessages := eventSender.GetSentEvents(0)
 	assert.Len(t, sentMessages, 1)
+}
+
+// Waits until the reporter goroutine has moved every queued event from its
+// intake channel into the in-memory batch. After that, asserting "nothing sent
+// yet" is deterministic: with the batch below maxBatchSize and no tick fired,
+// there is nothing that could have triggered a send.
+func waitForQueueDrained(t *testing.T, reporter *JobEventReporter) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		return len(reporter.eventBuffer) == 0
+	}, time.Second, 10*time.Millisecond, "reporter never drained its event buffer")
 }
 
 func createFailedEvent(t *testing.T, pod *v1.Pod) *armadaevents.EventSequence {

--- a/internal/executor/utilisation/job_utilisation_reporter_test.go
+++ b/internal/executor/utilisation/job_utilisation_reporter_test.go
@@ -43,33 +43,36 @@ func TestUtilisationEventReporter_ReportUtilisationEvents(t *testing.T) {
 	_, err = submitPod(clusterContext)
 	require.NoError(t, err)
 
-	deadline := time.Now().Add(time.Second)
-	for {
+	// Reporting is normally driven by a task scheduler, so the poll below stands
+	// in for the ticks while waiting for two reporting periods to elapse
+	require.Eventually(t, func() bool {
 		eventReporter.ReportUtilisationEvents()
-		time.Sleep(time.Millisecond)
+		return len(fakeEventReporter.GetReceivedEvents()) >= 2
+	}, time.Second, time.Millisecond, "two utilisation events must be reported")
 
-		if len(fakeEventReporter.ReceivedEvents) >= 2 || time.Now().After(deadline) {
-			break
-		}
-	}
-
-	assert.True(t, len(fakeEventReporter.ReceivedEvents) >= 2)
-	assert.Len(t, fakeEventReporter.ReceivedEvents[0].Event.Events, 1)
-	event1, ok := fakeEventReporter.ReceivedEvents[0].Event.Events[0].Event.(*armadaevents.EventSequence_Event_ResourceUtilisation)
+	receivedEvents := fakeEventReporter.GetReceivedEvents()
+	require.GreaterOrEqual(t, len(receivedEvents), 2)
+	assert.Len(t, receivedEvents[0].Event.Events, 1)
+	event1, ok := receivedEvents[0].Event.Events[0].Event.(*armadaevents.EventSequence_Event_ResourceUtilisation)
 	assert.True(t, ok)
-	assert.Len(t, fakeEventReporter.ReceivedEvents[1].Event.Events, 1)
-	_, ok = fakeEventReporter.ReceivedEvents[1].Event.Events[0].Event.(*armadaevents.EventSequence_Event_ResourceUtilisation)
+	assert.Len(t, receivedEvents[1].Event.Events, 1)
+	_, ok = receivedEvents[1].Event.Events[0].Event.(*armadaevents.EventSequence_Event_ResourceUtilisation)
 	assert.True(t, ok)
 
 	assert.Equal(t, testPodResources.CurrentUsage, armadaresource.FromProtoMap(event1.ResourceUtilisation.MaxResourcesForPeriod))
 	assert.Equal(t, testPodResources.CurrentUsage, armadaresource.FromProtoMap(event1.ResourceUtilisation.AvgResourcesForPeriod))
 	assert.Equal(t, testPodResources.CumulativeUsage, armadaresource.FromProtoMap(event1.ResourceUtilisation.TotalCumulativeUsage))
 
-	event1CreatedTime := fakeEventReporter.ReceivedEvents[0].Event.Events[0].Created
-	event2CreatedTime := fakeEventReporter.ReceivedEvents[1].Event.Events[0].Created
+	event1CreatedTime := receivedEvents[0].Event.Events[0].Created
+	event2CreatedTime := receivedEvents[1].Event.Events[0].Created
 	period := protoutil.ToStdTime(event2CreatedTime).Sub(protoutil.ToStdTime(event1CreatedTime))
 
-	assert.InDelta(t, float64(reportingPeriod), float64(period), float64(2*time.Millisecond))
+	// The reporter must hold the second event back for a full reporting period.
+	// The lower bound is what the reporter guarantees. The upper bound only
+	// checks the event was period-driven rather than immediate, with generous
+	// slack because a busy runner can delay the polling loop past the period.
+	assert.GreaterOrEqual(t, period, reportingPeriod-2*time.Millisecond)
+	assert.Less(t, period, reportingPeriod+100*time.Millisecond)
 }
 
 func TestUtilisationEventReporter_ReportUtilisationEvents_WhenNoUtilisationData(t *testing.T) {
@@ -83,19 +86,10 @@ func TestUtilisationEventReporter_ReportUtilisationEvents_WhenNoUtilisationData(
 	_, err = submitPod(clusterContext)
 	require.NoError(t, err)
 
-	deadline := time.Now().Add(time.Millisecond * 500)
-	count := 0
-	for {
+	assert.Never(t, func() bool {
 		eventReporter.ReportUtilisationEvents()
-		count++
-		time.Sleep(time.Millisecond)
-		if time.Now().After(deadline) {
-			break
-		}
-	}
-
-	assert.True(t, len(fakeEventReporter.ReceivedEvents) == 0)
-	assert.True(t, count > 0)
+		return len(fakeEventReporter.GetReceivedEvents()) > 0
+	}, 500*time.Millisecond, time.Millisecond, "empty utilisation data must not produce events")
 }
 
 func submitPod(clusterContext context.ClusterContext) (*v1.Pod, error) {


### PR DESCRIPTION
A few executor tests still synchronize with time.Sleep and raw reads of fake state. They pass the race detector today because the schedules happen not to overlap, but they use the same idiom that produced the races fixed in #5026, and the fixed sleeps make them slower and flakier than they need to be.

job_event_reporter_test.go now waits for the reporter goroutine to drain its intake channel before asserting that nothing was sent yet, which makes that negative assertion deterministic instead of a timing guess, and uses require.Eventually for the sends triggered by a full batch or by a tick. job_utilisation_reporter_test.go drives ReportUtilisationEvents from assert.Eventually and assert.Never conditions and reads events only through the mutex-guarded GetReceivedEvents accessor instead of the raw ReceivedEvents field.

Verified with `go test -race -count=3` on both packages.

The timing assertion at the end of TestUtilisationEventReporter_ReportUtilisationEvents previously required the gap between the two events to be within 2ms of the reporting period, which flaked on a busy CI runner (102.5ms observed against the 100ms period). It now asserts the guaranteed lower bound, that a full reporting period elapsed, and keeps only a generous upper bound to confirm the second event was period-driven rather than immediate.
