### PR TITLE
Enforce fair share preemption ordering

### DIFF
--- a/internal/scheduler/nodedb/nodedb.go
+++ b/internal/scheduler/nodedb/nodedb.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/armadaproject/armada/internal/common/armadaerrors"
+	log "github.com/armadaproject/armada/internal/common/logging"
 	"github.com/armadaproject/armada/internal/common/slices"
 	"github.com/armadaproject/armada/internal/common/types"
 	"github.com/armadaproject/armada/internal/common/util"
@@ -57,6 +58,11 @@ func (nodeDb *NodeDb) CreateAndInsertWithJobDbJobsWithTxn(txn *memdb.Txn, jobs [
 		return err
 	}
 	return nil
+}
+
+type JobPreemptionInfo struct {
+	PreemptedJob  *context.JobSchedulingContext
+	PreemptingJob *jobdb.Job
 }
 
 // EvictedJobSchedulingContext represents an evicted job.
@@ -375,7 +381,8 @@ func (nodeDb *NodeDb) GetNodesWithTxn(txn *memdb.Txn) ([]*internaltypes.Node, er
 	return nodes, nil
 }
 
-func (nodeDb *NodeDb) ScheduleManyWithTxn(txn *memdb.Txn, gctx *context.GangSchedulingContext) (bool, error) {
+func (nodeDb *NodeDb) ScheduleManyWithTxn(txn *memdb.Txn, gctx *context.GangSchedulingContext) (bool, []*JobPreemptionInfo, error) {
+	var preemptedJobs []*JobPreemptionInfo
 	// Attempt to schedule pods one by one in a transaction.
 	for _, jctx := range gctx.JobSchedulingContexts {
 		// In general, we may attempt to schedule a gang multiple times (in
@@ -383,30 +390,31 @@ func (nodeDb *NodeDb) ScheduleManyWithTxn(txn *memdb.Txn, gctx *context.GangSche
 		// previous attempts.
 		jctx.UnschedulableReason = ""
 
-		node, err := nodeDb.SelectNodeForJobWithTxn(txn, jctx)
+		node, jobsPreempted, err := nodeDb.SelectNodeForJobWithTxn(txn, jctx)
 		if err != nil {
-			return false, err
+			return false, nil, err
 		}
+		preemptedJobs = append(preemptedJobs, jobsPreempted...)
 
 		if node != nil {
 			// If we found a node for this pod, bind it and continue to the next pod.
 			if node, err := nodeDb.BindJobToNode(node, jctx.Job, jctx.PodSchedulingContext.ScheduledAtPriority); err != nil {
-				return false, err
+				return false, nil, err
 			} else {
 				if err := nodeDb.UpsertWithTxn(txn, node); err != nil {
-					return false, err
+					return false, nil, err
 				}
 			}
 
 			// Once a job is scheduled, it should no longer be considered for preemption.
 			if err := deleteEvictedJobSchedulingContextIfExistsWithTxn(txn, jctx.JobId); err != nil {
-				return false, err
+				return false, nil, err
 			}
 		} else {
-			return false, nil
+			return false, nil, nil
 		}
 	}
-	return true, nil
+	return true, preemptedJobs, nil
 }
 
 func deleteEvictedJobSchedulingContextIfExistsWithTxn(txn *memdb.Txn, jobId string) error {
@@ -420,7 +428,14 @@ func deleteEvictedJobSchedulingContextIfExistsWithTxn(txn *memdb.Txn, jobId stri
 }
 
 // SelectNodeForJobWithTxn selects a node on which the job can be scheduled.
-func (nodeDb *NodeDb) SelectNodeForJobWithTxn(txn *memdb.Txn, jctx *context.JobSchedulingContext) (*internaltypes.Node, error) {
+func (nodeDb *NodeDb) SelectNodeForJobWithTxn(txn *memdb.Txn, jctx *context.JobSchedulingContext) (*internaltypes.Node, []*JobPreemptionInfo, error) {
+	// A job that has already been preempted should not be rescheduled
+	// TODO This is a failsafe for now - in future either make it into an error OR just remove the check and rely on caller
+	if jctx.PreemptingJob != nil {
+		log.Errorf("job %s was offered for scheduling despite having been preempted by job %s; refusing to schedule it", jctx.JobId, jctx.PreemptingJob.Id())
+		return nil, nil, nil
+	}
+
 	priorityClass := jctx.Job.PriorityClass()
 
 	// If the job has already been scheduled, get the priority at which it was scheduled.
@@ -456,13 +471,13 @@ func (nodeDb *NodeDb) SelectNodeForJobWithTxn(txn *memdb.Txn, jctx *context.JobS
 	// If the nodeIdLabel selector is set, consider only that node.
 	if nodeId := jctx.GetAssignedNodeId(); nodeId != "" {
 		if it, err := txn.Get("nodes", "id", nodeId); err != nil {
-			return nil, errors.WithStack(err)
+			return nil, nil, errors.WithStack(err)
 		} else {
 			if node, err := nodeDb.selectNodeForPodWithItAtPriority(it, jctx, priority, true); err != nil {
-				return nil, err
+				return nil, nil, err
 			} else {
 				jctx.PodSchedulingContext.SchedulingMethod = context.Rescheduled
-				return node, nil
+				return node, nil, nil
 			}
 		}
 	}
@@ -470,37 +485,37 @@ func (nodeDb *NodeDb) SelectNodeForJobWithTxn(txn *memdb.Txn, jctx *context.JobS
 	for _, resourceName := range nodeDb.disallowedJobResources {
 		if jctx.KubernetesResourceRequirements.GetRawByNameZeroIfMissing(resourceName) > 0 {
 			pctx.NumExcludedNodesByReason[disallowedResourceRequested] = int(nodeDb.numNodes)
-			return nil, nil
+			return nil, nil, nil
 		}
 	}
 
 	if !nodeDb.disableHomeScheduling {
-		node, err := nodeDb.selectNodeForJobWithTxnAtPriority(txn, jctx)
+		node, preemptedJobs, err := nodeDb.selectNodeForJobWithTxnAtPriority(txn, jctx)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if node != nil {
-			return node, nil
+			return node, preemptedJobs, nil
 		}
 	}
 
 	awaySchedulingDisabled := nodeDb.disableAwayScheduling || (jctx.Job.IsInGang() && nodeDb.disableGangAwayScheduling)
 	if !awaySchedulingDisabled {
 		for _, awayNodeType := range priorityClass.AwayNodeTypes {
-			node, err := nodeDb.selectNodeForJobWithTxnAndAwayNodeType(txn, jctx, awayNodeType)
+			node, preemptedJobs, err := nodeDb.selectNodeForJobWithTxnAndAwayNodeType(txn, jctx, awayNodeType)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			if node != nil {
 				pctx.WellKnownNodeTypeName = awayNodeType.WellKnownNodeTypeName
 				pctx.SchedulingMethod = context.ScheduledAsAwayJob
 				pctx.ScheduledAway = true
-				return node, nil
+				return node, preemptedJobs, nil
 			}
 		}
 	}
 
-	return nil, nil
+	return nil, nil, nil
 }
 
 func matchesCondition(conditions []types.AwayNodeTypeCondition, jobResources internaltypes.ResourceList) bool {
@@ -552,8 +567,9 @@ func (nodeDb *NodeDb) selectNodeForJobWithTxnAndAwayNodeType(
 	txn *memdb.Txn,
 	jctx *context.JobSchedulingContext,
 	awayNodeType types.AwayNodeType,
-) (*internaltypes.Node, error) {
+) (*internaltypes.Node, []*JobPreemptionInfo, error) {
 	var node *internaltypes.Node
+	var preemptedJobs []*JobPreemptionInfo
 	var err error
 	// Save the number of additional tolerations that the job originally had; we
 	// use this value to restore the slice of additional toleration at the end
@@ -571,11 +587,11 @@ func (nodeDb *NodeDb) selectNodeForJobWithTxnAndAwayNodeType(
 
 	awayNodeTaints, err := nodeDb.getEffectiveAwayNodeTaints(awayNodeType, jctx.Job)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if len(awayNodeTaints) == 0 {
 		// No extra taints to tolerate will mean no extra scheduling capability
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	for _, taint := range awayNodeTaints {
@@ -590,41 +606,41 @@ func (nodeDb *NodeDb) selectNodeForJobWithTxnAndAwayNodeType(
 	}
 
 	jctx.PodSchedulingContext.ScheduledAtPriority = awayNodeType.Priority
-	node, err = nodeDb.selectNodeForJobWithTxnAtPriority(txn, jctx)
-	return node, err
+	node, preemptedJobs, err = nodeDb.selectNodeForJobWithTxnAtPriority(txn, jctx)
+	return node, preemptedJobs, err
 }
 
 func (nodeDb *NodeDb) selectNodeForJobWithTxnAtPriority(
 	txn *memdb.Txn,
 	jctx *context.JobSchedulingContext,
-) (*internaltypes.Node, error) {
+) (*internaltypes.Node, []*JobPreemptionInfo, error) {
 	pctx := jctx.PodSchedulingContext
 
 	matchingNodeTypeIds, numExcludedNodesByReason, err := nodeDb.NodeTypesMatchingJob(jctx)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Try scheduling at evictedPriority. If this succeeds, no preemption is necessary.
 	pctx.NumExcludedNodesByReason = maps.Clone(numExcludedNodesByReason)
 	if node, err := nodeDb.selectNodeForPodAtPriority(txn, jctx, matchingNodeTypeIds, internaltypes.EvictedPriority); err != nil {
-		return nil, err
+		return nil, nil, err
 	} else if err := assertPodSchedulingContextNode(pctx, node); err != nil {
-		return nil, err
+		return nil, nil, err
 	} else if node != nil {
 		pctx.SchedulingMethod = context.ScheduledWithoutPreemption
-		return node, nil
+		return node, nil, nil
 	}
 
 	// Try scheduling at the job priority. If this fails, scheduling is impossible and we return.
 	// This is an optimisation to avoid looking for preemption targets for unschedulable jobs.
 	pctx.NumExcludedNodesByReason = maps.Clone(numExcludedNodesByReason)
 	if node, err := nodeDb.selectNodeForPodAtPriority(txn, jctx, matchingNodeTypeIds, pctx.ScheduledAtPriority); err != nil {
-		return nil, err
+		return nil, nil, err
 	} else if err := assertPodSchedulingContextNode(pctx, node); err != nil {
-		return nil, err
+		return nil, nil, err
 	} else if node == nil {
-		return nil, nil
+		return nil, nil, nil
 	}
 	pctx.NodeId = ""
 	pctx.PreemptedAtPriority = internaltypes.MinPriority
@@ -632,13 +648,13 @@ func (nodeDb *NodeDb) selectNodeForJobWithTxnAtPriority(
 	// Schedule by preventing evicted jobs from being re-scheduled.
 	// This method respect fairness by preventing from re-scheduling jobs that appear as far back in the total order as possible.
 	if !nodeDb.disableFairshareScheduling {
-		if node, err := nodeDb.selectNodeForJobWithFairPreemption(txn, jctx); err != nil {
-			return nil, err
+		if node, preemptedJobs, err := nodeDb.selectNodeForJobWithFairPreemption(txn, jctx); err != nil {
+			return nil, nil, err
 		} else if err := assertPodSchedulingContextNode(pctx, node); err != nil {
-			return nil, err
+			return nil, nil, err
 		} else if node != nil {
 			pctx.SchedulingMethod = context.ScheduledWithFairSharePreemption
-			return node, nil
+			return node, preemptedJobs, nil
 		}
 	}
 
@@ -649,16 +665,16 @@ func (nodeDb *NodeDb) selectNodeForJobWithTxnAtPriority(
 	// This method does not respect fairness when choosing on which node to schedule the job.
 	if !nodeDb.disableUrgencyScheduling {
 		if node, err := nodeDb.selectNodeForJobWithUrgencyPreemption(txn, jctx, matchingNodeTypeIds); err != nil {
-			return nil, err
+			return nil, nil, err
 		} else if err := assertPodSchedulingContextNode(pctx, node); err != nil {
-			return nil, err
+			return nil, nil, err
 		} else if node != nil {
 			pctx.SchedulingMethod = context.ScheduledWithUrgencyBasedPreemption
-			return node, nil
+			return node, nil, nil
 		}
 	}
 
-	return nil, nil
+	return nil, nil, nil
 }
 
 func assertPodSchedulingContextNode(pctx *context.PodSchedulingContext, node *internaltypes.Node) error {
@@ -805,7 +821,7 @@ func (nodeDb *NodeDb) selectNodeForPodWithItAtPriority(
 //
 // It does this by considering all evicted jobs in the reverse order they would be scheduled in and preventing
 // from being re-scheduled the jobs that would be scheduled last.
-func (nodeDb *NodeDb) selectNodeForJobWithFairPreemption(txn *memdb.Txn, jctx *context.JobSchedulingContext) (*internaltypes.Node, error) {
+func (nodeDb *NodeDb) selectNodeForJobWithFairPreemption(txn *memdb.Txn, jctx *context.JobSchedulingContext) (*internaltypes.Node, []*JobPreemptionInfo, error) {
 	type consideredNode struct {
 		node                     *internaltypes.Node
 		availableResource        internaltypes.ResourceList
@@ -816,10 +832,11 @@ func (nodeDb *NodeDb) selectNodeForJobWithFairPreemption(txn *memdb.Txn, jctx *c
 	pctx := jctx.PodSchedulingContext
 
 	var selectedNode *internaltypes.Node
+	var preemptedJobs []*JobPreemptionInfo
 	nodesById := make(map[string]*consideredNode)
 	it, err := txn.ReverseLowerBound("evictedJobs", "index", math.MaxInt)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, nil, errors.WithStack(err)
 	}
 	maxPriority := internaltypes.MinPriority
 	for obj := it.Next(); obj != nil && selectedNode == nil; obj = it.Next() {
@@ -828,7 +845,7 @@ func (nodeDb *NodeDb) selectNodeForJobWithFairPreemption(txn *memdb.Txn, jctx *c
 
 		evictedJobSchedulingPriority, ok := nodeDb.GetScheduledAtPriority(evictedJctx.JobId)
 		if !ok {
-			return nil, errors.Errorf("evicted job %s does not have scheduled at priority set in nodedb", evictedJctx.JobId)
+			return nil, nil, errors.Errorf("evicted job %s does not have scheduled at priority set in nodedb", evictedJctx.JobId)
 		}
 
 		// Jobs should not preempt jobs with a higher priority, even via fairshare
@@ -838,13 +855,14 @@ func (nodeDb *NodeDb) selectNodeForJobWithFairPreemption(txn *memdb.Txn, jctx *c
 
 		nodeId := evictedJctx.GetAssignedNodeId()
 		if nodeId == "" {
-			return nil, errors.Errorf("evicted job %s does not have an assigned nodeId", evictedJctx.JobId)
+			return nil, nil, errors.Errorf("evicted job %s does not have an assigned nodeId", evictedJctx.JobId)
 		}
+
 		node, ok := nodesById[nodeId]
 		if !ok {
 			nodeFromDb, err := nodeDb.GetNodeWithTxn(txn, nodeId)
 			if err != nil {
-				return nil, errors.WithStack(err)
+				return nil, nil, errors.WithStack(err)
 			}
 			node = &consideredNode{
 				node:                     nodeFromDb,
@@ -871,7 +889,7 @@ func (nodeDb *NodeDb) selectNodeForJobWithFairPreemption(txn *memdb.Txn, jctx *c
 
 		staticRequirementsMet, reason, err := StaticJobRequirementsMet(node.node, jctx)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if !staticRequirementsMet {
 			node.staticRequirementsNotMet = true
@@ -885,11 +903,11 @@ func (nodeDb *NodeDb) selectNodeForJobWithFairPreemption(txn *memdb.Txn, jctx *c
 			// Remove preempted job from node
 			err = nodeDb.unbindJobFromNodeInPlace(job.JobSchedulingContext.Job, nodeCopy)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			// Remove preempted job from list of evicted jobs
 			if err := txn.Delete("evictedJobs", job); err != nil {
-				return nil, errors.WithStack(err)
+				return nil, nil, errors.WithStack(err)
 			}
 
 			priority, ok := nodeDb.GetScheduledAtPriority(job.JobSchedulingContext.JobId)
@@ -899,14 +917,17 @@ func (nodeDb *NodeDb) selectNodeForJobWithFairPreemption(txn *memdb.Txn, jctx *c
 			if priority > maxPriority {
 				maxPriority = priority
 			}
-			job.JobSchedulingContext.PreemptingJob = jctx.Job
+			preemptedJobs = append(preemptedJobs, &JobPreemptionInfo{
+				PreemptedJob:  job.JobSchedulingContext,
+				PreemptingJob: jctx.Job,
+			})
 		}
 
 		selectedNode = nodeCopy
 		pctx.NodeId = selectedNode.GetId()
 		pctx.PreemptedAtPriority = maxPriority
 	}
-	return selectedNode, nil
+	return selectedNode, preemptedJobs, nil
 }
 
 // BindJobToNode returns a copy of node with job bound to it.

--- a/internal/scheduler/nodedb/nodedb_test.go
+++ b/internal/scheduler/nodedb/nodedb_test.go
@@ -79,7 +79,7 @@ func TestSelectNodeForPod_NodeIdLabel_Success(t *testing.T) {
 	for _, jctx := range jctxs {
 		txn := db.Txn(false)
 		jctx.SetAssignedNode(testfixtures.TestSimpleNode(nodeId))
-		node, err := db.SelectNodeForJobWithTxn(txn, jctx)
+		node, _, err := db.SelectNodeForJobWithTxn(txn, jctx)
 		txn.Abort()
 		require.NoError(t, err)
 		pctx := jctx.PodSchedulingContext
@@ -104,7 +104,7 @@ func TestSelectNodeForPod_NodeIdLabel_Failure(t *testing.T) {
 	for _, jctx := range jctxs {
 		txn := db.Txn(false)
 		jctx.SetAssignedNode(testfixtures.TestSimpleNode("non-existent node"))
-		node, err := db.SelectNodeForJobWithTxn(txn, jctx)
+		node, _, err := db.SelectNodeForJobWithTxn(txn, jctx)
 		txn.Abort()
 		if !assert.NoError(t, err) {
 			continue
@@ -554,7 +554,7 @@ func TestScheduleIndividually(t *testing.T) {
 			for i, jctx := range jctxs {
 				nodeDbTxn := nodeDb.Txn(true)
 				gctx := context.NewGangSchedulingContext([]*context.JobSchedulingContext{jctx})
-				ok, err := nodeDb.ScheduleManyWithTxn(nodeDbTxn, gctx)
+				ok, _, err := nodeDb.ScheduleManyWithTxn(nodeDbTxn, gctx)
 				require.NoError(t, err)
 
 				require.Equal(t, tc.ExpectSuccess[i], ok)
@@ -641,7 +641,7 @@ func TestScheduleMany(t *testing.T) {
 				nodeDbTxn := nodeDb.Txn(true)
 				jctxs := context.JobSchedulingContextsFromJobs(jobs)
 				gctx := context.NewGangSchedulingContext(jctxs)
-				ok, err := nodeDb.ScheduleManyWithTxn(nodeDbTxn, gctx)
+				ok, _, err := nodeDb.ScheduleManyWithTxn(nodeDbTxn, gctx)
 				require.NoError(t, err)
 				require.Equal(t, tc.ExpectSuccess[i], ok)
 				if ok {
@@ -705,7 +705,7 @@ func TestDisallowedJobResources(t *testing.T) {
 
 			nodeDbTxn := nodeDb.Txn(true)
 			nodeDb.ConfigureScheduling(SchedulingOptions{DisallowedJobResources: tc.disallowedJobResources})
-			node, err := nodeDb.SelectNodeForJobWithTxn(nodeDbTxn, jctx)
+			node, _, err := nodeDb.SelectNodeForJobWithTxn(nodeDbTxn, jctx)
 			require.NoError(t, err)
 
 			if tc.expectScheduled {
@@ -795,7 +795,7 @@ func TestHomeNodeScheduling(t *testing.T) {
 			require.Empty(t, jctx.AdditionalTolerations)
 			gctx := context.NewGangSchedulingContext([]*context.JobSchedulingContext{jctx})
 
-			ok, err := nodeDb.ScheduleManyWithTxn(nodeDbTxn, gctx)
+			ok, _, err := nodeDb.ScheduleManyWithTxn(nodeDbTxn, gctx)
 			require.NoError(t, err)
 			if tc.expectSuccess {
 				require.True(t, ok)
@@ -898,7 +898,7 @@ func TestPreemptionScheduling(t *testing.T) {
 			gctx := context.NewGangSchedulingContext([]*context.JobSchedulingContext{jctx})
 
 			txn = nodeDb.Txn(true)
-			ok, err := nodeDb.ScheduleManyWithTxn(txn, gctx)
+			ok, _, err := nodeDb.ScheduleManyWithTxn(txn, gctx)
 			require.NoError(t, err)
 
 			require.Equal(t, tc.expectSuccess, ok)
@@ -976,7 +976,7 @@ func TestFairSharePreemption_RespectsPriorityOrder(t *testing.T) {
 
 			txn = nodeDb.Txn(true)
 			defer txn.Abort()
-			ok, err := nodeDb.ScheduleManyWithTxn(txn, gctx)
+			ok, _, err := nodeDb.ScheduleManyWithTxn(txn, gctx)
 			require.NoError(t, err)
 
 			require.Equal(t, tc.expectScheduled, ok)
@@ -988,6 +988,53 @@ func TestFairSharePreemption_RespectsPriorityOrder(t *testing.T) {
 			} else {
 				assert.False(t, jctx.PodSchedulingContext.IsSuccessful())
 				assert.Empty(t, jctx.PodSchedulingContext.NodeId)
+			}
+		})
+	}
+}
+
+func TestPreemptedJobIsNotRescheduled(t *testing.T) {
+	tests := map[string]struct {
+		alreadyPreempted bool
+		expectScheduled  bool
+	}{
+		"job not preempted schedules onto empty node": {
+			alreadyPreempted: false,
+			expectScheduled:  true,
+		},
+		"preempted job is not rescheduled despite empty node": {
+			alreadyPreempted: true,
+			expectScheduled:  false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			node := testfixtures.Test32CpuNode(testfixtures.TestPriorities)
+			nodeDb, err := newNodeDbWithNodes([]*internaltypes.Node{node})
+			require.NoError(t, err)
+
+			job := testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 1)[0]
+			jctx := context.JobSchedulingContextFromJob(job)
+			if tc.alreadyPreempted {
+				jctx.PreemptingJob = testfixtures.N1Cpu4GiJobs("B", testfixtures.PriorityClass1, 1)[0]
+			}
+			gctx := context.NewGangSchedulingContext([]*context.JobSchedulingContext{jctx})
+
+			txn := nodeDb.Txn(true)
+			defer txn.Abort()
+			ok, preemptedJobs, err := nodeDb.ScheduleManyWithTxn(txn, gctx)
+			assert.NoError(t, err)
+			assert.Empty(t, preemptedJobs)
+
+			if tc.expectScheduled {
+				assert.True(t, ok)
+				assert.NotNil(t, jctx.PodSchedulingContext)
+				assert.True(t, jctx.PodSchedulingContext.IsSuccessful())
+				assert.Equal(t, node.GetId(), jctx.PodSchedulingContext.NodeId)
+			} else {
+				assert.False(t, ok)
+				assert.Nil(t, jctx.PodSchedulingContext)
 			}
 		})
 	}
@@ -1122,7 +1169,7 @@ func TestConditionalAwayNodeScheduling(t *testing.T) {
 			jctx := context.JobSchedulingContextFromJob(tc.job)
 
 			nodeDbTxn := nodeDb.Txn(true)
-			node, err := nodeDb.SelectNodeForJobWithTxn(nodeDbTxn, jctx)
+			node, _, err := nodeDb.SelectNodeForJobWithTxn(nodeDbTxn, jctx)
 			require.NoError(t, err)
 
 			if tc.expectScheduled {
@@ -1244,7 +1291,7 @@ func TestAwayNodeScheduling(t *testing.T) {
 			require.Empty(t, jctx.AdditionalTolerations)
 			gctx := context.NewGangSchedulingContext([]*context.JobSchedulingContext{jctx})
 
-			ok, err := nodeDb.ScheduleManyWithTxn(nodeDbTxn, gctx)
+			ok, _, err := nodeDb.ScheduleManyWithTxn(nodeDbTxn, gctx)
 			require.NoError(t, err)
 			if tc.expectSuccess {
 				require.True(t, ok)
@@ -1455,7 +1502,7 @@ func benchmarkScheduleMany(b *testing.B, nodes []*internaltypes.Node, jobs []*jo
 		jctxs := context.JobSchedulingContextsFromJobs(jobs)
 		gctx := context.NewGangSchedulingContext(jctxs)
 		txn := nodeDb.Txn(true)
-		_, err := nodeDb.ScheduleManyWithTxn(txn, gctx)
+		_, _, err := nodeDb.ScheduleManyWithTxn(txn, gctx)
 		txn.Abort()
 		require.NoError(b, err)
 	}

--- a/internal/scheduler/scheduling/context/scheduling.go
+++ b/internal/scheduler/scheduling/context/scheduling.go
@@ -62,7 +62,10 @@ type SchedulingContext struct {
 	// Record of job scheduling requirements known to be unfeasible.
 	// Used to immediately reject new jobs with identical requirements.
 	// Maps to the JobSchedulingContext of a previous job attempted to schedule with the same key.
-	UnfeasibleSchedulingKeys     map[internaltypes.SchedulingKey]*JobSchedulingContext
+	UnfeasibleSchedulingKeys map[internaltypes.SchedulingKey]*JobSchedulingContext
+	// Ids of jobs preempted during this scheduling round (e.g. via fair-share preemption).
+	// Such jobs must not be re-offered as scheduling candidates
+	PreemptedJobIds              map[string]bool
 	ExperimentalIndicativeShares map[int]float64
 	SpotPrice                    *float64
 	// Time spent scheduling new jobs in this round.
@@ -86,6 +89,7 @@ func NewSchedulingContext(
 		EvictedResources:             internaltypes.ResourceList{},
 		SchedulingKeyGenerator:       internaltypes.NewSchedulingKeyGenerator(),
 		UnfeasibleSchedulingKeys:     make(map[internaltypes.SchedulingKey]*JobSchedulingContext),
+		PreemptedJobIds:              make(map[string]bool),
 		ExperimentalIndicativeShares: make(map[int]float64),
 	}
 }
@@ -488,6 +492,17 @@ func (sctx *SchedulingContext) QueueContextExists(job *jobdb.Job) bool {
 	queue := sctx.resolveQueueName(job)
 	_, ok := sctx.QueueSchedulingContexts[queue]
 	return ok
+}
+
+// MarkJobPreempted records that the job with the given id was preempted during this scheduling round.
+// Preempted jobs must not be re-scheduled; see IsJobPreempted.
+func (sctx *SchedulingContext) MarkJobPreempted(jobId string) {
+	sctx.PreemptedJobIds[jobId] = true
+}
+
+// IsJobPreempted reports whether the job with the given id was preempted during this scheduling round.
+func (sctx *SchedulingContext) IsJobPreempted(jobId string) bool {
+	return sctx.PreemptedJobIds[jobId]
 }
 
 func (sctx *SchedulingContext) PreemptJob(jctx *JobSchedulingContext) (bool, error) {

--- a/internal/scheduler/scheduling/context/scheduling_test.go
+++ b/internal/scheduler/scheduling/context/scheduling_test.go
@@ -376,6 +376,24 @@ func TestRecordNewJobSchedulingDuration(t *testing.T) {
 	}
 }
 
+func TestMarkJobPreempted(t *testing.T) {
+	sctx := NewSchedulingContext("pool", nil, nil, cpu(100))
+
+	// Unknown jobs are not preempted.
+	assert.False(t, sctx.IsJobPreempted("job-1"))
+
+	// Marking a job records it as preempted; other jobs are unaffected.
+	sctx.MarkJobPreempted("job-1")
+	assert.True(t, sctx.IsJobPreempted("job-1"))
+	assert.False(t, sctx.IsJobPreempted("job-2"))
+
+	// Marking is idempotent and additive.
+	sctx.MarkJobPreempted("job-1")
+	sctx.MarkJobPreempted("job-2")
+	assert.True(t, sctx.IsJobPreempted("job-1"))
+	assert.True(t, sctx.IsJobPreempted("job-2"))
+}
+
 func TestCalculateFairnessError(t *testing.T) {
 	tests := map[string]struct {
 		availableResources internaltypes.ResourceList

--- a/internal/scheduler/scheduling/gang_scheduler.go
+++ b/internal/scheduler/scheduling/gang_scheduler.go
@@ -183,7 +183,8 @@ func (sch *GangScheduler) trySchedule(ctx *armadacontext.Context, gctx *context.
 		}
 		addNodeSelectorToGctx(gctx, nodeUniformity, value)
 		txn := sch.nodeDb.Txn(true)
-		ok, unschedulableReason, err = sch.tryScheduleGangWithTxn(ctx, txn, gctx)
+		var preemptedJobs []*nodedb.JobPreemptionInfo
+		ok, unschedulableReason, preemptedJobs, err = sch.tryScheduleGangWithTxn(ctx, txn, gctx)
 		if err != nil {
 			txn.Abort()
 			return ok, unschedulableReason, err
@@ -195,6 +196,7 @@ func (sch *GangScheduler) trySchedule(ctx *armadacontext.Context, gctx *context.
 				// Store the selected label value in all job contexts
 				gctx.SetGangNodeUniformityValues(nodeUniformity, value)
 				txn.Commit()
+				sch.applyPreemptions(preemptedJobs)
 				return true, "", nil
 			}
 			if bestValue == "" || bestFit.Less(currentFit) {
@@ -203,6 +205,7 @@ func (sch *GangScheduler) trySchedule(ctx *armadacontext.Context, gctx *context.
 					// Store the selected label value in all job contexts
 					gctx.SetGangNodeUniformityValues(nodeUniformity, value)
 					txn.Commit()
+					sch.applyPreemptions(preemptedJobs)
 					return true, "", nil
 				}
 				// Record the best value seen so far.
@@ -226,21 +229,26 @@ func (sch *GangScheduler) trySchedule(ctx *armadacontext.Context, gctx *context.
 func (sch *GangScheduler) tryScheduleGang(ctx *armadacontext.Context, gctx *context.GangSchedulingContext) (bool, string, error) {
 	var ok bool
 	var unschedulableReason string
+	var preemptedJobs []*nodedb.JobPreemptionInfo
 	var err error
 	txn := sch.nodeDb.Txn(true)
 	defer txn.Abort()
-	ok, unschedulableReason, err = sch.tryScheduleGangWithTxn(ctx, txn, gctx)
+	ok, unschedulableReason, preemptedJobs, err = sch.tryScheduleGangWithTxn(ctx, txn, gctx)
 	if ok && err == nil {
 		txn.Commit()
+		// Only apply preemptions once the scheduling transaction has committed, so that aborted
+		// attempts (e.g. rejected node-uniformity values) never leak preemptions.
+		sch.applyPreemptions(preemptedJobs)
 	}
 	return ok, unschedulableReason, err
 }
 
-func (sch *GangScheduler) tryScheduleGangWithTxn(_ *armadacontext.Context, txn *memdb.Txn, gctx *context.GangSchedulingContext) (bool, string, error) {
+func (sch *GangScheduler) tryScheduleGangWithTxn(_ *armadacontext.Context, txn *memdb.Txn, gctx *context.GangSchedulingContext) (bool, string, []*nodedb.JobPreemptionInfo, error) {
 	var ok bool
 	var unschedulableReason string
+	var preemptedJobs []*nodedb.JobPreemptionInfo
 	var err error
-	if ok, err = sch.nodeDb.ScheduleManyWithTxn(txn, gctx); err == nil {
+	if ok, preemptedJobs, err = sch.nodeDb.ScheduleManyWithTxn(txn, gctx); err == nil {
 		if !ok {
 			if gctx.Cardinality() > 1 {
 				unschedulableReason = schedulerconstraints.GangDoesNotFitUnschedulableReason
@@ -248,9 +256,20 @@ func (sch *GangScheduler) tryScheduleGangWithTxn(_ *armadacontext.Context, txn *
 				unschedulableReason = schedulerconstraints.JobDoesNotFitUnschedulableReason
 			}
 		}
-		return ok, unschedulableReason, err
+		return ok, unschedulableReason, preemptedJobs, err
 	}
-	return ok, unschedulableReason, err
+	return ok, unschedulableReason, preemptedJobs, err
+}
+
+// applyPreemptions applies the preemptions reported by the NodeDb to the scheduling context.
+// NodeDb reports preemptions but does not mutate the preempted jobs' scheduling contexts; that is
+// done here, once the caller has committed the scheduling transaction. It records the preempting
+// job on each preempted job's context and marks the job as preempted so it is not re-scheduled.
+func (sch *GangScheduler) applyPreemptions(preemptedJobs []*nodedb.JobPreemptionInfo) {
+	for _, preemption := range preemptedJobs {
+		preemption.PreemptedJob.PreemptingJob = preemption.PreemptingJob
+		sch.schedulingContext.MarkJobPreempted(preemption.PreemptedJob.JobId)
+	}
 }
 
 func addNodeSelectorToGctx(gctx *context.GangSchedulingContext, nodeSelectorKey, nodeSelectorValue string) {

--- a/internal/scheduler/scheduling/gang_scheduler_test.go
+++ b/internal/scheduler/scheduling/gang_scheduler_test.go
@@ -727,6 +727,91 @@ func TestGangScheduler(t *testing.T) {
 	}
 }
 
+func TestGangScheduler_MarksPreemptedJobs(t *testing.T) {
+	schedulingConfig := testfixtures.TestSchedulingConfig()
+	node := testfixtures.Test32CpuNode(testfixtures.TestPriorities)
+
+	nodeDb, err := nodedb.NewNodeDb(
+		schedulingConfig.PriorityClasses,
+		schedulingConfig.IndexedResources,
+		schedulingConfig.IndexedTaints,
+		schedulingConfig.IndexedNodeLabels,
+		schedulingConfig.WellKnownNodeTypes,
+		testfixtures.TestResourceListFactory,
+	)
+	require.NoError(t, err)
+
+	// Fully allocate the node with a low-priority incumbent job.
+	txn := nodeDb.Txn(true)
+	incumbentJobs := testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 32)
+	require.NoError(t, nodeDb.CreateAndInsertWithJobDbJobsWithTxn(txn, incumbentJobs, node.DeepCopyNilKeys()))
+	txn.Commit()
+
+	// Evict the incumbents and register them so they are candidates for fair-share preemption.
+	dbNode, err := nodeDb.GetNode(node.GetId())
+	require.NoError(t, err)
+	evictedNode, err := nodeDb.EvictJobsFromNode(incumbentJobs, dbNode)
+	require.NoError(t, err)
+	txn = nodeDb.Txn(true)
+	require.NoError(t, nodeDb.UpsertWithTxn(txn, evictedNode))
+	evictedJctxByJobId := make(map[string]*context.JobSchedulingContext, len(incumbentJobs))
+	for i, job := range incumbentJobs {
+		evictedJctx := context.JobSchedulingContextFromJob(job)
+		evictedJctx.SetAssignedNode(evictedNode)
+		evictedJctxByJobId[job.Id()] = evictedJctx
+		require.NoError(t, nodeDb.AddEvictedJobSchedulingContextWithTxn(txn, i, evictedJctx))
+	}
+	txn.Commit()
+
+	totalResources := nodeDb.TotalKubernetesResources()
+	fairnessCostProvider, err := fairness.NewDominantResourceFairness(totalResources, testfixtures.TestPool, schedulingConfig)
+	require.NoError(t, err)
+	sctx := context.NewSchedulingContext(
+		"pool",
+		fairnessCostProvider,
+		rate.NewLimiter(rate.Limit(schedulingConfig.MaximumSchedulingRate), schedulingConfig.MaximumSchedulingBurst),
+		totalResources,
+	)
+	for _, queue := range []string{"A", "B"} {
+		require.NoError(t, sctx.AddQueueSchedulingContext(
+			queue, 1, 1, nil,
+			internaltypes.ResourceList{}, internaltypes.ResourceList{}, internaltypes.ResourceList{},
+			rate.NewLimiter(rate.Limit(schedulingConfig.MaximumPerQueueSchedulingRate), schedulingConfig.MaximumPerQueueSchedulingBurst),
+		))
+	}
+	constraints := schedulerconstraints.NewSchedulingConstraints("pool", totalResources, schedulingConfig,
+		[]*api.Queue{{Name: "A"}, {Name: "B"}})
+	floatingResourceTypes, err := floatingresources.NewFloatingResourceTypes(schedulingConfig.FloatingResources, testfixtures.TestResourceListFactory)
+	require.NoError(t, err)
+	sch, err := NewGangScheduler(sctx, constraints, floatingResourceTypes, nodeDb, false)
+	require.NoError(t, err)
+
+	// Schedule a single higher-priority job that only fits if an incumbent is preempted.
+	incoming := testfixtures.N1Cpu4GiJobs("B", testfixtures.PriorityClass1, 1)[0]
+	incomingJctx := context.JobSchedulingContextFromJob(incoming)
+	gctx := context.NewGangSchedulingContext([]*context.JobSchedulingContext{incomingJctx})
+
+	ok, reason, err := sch.Schedule(armadacontext.Background(), gctx)
+	require.NoError(t, err)
+	require.True(t, ok, "expected incoming job to schedule via fair-share preemption")
+	require.Empty(t, reason)
+	require.Equal(t, context.ScheduledWithFairSharePreemption, incomingJctx.PodSchedulingContext.SchedulingMethod)
+
+	// Exactly one incumbent should have been preempted, marked in both the jctx and the sctx.
+	preemptedCount := 0
+	for jobId, evictedJctx := range evictedJctxByJobId {
+		markedInSctx := sctx.IsJobPreempted(jobId)
+		markedInJctx := evictedJctx.PreemptingJob != nil
+		// The two markings must agree for a given job.
+		require.Equal(t, markedInSctx, markedInJctx, "sctx and jctx preemption marking disagree for job %s", jobId)
+		if markedInJctx {
+			preemptedCount++
+			require.Equal(t, incoming.Id(), evictedJctx.PreemptingJob.Id(), "preempting job should be the incoming job")
+		}
+	}
+	require.Equal(t, 1, preemptedCount, "expected exactly one incumbent to be preempted")
+}
+
 func createAwayJob() *jobdb.Job {
 	return testfixtures.Test1Cpu4GiJob(testfixtures.TestQueue, testfixtures.PriorityClass2).WithNewRun("executor-1", "node-1", "node-1", "away", 1)
 }

--- a/internal/scheduler/scheduling/market_driven_preempting_queue_scheduler_test.go
+++ b/internal/scheduler/scheduling/market_driven_preempting_queue_scheduler_test.go
@@ -384,7 +384,7 @@ func TestMarketDrivenPreemptingQueueScheduler(t *testing.T) {
 				},
 				{
 					// Schedule a gang filling the remaining space on both node
-					// Queue A is preeempted despite having a higher price, because the jobs are scheduled as away jobs
+					// Queue A is preempted despite having a higher price, because the jobs are scheduled as away jobs
 					JobsByQueue: map[string][]*jobdb.Job{
 						"B": testfixtures.N1GpuJobsWithPriceBandAndPriorityClass("B", bidstore.PriceBand_PRICE_BAND_A, testfixtures.PriorityClass6Preemptible, 16),
 					},

--- a/internal/scheduler/scheduling/preempting_queue_scheduler.go
+++ b/internal/scheduler/scheduling/preempting_queue_scheduler.go
@@ -6,7 +6,6 @@ import (
 	"reflect"
 	"time"
 
-	log "github.com/armadaproject/armada/internal/common/logging"
 	"github.com/benbjohnson/immutable"
 	"github.com/hashicorp/go-memdb"
 	"github.com/pkg/errors"
@@ -15,6 +14,7 @@ import (
 	"k8s.io/utils/clock"
 
 	"github.com/armadaproject/armada/internal/common/armadacontext"
+	log "github.com/armadaproject/armada/internal/common/logging"
 	armadamaps "github.com/armadaproject/armada/internal/common/maps"
 	armadaslices "github.com/armadaproject/armada/internal/common/slices"
 	"github.com/armadaproject/armada/internal/scheduler/configuration"

--- a/internal/scheduler/scheduling/preempting_queue_scheduler.go
+++ b/internal/scheduler/scheduling/preempting_queue_scheduler.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"time"
 
+	log "github.com/armadaproject/armada/internal/common/logging"
 	"github.com/benbjohnson/immutable"
 	"github.com/hashicorp/go-memdb"
 	"github.com/pkg/errors"
@@ -196,6 +197,7 @@ func (sch *PreemptingQueueScheduler) Schedule(ctx *armadacontext.Context) (*Sche
 	// Only necessary if a non-zero number of jobs were evicted.
 	if len(reevictResult.EvictedJctxsByJobId) > 0 {
 		ctx.Logger().WithField("stage", "scheduling-algo").Info("Performing second scheduling ")
+		log.Info("####################")
 		rescheduleSchedulerResult, rescheduleErr := sch.schedule(
 			armadacontext.WithLogField(ctx, "stage", "schedule after oversubscribed eviction"),
 			inMemoryJobRepo,

--- a/internal/scheduler/scheduling/preempting_queue_scheduler.go
+++ b/internal/scheduler/scheduling/preempting_queue_scheduler.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/utils/clock"
 
 	"github.com/armadaproject/armada/internal/common/armadacontext"
-	log "github.com/armadaproject/armada/internal/common/logging"
 	armadamaps "github.com/armadaproject/armada/internal/common/maps"
 	armadaslices "github.com/armadaproject/armada/internal/common/slices"
 	"github.com/armadaproject/armada/internal/scheduler/configuration"
@@ -197,7 +196,6 @@ func (sch *PreemptingQueueScheduler) Schedule(ctx *armadacontext.Context) (*Sche
 	// Only necessary if a non-zero number of jobs were evicted.
 	if len(reevictResult.EvictedJctxsByJobId) > 0 {
 		ctx.Logger().WithField("stage", "scheduling-algo").Info("Performing second scheduling ")
-		log.Info("####################")
 		rescheduleSchedulerResult, rescheduleErr := sch.schedule(
 			armadacontext.WithLogField(ctx, "stage", "schedule after oversubscribed eviction"),
 			inMemoryJobRepo,

--- a/internal/scheduler/scheduling/preempting_queue_scheduler_test.go
+++ b/internal/scheduler/scheduling/preempting_queue_scheduler_test.go
@@ -771,7 +771,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 			Nodes:            testfixtures.N32CpuNodes(2, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
-					// Fill half of node 1 and half of node 2.
+					// Fill half capacity with jobs from queues A and B
 					JobsByQueue: map[string][]*jobdb.Job{
 						"A": testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 16),
 						"B": testfixtures.N1Cpu4GiJobs("B", testfixtures.PriorityClass0, 16),
@@ -782,7 +782,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 					},
 				},
 				{
-					// Schedule a gang filling the remaining space on both nodes.
+					// Schedule a gang filling the remaining space
 					JobsByQueue: map[string][]*jobdb.Job{
 						"C": testfixtures.WithGangAnnotationsJobs(testfixtures.N1Cpu4GiJobs("C", testfixtures.PriorityClass0, 32)),
 					},
@@ -2300,6 +2300,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 						m = make(map[string]internaltypes.ResourceList)
 						allocatedByQueueAndPriorityClass[job.Queue()] = m
 					}
+
 					m[job.PriorityClassName()] = m[job.PriorityClassName()].Subtract(job.AllResourceRequirements())
 				}
 				for _, jctx := range result.ScheduledJobs {

--- a/internal/scheduler/scheduling/preemption_description.go
+++ b/internal/scheduler/scheduling/preemption_description.go
@@ -9,35 +9,29 @@ import (
 )
 
 const (
-	unknownPreemptionCause            = "Preempted by scheduler due to the job failing to reschedule - possibly node resource changed causing this job to be unschedulable\nNode Summary:\n%s"
-	unknownGangPreemptionCause        = "Preempted by scheduler due to the job failing to reschedule - possibly another job in the gang was preempted or the node resource changed causing this job to be unschedulable"
-	fairSharePreemptionTemplate       = "Preempted by scheduler using fair share preemption - preempting job %s"
-	marketBasedPreemptionTemplate     = "Preempted by scheduler using market based preemption - current job has a bid of %f - preempting job %s has a bid of %f"
-	urgencyPreemptionTemplate         = "Preempted by scheduler using urgency preemption - preempting job %s"
-	urgencyPreemptionMultiJobTemplate = "Preempted by scheduler using urgency preemption - preemption caused by one of the following jobs %s"
+	unknownPreemptionCause                 = "Preempted by scheduler due to the job failing to reschedule - possibly node resource changed causing this job to be unschedulable\nNode Summary:\n%s"
+	unknownGangPreemptionCause             = "Preempted by scheduler due to the job failing to reschedule - possibly another job in the gang was preempted or the node resource changed causing this job to be unschedulable"
+	gangSiblingFairSharePreemptionTemplate = "Preempted by scheduler using fair share preemption because the following gang members were preempted: %s"
+	fairSharePreemptionTemplate            = "Preempted by scheduler using fair share preemption - preempting job %s"
+	marketBasedPreemptionTemplate          = "Preempted by scheduler using market based preemption - current job has a bid of %f - preempting job %s has a bid of %f"
+	urgencyPreemptionTemplate              = "Preempted by scheduler using urgency preemption - preempting job %s"
+	urgencyPreemptionMultiJobTemplate      = "Preempted by scheduler using urgency preemption - preemption caused by one of the following jobs %s"
 )
 
-func PopulatePreemptionDescriptions(marketBasedScheduling bool, pool string, preemptedJobs []*context.JobSchedulingContext, scheduledJobs []*context.JobSchedulingContext) {
-	jobsScheduledWithUrgencyBasedPreemptionByNode := map[string][]*context.JobSchedulingContext{}
-	for _, schedJctx := range scheduledJobs {
-		if schedJctx.PodSchedulingContext == nil {
-			continue
-		}
-		if schedJctx.PodSchedulingContext.SchedulingMethod != context.ScheduledWithUrgencyBasedPreemption {
-			continue
-		}
+type preemptionInfo struct {
+	preemptedJobId  string
+	preemptingJobId string
+}
 
-		nodeId := schedJctx.PodSchedulingContext.NodeId
-		if _, ok := jobsScheduledWithUrgencyBasedPreemptionByNode[nodeId]; !ok {
-			jobsScheduledWithUrgencyBasedPreemptionByNode[nodeId] = []*context.JobSchedulingContext{}
-		}
-		jobsScheduledWithUrgencyBasedPreemptionByNode[nodeId] = append(jobsScheduledWithUrgencyBasedPreemptionByNode[nodeId], schedJctx)
-	}
+func PopulatePreemptionDescriptions(marketBasedScheduling bool, pool string, preemptedJobs []*context.JobSchedulingContext, scheduledJobs []*context.JobSchedulingContext) {
+	preemptedGangMembersByGangKey := calculatePreemptedGangMembersByGangKey(preemptedJobs)
+	jobsScheduledWithUrgencyBasedPreemptionByNode := calculateJobsScheduledWithUrgencyBasedPreemptionByNode(scheduledJobs)
 
 	for _, preemptedJctx := range preemptedJobs {
 		if preemptedJctx.PreemptionDescription != "" {
 			continue
 		}
+		siblingPreemptions := gangSiblingPreemptions(preemptedGangMembersByGangKey, preemptedJctx)
 		if preemptedJctx.PreemptingJob != nil {
 			if marketBasedScheduling {
 				preemptedJctx.PreemptionDescription = fmt.Sprintf(marketBasedPreemptionTemplate,
@@ -47,12 +41,17 @@ func PopulatePreemptionDescriptions(marketBasedScheduling bool, pool string, pre
 				preemptedJctx.PreemptionDescription = fmt.Sprintf(fairSharePreemptionTemplate, preemptedJctx.PreemptingJob.Id())
 				preemptedJctx.PreemptionType = context.PreemptedWithFairsharePreemption
 			}
+		} else if preemptedJctx.Job.IsInGang() && len(siblingPreemptions) > 0 {
+			if siblingPreemptions := gangSiblingPreemptions(preemptedGangMembersByGangKey, preemptedJctx); len(siblingPreemptions) > 0 {
+				preemptedJctx.PreemptionDescription = fmt.Sprintf(gangSiblingFairSharePreemptionTemplate, describeGangMemberPreemptions(siblingPreemptions))
+				preemptedJctx.PreemptionType = context.PreemptedWithFairsharePreemption
+				continue
+			}
 		} else {
 			potentialPreemptingJobs := jobsScheduledWithUrgencyBasedPreemptionByNode[preemptedJctx.GetAssignedNodeId()]
-
 			if len(potentialPreemptingJobs) == 0 {
 				if preemptedJctx.Job.IsInGang() {
-					preemptedJctx.PreemptionDescription = fmt.Sprintf(unknownGangPreemptionCause)
+					preemptedJctx.PreemptionDescription = unknownGangPreemptionCause
 					preemptedJctx.PreemptionType = context.UnknownGangJob
 				} else {
 					preemptedJctx.PreemptionDescription = fmt.Sprintf(unknownPreemptionCause, preemptedJctx.GetAssignedNode().SummaryString())
@@ -70,4 +69,61 @@ func PopulatePreemptionDescriptions(marketBasedScheduling bool, pool string, pre
 			}
 		}
 	}
+}
+
+func calculatePreemptedGangMembersByGangKey(preemptedJobs []*context.JobSchedulingContext) map[gangKey][]preemptionInfo {
+	preemptedGangMembersByGangKey := map[gangKey][]preemptionInfo{}
+	for _, preemptedJctx := range preemptedJobs {
+		if preemptedJctx.PreemptingJob == nil || preemptedJctx.Job == nil || !preemptedJctx.Job.IsInGang() {
+			continue
+		}
+		key := gangKeyForJob(preemptedJctx)
+		preemptedGangMembersByGangKey[key] = append(preemptedGangMembersByGangKey[key], preemptionInfo{
+			preemptedJobId:  preemptedJctx.JobId,
+			preemptingJobId: preemptedJctx.PreemptingJob.Id(),
+		})
+	}
+	return preemptedGangMembersByGangKey
+}
+
+func calculateJobsScheduledWithUrgencyBasedPreemptionByNode(scheduledJobs []*context.JobSchedulingContext) map[string][]*context.JobSchedulingContext {
+	jobsScheduledWithUrgencyBasedPreemptionByNode := map[string][]*context.JobSchedulingContext{}
+	for _, schedJctx := range scheduledJobs {
+		if schedJctx.PodSchedulingContext == nil {
+			continue
+		}
+		if schedJctx.PodSchedulingContext.SchedulingMethod != context.ScheduledWithUrgencyBasedPreemption {
+			continue
+		}
+
+		nodeId := schedJctx.PodSchedulingContext.NodeId
+		jobsScheduledWithUrgencyBasedPreemptionByNode[nodeId] = append(jobsScheduledWithUrgencyBasedPreemptionByNode[nodeId], schedJctx)
+	}
+	return jobsScheduledWithUrgencyBasedPreemptionByNode
+}
+
+func gangSiblingPreemptions(preemptedGangMembersByGangKey map[gangKey][]preemptionInfo, jctx *context.JobSchedulingContext) []preemptionInfo {
+	if !jctx.Job.IsInGang() {
+		return nil
+	}
+	preemptions := preemptedGangMembersByGangKey[gangKeyForJob(jctx)]
+	siblingPreemptions := make([]preemptionInfo, 0, len(preemptions))
+	for _, preemption := range preemptions {
+		if preemption.preemptedJobId == jctx.JobId {
+			continue
+		}
+		siblingPreemptions = append(siblingPreemptions, preemption)
+	}
+	return siblingPreemptions
+}
+
+func gangKeyForJob(jctx *context.JobSchedulingContext) gangKey {
+	return gangKey{queue: jctx.Job.Queue(), gangId: jctx.Job.GetGangInfo().Id()}
+}
+
+func describeGangMemberPreemptions(preemptions []preemptionInfo) string {
+	descriptions := armadaslices.Map(preemptions, func(p preemptionInfo) string {
+		return fmt.Sprintf("%s (preempted by job %s)", p.preemptedJobId, p.preemptingJobId)
+	})
+	return strings.Join(descriptions, ", ")
 }

--- a/internal/scheduler/scheduling/preemption_description_test.go
+++ b/internal/scheduler/scheduling/preemption_description_test.go
@@ -34,100 +34,138 @@ func TestPopulatePreemptionDescriptions(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		marketBased                 bool
-		preemptedJobContext         *context.JobSchedulingContext
-		expectedPreemptedJobContext *context.JobSchedulingContext
+		marketBased                  bool
+		preemptedJobContexts         []*context.JobSchedulingContext
+		expectedPreemptedJobContexts []*context.JobSchedulingContext
 	}{
 		"unknown cause - basic job": {
-			preemptedJobContext: &context.JobSchedulingContext{
+			preemptedJobContexts: []*context.JobSchedulingContext{{
 				JobId:        "job-1",
 				AssignedNode: testfixtures.TestSimpleNode("node-3"),
 				Job:          makeJob(t, "job-1", false),
-			},
-			expectedPreemptedJobContext: &context.JobSchedulingContext{
+			}},
+			expectedPreemptedJobContexts: []*context.JobSchedulingContext{{
 				JobId:                 "job-1",
 				AssignedNode:          testfixtures.TestSimpleNode("node-3"),
 				Job:                   makeJob(t, "job-1", false),
 				PreemptionDescription: fmt.Sprintf(unknownPreemptionCause, testfixtures.TestSimpleNode("node-3").SummaryString()),
 				PreemptionType:        context.Unknown,
-			},
+			}},
 		},
 		"unknown cause - gang job": {
-			preemptedJobContext: &context.JobSchedulingContext{
+			preemptedJobContexts: []*context.JobSchedulingContext{{
 				JobId:        "job-1",
 				AssignedNode: testfixtures.TestSimpleNode("node-3"),
 				Job:          makeJob(t, "job-1", true),
-			},
-			expectedPreemptedJobContext: &context.JobSchedulingContext{
+			}},
+			expectedPreemptedJobContexts: []*context.JobSchedulingContext{{
 				JobId:                 "job-1",
 				AssignedNode:          testfixtures.TestSimpleNode("node-3"),
 				Job:                   makeJob(t, "job-1", true),
 				PreemptionDescription: unknownGangPreemptionCause,
 				PreemptionType:        context.UnknownGangJob,
-			},
+			}},
 		},
 		"urgency preemption - single preempting job": {
-			preemptedJobContext: &context.JobSchedulingContext{
+			preemptedJobContexts: []*context.JobSchedulingContext{{
 				JobId:        "job-1",
 				AssignedNode: testfixtures.TestSimpleNode("node-1"),
-			},
-			expectedPreemptedJobContext: &context.JobSchedulingContext{
+				Job:          makeJob(t, "job-1", false),
+			}},
+			expectedPreemptedJobContexts: []*context.JobSchedulingContext{{
 				JobId:                 "job-1",
 				AssignedNode:          testfixtures.TestSimpleNode("node-1"),
+				Job:                   makeJob(t, "job-1", false),
 				PreemptionDescription: fmt.Sprintf(urgencyPreemptionTemplate, "job-2"),
 				PreemptionType:        context.PreemptedWithUrgencyPreemption,
-			},
+			}},
 		},
 		"urgency preemption - multiple preempting jobs": {
-			preemptedJobContext: &context.JobSchedulingContext{
+			preemptedJobContexts: []*context.JobSchedulingContext{{
 				JobId:        "job-1",
 				AssignedNode: testfixtures.TestSimpleNode("node-2"),
-			},
-			expectedPreemptedJobContext: &context.JobSchedulingContext{
+				Job:          makeJob(t, "job-1", false),
+			}},
+			expectedPreemptedJobContexts: []*context.JobSchedulingContext{{
 				JobId:                 "job-1",
 				AssignedNode:          testfixtures.TestSimpleNode("node-2"),
+				Job:                   makeJob(t, "job-1", false),
 				PreemptionDescription: fmt.Sprintf(urgencyPreemptionMultiJobTemplate, "job-3,job-4"),
 				PreemptionType:        context.PreemptedWithUrgencyPreemption,
-			},
+			}},
 		},
 		"fairshare": {
-			preemptedJobContext: &context.JobSchedulingContext{
+			preemptedJobContexts: []*context.JobSchedulingContext{{
 				JobId:         "job-1",
 				AssignedNode:  testfixtures.TestSimpleNode("node-4"),
+				Job:           makeJob(t, "job-1", false),
 				PreemptingJob: makeJob(t, "job-7", false),
-			},
-			expectedPreemptedJobContext: &context.JobSchedulingContext{
+			}},
+			expectedPreemptedJobContexts: []*context.JobSchedulingContext{{
 				JobId:                 "job-1",
 				AssignedNode:          testfixtures.TestSimpleNode("node-4"),
+				Job:                   makeJob(t, "job-1", false),
 				PreemptingJob:         makeJob(t, "job-7", false),
 				PreemptionDescription: fmt.Sprintf(fairSharePreemptionTemplate, "job-7"),
 				PreemptionType:        context.PreemptedWithFairsharePreemption,
+			}},
+		},
+		"fairshare - gang": {
+			preemptedJobContexts: []*context.JobSchedulingContext{
+				{
+					JobId:        "job-1",
+					AssignedNode: testfixtures.TestSimpleNode("node-4"),
+					Job:          makeJob(t, "job-1", true),
+				},
+				{
+					JobId:         "job-8",
+					AssignedNode:  testfixtures.TestSimpleNode("node-3"),
+					Job:           makeJob(t, "job-8", true),
+					PreemptingJob: makeJob(t, "job-7", false),
+				},
+			},
+			expectedPreemptedJobContexts: []*context.JobSchedulingContext{
+				{
+					JobId:                 "job-1",
+					AssignedNode:          testfixtures.TestSimpleNode("node-4"),
+					Job:                   makeJob(t, "job-1", true),
+					PreemptionDescription: fmt.Sprintf(gangSiblingFairSharePreemptionTemplate, describeGangMemberPreemptions([]preemptionInfo{{"job-8", "job-7"}})),
+					PreemptionType:        context.PreemptedWithFairsharePreemption,
+				},
+				{
+					JobId:                 "job-8",
+					AssignedNode:          testfixtures.TestSimpleNode("node-3"),
+					Job:                   makeJob(t, "job-8", true),
+					PreemptingJob:         makeJob(t, "job-7", false),
+					PreemptionDescription: fmt.Sprintf(fairSharePreemptionTemplate, "job-7"),
+					PreemptionType:        context.PreemptedWithFairsharePreemption,
+				},
 			},
 		},
 		"fairshare - market based": {
 			marketBased: true,
-			preemptedJobContext: &context.JobSchedulingContext{
+			preemptedJobContexts: []*context.JobSchedulingContext{{
 				JobId:         "job-1",
 				Job:           makeJobWithPrice(t, "job-1", false, 0),
 				AssignedNode:  testfixtures.TestSimpleNode("node-4"),
 				PreemptingJob: makeJobWithPrice(t, "job-7", false, 5),
-			},
-			expectedPreemptedJobContext: &context.JobSchedulingContext{
+			}},
+			expectedPreemptedJobContexts: []*context.JobSchedulingContext{{
 				JobId:                 "job-1",
 				Job:                   makeJobWithPrice(t, "job-1", false, 0),
 				AssignedNode:          testfixtures.TestSimpleNode("node-4"),
 				PreemptingJob:         makeJobWithPrice(t, "job-7", false, 5),
 				PreemptionDescription: fmt.Sprintf(marketBasedPreemptionTemplate, float64(0), "job-7", float64(5)),
 				PreemptionType:        context.PreemptedWithFairsharePreemption,
-			},
+			}},
 		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			PopulatePreemptionDescriptions(tc.marketBased, testfixtures.TestPool, []*context.JobSchedulingContext{tc.preemptedJobContext}, scheduledJobContexts)
+			PopulatePreemptionDescriptions(tc.marketBased, testfixtures.TestPool, tc.preemptedJobContexts, scheduledJobContexts)
 			assert.Equal(t, expectedScheduleJobContexts, scheduledJobContexts)
-			assert.Equal(t, []*context.JobSchedulingContext{tc.expectedPreemptedJobContext}, []*context.JobSchedulingContext{tc.preemptedJobContext})
+			assert.Equal(t, tc.expectedPreemptedJobContexts, tc.preemptedJobContexts)
 		})
 	}
 }

--- a/internal/scheduler/scheduling/queue_scheduler.go
+++ b/internal/scheduler/scheduling/queue_scheduler.go
@@ -122,6 +122,14 @@ func (sch *QueueScheduler) Schedule(ctx *armadacontext.Context) (*SchedulingResu
 			}
 			continue
 		}
+
+		// Skip gangs containing a job already preempted this round; they must not be re-scheduled.
+		if gangContainsPreemptedJob(sctx, gctx.JobSchedulingContexts) {
+			if err := sch.candidateGangIterator.Clear(); err != nil {
+				return nil, err
+			}
+			continue
+		}
 		start := sch.clock.Now()
 		scheduledOk, unschedulableReason, err := sch.gangScheduler.Schedule(ctx, gctx)
 		if err != nil {
@@ -310,6 +318,15 @@ func (it *QueuedGangIterator) OnlyYieldEvicted() {
 
 func (it *QueuedGangIterator) Clear() {
 	it.next = nil
+}
+
+func gangContainsPreemptedJob(sctx *schedulercontext.SchedulingContext, gang []*schedulercontext.JobSchedulingContext) bool {
+	for _, jctx := range gang {
+		if sctx.IsJobPreempted(jctx.JobId) {
+			return true
+		}
+	}
+	return false
 }
 
 func (it *QueuedGangIterator) Peek() (*schedulercontext.GangSchedulingContext, error) {

--- a/internal/scheduler/scheduling/queue_scheduler_test.go
+++ b/internal/scheduler/scheduling/queue_scheduler_test.go
@@ -681,6 +681,123 @@ func TestQueueScheduler(t *testing.T) {
 	}
 }
 
+func newQueueSchedulerSctx(t *testing.T, config configuration.SchedulingConfig, totalResources internaltypes.ResourceList, queues []string) *context.SchedulingContext {
+	t.Helper()
+	fairnessCostProvider, err := fairness.NewDominantResourceFairness(totalResources, testfixtures.TestPool, config)
+	require.NoError(t, err)
+	sctx := context.NewSchedulingContext(
+		"pool",
+		fairnessCostProvider,
+		rate.NewLimiter(rate.Limit(config.MaximumSchedulingRate), config.MaximumSchedulingBurst),
+		totalResources,
+	)
+	for _, q := range queues {
+		require.NoError(t, sctx.AddQueueSchedulingContext(
+			q, 1, 1, nil,
+			internaltypes.ResourceList{}, internaltypes.ResourceList{}, internaltypes.ResourceList{},
+			rate.NewLimiter(rate.Limit(config.MaximumPerQueueSchedulingRate), config.MaximumPerQueueSchedulingBurst),
+		))
+	}
+	sctx.UpdateFairShares()
+	return sctx
+}
+
+func TestQueueScheduler_PreemptedJobsGetMarkedInSctx(t *testing.T) {
+	config := testfixtures.TestSchedulingConfig()
+	nodeDb, err := NewNodeDb(config, stringinterner.New(1024))
+	require.NoError(t, err)
+
+	// Fully allocate the node with a low-priority jobs in queue A.
+	node := testfixtures.Test32CpuNode(testfixtures.TestPriorities)
+	existingJobs := testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 32)
+	txn := nodeDb.Txn(true)
+	require.NoError(t, nodeDb.CreateAndInsertWithJobDbJobsWithTxn(txn, existingJobs, node.DeepCopyNilKeys()))
+	txn.Commit()
+
+	// Evict the existing jobs and register them so they are candidates for fair-share preemption.
+	dbNode, err := nodeDb.GetNode(node.GetId())
+	require.NoError(t, err)
+	evictedNode, err := nodeDb.EvictJobsFromNode(existingJobs, dbNode)
+	require.NoError(t, err)
+	txn = nodeDb.Txn(true)
+	require.NoError(t, nodeDb.UpsertWithTxn(txn, evictedNode))
+	evictedJctxByJobId := make(map[string]*context.JobSchedulingContext, len(existingJobs))
+	for i, job := range existingJobs {
+		evictedJctx := context.JobSchedulingContextFromJob(job)
+		evictedJctx.SetAssignedNode(evictedNode)
+		evictedJctxByJobId[job.Id()] = evictedJctx
+		require.NoError(t, nodeDb.AddEvictedJobSchedulingContextWithTxn(txn, i, evictedJctx))
+	}
+	txn.Commit()
+
+	sctx := newQueueSchedulerSctx(t, config, nodeDb.TotalKubernetesResources(), []string{"A", "B"})
+	constraints := schedulerconstraints.NewSchedulingConstraints("pool", nodeDb.TotalKubernetesResources(), config,
+		[]*api.Queue{{Name: "A"}, {Name: "B"}})
+
+	// New job must preempt one of the existing jobs to fit on
+	job := testfixtures.Test1Cpu4GiJob("B", testfixtures.PriorityClass1)
+	jobRepo := NewInMemoryJobRepository(testfixtures.TestPool, jobdb.JobPriorityComparer{})
+	jobRepo.EnqueueMany(context.JobSchedulingContextsFromJobs([]*jobdb.Job{job}))
+	jobIteratorByQueue := map[string]JobContextIterator{
+		"A": jobRepo.GetJobIterator("A"),
+		"B": jobRepo.GetJobIterator("B"),
+	}
+
+	sch, err := NewQueueScheduler(sctx, constraints, testfixtures.TestEmptyFloatingResources, nodeDb, jobIteratorByQueue, false, true, config.EnablePreferLargeJobOrdering, config.MaxQueueLookback, false, 0, clock.RealClock{})
+	require.NoError(t, err)
+
+	result, err := sch.Schedule(armadacontext.Background())
+	require.NoError(t, err)
+
+	require.Len(t, result.ScheduledJobs, 1)
+	require.Equal(t, job.Id(), result.ScheduledJobs[0].JobId)
+
+	// Exactly one incumbent should be preempted, marked in both the jctx and the sctx.
+	preemptedCount := 0
+	for jobId, evictedJctx := range evictedJctxByJobId {
+		markedInSctx := sctx.IsJobPreempted(jobId)
+		markedInJctx := evictedJctx.PreemptingJob != nil
+		require.Equal(t, markedInSctx, markedInJctx, "sctx and jctx preemption marking disagree for job %s", jobId)
+		if markedInJctx {
+			preemptedCount++
+			require.Equal(t, job.Id(), evictedJctx.PreemptingJob.Id())
+		}
+	}
+	require.Equal(t, 1, preemptedCount, "expected exactly one incumbent to be preempted")
+}
+
+func TestQueueScheduler_SkipsPreemptedCandidate(t *testing.T) {
+	config := testfixtures.TestSchedulingConfig()
+	nodeDb, err := NewNodeDb(config, stringinterner.New(1024))
+	require.NoError(t, err)
+
+	txn := nodeDb.Txn(true)
+	require.NoError(t, nodeDb.CreateAndInsertWithJobDbJobsWithTxn(txn, nil, testfixtures.Test32CpuNode(testfixtures.TestPriorities)))
+	txn.Commit()
+
+	sctx := newQueueSchedulerSctx(t, config, nodeDb.TotalKubernetesResources(), []string{"A"})
+	constraints := schedulerconstraints.NewSchedulingConstraints("pool", nodeDb.TotalKubernetesResources(), config,
+		[]*api.Queue{{Name: "A"}})
+
+	jobs := testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 2)
+	jctxs := context.JobSchedulingContextsFromJobs(jobs)
+	// Mark the first job as already preempted this round; it must not be re-scheduled.
+	sctx.MarkJobPreempted(jobs[0].Id())
+
+	jobRepo := NewInMemoryJobRepository(testfixtures.TestPool, jobdb.JobPriorityComparer{})
+	jobRepo.EnqueueMany(jctxs)
+	jobIteratorByQueue := map[string]JobContextIterator{"A": jobRepo.GetJobIterator("A")}
+
+	sch, err := NewQueueScheduler(sctx, constraints, testfixtures.TestEmptyFloatingResources, nodeDb, jobIteratorByQueue, false, false, config.EnablePreferLargeJobOrdering, config.MaxQueueLookback, false, 0, clock.RealClock{})
+	require.NoError(t, err)
+
+	result, err := sch.Schedule(armadacontext.Background())
+	require.NoError(t, err)
+
+	assert.Len(t, result.ScheduledJobs, 1)
+	require.Equal(t, jobs[1].Id(), result.ScheduledJobs[0].JobId)
+}
+
 func NewNodeDb(config configuration.SchedulingConfig, stringInterner *stringinterner.StringInterner) (*nodedb.NodeDb, error) {
 	nodeDb, err := nodedb.NewNodeDb(
 		config.PriorityClasses,
@@ -1036,6 +1153,35 @@ func createJctx(evicted bool) *context.JobSchedulingContext {
 	jctx := context.JobSchedulingContextFromJob(job)
 	jctx.IsEvicted = evicted
 	return jctx
+}
+
+func createGangJctx(gangId string, cardinality int) *context.JobSchedulingContext {
+	job := testfixtures.Test1Cpu4GiJob("A", testfixtures.PriorityClass0).
+		WithGangInfo(jobdb.CreateGangInfo(gangId, cardinality, ""))
+	jctx := context.JobSchedulingContextFromJob(job)
+	jctx.IsEvicted = true
+	return jctx
+}
+
+func TestGangContainsPreemptedJob(t *testing.T) {
+	sctx := context.NewSchedulingContext("pool", nil, nil, testfixtures.TestResourceListFactory.MakeAllZero())
+
+	gangJob1 := createGangJctx("gang-1", 2)
+	gangJob2 := createGangJctx("gang-1", 2)
+	standalone := createJctx(true)
+
+	// No preempted jobs registered: nothing is skipped.
+	assert.False(t, gangContainsPreemptedJob(sctx, []*context.JobSchedulingContext{gangJob1, gangJob2}))
+	assert.False(t, gangContainsPreemptedJob(sctx, []*context.JobSchedulingContext{standalone}))
+
+	// A gang with any preempted member is considered preempted
+	sctx.MarkJobPreempted(gangJob1.JobId)
+	assert.True(t, gangContainsPreemptedJob(sctx, []*context.JobSchedulingContext{gangJob1, gangJob2}))
+	assert.False(t, gangContainsPreemptedJob(sctx, []*context.JobSchedulingContext{standalone}))
+
+	// A preempted standalone job marked as preempted is considered preempted
+	sctx.MarkJobPreempted(standalone.JobId)
+	assert.True(t, gangContainsPreemptedJob(sctx, []*context.JobSchedulingContext{standalone}))
 }
 
 func TestQueueSchedulerTimeouts(t *testing.T) {

--- a/internal/scheduler/submitcheck.go
+++ b/internal/scheduler/submitcheck.go
@@ -360,7 +360,7 @@ poolStart:
 			})
 
 			txn := ex.nodeDb.Txn(true)
-			ok, err := ex.nodeDb.ScheduleManyWithTxn(txn, gctx)
+			ok, _, err := ex.nodeDb.ScheduleManyWithTxn(txn, gctx)
 			txn.Abort()
 
 			sb.WriteString(ex.id)


### PR DESCRIPTION
### Issue

Currently fairshare preemption follows this path:

- Evict jobs (in approximately re-scheduling order)
- When scheduling a new job, look through the list of evicted jobs to decide if preempting any of them will allow the new job to schedule
 - If so - schedule the new job and mark those jobs as preempted (on their jctx)
 
 However as the order calculated upfront (in evict jobs) is static and the actual scheduling order is dynamic they can diverge
  - For example if a queue has all its jobs evicted, then one of its jobs get preempted. When it comes to schedule the preempted job it'll fail to schedule, so then that queue get another go immediately - which diverges from the static order calculated upfront

When these scheduling orders diverge, jobs marked as preempted can still end up getting scheduled, as we rely fully on those 2 orders matching to prevent the "preempted" job from re-scheduling.

These jobs that were meant to be preempted but actually got to re-schedule then fill the node up and eventually a job will come along that wasn't supposed to be preempted, but can no longer fit on the node and is preempted.
 - This is an out of order preemption

### This change

We now record when a job was preempted via fairshare and we do not let it re-schedule. This maintains the ordering of preemption to match our expectation and does not result in out of order preemptions
 - Jobs that were preempted cannot re-schedule, so the nodes don't get filled up unexpectedly and therefore all jobs that should re-schedule, can

This is done in two places:
 - The preemption is recorded in sctx and the queue_scheduler skips any jobs in this list
   - Done in the sctx as it will make future work easier (rate limiting preemptions) as now we have a central place where preemptions are recorded
   - This is admittedly weak in that we record this preemption on the jctx AND sctx with no real enforcement between them. We should come back to this in future and try combine them more neatly
 - The nodedb also will skip any jctx that is marked as preempted
   - This is a fallback as there is a lot of paths through the scheduler, and to ensure we've caught them all in this new feature we have a fallback that logs when hit.
   - In future either we'll just simply remove this (and trust the rest of the code) or make it return an err

Additionally I've tidied up the gang preemption reason now we have a more robust preemption mechanism. If a gang member is preempted because another member of the gang was preempted via fairshare - we now report that explicitly and list which members were preempted
  - Urgency based preemption reporting for gangs will be the same as before and still needs improvement