### PR TITLE
Move requireGrpcCode test helper into shared servertest package

### DIFF
--- a/internal/server/executor/executor_server_test.go
+++ b/internal/server/executor/executor_server_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc/codes"
-	grpcstatus "google.golang.org/grpc/status"
 	clocktesting "k8s.io/utils/clock/testing"
 
 	"github.com/armadaproject/armada/internal/common/armadacontext"
@@ -20,6 +19,7 @@ import (
 	protoutil "github.com/armadaproject/armada/internal/common/proto"
 	servermocks "github.com/armadaproject/armada/internal/server/mocks"
 	"github.com/armadaproject/armada/internal/server/permissions"
+	"github.com/armadaproject/armada/internal/server/servertest"
 	"github.com/armadaproject/armada/pkg/api"
 	"github.com/armadaproject/armada/pkg/controlplaneevents"
 )
@@ -40,13 +40,6 @@ func newExecutorTestServer(t *testing.T) (*Server, *executorTestMocks) {
 	return s, m
 }
 
-func requireGrpcCode(t *testing.T, err error, code codes.Code) {
-	t.Helper()
-	st, ok := grpcstatus.FromError(err)
-	require.True(t, ok, "expected gRPC status error")
-	assert.Equal(t, code, st.Code())
-}
-
 func TestUpsertExecutorSettings_PermissionDenied(t *testing.T) {
 	s, m := newExecutorTestServer(t)
 	grpcCtx := armadacontext.Background()
@@ -59,7 +52,7 @@ func TestUpsertExecutorSettings_PermissionDenied(t *testing.T) {
 
 	_, err := s.UpsertExecutorSettings(grpcCtx, &api.ExecutorSettingsUpsertRequest{Name: "executor-1"})
 	require.Error(t, err)
-	requireGrpcCode(t, err, codes.PermissionDenied)
+	servertest.RequireGrpcCode(t, err, codes.PermissionDenied)
 }
 
 func TestUpsertExecutorSettings_AuthorizeErrorUnavailable(t *testing.T) {
@@ -74,7 +67,7 @@ func TestUpsertExecutorSettings_AuthorizeErrorUnavailable(t *testing.T) {
 
 	_, err := s.UpsertExecutorSettings(grpcCtx, &api.ExecutorSettingsUpsertRequest{Name: "executor-1"})
 	require.Error(t, err)
-	requireGrpcCode(t, err, codes.Unavailable)
+	servertest.RequireGrpcCode(t, err, codes.Unavailable)
 }
 
 func TestUpsertExecutorSettings_ValidationName(t *testing.T) {
@@ -125,7 +118,7 @@ func TestUpsertExecutorSettings_PublishErrorInternal(t *testing.T) {
 
 	_, err := s.UpsertExecutorSettings(grpcCtx, &api.ExecutorSettingsUpsertRequest{Name: "executor-1"})
 	require.Error(t, err)
-	requireGrpcCode(t, err, codes.Internal)
+	servertest.RequireGrpcCode(t, err, codes.Internal)
 }
 
 func TestUpsertExecutorSettings_SuccessPublishesExpectedEvent(t *testing.T) {
@@ -186,7 +179,7 @@ func TestDeleteExecutorSettings_PermissionDenied(t *testing.T) {
 
 	_, err := s.DeleteExecutorSettings(grpcCtx, &api.ExecutorSettingsDeleteRequest{Name: "executor-1"})
 	require.Error(t, err)
-	requireGrpcCode(t, err, codes.PermissionDenied)
+	servertest.RequireGrpcCode(t, err, codes.PermissionDenied)
 }
 
 func TestDeleteExecutorSettings_AuthorizeErrorUnavailable(t *testing.T) {
@@ -201,7 +194,7 @@ func TestDeleteExecutorSettings_AuthorizeErrorUnavailable(t *testing.T) {
 
 	_, err := s.DeleteExecutorSettings(grpcCtx, &api.ExecutorSettingsDeleteRequest{Name: "executor-1"})
 	require.Error(t, err)
-	requireGrpcCode(t, err, codes.Unavailable)
+	servertest.RequireGrpcCode(t, err, codes.Unavailable)
 }
 
 func TestDeleteExecutorSettings_ValidationName(t *testing.T) {
@@ -237,7 +230,7 @@ func TestDeleteExecutorSettings_PublishErrorInternal(t *testing.T) {
 
 	_, err := s.DeleteExecutorSettings(grpcCtx, &api.ExecutorSettingsDeleteRequest{Name: "executor-1"})
 	require.Error(t, err)
-	requireGrpcCode(t, err, codes.Internal)
+	servertest.RequireGrpcCode(t, err, codes.Internal)
 }
 
 func TestDeleteExecutorSettings_SuccessPublishesExpectedEvent(t *testing.T) {
@@ -288,7 +281,7 @@ func TestPreemptOnExecutor_PermissionDenied(t *testing.T) {
 
 	_, err := s.PreemptOnExecutor(grpcCtx, &api.ExecutorPreemptRequest{Name: "executor-1"})
 	require.Error(t, err)
-	requireGrpcCode(t, err, codes.PermissionDenied)
+	servertest.RequireGrpcCode(t, err, codes.PermissionDenied)
 }
 
 func TestPreemptOnExecutor_AuthorizeErrorUnavailable(t *testing.T) {
@@ -303,7 +296,7 @@ func TestPreemptOnExecutor_AuthorizeErrorUnavailable(t *testing.T) {
 
 	_, err := s.PreemptOnExecutor(grpcCtx, &api.ExecutorPreemptRequest{Name: "executor-1"})
 	require.Error(t, err)
-	requireGrpcCode(t, err, codes.Unavailable)
+	servertest.RequireGrpcCode(t, err, codes.Unavailable)
 }
 
 func TestPreemptOnExecutor_ValidationName(t *testing.T) {
@@ -339,7 +332,7 @@ func TestPreemptOnExecutor_PublishErrorInternal(t *testing.T) {
 
 	_, err := s.PreemptOnExecutor(grpcCtx, &api.ExecutorPreemptRequest{Name: "executor-1"})
 	require.Error(t, err)
-	requireGrpcCode(t, err, codes.Internal)
+	servertest.RequireGrpcCode(t, err, codes.Internal)
 }
 
 func TestPreemptOnExecutor_SuccessPublishesExpectedEvent(t *testing.T) {
@@ -392,7 +385,7 @@ func TestCancelOnExecutor_PermissionDenied(t *testing.T) {
 
 	_, err := s.CancelOnExecutor(grpcCtx, &api.ExecutorCancelRequest{Name: "executor-1"})
 	require.Error(t, err)
-	requireGrpcCode(t, err, codes.PermissionDenied)
+	servertest.RequireGrpcCode(t, err, codes.PermissionDenied)
 }
 
 func TestCancelOnExecutor_AuthorizeErrorUnavailable(t *testing.T) {
@@ -407,7 +400,7 @@ func TestCancelOnExecutor_AuthorizeErrorUnavailable(t *testing.T) {
 
 	_, err := s.CancelOnExecutor(grpcCtx, &api.ExecutorCancelRequest{Name: "executor-1"})
 	require.Error(t, err)
-	requireGrpcCode(t, err, codes.Unavailable)
+	servertest.RequireGrpcCode(t, err, codes.Unavailable)
 }
 
 func TestCancelOnExecutor_ValidationName(t *testing.T) {
@@ -443,7 +436,7 @@ func TestCancelOnExecutor_PublishErrorInternal(t *testing.T) {
 
 	_, err := s.CancelOnExecutor(grpcCtx, &api.ExecutorCancelRequest{Name: "executor-1"})
 	require.Error(t, err)
-	requireGrpcCode(t, err, codes.Internal)
+	servertest.RequireGrpcCode(t, err, codes.Internal)
 }
 
 func TestCancelOnExecutor_SuccessPublishesExpectedEvent(t *testing.T) {

--- a/internal/server/node/node_test.go
+++ b/internal/server/node/node_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc/codes"
-	grpcstatus "google.golang.org/grpc/status"
 	clocktesting "k8s.io/utils/clock/testing"
 
 	"github.com/armadaproject/armada/internal/common/armadacontext"
@@ -19,6 +18,7 @@ import (
 	protoutil "github.com/armadaproject/armada/internal/common/proto"
 	servermocks "github.com/armadaproject/armada/internal/server/mocks"
 	"github.com/armadaproject/armada/internal/server/permissions"
+	"github.com/armadaproject/armada/internal/server/servertest"
 	"github.com/armadaproject/armada/pkg/api"
 	"github.com/armadaproject/armada/pkg/controlplaneevents"
 )
@@ -39,13 +39,6 @@ func newTestServer(t *testing.T) (*Server, *testMocks) {
 	return s, m
 }
 
-func requireGrpcCode(t *testing.T, err error, code codes.Code) {
-	t.Helper()
-	st, ok := grpcstatus.FromError(err)
-	require.True(t, ok, "expected gRPC status error")
-	assert.Equal(t, code, st.Code())
-}
-
 func TestPreemptOnNode_PermissionDenied(t *testing.T) {
 	s, m := newTestServer(t)
 	ctx := armadacontext.Background()
@@ -58,7 +51,7 @@ func TestPreemptOnNode_PermissionDenied(t *testing.T) {
 
 	_, err := s.PreemptOnNode(ctx, &api.NodePreemptRequest{Name: "executor-1", Executor: "executor-id"})
 	require.Error(t, err)
-	requireGrpcCode(t, err, codes.PermissionDenied)
+	servertest.RequireGrpcCode(t, err, codes.PermissionDenied)
 }
 
 func TestPreemptOnNode_AuthorizeErrorUnavailable(t *testing.T) {
@@ -73,7 +66,7 @@ func TestPreemptOnNode_AuthorizeErrorUnavailable(t *testing.T) {
 
 	_, err := s.PreemptOnNode(ctx, &api.NodePreemptRequest{Name: "executor-1", Executor: "executor-id"})
 	require.Error(t, err)
-	requireGrpcCode(t, err, codes.Internal)
+	servertest.RequireGrpcCode(t, err, codes.Internal)
 }
 
 func TestPreemptOnNode_Validation(t *testing.T) {
@@ -109,7 +102,7 @@ func TestPreemptOnNode_PublishErrorInternal(t *testing.T) {
 
 	_, err := s.PreemptOnNode(ctx, &api.NodePreemptRequest{Name: "executor-1", Executor: "executor-id"})
 	require.Error(t, err)
-	requireGrpcCode(t, err, codes.Internal)
+	servertest.RequireGrpcCode(t, err, codes.Internal)
 }
 
 func TestPreemptOnNode_SuccessPublishesExpectedEvent(t *testing.T) {
@@ -168,7 +161,7 @@ func TestCancelOnNode_PermissionDenied(t *testing.T) {
 
 	_, err := s.CancelOnNode(ctx, &api.NodeCancelRequest{Name: "executor-1", Executor: "executor-id"})
 	require.Error(t, err)
-	requireGrpcCode(t, err, codes.PermissionDenied)
+	servertest.RequireGrpcCode(t, err, codes.PermissionDenied)
 }
 
 func TestCancelOnNode_AuthorizeErrorUnavailable(t *testing.T) {
@@ -183,7 +176,7 @@ func TestCancelOnNode_AuthorizeErrorUnavailable(t *testing.T) {
 
 	_, err := s.CancelOnNode(ctx, &api.NodeCancelRequest{Name: "executor-1", Executor: "executor-id"})
 	require.Error(t, err)
-	requireGrpcCode(t, err, codes.Internal)
+	servertest.RequireGrpcCode(t, err, codes.Internal)
 }
 
 func TestCancelOnNode_Validation(t *testing.T) {
@@ -219,7 +212,7 @@ func TestCancelOnNode_PublishErrorInternal(t *testing.T) {
 
 	_, err := s.CancelOnNode(ctx, &api.NodeCancelRequest{Name: "executor-1", Executor: "executor-id"})
 	require.Error(t, err)
-	requireGrpcCode(t, err, codes.Internal)
+	servertest.RequireGrpcCode(t, err, codes.Internal)
 }
 
 func TestCancelOnNode_SuccessPublishesExpectedEvent(t *testing.T) {

--- a/internal/server/queue/queue_service_test.go
+++ b/internal/server/queue/queue_service_test.go
@@ -12,7 +12,6 @@ import (
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
-	grpcstatus "google.golang.org/grpc/status"
 	clocktesting "k8s.io/utils/clock/testing"
 
 	"github.com/armadaproject/armada/internal/common/armadacontext"
@@ -23,6 +22,7 @@ import (
 	protoutil "github.com/armadaproject/armada/internal/common/proto"
 	servermocks "github.com/armadaproject/armada/internal/server/mocks"
 	"github.com/armadaproject/armada/internal/server/permissions"
+	"github.com/armadaproject/armada/internal/server/servertest"
 	"github.com/armadaproject/armada/pkg/api"
 	"github.com/armadaproject/armada/pkg/client/queue"
 	"github.com/armadaproject/armada/pkg/controlplaneevents"
@@ -46,13 +46,6 @@ func newTestQueueServer(t *testing.T) (*Server, *queueServiceTestMocks) {
 	return s, m
 }
 
-func requireGrpcCode(t *testing.T, err error, code codes.Code) {
-	t.Helper()
-	st, ok := grpcstatus.FromError(err)
-	require.True(t, ok, "expected gRPC status error")
-	assert.Equal(t, code, st.Code())
-}
-
 func TestCreateQueue_PermissionDenied(t *testing.T) {
 	s, m := newTestQueueServer(t)
 	ctx := armadacontext.Background()
@@ -65,7 +58,7 @@ func TestCreateQueue_PermissionDenied(t *testing.T) {
 
 	_, err := s.CreateQueue(ctx, &api.Queue{Name: "q1"})
 	require.Error(t, err)
-	requireGrpcCode(t, err, codes.PermissionDenied)
+	servertest.RequireGrpcCode(t, err, codes.PermissionDenied)
 }
 
 func TestCreateQueue_AuthorizeErrorUnavailable(t *testing.T) {
@@ -80,7 +73,7 @@ func TestCreateQueue_AuthorizeErrorUnavailable(t *testing.T) {
 
 	_, err := s.CreateQueue(ctx, &api.Queue{Name: "q1"})
 	require.Error(t, err)
-	requireGrpcCode(t, err, codes.Unavailable)
+	servertest.RequireGrpcCode(t, err, codes.Unavailable)
 }
 
 func TestCreateQueue_DefaultsUserOwnerFromPrincipal(t *testing.T) {
@@ -132,7 +125,7 @@ func TestCreateQueue_ValidationInvalidArgument(t *testing.T) {
 
 	_, err := s.CreateQueue(ctx, &api.Queue{Name: "q1", PriorityFactor: 1, Labels: map[string]string{"k": ""}})
 	require.Error(t, err)
-	requireGrpcCode(t, err, codes.InvalidArgument)
+	servertest.RequireGrpcCode(t, err, codes.InvalidArgument)
 }
 
 func TestCreateQueue_AlreadyExists(t *testing.T) {
@@ -153,7 +146,7 @@ func TestCreateQueue_AlreadyExists(t *testing.T) {
 
 	_, err := s.CreateQueue(ctx, &api.Queue{Name: "q1", PriorityFactor: 1})
 	require.Error(t, err)
-	requireGrpcCode(t, err, codes.AlreadyExists)
+	servertest.RequireGrpcCode(t, err, codes.AlreadyExists)
 }
 
 func TestUpdateQueue_NotFound(t *testing.T) {
@@ -174,7 +167,7 @@ func TestUpdateQueue_NotFound(t *testing.T) {
 
 	_, err := s.UpdateQueue(ctx, &api.Queue{Name: "q1", PriorityFactor: 1})
 	require.Error(t, err)
-	requireGrpcCode(t, err, codes.NotFound)
+	servertest.RequireGrpcCode(t, err, codes.NotFound)
 }
 
 func TestDeleteQueue_RepoErrorInvalidArgument(t *testing.T) {
@@ -195,7 +188,7 @@ func TestDeleteQueue_RepoErrorInvalidArgument(t *testing.T) {
 
 	_, err := s.DeleteQueue(ctx, &api.QueueDeleteRequest{Name: "q1"})
 	require.Error(t, err)
-	requireGrpcCode(t, err, codes.InvalidArgument)
+	servertest.RequireGrpcCode(t, err, codes.InvalidArgument)
 }
 
 func TestGetQueue_NotFound(t *testing.T) {
@@ -210,7 +203,7 @@ func TestGetQueue_NotFound(t *testing.T) {
 
 	_, err := s.GetQueue(ctx, &api.QueueGetRequest{Name: "q1"})
 	require.Error(t, err)
-	requireGrpcCode(t, err, codes.NotFound)
+	servertest.RequireGrpcCode(t, err, codes.NotFound)
 }
 
 type fakeQueueStream struct {
@@ -289,7 +282,7 @@ func TestCancelOnQueue_PublishErrorInternal(t *testing.T) {
 
 	_, err := s.CancelOnQueue(ctx, &api.QueueCancelRequest{Name: "q1", JobStates: []api.JobState{api.JobState_RUNNING}})
 	require.Error(t, err)
-	requireGrpcCode(t, err, codes.Internal)
+	servertest.RequireGrpcCode(t, err, codes.Internal)
 }
 
 func TestCancelOnQueue_SuccessPublishesExpectedEvent(t *testing.T) {
@@ -479,7 +472,7 @@ func TestQueueRetryPolicies_UnknownPolicyRejected(t *testing.T) {
 
 			err := tc.call(s, ctx)
 			require.Error(t, err)
-			requireGrpcCode(t, err, codes.InvalidArgument)
+			servertest.RequireGrpcCode(t, err, codes.InvalidArgument)
 			assert.Contains(t, err.Error(), "ghost")
 		})
 	}

--- a/internal/server/retrypolicy/service_test.go
+++ b/internal/server/retrypolicy/service_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc/codes"
-	grpcstatus "google.golang.org/grpc/status"
 
 	"github.com/armadaproject/armada/internal/common/armadacontext"
 	"github.com/armadaproject/armada/internal/common/armadaerrors"
@@ -20,15 +19,9 @@ import (
 	"github.com/armadaproject/armada/internal/common/logging"
 	servermocks "github.com/armadaproject/armada/internal/server/mocks"
 	"github.com/armadaproject/armada/internal/server/permissions"
+	"github.com/armadaproject/armada/internal/server/servertest"
 	"github.com/armadaproject/armada/pkg/api"
 )
-
-func requireGrpcCode(t *testing.T, err error, code codes.Code) {
-	t.Helper()
-	st, ok := grpcstatus.FromError(err)
-	require.True(t, ok, "expected gRPC status error")
-	assert.Equal(t, code, st.Code())
-}
 
 type testMocks struct {
 	authorizer *servermocks.MockActionAuthorizer
@@ -119,7 +112,7 @@ func TestRetryPolicyService_AuthorizationFailures(t *testing.T) {
 				ctx := armadacontext.Background()
 				m.expectAuthorizeAction(ctx, rpc.permission, outcome.authErr)
 
-				requireGrpcCode(t, rpc.call(s, ctx), outcome.wantCode)
+				servertest.RequireGrpcCode(t, rpc.call(s, ctx), outcome.wantCode)
 			})
 		}
 	}
@@ -209,7 +202,7 @@ func TestRetryPolicyService_RepositoryErrorMapping(t *testing.T) {
 			}
 			tc.setupRepo(m)
 
-			requireGrpcCode(t, tc.call(s, ctx), tc.wantCode)
+			servertest.RequireGrpcCode(t, tc.call(s, ctx), tc.wantCode)
 		})
 	}
 }
@@ -257,7 +250,7 @@ func TestRetryPolicyService_RejectsBadRequests(t *testing.T) {
 				m.expectAuthorizeAction(ctx, tc.permission, nil)
 			}
 
-			requireGrpcCode(t, tc.call(s, ctx), codes.InvalidArgument)
+			servertest.RequireGrpcCode(t, tc.call(s, ctx), codes.InvalidArgument)
 		})
 	}
 }

--- a/internal/server/servertest/grpc.go
+++ b/internal/server/servertest/grpc.go
@@ -1,0 +1,17 @@
+package servertest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// RequireGrpcCode asserts that err is a gRPC status error with the given code.
+func RequireGrpcCode(t *testing.T, err error, code codes.Code) {
+	t.Helper()
+	st, ok := status.FromError(err)
+	require.True(t, ok, "expected gRPC status error")
+	require.Equal(t, code, st.Code())
+}


### PR DESCRIPTION
The executor, node, queue, and retry policy server tests each defined their own private `requireGrpcCode` helper for asserting that an error is a gRPC status with a given code. This moves the helper into the shared `servertest` package as `RequireGrpcCode` and switches all four to it.

The private copies used `assert.Equal` for the code comparison and the shared helper uses `require.Equal`, so a mismatched code now stops the test instead of letting it carry on.

The retry policy copy came in with #5049, which noted it could switch to the shared helper once both were in. That is done here, so no private copies remain.