### PR TITLE
Fix job eviction ordering bug

### DIFF
--- a/internal/scheduler/scheduling/preempting_queue_scheduler.go
+++ b/internal/scheduler/scheduling/preempting_queue_scheduler.go
@@ -596,12 +596,12 @@ func (sch *PreemptingQueueScheduler) addEvictedJobsToNodeDb(_ *armadacontext.Con
 	var candidateGangIterator CandidateGangIterator
 	var err error
 	if sch.marketDriven {
-		candidateGangIterator, err = NewMarketCandidateGangIterator(sctx.Pool, sctx, gangItByQueue)
+		candidateGangIterator, err = NewMarketCandidateGangIterator(sctx.Pool, qr, gangItByQueue)
 		if err != nil {
 			return err
 		}
 	} else {
-		candidateGangIterator, err = NewCostBasedCandidateGangIterator(sctx.Pool, sctx, sctx.FairnessCostProvider, gangItByQueue, false, sch.preferLargeJobOrdering)
+		candidateGangIterator, err = NewCostBasedCandidateGangIterator(sctx.Pool, qr, sctx.FairnessCostProvider, gangItByQueue, false, sch.preferLargeJobOrdering)
 		if err != nil {
 			return err
 		}
@@ -622,7 +622,8 @@ func (sch *PreemptingQueueScheduler) addEvictedJobsToNodeDb(_ *armadacontext.Con
 				i++
 			}
 			q := qr.queues[gctx.Queue]
-			q.allocation.Add(gctx.TotalResourceRequests)
+			q.allocation = q.allocation.Add(gctx.TotalResourceRequests)
+			qr.queues[gctx.Queue] = q
 		}
 		if err := candidateGangIterator.Clear(); err != nil {
 			return err

--- a/internal/scheduler/scheduling/preempting_queue_scheduler_test.go
+++ b/internal/scheduler/scheduling/preempting_queue_scheduler_test.go
@@ -165,54 +165,6 @@ func TestEvictOversubscribed(t *testing.T) {
 	}
 }
 
-func TestEvict(t *testing.T) {
-	config := testfixtures.TestSchedulingConfig()
-
-	priorities := types.AllowedPriorities(config.PriorityClasses)
-
-	queueAJobs := testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass6Preemptible, 3)
-	queueBJobs := testfixtures.N1Cpu4GiJobs("B", testfixtures.PriorityClass6Preemptible, 3)
-	queueCJobs := testfixtures.N1Cpu4GiJobs("C", testfixtures.PriorityClass6Preemptible, 3)
-
-	jobs := make([]*jobdb.Job, 0, 10)
-	jobs = append(jobs, queueAJobs...)
-	jobs = append(jobs, queueBJobs...)
-	jobs = append(jobs, queueCJobs...)
-
-	stringInterner := stringinterner.New(1024)
-
-	nodeDb, err := NewNodeDb(config, stringInterner)
-	require.NoError(t, err)
-	nodeDbTxn := nodeDb.Txn(true)
-	err = nodeDb.CreateAndInsertWithJobDbJobsWithTxn(
-		nodeDbTxn,
-		jobs,
-		testfixtures.Test32CpuNode(priorities),
-	)
-	require.NoError(t, err)
-
-	jobDb := jobdb.NewJobDb(config.PriorityClasses, config.DefaultPriorityClassName, stringInterner, testfixtures.TestResourceListFactory)
-	jobDbTxn := jobDb.WriteTxn()
-	err = jobDbTxn.Upsert(jobs)
-	require.NoError(t, err)
-
-	evictor := NewNodeEvictor(
-		jobDb.ReadTxn(),
-		nodeDb,
-		func(ctx *armadacontext.Context, job *jobdb.Job) (bool, string) { return true, "" },
-	)
-	result, err := evictor.Evict(armadacontext.Background(), nodeDbTxn)
-	require.NoError(t, err)
-
-	for nodeId, node := range result.AffectedNodesById {
-		for _, p := range priorities {
-			for _, r := range node.AllocatableByPriority[p].GetAll() {
-				assert.False(t, r.IsNegative(), "resource oversubscribed by %s on node %s", r.String(), nodeId)
-			}
-		}
-	}
-}
-
 func TestPreemptingQueueScheduler(t *testing.T) {
 	type SchedulingRound struct {
 		// Map from queue name to pod requirements for that queue.

--- a/internal/scheduler/scheduling/preempting_queue_scheduler_test.go
+++ b/internal/scheduler/scheduling/preempting_queue_scheduler_test.go
@@ -44,6 +44,84 @@ func (t testQueueContextChecker) QueueContextExists(job *jobdb.Job) bool {
 	return t.jobIds[job.Id()]
 }
 
+func TestEvict_JobsEvictedInFairshareOrder(t *testing.T) {
+	config := testfixtures.TestSchedulingConfig()
+	stringInterner := stringinterner.New(1024)
+
+	node := testfixtures.Test32CpuNode(testfixtures.TestPriorities)
+	queueNames := []string{"A", "B", "C"}
+	const jobsPerQueue = 3
+
+	totalResources := node.GetAllocatableResources()
+	fairnessCostProvider, err := fairness.NewDominantResourceFairness(totalResources, testfixtures.TestPool, config)
+	require.NoError(t, err)
+	sctx := schedulingcontext.NewSchedulingContext(
+		testfixtures.TestPool, fairnessCostProvider, rate.NewLimiter(rate.Inf, 1000), totalResources,
+	)
+
+	var allJobs []*jobdb.Job
+	queues := make([]*api.Queue, 0, len(queueNames))
+	for _, queue := range queueNames {
+		demand := internaltypes.ResourceList{}
+		for _, job := range testfixtures.N1Cpu4GiJobs(queue, config.DefaultPriorityClassName, jobsPerQueue) {
+			running := job.WithQueued(false).WithNewRun(
+				node.GetExecutor(), node.GetId(), node.GetName(), node.GetPool(), job.PriorityClass().Priority,
+			)
+			allJobs = append(allJobs, running)
+			demand = demand.Add(running.AllResourceRequirements())
+		}
+		require.NoError(t, sctx.AddQueueSchedulingContext(
+			queue, 1.0, 1.0, map[string]internaltypes.ResourceList{config.DefaultPriorityClassName: demand},
+			demand, demand, internaltypes.ResourceList{},
+			rate.NewLimiter(rate.Inf, 1000),
+		))
+		queues = append(queues, &api.Queue{Name: queue, PriorityFactor: 1.0})
+	}
+	sctx.UpdateFairShares()
+
+	nodeDb, err := NewNodeDb(config, stringInterner)
+	require.NoError(t, err)
+	nodeDbTxn := nodeDb.Txn(true)
+	require.NoError(t, nodeDb.CreateAndInsertWithJobDbJobsWithTxn(nodeDbTxn, allJobs, node.DeepCopyNilKeys()))
+	nodeDbTxn.Commit()
+
+	jobDb := jobdb.NewJobDb(config.PriorityClasses, config.DefaultPriorityClassName, stringInterner, testfixtures.TestResourceListFactory)
+	jobDbTxn := jobDb.WriteTxn()
+	require.NoError(t, jobDbTxn.Upsert(allJobs))
+
+	constraints := schedulerconstraints.NewSchedulingConstraints(testfixtures.TestPool, totalResources, config, queues)
+	sch := NewPreemptingQueueScheduler(
+		sctx, constraints, testfixtures.TestEmptyFloatingResources, config,
+		jobDbTxn, nodeDb, false, clock.RealClock{},
+	)
+
+	// A NodeEvictor whose job filter evicts every job.
+	evictor := NewNodeEvictor(jobDbTxn, nodeDb, func(_ *armadacontext.Context, _ *jobdb.Job) (bool, string) {
+		return true, ""
+	})
+	result, _, err := sch.evict(armadacontext.Background(), evictor)
+	require.NoError(t, err)
+	require.Len(t, result.EvictedJctxsByJobId, len(queueNames)*jobsPerQueue, "every job should have been evicted")
+	// The interleaving loop mutates a throwaway queue-repository copy, not the scheduling context;
+	// after evicting all jobs the scheduling context's allocation should be back to zero.
+	assert.True(t, sctx.Allocated.AllZero(), "scheduling context allocation should not be corrupted by eviction ordering")
+
+	// Read the evicted jobs back in the order they were added to the NodeDb (by index).
+	readTxn := nodeDb.Txn(false)
+	defer readTxn.Abort()
+	it, err := readTxn.Get("evictedJobs", "index")
+	require.NoError(t, err)
+	var actualQueueOrder []string
+	for obj := it.Next(); obj != nil; obj = it.Next() {
+		evicted := obj.(*nodedb.EvictedJobSchedulingContext)
+		actualQueueOrder = append(actualQueueOrder, evicted.JobSchedulingContext.Job.Queue())
+	}
+
+	// Relies on tie-break of queue name as all other job features should be the same
+	expectedQueueOrder := []string{"A", "B", "C", "A", "B", "C", "A", "B", "C"}
+	assert.Equal(t, expectedQueueOrder, actualQueueOrder)
+}
+
 func TestEvictOversubscribed(t *testing.T) {
 	config := testfixtures.TestSchedulingConfig()
 
@@ -75,6 +153,54 @@ func TestEvictOversubscribed(t *testing.T) {
 		testQueueContextChecker{},
 		jobDbTxn,
 		nodeDb)
+	result, err := evictor.Evict(armadacontext.Background(), nodeDbTxn)
+	require.NoError(t, err)
+
+	for nodeId, node := range result.AffectedNodesById {
+		for _, p := range priorities {
+			for _, r := range node.AllocatableByPriority[p].GetAll() {
+				assert.False(t, r.IsNegative(), "resource oversubscribed by %s on node %s", r.String(), nodeId)
+			}
+		}
+	}
+}
+
+func TestEvict(t *testing.T) {
+	config := testfixtures.TestSchedulingConfig()
+
+	priorities := types.AllowedPriorities(config.PriorityClasses)
+
+	queueAJobs := testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass6Preemptible, 3)
+	queueBJobs := testfixtures.N1Cpu4GiJobs("B", testfixtures.PriorityClass6Preemptible, 3)
+	queueCJobs := testfixtures.N1Cpu4GiJobs("C", testfixtures.PriorityClass6Preemptible, 3)
+
+	jobs := make([]*jobdb.Job, 0, 10)
+	jobs = append(jobs, queueAJobs...)
+	jobs = append(jobs, queueBJobs...)
+	jobs = append(jobs, queueCJobs...)
+
+	stringInterner := stringinterner.New(1024)
+
+	nodeDb, err := NewNodeDb(config, stringInterner)
+	require.NoError(t, err)
+	nodeDbTxn := nodeDb.Txn(true)
+	err = nodeDb.CreateAndInsertWithJobDbJobsWithTxn(
+		nodeDbTxn,
+		jobs,
+		testfixtures.Test32CpuNode(priorities),
+	)
+	require.NoError(t, err)
+
+	jobDb := jobdb.NewJobDb(config.PriorityClasses, config.DefaultPriorityClassName, stringInterner, testfixtures.TestResourceListFactory)
+	jobDbTxn := jobDb.WriteTxn()
+	err = jobDbTxn.Upsert(jobs)
+	require.NoError(t, err)
+
+	evictor := NewNodeEvictor(
+		jobDb.ReadTxn(),
+		nodeDb,
+		func(ctx *armadacontext.Context, job *jobdb.Job) (bool, string) { return true, "" },
+	)
 	result, err := evictor.Evict(armadacontext.Background(), nodeDbTxn)
 	require.NoError(t, err)
 


### PR DESCRIPTION
Currently when jobs are evicted, we do small scheduling round to decide which order these jobs are evicted in
 - This simply determines which order preempting jobs should consider the evicted jobs for preemption

However there is a bug where the allocation isn't getting updated during this scheduling round, resulting in the code falling back to tie-breaking on queue each time

In effect this means evicted jobs are purely ordered by queue name, so queue A's evicted jobs are all at the front of the evicted list, then queue B's and so on

An example of this bug shown below, each letter represents a job in the named A - i.e A = job in queue A

Before PR - evicted order of jobs :
`A A A B B B C C C`

After PR - evicted order of jobs:
`A B C A B C A B C`

This is clearly unfair on certain queues and not the intended behaviour.

This PR fixes the bug and adds a test to assert jobs get evicted back in the appropriate order

