### PR TITLE
Make cost based iterators prefer higher priority jobs everywhere

### DIFF
--- a/internal/scheduler/scheduling/idealised_value_scheduler.go
+++ b/internal/scheduler/scheduling/idealised_value_scheduler.go
@@ -93,7 +93,7 @@ func (sch *IdealisedValueScheduler) Schedule(ctx *armadacontext.Context) (*Sched
 		sch.nodeDb,
 		jobIteratorsByQueue,
 		false,
-		false,
+		true,
 		false,
 		sch.schedulingConfig.MaxQueueLookback,
 		true,

--- a/internal/scheduler/scheduling/optimising_queue_scheduler.go
+++ b/internal/scheduler/scheduling/optimising_queue_scheduler.go
@@ -217,7 +217,7 @@ func (q *OptimisingQueueScheduler) createCandidateGangIterator(
 		gangIteratorsByQueue[queue] = NewQueuedGangIterator(sctx, it, q.maxQueueLookBack, true)
 	}
 
-	candidateGangIterator, err := NewCostBasedCandidateGangIterator(sctx.Pool, sctx, sctx.FairnessCostProvider, gangIteratorsByQueue, false, q.prioritiseLargerJobs)
+	candidateGangIterator, err := NewCostBasedCandidateGangIterator(sctx.Pool, sctx, sctx.FairnessCostProvider, gangIteratorsByQueue, true, q.prioritiseLargerJobs)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/scheduler/scheduling/preempting_queue_scheduler.go
+++ b/internal/scheduler/scheduling/preempting_queue_scheduler.go
@@ -149,7 +149,7 @@ func (sch *PreemptingQueueScheduler) Schedule(ctx *armadacontext.Context) (*Sche
 		inMemoryJobRepo,
 		sch.jobRepo,
 		false,
-		false,
+		true,
 	)
 	if err != nil {
 		return nil, err
@@ -601,7 +601,7 @@ func (sch *PreemptingQueueScheduler) addEvictedJobsToNodeDb(_ *armadacontext.Con
 			return err
 		}
 	} else {
-		candidateGangIterator, err = NewCostBasedCandidateGangIterator(sctx.Pool, qr, sctx.FairnessCostProvider, gangItByQueue, false, sch.preferLargeJobOrdering)
+		candidateGangIterator, err = NewCostBasedCandidateGangIterator(sctx.Pool, qr, sctx.FairnessCostProvider, gangItByQueue, true, sch.preferLargeJobOrdering)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This change makes it so we set `considerPriorityClass` to true in our iterators, meaning that jobs with a higher priority class are scheduled before jobs with lower priority class

The reason to do this is:
 - It is more intuitive and inline with how the system should work - higher priority jobs scheduled ahead of lower priority jobs
 - Higher priority jobs will just urgency based lower priority jobs scheduled ahead of them, so it will just be wasteful to do it the other way around

The reason this change hasn't mattered much before is because for the most part we've not used priority classes with different priorities, so the ordering never mattered

One caveat worth mentioning:
 - For a given queue, active (lower priority) jobs are still scheduled ahead of higher priority queued jobs. We will likely want to change that in future but that'll be a bigger change.

