### PR TITLE
feat(airflow): raise structured exception when job fails without retry

### DIFF
--- a/third_party/airflow/armada/_compat.py
+++ b/third_party/airflow/armada/_compat.py
@@ -29,6 +29,13 @@ try:
 except ImportError:
     from airflow.operators.python import get_current_context  # Airflow 2.x
 
+# AirflowFailException's canonical home moved to airflow.sdk.exceptions in
+# Airflow 3.0 (airflow.exceptions re-exports the same class on 3.x).
+try:
+    from airflow.sdk.exceptions import AirflowFailException  # Airflow >= 3.0
+except ImportError:
+    from airflow.exceptions import AirflowFailException  # Airflow 2.x
+
 # Context moved to airflow.sdk.definitions.context in Airflow 3.0. The shim at
 # airflow.utils.context.Context still resolves on 3.x, but it is exposed via a
 # module-level __getattr__ that returns the *module*, not the class - which
@@ -57,6 +64,7 @@ __all__ = [
     "deserialize",
     "_extra_allowed",
     "get_current_context",
+    "AirflowFailException",
     "Context",
     "AIRFLOW_V_3_0_PLUS",
 ]

--- a/third_party/airflow/armada/operators/armada.py
+++ b/third_party/airflow/armada/operators/armada.py
@@ -522,11 +522,11 @@ class ArmadaOperator(BaseOperator, LoggingMixin):
         policy_func = self._reattach_policy(context)
         # A retry would reattach to this already-terminated job, so retrying
         # is pointless; REJECTED jobs are never worth retrying either.
-        retry_is_futile = (
+        fail_without_retry = (
             policy_func(job_context.state, termination_reason)
             or job_context.state == JobState.REJECTED
         )
-        if retry_is_futile:
+        if fail_without_retry:
             raise ArmadaOperatorJobFailedFatalError(
                 job_context.armada_queue,
                 job_context.job_id,

--- a/third_party/airflow/armada/operators/armada.py
+++ b/third_party/airflow/armada/operators/armada.py
@@ -29,12 +29,6 @@ import tenacity
 import re
 
 from airflow.configuration import conf
-
-try:
-    from airflow.sdk.exceptions import AirflowFailException
-except ImportError:
-    from airflow.exceptions import AirflowFailException
-
 from airflow.models import BaseOperator
 from airflow.models.taskinstance import TaskInstance, TaskInstanceKey
 from airflow.utils.log.logging_mixin import LoggingMixin
@@ -46,7 +40,7 @@ from armada_client.typings import JobState
 from google.protobuf.json_format import MessageToDict, ParseDict
 from pendulum import DateTime
 
-from .errors import ArmadaOperatorJobFailedError
+from .errors import ArmadaOperatorJobFailedError, ArmadaOperatorJobFailedFatalError
 from .._compat import Context, deserialize, get_current_context
 from ..hooks import ArmadaHook
 from ..model import RunningJobContext
@@ -521,25 +515,30 @@ class ArmadaOperator(BaseOperator, LoggingMixin):
         self.log.info(
             f"job {job_context.job_id} terminated with state: {job_context.state.name}"
         )
-        if job_context.state != JobState.SUCCEEDED:
-            error = ArmadaOperatorJobFailedError(
+        if job_context.state == JobState.SUCCEEDED:
+            return
+
+        termination_reason = self.hook.job_termination_reason(job_context)
+        policy_func = self._reattach_policy(context)
+        # A retry would reattach to this already-terminated job, so retrying
+        # is pointless; REJECTED jobs are never worth retrying either.
+        retry_is_futile = (
+            policy_func(job_context.state, termination_reason)
+            or job_context.state == JobState.REJECTED
+        )
+        if retry_is_futile:
+            raise ArmadaOperatorJobFailedFatalError(
                 job_context.armada_queue,
                 job_context.job_id,
                 job_context.state,
-                self.hook.job_termination_reason(job_context),
+                termination_reason,
             )
-            policy_func = self._reattach_policy(context)
-            if policy_func(error.state, error.reason):
-                self.log.error(str(error))
-                raise AirflowFailException()
-            elif job_context.state == JobState.REJECTED:
-                self.log.error(
-                    f"Armada job ({job_context.job_id}) was REJECTED: "
-                    f"{str(error)} will not retry"
-                )
-                raise AirflowFailException()
-            else:
-                raise error
+        raise ArmadaOperatorJobFailedError(
+            job_context.armada_queue,
+            job_context.job_id,
+            job_context.state,
+            termination_reason,
+        )
 
     def _not_acknowledged_within_timeout(self, job_context: RunningJobContext) -> bool:
         if job_context.state == JobState.UNKNOWN:

--- a/third_party/airflow/armada/operators/errors.py
+++ b/third_party/airflow/armada/operators/errors.py
@@ -1,11 +1,8 @@
 from airflow.exceptions import AirflowException
 
-try:
-    from airflow.sdk.exceptions import AirflowFailException
-except ImportError:
-    from airflow.exceptions import AirflowFailException
-
 from armada_client.typings import JobState
+
+from .._compat import AirflowFailException
 
 
 class ArmadaOperatorJobFailedError(AirflowException):

--- a/third_party/airflow/armada/operators/errors.py
+++ b/third_party/airflow/armada/operators/errors.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict, Tuple, Union
+
 from airflow.exceptions import AirflowException
 
 from armada_client.typings import JobState
@@ -13,19 +15,42 @@ class ArmadaOperatorJobFailedError(AirflowException):
     :type job_id: str
     :param queue: The queue the job was submitted to.
     :type queue: str
-    :param state: The termination state of the job.
-    :type state: TerminationState
+    :param state: The termination state of the job. Accepts the state name as
+        a string so Airflow can reconstruct the exception from serialize().
+    :type state: Union[JobState, str]
     :param reason: The termination reason, if provided.
     :type reason: str
     """
 
-    def __init__(self, queue: str, job_id: str, state: JobState, reason: str = ""):
+    def __init__(
+        self,
+        queue: str,
+        job_id: str,
+        state: Union[JobState, str],
+        reason: str = "",
+    ):
         self.job_id = job_id
         self.queue = queue
-        self.state = state
+        self.state = JobState[state] if isinstance(state, str) else state
         self.reason = reason
         self.message = self._generate_message()
         super().__init__(self.message)
+
+    def serialize(self) -> Tuple[str, Tuple[str, str, str, str], Dict[str, Any]]:
+        """
+        Serialize into (classpath, args, kwargs) as expected by Airflow's
+        exception serialization, which reconstructs with cls(*args, **kwargs).
+        The state is passed by name since JobState is not serializable.
+
+        :return: Tuple of class path, constructor args and kwargs.
+        :rtype: Tuple[str, Tuple[str, str, str, str], Dict[str, Any]]
+        """
+        cls = self.__class__
+        return (
+            f"{cls.__module__}.{cls.__name__}",
+            (self.queue, self.job_id, self.state.name, self.reason),
+            {},
+        )
 
     def _generate_message(self) -> str:
         """

--- a/third_party/airflow/armada/operators/errors.py
+++ b/third_party/airflow/armada/operators/errors.py
@@ -1,5 +1,10 @@
 from airflow.exceptions import AirflowException
 
+try:
+    from airflow.sdk.exceptions import AirflowFailException
+except ImportError:
+    from airflow.exceptions import AirflowFailException
+
 from armada_client.typings import JobState
 
 
@@ -48,3 +53,16 @@ class ArmadaOperatorJobFailedError(AirflowException):
         :rtype: str
         """
         return self.message
+
+
+class ArmadaOperatorJobFailedFatalError(
+    ArmadaOperatorJobFailedError, AirflowFailException
+):
+    """
+    Raised when an ArmadaOperator job has terminated unsuccessfully on Armada
+    and the task must not be retried.
+
+    Subclasses AirflowFailException so Airflow fails the task without
+    scheduling further retries, while carrying the same structured job
+    context (queue, job_id, state, reason) as ArmadaOperatorJobFailedError.
+    """

--- a/third_party/airflow/pyproject.toml
+++ b/third_party/airflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "armada_airflow"
-version = "1.2.0"
+version = "1.1.2"
 description = "Armada Airflow Operator"
 readme='README.md'
 authors = [{name = "Armada-GROSS", email = "armada@armadaproject.io"}]

--- a/third_party/airflow/pyproject.toml
+++ b/third_party/airflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "armada_airflow"
-version = "1.1.1"
+version = "1.2.0"
 description = "Armada Airflow Operator"
 readme='README.md'
 authors = [{name = "Armada-GROSS", email = "armada@armadaproject.io"}]

--- a/third_party/airflow/test/unit/operators/test_armada.py
+++ b/third_party/airflow/test/unit/operators/test_armada.py
@@ -7,7 +7,10 @@ import pytest
 from airflow.exceptions import TaskDeferred
 from armada.model import GrpcChannelArgs, RunningJobContext
 from armada.operators.armada import ArmadaOperator
-from armada.operators.errors import ArmadaOperatorJobFailedError
+from armada.operators.errors import (
+    ArmadaOperatorJobFailedError,
+    ArmadaOperatorJobFailedFatalError,
+)
 from armada.triggers import ArmadaPollJobTrigger
 from armada_client.armada.submit_pb2 import JobSubmitRequestItem
 from armada_client.typings import JobState
@@ -191,6 +194,38 @@ def test_execute_fail(terminal_state, context):
 
     # We're not polling for logs
     op.pod_manager.fetch_container_logs.assert_not_called()
+
+
+def test_execute_fail_rejected_does_not_retry(context):
+    op = operator(JobSubmitRequestItem())
+
+    op.hook.refresh_context.side_effect = [
+        running_job_context(cluster="cluster-1", job_state=s.name)
+        for s in [JobState.RUNNING, JobState.REJECTED]
+    ]
+
+    with pytest.raises(ArmadaOperatorJobFailedFatalError) as exec_info:
+        op.execute(context)
+
+    # Error message contains terminal state and job id
+    assert DEFAULT_JOB_ID in str(exec_info.value)
+    assert JobState.REJECTED.name.capitalize() in str(exec_info.value)
+
+
+def test_execute_fail_when_reattach_policy_matches_terminal_job(context):
+    op = operator(JobSubmitRequestItem(), reattach_policy=lambda state, reason: True)
+
+    op.hook.refresh_context.side_effect = [
+        running_job_context(cluster="cluster-1", job_state=s.name)
+        for s in [JobState.RUNNING, JobState.FAILED]
+    ]
+
+    # A retry would reattach to the same failed job, so we fail without retry.
+    with pytest.raises(ArmadaOperatorJobFailedFatalError) as exec_info:
+        op.execute(context)
+
+    assert DEFAULT_JOB_ID in str(exec_info.value)
+    assert JobState.FAILED.name.capitalize() in str(exec_info.value)
 
 
 @patch("armada.operators.armada.get_current_context")

--- a/third_party/airflow/test/unit/operators/test_errors.py
+++ b/third_party/airflow/test/unit/operators/test_errors.py
@@ -1,14 +1,10 @@
 import pytest
 from armada_client.typings import JobState
+from armada._compat import AirflowFailException
 from armada.operators.errors import (
     ArmadaOperatorJobFailedError,
     ArmadaOperatorJobFailedFatalError,
 )
-
-try:
-    from airflow.sdk.exceptions import AirflowFailException
-except ImportError:
-    from airflow.exceptions import AirflowFailException
 
 
 def test_constructor():

--- a/third_party/airflow/test/unit/operators/test_errors.py
+++ b/third_party/airflow/test/unit/operators/test_errors.py
@@ -1,6 +1,14 @@
 import pytest
 from armada_client.typings import JobState
-from armada.operators.errors import ArmadaOperatorJobFailedError
+from armada.operators.errors import (
+    ArmadaOperatorJobFailedError,
+    ArmadaOperatorJobFailedFatalError,
+)
+
+try:
+    from airflow.sdk.exceptions import AirflowFailException
+except ImportError:
+    from airflow.exceptions import AirflowFailException
 
 
 def test_constructor():
@@ -37,3 +45,20 @@ def test_message(reason: str, expected_message: str):
         "default-queue", "test-job", JobState.FAILED, reason
     )
     assert str(error) == expected_message
+
+
+def test_fatal_error_fails_airflow_task_without_retry():
+    error = ArmadaOperatorJobFailedFatalError(
+        "default-queue", "test-job", JobState.REJECTED, "Invalid pod spec"
+    )
+
+    assert isinstance(error, AirflowFailException)
+    assert isinstance(error, ArmadaOperatorJobFailedError)
+    assert error.queue == "default-queue"
+    assert error.job_id == "test-job"
+    assert error.state == JobState.REJECTED
+    assert error.reason == "Invalid pod spec"
+    assert str(error) == (
+        "ArmadaOperator job 'test-job' in queue 'default-queue' terminated "
+        "with state 'Rejected'. Termination reason: Invalid pod spec"
+    )

--- a/third_party/airflow/test/unit/operators/test_errors.py
+++ b/third_party/airflow/test/unit/operators/test_errors.py
@@ -1,4 +1,5 @@
 import pytest
+from airflow.serialization.serialized_objects import BaseSerialization
 from armada_client.typings import JobState
 from armada._compat import AirflowFailException
 from armada.operators.errors import (
@@ -58,3 +59,20 @@ def test_fatal_error_fails_airflow_task_without_retry():
         "ArmadaOperator job 'test-job' in queue 'default-queue' terminated "
         "with state 'Rejected'. Termination reason: Invalid pod spec"
     )
+
+
+@pytest.mark.parametrize(
+    "error_cls",
+    [ArmadaOperatorJobFailedError, ArmadaOperatorJobFailedFatalError],
+)
+def test_error_round_trips_through_airflow_serialization(error_cls):
+    error = error_cls("default-queue", "test-job", JobState.FAILED, "Out of memory")
+
+    restored = BaseSerialization.deserialize(BaseSerialization.serialize(error))
+
+    assert type(restored) is error_cls
+    assert restored.queue == error.queue
+    assert restored.job_id == error.job_id
+    assert restored.state == error.state
+    assert restored.reason == error.reason
+    assert str(restored) == str(error)


### PR DESCRIPTION
## What

`ArmadaOperator._running_job_terminated` raised a bare `AirflowFailException()` when a failed job should not be retried (reattach policy matches the terminal state, or the job was `REJECTED`). The Airflow UI then showed an empty exception, and the actual failure context (queue, job id, state, termination reason) was only visible in a log line above.

This PR introduces `ArmadaOperatorJobFailedFatalError`, which subclasses both `ArmadaOperatorJobFailedError` and `AirflowFailException`, so the no-retry semantics are preserved while the exception itself carries the structured job context and a descriptive message.

## Changes

- `armada/operators/errors.py`:
  - New `ArmadaOperatorJobFailedFatalError(ArmadaOperatorJobFailedError, AirflowFailException)`.
  - `ArmadaOperatorJobFailedError.serialize()` now emits the real constructor args (state passed by name), and `__init__` accepts the state name as a string. Previously the inherited `AirflowException.serialize()` assumed single-message reconstruction, so rehydrating the exception across process boundaries (e.g. triggerer error propagation) raised `TypeError`.
- `armada/operators/armada.py`: `_running_job_terminated` now raises the fatal error (with queue/job id/state/reason) instead of `log.error` + bare `AirflowFailException()`; the retryable path still raises `ArmadaOperatorJobFailedError`.
- `armada/_compat.py`: `AirflowFailException` compat import (airflow.sdk.exceptions on 3.x, airflow.exceptions on 2.x) centralized here, replacing the inline try/except in `armada.py`.
- `pyproject.toml`: `armada_airflow` 1.1.1 → 1.2.0.
- Tests: fatal path (REJECTED, and reattach-policy-matches-terminal-job), exception hierarchy/message, and `BaseSerialization` round-trip for both exception classes.

## Notes

- Behavior is otherwise unchanged: same branch conditions, `job_termination_reason` still called once. The two `log.error` calls were dropped as the raised exception now carries the same message.
- MRO verified against installed Airflow 3.2.2 (where `airflow.exceptions.AirflowFailException` is a re-export of `airflow.sdk.exceptions.AirflowFailException`) and the 2.x fallback; Airflow's fail-fast `isinstance` handling matches the new class.

## Testing

- `uvx tox -e py312` — 63 passed, 4 skipped.
- `uvx tox -e format-check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)