### PR TITLE
Add a per pool fair share preemption rate limit 

### DIFF
--- a/docs/superpowers/specs/2026-07-29-preemption-rate-limit-design.md
+++ b/docs/superpowers/specs/2026-07-29-preemption-rate-limit-design.md
@@ -1,0 +1,269 @@
+# Per-pool fairshare preemption rate limit — Design
+
+Date: 2026-07-29
+Branch: `preemption_rate_limit`
+
+## Goal
+
+Add a per-pool rate limit that throttles **fairshare** preemptions, analogous to the
+existing job scheduling rate limit. The limit:
+
+- Is configured **per pool**.
+- **Defaults to off** (no limit) when unconfigured.
+- Counts **one token per preempted job** (mirrors how the scheduling limiter counts job
+  cardinality).
+- Is **retrospective**: preemptions are counted after the fact (we only know how many
+  jobs were preempted once the NodeDb reports them). The token bucket is therefore
+  allowed to go (minorly) negative. Fairshare preemption stays disabled until the bucket
+  refills to a positive balance.
+
+## Background — how the existing pieces work
+
+Facts established from the current codebase (`internal/scheduler`):
+
+- **Scheduling rate limit** uses `golang.org/x/time/rate` token buckets. A global limiter
+  lives on `FairSchedulingAlgo.limiter` and a per-queue map on
+  `FairSchedulingAlgo.limiterByQueue`. Both persist across scheduling rounds. They are
+  checked with `TokensAt(sctx.Started)` (frozen at round start) in
+  `constraints.CheckJobConstraints`, and consumed with `ReserveN(sctx.Started, cardinality)`
+  in `gang_scheduler.go` (deferred block, ~line 117-123).
+
+- **Fairshare preemptions are marked** in `GangScheduler.applyPreemptions`
+  (`gang_scheduler.go` ~line 264-273), which iterates the `[]*nodedb.JobPreemptionInfo`
+  returned by the NodeDb and calls `sch.schedulingContext.MarkJobPreempted(jobId)`.
+  This path is **exclusively fairshare**: urgency preemption returns `nil` preempted jobs,
+  and the optimiser uses a separate `PreemptJob` path. So counting here isolates fairshare
+  preemptions with no extra classification needed.
+
+- **The NodeDb already has a `disableFairshareScheduling` flag** (`nodedb.go` ~line 166),
+  which gates the entire fairshare preemption branch in `selectNodeForJobWithTxnAtPriority`
+  (~line 650). It is currently set once per pool per round via
+  `ConfigureScheduling(SchedulingOptions{...})` in `scheduling_algo.go` (~line 241-248),
+  sourced from `PoolConfig.DisableFairshareScheduling`. `ConfigureScheduling` overwrites
+  **all** disable flags at once.
+
+- **`SchedulingContext` is per-pool per-round**, holds `Started time.Time` and the
+  scheduling `Limiter`, and is constructed in `constructSchedulingContext`
+  (`scheduling_algo.go` ~line 700) via `NewSchedulingContext(...)`.
+
+- **The `QueueScheduler`** (`queue_scheduler.go`) holds `schedulingContext` and
+  `gangScheduler`; it reaches the NodeDb indirectly via `sch.gangScheduler.nodeDb`
+  (same package). Its `Schedule` loop (~line 100-244) peeks candidate gangs and delegates
+  to `sch.gangScheduler.Schedule(ctx, gctx)`.
+
+- **Per-pool config** lives in `PoolConfig` (`configuration.go` ~line 384), with a
+  `Get<X>(poolName)` getter idiom on `SchedulingConfig` (e.g.
+  `GetProtectedFractionOfFairShare`). No preemption rate limit exists anywhere today.
+
+## Design
+
+### 1. Config surface
+
+Add nested per-pool config, scoped to fairshare (leaving room for other preemption limits
+later). In `internal/scheduler/configuration/configuration.go`:
+
+```go
+// New types
+type PoolPreemptionConfig struct {
+    // Fairshare, when non-nil, rate-limits fairshare preemptions for this pool.
+    // nil => no limit (default / off).
+    Fairshare *PreemptionRateLimitConfig
+}
+
+type PreemptionRateLimitConfig struct {
+    // Sustained preemptions per second (tokens/sec).
+    MaximumRate  float64 `validate:"gte=0"`
+    // Bucket capacity: max preemptions that can bunch up in a single round.
+    MaximumBurst int     `validate:"gte=0"`
+}
+
+// On PoolConfig, add:
+Preemption PoolPreemptionConfig
+```
+
+YAML shape:
+
+```yaml
+pools:
+  - name: cpu
+    preemption:
+      fairshare:
+        maximumRate: 10
+        maximumBurst: 20
+```
+
+Notes:
+- `Preemption` is a plain (non-pointer) struct; its zero value has `Fairshare == nil`,
+  i.e. off. So default-off requires no config and no `config.yaml` change (a commented
+  example may be added for discoverability).
+- Validation tags are `gte=0`, **not** `gt=0` — the scheduling fields use `gt=0`, but we
+  must permit zero.
+
+Add a getter mirroring `GetProtectedFractionOfFairShare`:
+
+```go
+// GetFairsharePreemptionRateLimit returns the configured fairshare preemption rate and
+// burst for the pool, and whether a limit is configured at all. When enabled is false,
+// callers should treat preemption as unlimited.
+func (sc *SchedulingConfig) GetFairsharePreemptionRateLimit(poolName string) (rate float64, burst int, enabled bool)
+```
+
+### 2. Limiter storage & lifecycle
+
+The token bucket must persist **across rounds** so it refills over wall-clock time (like
+the scheduling `limiter`). It therefore lives on `FairSchedulingAlgo`, not the per-round
+context.
+
+- Add to `FairSchedulingAlgo` (`scheduling_algo.go` ~line 45):
+
+  ```go
+  // Per-pool fairshare preemption rate-limiters (persist across rounds).
+  preemptionLimiterByPool map[string]*rate.Limiter
+  ```
+
+  Initialize `make(map[string]*rate.Limiter)` in `NewFairSchedulingAlgo`.
+
+- Add a `PreemptionLimiter *rate.Limiter` field to `SchedulingContext`
+  (`context/scheduling.go`), mirroring `Limiter`. To avoid churning every
+  `NewSchedulingContext` call site (simulator, tests), **default it in the constructor** to
+  a no-op unlimited limiter:
+
+  ```go
+  // In NewSchedulingContext:
+  PreemptionLimiter: rate.NewLimiter(rate.Inf, math.MaxInt),
+  ```
+
+  This means simulator/dry-run/test contexts get unlimited preemption by default —
+  consistent with how they already treat the scheduling limiter.
+
+- In `constructSchedulingContext` (`scheduling_algo.go` ~line 713), after creating `sctx`,
+  look up / lazily create the pool's persistent limiter and assign it:
+
+  ```go
+  sctx.PreemptionLimiter = l.getOrCreatePreemptionLimiter(pool)
+  ```
+
+  where `getOrCreatePreemptionLimiter`:
+  - returns the cached limiter for the pool if present **and** its rate/burst still match
+    config;
+  - otherwise builds one: if `enabled`, `rate.NewLimiter(rate.Limit(rate), burst)`;
+    if not enabled, `rate.NewLimiter(rate.Inf, math.MaxInt)` (the no-op idiom already used
+    by `noOpRateLimiter` in `idealised_value.go`);
+  - caches it (keyed by pool) alongside the rate/burst it was built with, so a config
+    reload that changes rate/burst rebuilds the limiter rather than serving a stale one.
+
+  Note: `constructSchedulingContext` takes `pool string`; the getter takes a pool name, so
+  this is a straightforward lookup.
+
+### 3. Consuming tokens (retrospective count)
+
+In `GangScheduler.applyPreemptions` (`gang_scheduler.go`), after marking preempted jobs,
+consume one token per preempted job:
+
+```go
+func (sch *GangScheduler) applyPreemptions(preemptedJobs []*nodedb.JobPreemptionInfo) {
+    for _, preemption := range preemptedJobs {
+        preemption.PreemptedJob.PreemptingJob = preemption.PreemptingJob
+        sch.schedulingContext.MarkJobPreempted(preemption.PreemptedJob.JobId)
+    }
+    if n := len(preemptedJobs); n > 0 {
+        sch.schedulingContext.PreemptionLimiter.ReserveN(sch.schedulingContext.Started, n)
+    }
+}
+```
+
+`ReserveN` always succeeds and allows the bucket to go negative when a round preempts more
+than the remaining tokens — matching the "happy for it to go minorly negative" requirement.
+Because the reservation mutates the bucket state, subsequent `TokensAt(sctx.Started)` calls
+within the same round reflect the consumed tokens immediately.
+
+`applyPreemptions` is called from all three commit sites in `gang_scheduler.go` (the two
+node-uniformity paths ~line 199/208 and the common path ~line 241), always after the NodeDb
+transaction commits, so aborted attempts never consume tokens.
+
+### 4. Checking & disabling (queue scheduler → NodeDb)
+
+Add a targeted setter on `NodeDb` so we don't clobber the other `disable*` flags that
+`ConfigureScheduling` sets:
+
+```go
+// nodedb.go
+func (nodeDb *NodeDb) SetDisableFairshareScheduling(disable bool) {
+    nodeDb.disableFairshareScheduling = disable
+}
+```
+
+In `QueueScheduler.Schedule` (`queue_scheduler.go`), inside the main loop, before
+delegating to the gang scheduler, check the pool limiter and disable fairshare preemption
+when exhausted:
+
+```go
+if sctx.PreemptionLimiter.TokensAt(sctx.Started) < 1 {
+    sch.gangScheduler.nodeDb.SetDisableFairshareScheduling(true)
+}
+```
+
+(If reaching `sch.gangScheduler.nodeDb` directly reads poorly, add a small accessor on
+`GangScheduler`, e.g. `NodeDb()`; both types are in package `scheduling`.)
+
+Semantics:
+- We only ever **disable** (set `true`), never re-enable within a round. Tokens are frozen
+  at `sctx.Started`, so they cannot refill mid-round; once exhausted, fairshare preemption
+  stays disabled for the remainder of the round. A pool configured with
+  `DisableFairshareScheduling = true` is never accidentally re-enabled.
+- Each new round constructs a fresh `SchedulingContext` (new `Started`) and calls
+  `ConfigureScheduling(...)` in `scheduling_algo.go`, which resets
+  `disableFairshareScheduling` from `PoolConfig` before the round begins. So the disable is
+  scoped to the round in which the budget was exhausted; the next round re-evaluates against
+  the refilled bucket.
+- When the pool has no configured limit, `PreemptionLimiter` is the `rate.Inf` no-op:
+  `TokensAt` returns effectively infinite, so the branch never fires and behaviour is
+  unchanged.
+
+This is the deliberately simple ("naive") approach described in the task: toggle the NodeDb
+flag rather than threading per-attempt fairshare-permission into the NodeDb's per-job
+selection logic.
+
+### Trade-off (accepted by design)
+
+Because the check is per-gang and consumption is retrospective, a single gang can overshoot
+the limit (drive the bucket negative) before the next check disables fairshare preemption.
+The limit is a throttle, not a hard cap. This is intentional per the requirement.
+
+## Testing
+
+- **Config getter** (`configuration_test.go` or equivalent): nil `Fairshare` → `enabled=false`;
+  configured → returns the rate/burst.
+- **`applyPreemptions` token consumption**: after preempting N jobs, the pool limiter's
+  `TokensAt(Started)` has dropped by N; preempting more than the balance drives it negative
+  and does not error.
+- **Limiter lifecycle**: `getOrCreatePreemptionLimiter` returns the same instance across
+  rounds for an unchanged pool config, and rebuilds when rate/burst change; returns a no-op
+  `rate.Inf` limiter when unconfigured.
+- **Queue-scheduler integration**: a pool with a low fairshare preemption limit disables
+  fairshare preemption once the per-round budget is spent (later gangs in the round schedule
+  without fairshare preemption), while a pool with no configured limit preempts freely.
+  Reuse the `TestFairSharePreemption_*` style in `nodedb_test.go` and the existing
+  queue/preempting scheduler test fixtures.
+- **Default-off**: unconfigured pools behave exactly as today (no disabling, unlimited
+  preemption).
+
+## Files touched (anticipated)
+
+- `internal/scheduler/configuration/configuration.go` — new config types + getter.
+- `internal/scheduler/scheduling/context/scheduling.go` — `PreemptionLimiter` field +
+  no-op default in `NewSchedulingContext`.
+- `internal/scheduler/scheduling/scheduling_algo.go` — `preemptionLimiterByPool` field,
+  init, `getOrCreatePreemptionLimiter`, assignment in `constructSchedulingContext`.
+- `internal/scheduler/scheduling/gang_scheduler.go` — `ReserveN` in `applyPreemptions`.
+- `internal/scheduler/scheduling/queue_scheduler.go` — limiter check + disable call.
+- `internal/scheduler/nodedb/nodedb.go` — `SetDisableFairshareScheduling` setter.
+- `config/scheduler/config.yaml` — optional commented example (no functional default).
+- Tests as above.
+
+## Out of scope
+
+- Per-queue or global preemption rate limits (only per-pool requested).
+- Resource-weighted counting (per-job counting chosen).
+- Threading per-attempt fairshare permission into the NodeDb (kept simple per task).
+- Urgency-based and optimiser preemption (untouched; only fairshare is limited).

--- a/internal/scheduler/configuration/configuration.go
+++ b/internal/scheduler/configuration/configuration.go
@@ -502,15 +502,6 @@ func (sc *SchedulingConfig) GetProtectedFractionOfFairShare(poolName string) flo
 	return sc.ProtectedFractionOfFairShare
 }
 
-func (sc *SchedulingConfig) GetFairsharePreemptionRateLimit(poolName string) (rate float64, burst int, enabled bool) {
-	for _, poolConfig := range sc.Pools {
-		if poolConfig.Name == poolName && poolConfig.FairsharePreemptionRateLimit != nil {
-			return poolConfig.FairsharePreemptionRateLimit.MaximumRate, poolConfig.FairsharePreemptionRateLimit.MaximumBurst, true
-		}
-	}
-	return 0, 0, false
-}
-
 func (sc *SchedulingConfig) GetProtectUncappedAdjustedFairShare(poolName string) bool {
 	for _, poolConfig := range sc.Pools {
 		if poolConfig.Name == poolName {

--- a/internal/scheduler/configuration/configuration.go
+++ b/internal/scheduler/configuration/configuration.go
@@ -348,11 +348,12 @@ type SchedulingConfig struct {
 }
 
 const (
-	DuplicateWellKnownNodeTypeErrorMessage           = "duplicate well-known node type name"
-	AwayNodeTypesWithoutPreemptionErrorMessage       = "priority class has away node types but is not preemptible"
-	UnknownWellKnownNodeTypeErrorMessage             = "priority class refers to unknown well-known node type"
-	WildCardWellKnownNodeTypeValue                   = "*"
-	InvalidAwayNodeTypeConditionOperatorErrorMessage = "away node type condition has invalid operator; must be one of >, <, =="
+	DuplicateWellKnownNodeTypeErrorMessage              = "duplicate well-known node type name"
+	AwayNodeTypesWithoutPreemptionErrorMessage          = "priority class has away node types but is not preemptible"
+	UnknownWellKnownNodeTypeErrorMessage                = "priority class refers to unknown well-known node type"
+	WildCardWellKnownNodeTypeValue                      = "*"
+	InvalidAwayNodeTypeConditionOperatorErrorMessage    = "away node type condition has invalid operator; must be one of >, <, =="
+	PreemptionRateLimitWithMarketSchedulingErrorMessage = "preemption rate limit is not supported with market scheduling enabled on the same pool"
 )
 
 // ResourceType represents a resource the scheduler indexes for efficient lookup.
@@ -405,6 +406,15 @@ type PoolConfig struct {
 	DisableGangAwayScheduling        bool
 	DisableFairshareScheduling       bool
 	DisableUrgencyScheduling         bool
+	FairsharePreemptionRateLimit     *RateLimit
+}
+
+// RateLimit The rate at which an action can happen using a token bucket approach
+type RateLimit struct {
+	// Sustained actions per second (tokens/sec).
+	MaximumRate float64 `validate:"gte=0"`
+	// Bucket capacity: the maximum number of actions that can bunch up in a single scheduling round.
+	MaximumBurst int `validate:"gte=0"`
 }
 
 func (p PoolConfig) GetSubmissionGroup() string {
@@ -490,6 +500,15 @@ func (sc *SchedulingConfig) GetProtectedFractionOfFairShare(poolName string) flo
 		}
 	}
 	return sc.ProtectedFractionOfFairShare
+}
+
+func (sc *SchedulingConfig) GetFairsharePreemptionRateLimit(poolName string) (rate float64, burst int, enabled bool) {
+	for _, poolConfig := range sc.Pools {
+		if poolConfig.Name == poolName && poolConfig.FairsharePreemptionRateLimit != nil {
+			return poolConfig.FairsharePreemptionRateLimit.MaximumRate, poolConfig.FairsharePreemptionRateLimit.MaximumBurst, true
+		}
+	}
+	return 0, 0, false
 }
 
 func (sc *SchedulingConfig) GetProtectUncappedAdjustedFairShare(poolName string) bool {

--- a/internal/scheduler/configuration/configuration_test.go
+++ b/internal/scheduler/configuration/configuration_test.go
@@ -39,6 +39,49 @@ func TestGetProtectedFractionOfFairShare(t *testing.T) {
 	assert.Equal(t, 0.1, sc.GetProtectedFractionOfFairShare("missing-pool"))
 }
 
+func TestGetFairsharePreemptionRateLimit(t *testing.T) {
+	sc := SchedulingConfig{
+		Pools: []PoolConfig{
+			{
+				Name: "limited-pool",
+				FairsharePreemptionRateLimit: &RateLimit{
+					MaximumRate:  10,
+					MaximumBurst: 20,
+				},
+			},
+			{
+				Name: "zero-pool",
+				FairsharePreemptionRateLimit: &RateLimit{
+					MaximumRate:  0,
+					MaximumBurst: 0,
+				},
+			},
+			{
+				Name: "unlimited-pool",
+			},
+		},
+	}
+
+	rate, burst, enabled := sc.GetFairsharePreemptionRateLimit("limited-pool")
+	assert.True(t, enabled)
+	assert.Equal(t, 10.0, rate)
+	assert.Equal(t, 20, burst)
+
+	// A configured-but-zero limit is still "enabled" (allows nothing until it refills).
+	rate, burst, enabled = sc.GetFairsharePreemptionRateLimit("zero-pool")
+	assert.True(t, enabled)
+	assert.Equal(t, 0.0, rate)
+	assert.Equal(t, 0, burst)
+
+	// A pool without preemption config is unlimited (disabled).
+	_, _, enabled = sc.GetFairsharePreemptionRateLimit("unlimited-pool")
+	assert.False(t, enabled)
+
+	// An unknown pool is unlimited (disabled).
+	_, _, enabled = sc.GetFairsharePreemptionRateLimit("missing-pool")
+	assert.False(t, enabled)
+}
+
 func TestApplyRespectNodePodLimits(t *testing.T) {
 	cpu := ResourceType{Name: "cpu", Resolution: resource.MustParse("1m")}
 	mem := ResourceType{Name: "memory", Resolution: resource.MustParse("1")}

--- a/internal/scheduler/configuration/configuration_test.go
+++ b/internal/scheduler/configuration/configuration_test.go
@@ -39,49 +39,6 @@ func TestGetProtectedFractionOfFairShare(t *testing.T) {
 	assert.Equal(t, 0.1, sc.GetProtectedFractionOfFairShare("missing-pool"))
 }
 
-func TestGetFairsharePreemptionRateLimit(t *testing.T) {
-	sc := SchedulingConfig{
-		Pools: []PoolConfig{
-			{
-				Name: "limited-pool",
-				FairsharePreemptionRateLimit: &RateLimit{
-					MaximumRate:  10,
-					MaximumBurst: 20,
-				},
-			},
-			{
-				Name: "zero-pool",
-				FairsharePreemptionRateLimit: &RateLimit{
-					MaximumRate:  0,
-					MaximumBurst: 0,
-				},
-			},
-			{
-				Name: "unlimited-pool",
-			},
-		},
-	}
-
-	rate, burst, enabled := sc.GetFairsharePreemptionRateLimit("limited-pool")
-	assert.True(t, enabled)
-	assert.Equal(t, 10.0, rate)
-	assert.Equal(t, 20, burst)
-
-	// A configured-but-zero limit is still "enabled" (allows nothing until it refills).
-	rate, burst, enabled = sc.GetFairsharePreemptionRateLimit("zero-pool")
-	assert.True(t, enabled)
-	assert.Equal(t, 0.0, rate)
-	assert.Equal(t, 0, burst)
-
-	// A pool without preemption config is unlimited (disabled).
-	_, _, enabled = sc.GetFairsharePreemptionRateLimit("unlimited-pool")
-	assert.False(t, enabled)
-
-	// An unknown pool is unlimited (disabled).
-	_, _, enabled = sc.GetFairsharePreemptionRateLimit("missing-pool")
-	assert.False(t, enabled)
-}
-
 func TestApplyRespectNodePodLimits(t *testing.T) {
 	cpu := ResourceType{Name: "cpu", Resolution: resource.MustParse("1m")}
 	mem := ResourceType{Name: "memory", Resolution: resource.MustParse("1")}

--- a/internal/scheduler/configuration/validation.go
+++ b/internal/scheduler/configuration/validation.go
@@ -34,6 +34,15 @@ func (c *Configuration) Validate() error {
 func SchedulingConfigValidation(sl validator.StructLevel) {
 	c := sl.Current().Interface().(SchedulingConfig)
 
+	for i, pool := range c.Pools {
+		// The preemption rate limit relies on rescheduling evicted jobs before new jobs, which the
+		// market-driven scheduler does not support. Reject the combination rather than silently no-op.
+		if pool.FairsharePreemptionRateLimit != nil && pool.ExperimentalMarketScheduling != nil && pool.ExperimentalMarketScheduling.Enabled {
+			fieldName := fmt.Sprintf("Pools[%d].FairsharePreemptionRateLimit", i)
+			sl.ReportError(pool.FairsharePreemptionRateLimit, fieldName, "", PreemptionRateLimitWithMarketSchedulingErrorMessage, "")
+		}
+	}
+
 	wellKnownNodeTypes := make(map[string]bool)
 	for i, wellKnownNodeType := range c.WellKnownNodeTypes {
 		if wellKnownNodeTypes[wellKnownNodeType.Name] {

--- a/internal/scheduler/configuration/validation_test.go
+++ b/internal/scheduler/configuration/validation_test.go
@@ -217,6 +217,62 @@ func createValidMinimalConfig() Configuration {
 	}
 }
 
+func TestValidate_PreemptionRateLimitWithMarketScheduling(t *testing.T) {
+	rateLimit := &RateLimit{MaximumRate: 10, MaximumBurst: 20}
+
+	tests := map[string]struct {
+		pool      PoolConfig
+		expectErr bool
+	}{
+		"rate limit without market scheduling is allowed": {
+			pool: PoolConfig{
+				Name:                         "cpu",
+				FairsharePreemptionRateLimit: rateLimit,
+			},
+			expectErr: false,
+		},
+		"market scheduling without rate limit is allowed": {
+			pool: PoolConfig{
+				Name:                         "cpu",
+				ExperimentalMarketScheduling: &MarketSchedulingConfig{Enabled: true, GangIndicativePricingTimeout: time.Second},
+			},
+			expectErr: false,
+		},
+		"rate limit with market scheduling disabled is allowed": {
+			pool: PoolConfig{
+				Name:                         "cpu",
+				FairsharePreemptionRateLimit: rateLimit,
+				ExperimentalMarketScheduling: &MarketSchedulingConfig{Enabled: false, GangIndicativePricingTimeout: time.Second},
+			},
+			expectErr: false,
+		},
+		"rate limit with market scheduling enabled is rejected": {
+			pool: PoolConfig{
+				Name:                         "cpu",
+				FairsharePreemptionRateLimit: rateLimit,
+				ExperimentalMarketScheduling: &MarketSchedulingConfig{Enabled: true, GangIndicativePricingTimeout: time.Second},
+			},
+			expectErr: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			c := createValidMinimalConfig()
+			c.Scheduling.Pools = []PoolConfig{tc.pool}
+
+			err := c.Validate()
+
+			if tc.expectErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), PreemptionRateLimitWithMarketSchedulingErrorMessage)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestSchedulingConfigValidate(t *testing.T) {
 	c := Configuration{
 		Scheduling: SchedulingConfig{

--- a/internal/scheduler/nodedb/nodedb.go
+++ b/internal/scheduler/nodedb/nodedb.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/armadaproject/armada/internal/common/armadaerrors"
+	log "github.com/armadaproject/armada/internal/common/logging"
 	"github.com/armadaproject/armada/internal/common/slices"
 	"github.com/armadaproject/armada/internal/common/types"
 	"github.com/armadaproject/armada/internal/common/util"
@@ -57,6 +58,11 @@ func (nodeDb *NodeDb) CreateAndInsertWithJobDbJobsWithTxn(txn *memdb.Txn, jobs [
 		return err
 	}
 	return nil
+}
+
+type JobPreemptionInfo struct {
+	PreemptedJob  *context.JobSchedulingContext
+	PreemptingJob *jobdb.Job
 }
 
 // EvictedJobSchedulingContext represents an evicted job.
@@ -375,7 +381,8 @@ func (nodeDb *NodeDb) GetNodesWithTxn(txn *memdb.Txn) ([]*internaltypes.Node, er
 	return nodes, nil
 }
 
-func (nodeDb *NodeDb) ScheduleManyWithTxn(txn *memdb.Txn, gctx *context.GangSchedulingContext) (bool, error) {
+func (nodeDb *NodeDb) ScheduleManyWithTxn(txn *memdb.Txn, gctx *context.GangSchedulingContext) (bool, []*JobPreemptionInfo, error) {
+	var preemptedJobs []*JobPreemptionInfo
 	// Attempt to schedule pods one by one in a transaction.
 	for _, jctx := range gctx.JobSchedulingContexts {
 		// In general, we may attempt to schedule a gang multiple times (in
@@ -383,30 +390,31 @@ func (nodeDb *NodeDb) ScheduleManyWithTxn(txn *memdb.Txn, gctx *context.GangSche
 		// previous attempts.
 		jctx.UnschedulableReason = ""
 
-		node, err := nodeDb.SelectNodeForJobWithTxn(txn, jctx)
+		node, jobsPreempted, err := nodeDb.SelectNodeForJobWithTxn(txn, jctx)
 		if err != nil {
-			return false, err
+			return false, nil, err
 		}
+		preemptedJobs = append(preemptedJobs, jobsPreempted...)
 
 		if node != nil {
 			// If we found a node for this pod, bind it and continue to the next pod.
 			if node, err := nodeDb.BindJobToNode(node, jctx.Job, jctx.PodSchedulingContext.ScheduledAtPriority); err != nil {
-				return false, err
+				return false, nil, err
 			} else {
 				if err := nodeDb.UpsertWithTxn(txn, node); err != nil {
-					return false, err
+					return false, nil, err
 				}
 			}
 
 			// Once a job is scheduled, it should no longer be considered for preemption.
 			if err := deleteEvictedJobSchedulingContextIfExistsWithTxn(txn, jctx.JobId); err != nil {
-				return false, err
+				return false, nil, err
 			}
 		} else {
-			return false, nil
+			return false, nil, nil
 		}
 	}
-	return true, nil
+	return true, preemptedJobs, nil
 }
 
 func deleteEvictedJobSchedulingContextIfExistsWithTxn(txn *memdb.Txn, jobId string) error {
@@ -420,7 +428,14 @@ func deleteEvictedJobSchedulingContextIfExistsWithTxn(txn *memdb.Txn, jobId stri
 }
 
 // SelectNodeForJobWithTxn selects a node on which the job can be scheduled.
-func (nodeDb *NodeDb) SelectNodeForJobWithTxn(txn *memdb.Txn, jctx *context.JobSchedulingContext) (*internaltypes.Node, error) {
+func (nodeDb *NodeDb) SelectNodeForJobWithTxn(txn *memdb.Txn, jctx *context.JobSchedulingContext) (*internaltypes.Node, []*JobPreemptionInfo, error) {
+	// A job that has already been preempted should not be rescheduled
+	// TODO This is a failsafe for now - in future either make it into an error OR just remove the check and rely on caller
+	if jctx.PreemptingJob != nil {
+		log.Errorf("job %s was offered for scheduling despite having been preempted by job %s; refusing to schedule it", jctx.JobId, jctx.PreemptingJob.Id())
+		return nil, nil, nil
+	}
+
 	priorityClass := jctx.Job.PriorityClass()
 
 	// If the job has already been scheduled, get the priority at which it was scheduled.
@@ -456,13 +471,13 @@ func (nodeDb *NodeDb) SelectNodeForJobWithTxn(txn *memdb.Txn, jctx *context.JobS
 	// If the nodeIdLabel selector is set, consider only that node.
 	if nodeId := jctx.GetAssignedNodeId(); nodeId != "" {
 		if it, err := txn.Get("nodes", "id", nodeId); err != nil {
-			return nil, errors.WithStack(err)
+			return nil, nil, errors.WithStack(err)
 		} else {
 			if node, err := nodeDb.selectNodeForPodWithItAtPriority(it, jctx, priority, true); err != nil {
-				return nil, err
+				return nil, nil, err
 			} else {
 				jctx.PodSchedulingContext.SchedulingMethod = context.Rescheduled
-				return node, nil
+				return node, nil, nil
 			}
 		}
 	}
@@ -470,37 +485,37 @@ func (nodeDb *NodeDb) SelectNodeForJobWithTxn(txn *memdb.Txn, jctx *context.JobS
 	for _, resourceName := range nodeDb.disallowedJobResources {
 		if jctx.KubernetesResourceRequirements.GetRawByNameZeroIfMissing(resourceName) > 0 {
 			pctx.NumExcludedNodesByReason[disallowedResourceRequested] = int(nodeDb.numNodes)
-			return nil, nil
+			return nil, nil, nil
 		}
 	}
 
 	if !nodeDb.disableHomeScheduling {
-		node, err := nodeDb.selectNodeForJobWithTxnAtPriority(txn, jctx)
+		node, preemptedJobs, err := nodeDb.selectNodeForJobWithTxnAtPriority(txn, jctx)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if node != nil {
-			return node, nil
+			return node, preemptedJobs, nil
 		}
 	}
 
 	awaySchedulingDisabled := nodeDb.disableAwayScheduling || (jctx.Job.IsInGang() && nodeDb.disableGangAwayScheduling)
 	if !awaySchedulingDisabled {
 		for _, awayNodeType := range priorityClass.AwayNodeTypes {
-			node, err := nodeDb.selectNodeForJobWithTxnAndAwayNodeType(txn, jctx, awayNodeType)
+			node, preemptedJobs, err := nodeDb.selectNodeForJobWithTxnAndAwayNodeType(txn, jctx, awayNodeType)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			if node != nil {
 				pctx.WellKnownNodeTypeName = awayNodeType.WellKnownNodeTypeName
 				pctx.SchedulingMethod = context.ScheduledAsAwayJob
 				pctx.ScheduledAway = true
-				return node, nil
+				return node, preemptedJobs, nil
 			}
 		}
 	}
 
-	return nil, nil
+	return nil, nil, nil
 }
 
 func matchesCondition(conditions []types.AwayNodeTypeCondition, jobResources internaltypes.ResourceList) bool {
@@ -552,8 +567,9 @@ func (nodeDb *NodeDb) selectNodeForJobWithTxnAndAwayNodeType(
 	txn *memdb.Txn,
 	jctx *context.JobSchedulingContext,
 	awayNodeType types.AwayNodeType,
-) (*internaltypes.Node, error) {
+) (*internaltypes.Node, []*JobPreemptionInfo, error) {
 	var node *internaltypes.Node
+	var preemptedJobs []*JobPreemptionInfo
 	var err error
 	// Save the number of additional tolerations that the job originally had; we
 	// use this value to restore the slice of additional toleration at the end
@@ -571,11 +587,11 @@ func (nodeDb *NodeDb) selectNodeForJobWithTxnAndAwayNodeType(
 
 	awayNodeTaints, err := nodeDb.getEffectiveAwayNodeTaints(awayNodeType, jctx.Job)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if len(awayNodeTaints) == 0 {
 		// No extra taints to tolerate will mean no extra scheduling capability
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	for _, taint := range awayNodeTaints {
@@ -590,41 +606,41 @@ func (nodeDb *NodeDb) selectNodeForJobWithTxnAndAwayNodeType(
 	}
 
 	jctx.PodSchedulingContext.ScheduledAtPriority = awayNodeType.Priority
-	node, err = nodeDb.selectNodeForJobWithTxnAtPriority(txn, jctx)
-	return node, err
+	node, preemptedJobs, err = nodeDb.selectNodeForJobWithTxnAtPriority(txn, jctx)
+	return node, preemptedJobs, err
 }
 
 func (nodeDb *NodeDb) selectNodeForJobWithTxnAtPriority(
 	txn *memdb.Txn,
 	jctx *context.JobSchedulingContext,
-) (*internaltypes.Node, error) {
+) (*internaltypes.Node, []*JobPreemptionInfo, error) {
 	pctx := jctx.PodSchedulingContext
 
 	matchingNodeTypeIds, numExcludedNodesByReason, err := nodeDb.NodeTypesMatchingJob(jctx)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Try scheduling at evictedPriority. If this succeeds, no preemption is necessary.
 	pctx.NumExcludedNodesByReason = maps.Clone(numExcludedNodesByReason)
 	if node, err := nodeDb.selectNodeForPodAtPriority(txn, jctx, matchingNodeTypeIds, internaltypes.EvictedPriority); err != nil {
-		return nil, err
+		return nil, nil, err
 	} else if err := assertPodSchedulingContextNode(pctx, node); err != nil {
-		return nil, err
+		return nil, nil, err
 	} else if node != nil {
 		pctx.SchedulingMethod = context.ScheduledWithoutPreemption
-		return node, nil
+		return node, nil, nil
 	}
 
 	// Try scheduling at the job priority. If this fails, scheduling is impossible and we return.
 	// This is an optimisation to avoid looking for preemption targets for unschedulable jobs.
 	pctx.NumExcludedNodesByReason = maps.Clone(numExcludedNodesByReason)
 	if node, err := nodeDb.selectNodeForPodAtPriority(txn, jctx, matchingNodeTypeIds, pctx.ScheduledAtPriority); err != nil {
-		return nil, err
+		return nil, nil, err
 	} else if err := assertPodSchedulingContextNode(pctx, node); err != nil {
-		return nil, err
+		return nil, nil, err
 	} else if node == nil {
-		return nil, nil
+		return nil, nil, nil
 	}
 	pctx.NodeId = ""
 	pctx.PreemptedAtPriority = internaltypes.MinPriority
@@ -632,13 +648,13 @@ func (nodeDb *NodeDb) selectNodeForJobWithTxnAtPriority(
 	// Schedule by preventing evicted jobs from being re-scheduled.
 	// This method respect fairness by preventing from re-scheduling jobs that appear as far back in the total order as possible.
 	if !nodeDb.disableFairshareScheduling {
-		if node, err := nodeDb.selectNodeForJobWithFairPreemption(txn, jctx); err != nil {
-			return nil, err
+		if node, preemptedJobs, err := nodeDb.selectNodeForJobWithFairPreemption(txn, jctx); err != nil {
+			return nil, nil, err
 		} else if err := assertPodSchedulingContextNode(pctx, node); err != nil {
-			return nil, err
+			return nil, nil, err
 		} else if node != nil {
 			pctx.SchedulingMethod = context.ScheduledWithFairSharePreemption
-			return node, nil
+			return node, preemptedJobs, nil
 		}
 	}
 
@@ -649,16 +665,16 @@ func (nodeDb *NodeDb) selectNodeForJobWithTxnAtPriority(
 	// This method does not respect fairness when choosing on which node to schedule the job.
 	if !nodeDb.disableUrgencyScheduling {
 		if node, err := nodeDb.selectNodeForJobWithUrgencyPreemption(txn, jctx, matchingNodeTypeIds); err != nil {
-			return nil, err
+			return nil, nil, err
 		} else if err := assertPodSchedulingContextNode(pctx, node); err != nil {
-			return nil, err
+			return nil, nil, err
 		} else if node != nil {
 			pctx.SchedulingMethod = context.ScheduledWithUrgencyBasedPreemption
-			return node, nil
+			return node, nil, nil
 		}
 	}
 
-	return nil, nil
+	return nil, nil, nil
 }
 
 func assertPodSchedulingContextNode(pctx *context.PodSchedulingContext, node *internaltypes.Node) error {
@@ -805,7 +821,7 @@ func (nodeDb *NodeDb) selectNodeForPodWithItAtPriority(
 //
 // It does this by considering all evicted jobs in the reverse order they would be scheduled in and preventing
 // from being re-scheduled the jobs that would be scheduled last.
-func (nodeDb *NodeDb) selectNodeForJobWithFairPreemption(txn *memdb.Txn, jctx *context.JobSchedulingContext) (*internaltypes.Node, error) {
+func (nodeDb *NodeDb) selectNodeForJobWithFairPreemption(txn *memdb.Txn, jctx *context.JobSchedulingContext) (*internaltypes.Node, []*JobPreemptionInfo, error) {
 	type consideredNode struct {
 		node                     *internaltypes.Node
 		availableResource        internaltypes.ResourceList
@@ -816,10 +832,11 @@ func (nodeDb *NodeDb) selectNodeForJobWithFairPreemption(txn *memdb.Txn, jctx *c
 	pctx := jctx.PodSchedulingContext
 
 	var selectedNode *internaltypes.Node
+	var preemptedJobs []*JobPreemptionInfo
 	nodesById := make(map[string]*consideredNode)
 	it, err := txn.ReverseLowerBound("evictedJobs", "index", math.MaxInt)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, nil, errors.WithStack(err)
 	}
 	maxPriority := internaltypes.MinPriority
 	for obj := it.Next(); obj != nil && selectedNode == nil; obj = it.Next() {
@@ -828,7 +845,7 @@ func (nodeDb *NodeDb) selectNodeForJobWithFairPreemption(txn *memdb.Txn, jctx *c
 
 		evictedJobSchedulingPriority, ok := nodeDb.GetScheduledAtPriority(evictedJctx.JobId)
 		if !ok {
-			return nil, errors.Errorf("evicted job %s does not have scheduled at priority set in nodedb", evictedJctx.JobId)
+			return nil, nil, errors.Errorf("evicted job %s does not have scheduled at priority set in nodedb", evictedJctx.JobId)
 		}
 
 		// Jobs should not preempt jobs with a higher priority, even via fairshare
@@ -838,13 +855,14 @@ func (nodeDb *NodeDb) selectNodeForJobWithFairPreemption(txn *memdb.Txn, jctx *c
 
 		nodeId := evictedJctx.GetAssignedNodeId()
 		if nodeId == "" {
-			return nil, errors.Errorf("evicted job %s does not have an assigned nodeId", evictedJctx.JobId)
+			return nil, nil, errors.Errorf("evicted job %s does not have an assigned nodeId", evictedJctx.JobId)
 		}
+
 		node, ok := nodesById[nodeId]
 		if !ok {
 			nodeFromDb, err := nodeDb.GetNodeWithTxn(txn, nodeId)
 			if err != nil {
-				return nil, errors.WithStack(err)
+				return nil, nil, errors.WithStack(err)
 			}
 			node = &consideredNode{
 				node:                     nodeFromDb,
@@ -871,7 +889,7 @@ func (nodeDb *NodeDb) selectNodeForJobWithFairPreemption(txn *memdb.Txn, jctx *c
 
 		staticRequirementsMet, reason, err := StaticJobRequirementsMet(node.node, jctx)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if !staticRequirementsMet {
 			node.staticRequirementsNotMet = true
@@ -885,11 +903,11 @@ func (nodeDb *NodeDb) selectNodeForJobWithFairPreemption(txn *memdb.Txn, jctx *c
 			// Remove preempted job from node
 			err = nodeDb.unbindJobFromNodeInPlace(job.JobSchedulingContext.Job, nodeCopy)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			// Remove preempted job from list of evicted jobs
 			if err := txn.Delete("evictedJobs", job); err != nil {
-				return nil, errors.WithStack(err)
+				return nil, nil, errors.WithStack(err)
 			}
 
 			priority, ok := nodeDb.GetScheduledAtPriority(job.JobSchedulingContext.JobId)
@@ -899,14 +917,17 @@ func (nodeDb *NodeDb) selectNodeForJobWithFairPreemption(txn *memdb.Txn, jctx *c
 			if priority > maxPriority {
 				maxPriority = priority
 			}
-			job.JobSchedulingContext.PreemptingJob = jctx.Job
+			preemptedJobs = append(preemptedJobs, &JobPreemptionInfo{
+				PreemptedJob:  job.JobSchedulingContext,
+				PreemptingJob: jctx.Job,
+			})
 		}
 
 		selectedNode = nodeCopy
 		pctx.NodeId = selectedNode.GetId()
 		pctx.PreemptedAtPriority = maxPriority
 	}
-	return selectedNode, nil
+	return selectedNode, preemptedJobs, nil
 }
 
 // BindJobToNode returns a copy of node with job bound to it.

--- a/internal/scheduler/nodedb/nodedb_test.go
+++ b/internal/scheduler/nodedb/nodedb_test.go
@@ -79,7 +79,7 @@ func TestSelectNodeForPod_NodeIdLabel_Success(t *testing.T) {
 	for _, jctx := range jctxs {
 		txn := db.Txn(false)
 		jctx.SetAssignedNode(testfixtures.TestSimpleNode(nodeId))
-		node, err := db.SelectNodeForJobWithTxn(txn, jctx)
+		node, _, err := db.SelectNodeForJobWithTxn(txn, jctx)
 		txn.Abort()
 		require.NoError(t, err)
 		pctx := jctx.PodSchedulingContext
@@ -104,7 +104,7 @@ func TestSelectNodeForPod_NodeIdLabel_Failure(t *testing.T) {
 	for _, jctx := range jctxs {
 		txn := db.Txn(false)
 		jctx.SetAssignedNode(testfixtures.TestSimpleNode("non-existent node"))
-		node, err := db.SelectNodeForJobWithTxn(txn, jctx)
+		node, _, err := db.SelectNodeForJobWithTxn(txn, jctx)
 		txn.Abort()
 		if !assert.NoError(t, err) {
 			continue
@@ -554,7 +554,7 @@ func TestScheduleIndividually(t *testing.T) {
 			for i, jctx := range jctxs {
 				nodeDbTxn := nodeDb.Txn(true)
 				gctx := context.NewGangSchedulingContext([]*context.JobSchedulingContext{jctx})
-				ok, err := nodeDb.ScheduleManyWithTxn(nodeDbTxn, gctx)
+				ok, _, err := nodeDb.ScheduleManyWithTxn(nodeDbTxn, gctx)
 				require.NoError(t, err)
 
 				require.Equal(t, tc.ExpectSuccess[i], ok)
@@ -641,7 +641,7 @@ func TestScheduleMany(t *testing.T) {
 				nodeDbTxn := nodeDb.Txn(true)
 				jctxs := context.JobSchedulingContextsFromJobs(jobs)
 				gctx := context.NewGangSchedulingContext(jctxs)
-				ok, err := nodeDb.ScheduleManyWithTxn(nodeDbTxn, gctx)
+				ok, _, err := nodeDb.ScheduleManyWithTxn(nodeDbTxn, gctx)
 				require.NoError(t, err)
 				require.Equal(t, tc.ExpectSuccess[i], ok)
 				if ok {
@@ -705,7 +705,7 @@ func TestDisallowedJobResources(t *testing.T) {
 
 			nodeDbTxn := nodeDb.Txn(true)
 			nodeDb.ConfigureScheduling(SchedulingOptions{DisallowedJobResources: tc.disallowedJobResources})
-			node, err := nodeDb.SelectNodeForJobWithTxn(nodeDbTxn, jctx)
+			node, _, err := nodeDb.SelectNodeForJobWithTxn(nodeDbTxn, jctx)
 			require.NoError(t, err)
 
 			if tc.expectScheduled {
@@ -795,7 +795,7 @@ func TestHomeNodeScheduling(t *testing.T) {
 			require.Empty(t, jctx.AdditionalTolerations)
 			gctx := context.NewGangSchedulingContext([]*context.JobSchedulingContext{jctx})
 
-			ok, err := nodeDb.ScheduleManyWithTxn(nodeDbTxn, gctx)
+			ok, _, err := nodeDb.ScheduleManyWithTxn(nodeDbTxn, gctx)
 			require.NoError(t, err)
 			if tc.expectSuccess {
 				require.True(t, ok)
@@ -898,7 +898,7 @@ func TestPreemptionScheduling(t *testing.T) {
 			gctx := context.NewGangSchedulingContext([]*context.JobSchedulingContext{jctx})
 
 			txn = nodeDb.Txn(true)
-			ok, err := nodeDb.ScheduleManyWithTxn(txn, gctx)
+			ok, _, err := nodeDb.ScheduleManyWithTxn(txn, gctx)
 			require.NoError(t, err)
 
 			require.Equal(t, tc.expectSuccess, ok)
@@ -976,7 +976,7 @@ func TestFairSharePreemption_RespectsPriorityOrder(t *testing.T) {
 
 			txn = nodeDb.Txn(true)
 			defer txn.Abort()
-			ok, err := nodeDb.ScheduleManyWithTxn(txn, gctx)
+			ok, _, err := nodeDb.ScheduleManyWithTxn(txn, gctx)
 			require.NoError(t, err)
 
 			require.Equal(t, tc.expectScheduled, ok)
@@ -988,6 +988,53 @@ func TestFairSharePreemption_RespectsPriorityOrder(t *testing.T) {
 			} else {
 				assert.False(t, jctx.PodSchedulingContext.IsSuccessful())
 				assert.Empty(t, jctx.PodSchedulingContext.NodeId)
+			}
+		})
+	}
+}
+
+func TestPreemptedJobIsNotRescheduled(t *testing.T) {
+	tests := map[string]struct {
+		alreadyPreempted bool
+		expectScheduled  bool
+	}{
+		"job not preempted schedules onto empty node": {
+			alreadyPreempted: false,
+			expectScheduled:  true,
+		},
+		"preempted job is not rescheduled despite empty node": {
+			alreadyPreempted: true,
+			expectScheduled:  false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			node := testfixtures.Test32CpuNode(testfixtures.TestPriorities)
+			nodeDb, err := newNodeDbWithNodes([]*internaltypes.Node{node})
+			require.NoError(t, err)
+
+			job := testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 1)[0]
+			jctx := context.JobSchedulingContextFromJob(job)
+			if tc.alreadyPreempted {
+				jctx.PreemptingJob = testfixtures.N1Cpu4GiJobs("B", testfixtures.PriorityClass1, 1)[0]
+			}
+			gctx := context.NewGangSchedulingContext([]*context.JobSchedulingContext{jctx})
+
+			txn := nodeDb.Txn(true)
+			defer txn.Abort()
+			ok, preemptedJobs, err := nodeDb.ScheduleManyWithTxn(txn, gctx)
+			assert.NoError(t, err)
+			assert.Empty(t, preemptedJobs)
+
+			if tc.expectScheduled {
+				assert.True(t, ok)
+				assert.NotNil(t, jctx.PodSchedulingContext)
+				assert.True(t, jctx.PodSchedulingContext.IsSuccessful())
+				assert.Equal(t, node.GetId(), jctx.PodSchedulingContext.NodeId)
+			} else {
+				assert.False(t, ok)
+				assert.Nil(t, jctx.PodSchedulingContext)
 			}
 		})
 	}
@@ -1122,7 +1169,7 @@ func TestConditionalAwayNodeScheduling(t *testing.T) {
 			jctx := context.JobSchedulingContextFromJob(tc.job)
 
 			nodeDbTxn := nodeDb.Txn(true)
-			node, err := nodeDb.SelectNodeForJobWithTxn(nodeDbTxn, jctx)
+			node, _, err := nodeDb.SelectNodeForJobWithTxn(nodeDbTxn, jctx)
 			require.NoError(t, err)
 
 			if tc.expectScheduled {
@@ -1244,7 +1291,7 @@ func TestAwayNodeScheduling(t *testing.T) {
 			require.Empty(t, jctx.AdditionalTolerations)
 			gctx := context.NewGangSchedulingContext([]*context.JobSchedulingContext{jctx})
 
-			ok, err := nodeDb.ScheduleManyWithTxn(nodeDbTxn, gctx)
+			ok, _, err := nodeDb.ScheduleManyWithTxn(nodeDbTxn, gctx)
 			require.NoError(t, err)
 			if tc.expectSuccess {
 				require.True(t, ok)
@@ -1455,7 +1502,7 @@ func benchmarkScheduleMany(b *testing.B, nodes []*internaltypes.Node, jobs []*jo
 		jctxs := context.JobSchedulingContextsFromJobs(jobs)
 		gctx := context.NewGangSchedulingContext(jctxs)
 		txn := nodeDb.Txn(true)
-		_, err := nodeDb.ScheduleManyWithTxn(txn, gctx)
+		_, _, err := nodeDb.ScheduleManyWithTxn(txn, gctx)
 		txn.Abort()
 		require.NoError(b, err)
 	}

--- a/internal/scheduler/scheduling/context/scheduling.go
+++ b/internal/scheduler/scheduling/context/scheduling.go
@@ -36,6 +36,10 @@ type SchedulingContext struct {
 	// Limits job scheduling rate globally across all queues.
 	// Use the "Started" time to ensure limiter state remains constant within each scheduling round.
 	Limiter *rate.Limiter
+	// Limits the rate of fairshare preemptions for this pool, counting one token per preempted job.
+	// nil means no limit (the pool is not configured with a fairshare preemption rate limit).
+	// Use the "Started" time to ensure limiter state remains constant within each scheduling round.
+	FairsharePreemptionLimiter *rate.Limiter
 	// Sum of queue weights across all queues.
 	WeightSum float64
 	// Per-queue scheduling contexts.
@@ -76,6 +80,7 @@ func NewSchedulingContext(
 	pool string,
 	fairnessCostProvider fairness.FairnessCostProvider,
 	limiter *rate.Limiter,
+	fairsharePreemptionLimiter *rate.Limiter,
 	totalResources internaltypes.ResourceList,
 ) *SchedulingContext {
 	return &SchedulingContext{
@@ -83,6 +88,7 @@ func NewSchedulingContext(
 		Pool:                         pool,
 		FairnessCostProvider:         fairnessCostProvider,
 		Limiter:                      limiter,
+		FairsharePreemptionLimiter:   fairsharePreemptionLimiter,
 		QueueSchedulingContexts:      make(map[string]*QueueSchedulingContext),
 		TotalResources:               totalResources,
 		ScheduledResources:           internaltypes.ResourceList{},
@@ -496,13 +502,29 @@ func (sctx *SchedulingContext) QueueContextExists(job *jobdb.Job) bool {
 
 // MarkJobPreempted records that the job with the given id was preempted during this scheduling round.
 // Preempted jobs must not be re-scheduled; see IsJobPreempted.
+// Each newly-preempted job consumes one token from the pool's fairshare preemption rate limiter.
+// This is retrospective (the bucket may go negative) and idempotent: re-marking a job does not
+// consume additional tokens.
 func (sctx *SchedulingContext) MarkJobPreempted(jobId string) {
+	if sctx.PreemptedJobIds[jobId] {
+		return
+	}
 	sctx.PreemptedJobIds[jobId] = true
+	if sctx.FairsharePreemptionLimiter != nil {
+		sctx.FairsharePreemptionLimiter.ReserveN(sctx.Started, 1)
+	}
 }
 
 // IsJobPreempted reports whether the job with the given id was preempted during this scheduling round.
 func (sctx *SchedulingContext) IsJobPreempted(jobId string) bool {
 	return sctx.PreemptedJobIds[jobId]
+}
+
+func (sctx *SchedulingContext) AtFairsharePreemptionRateLimit() bool {
+	if sctx.FairsharePreemptionLimiter == nil {
+		return false
+	}
+	return sctx.FairsharePreemptionLimiter.TokensAt(sctx.Started) < 1
 }
 
 func (sctx *SchedulingContext) PreemptJob(jctx *JobSchedulingContext) (bool, error) {

--- a/internal/scheduler/scheduling/context/scheduling.go
+++ b/internal/scheduler/scheduling/context/scheduling.go
@@ -62,7 +62,10 @@ type SchedulingContext struct {
 	// Record of job scheduling requirements known to be unfeasible.
 	// Used to immediately reject new jobs with identical requirements.
 	// Maps to the JobSchedulingContext of a previous job attempted to schedule with the same key.
-	UnfeasibleSchedulingKeys     map[internaltypes.SchedulingKey]*JobSchedulingContext
+	UnfeasibleSchedulingKeys map[internaltypes.SchedulingKey]*JobSchedulingContext
+	// Ids of jobs preempted during this scheduling round (e.g. via fair-share preemption).
+	// Such jobs must not be re-offered as scheduling candidates
+	PreemptedJobIds              map[string]bool
 	ExperimentalIndicativeShares map[int]float64
 	SpotPrice                    *float64
 	// Time spent scheduling new jobs in this round.
@@ -86,6 +89,7 @@ func NewSchedulingContext(
 		EvictedResources:             internaltypes.ResourceList{},
 		SchedulingKeyGenerator:       internaltypes.NewSchedulingKeyGenerator(),
 		UnfeasibleSchedulingKeys:     make(map[internaltypes.SchedulingKey]*JobSchedulingContext),
+		PreemptedJobIds:              make(map[string]bool),
 		ExperimentalIndicativeShares: make(map[int]float64),
 	}
 }
@@ -488,6 +492,17 @@ func (sctx *SchedulingContext) QueueContextExists(job *jobdb.Job) bool {
 	queue := sctx.resolveQueueName(job)
 	_, ok := sctx.QueueSchedulingContexts[queue]
 	return ok
+}
+
+// MarkJobPreempted records that the job with the given id was preempted during this scheduling round.
+// Preempted jobs must not be re-scheduled; see IsJobPreempted.
+func (sctx *SchedulingContext) MarkJobPreempted(jobId string) {
+	sctx.PreemptedJobIds[jobId] = true
+}
+
+// IsJobPreempted reports whether the job with the given id was preempted during this scheduling round.
+func (sctx *SchedulingContext) IsJobPreempted(jobId string) bool {
+	return sctx.PreemptedJobIds[jobId]
 }
 
 func (sctx *SchedulingContext) PreemptJob(jctx *JobSchedulingContext) (bool, error) {

--- a/internal/scheduler/scheduling/context/scheduling_test.go
+++ b/internal/scheduler/scheduling/context/scheduling_test.go
@@ -376,6 +376,24 @@ func TestRecordNewJobSchedulingDuration(t *testing.T) {
 	}
 }
 
+func TestMarkJobPreempted(t *testing.T) {
+	sctx := NewSchedulingContext("pool", nil, nil, cpu(100))
+
+	// Unknown jobs are not preempted.
+	assert.False(t, sctx.IsJobPreempted("job-1"))
+
+	// Marking a job records it as preempted; other jobs are unaffected.
+	sctx.MarkJobPreempted("job-1")
+	assert.True(t, sctx.IsJobPreempted("job-1"))
+	assert.False(t, sctx.IsJobPreempted("job-2"))
+
+	// Marking is idempotent and additive.
+	sctx.MarkJobPreempted("job-1")
+	sctx.MarkJobPreempted("job-2")
+	assert.True(t, sctx.IsJobPreempted("job-1"))
+	assert.True(t, sctx.IsJobPreempted("job-2"))
+}
+
 func TestCalculateFairnessError(t *testing.T) {
 	tests := map[string]struct {
 		availableResources internaltypes.ResourceList

--- a/internal/scheduler/scheduling/context/scheduling_test.go
+++ b/internal/scheduler/scheduling/context/scheduling_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/armadaproject/armada/internal/common/pointer"
@@ -19,6 +20,19 @@ import (
 	"github.com/armadaproject/armada/internal/scheduler/testfixtures"
 )
 
+func TestNewSchedulingContextDefaultsPreemptionLimiterToUnset(t *testing.T) {
+	totalResources := testfixtures.TestResourceListFactory.FromNodeProto(
+		map[string]*resource.Quantity{"cpu": pointer.MustParseResource("1")},
+	)
+	fairnessCostProvider, err := fairness.NewDominantResourceFairness(totalResources, "pool", configuration.SchedulingConfig{DominantResourceFairnessResourcesToConsider: []string{"cpu"}})
+	require.NoError(t, err)
+	sctx := NewSchedulingContext("pool", fairnessCostProvider, nil, nil, totalResources)
+
+	// A nil fairshare preemption limiter means no limit; the pool is never at the rate limit.
+	assert.Nil(t, sctx.FairsharePreemptionLimiter)
+	assert.False(t, sctx.AtFairsharePreemptionRateLimit())
+}
+
 func TestSchedulingContextAccounting(t *testing.T) {
 	totalResources := testfixtures.TestResourceListFactory.FromNodeProto(
 		map[string]*resource.Quantity{"cpu": pointer.MustParseResource("1")},
@@ -28,6 +42,7 @@ func TestSchedulingContextAccounting(t *testing.T) {
 	sctx := NewSchedulingContext(
 		"pool",
 		fairnessCostProvider,
+		nil,
 		nil,
 		totalResources,
 	)
@@ -204,6 +219,7 @@ func TestCalculateFairShares(t *testing.T) {
 				"pool",
 				fairnessCostProvider,
 				nil,
+				nil,
 				tc.availableResources,
 			)
 			for qName, q := range tc.queueCtxs {
@@ -296,6 +312,7 @@ func TestCalculateTheoreticalShare(t *testing.T) {
 				"pool",
 				fairnessCostProvider,
 				nil,
+				nil,
 				tc.availableResources,
 			)
 			for qName, q := range tc.queueCtxs {
@@ -355,7 +372,7 @@ func TestRecordNewJobSchedulingDuration(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			fairnessCostProvider, err := fairness.NewDominantResourceFairness(cpu(100), "pool", configuration.SchedulingConfig{DominantResourceFairnessResourcesToConsider: []string{"cpu"}})
 			require.NoError(t, err)
-			sctx := NewSchedulingContext("pool", fairnessCostProvider, nil, cpu(100))
+			sctx := NewSchedulingContext("pool", fairnessCostProvider, nil, nil, cpu(100))
 			if tc.initialTotalSchedulingDuration > 0 {
 				sctx.TotalNewJobSchedulingTime = tc.initialTotalSchedulingDuration
 			}
@@ -377,7 +394,7 @@ func TestRecordNewJobSchedulingDuration(t *testing.T) {
 }
 
 func TestMarkJobPreempted(t *testing.T) {
-	sctx := NewSchedulingContext("pool", nil, nil, cpu(100))
+	sctx := NewSchedulingContext("pool", nil, nil, nil, cpu(100))
 
 	// Unknown jobs are not preempted.
 	assert.False(t, sctx.IsJobPreempted("job-1"))
@@ -392,6 +409,33 @@ func TestMarkJobPreempted(t *testing.T) {
 	sctx.MarkJobPreempted("job-2")
 	assert.True(t, sctx.IsJobPreempted("job-1"))
 	assert.True(t, sctx.IsJobPreempted("job-2"))
+}
+
+func TestMarkJobPreempted_ConsumesPreemptionLimiterTokens(t *testing.T) {
+	sctx := NewSchedulingContext("pool", nil, nil, nil, cpu(100))
+	sctx.FairsharePreemptionLimiter = rate.NewLimiter(rate.Limit(1), 5)
+	before := sctx.FairsharePreemptionLimiter.TokensAt(sctx.Started)
+
+	// Each newly-preempted job consumes one token.
+	sctx.MarkJobPreempted("job-1")
+	sctx.MarkJobPreempted("job-2")
+	assert.InDelta(t, before-2, sctx.FairsharePreemptionLimiter.TokensAt(sctx.Started), 1e-9)
+
+	// Re-marking an already-preempted job does not consume additional tokens.
+	sctx.MarkJobPreempted("job-1")
+	assert.InDelta(t, before-2, sctx.FairsharePreemptionLimiter.TokensAt(sctx.Started), 1e-9)
+}
+
+func TestMarkJobPreempted_PreemptionLimiterMayGoNegative(t *testing.T) {
+	sctx := NewSchedulingContext("pool", nil, nil, nil, cpu(100))
+	// Budget of 1 token, but preempt 3 jobs: the bucket is allowed to go negative (retrospective limit).
+	sctx.FairsharePreemptionLimiter = rate.NewLimiter(rate.Limit(1), 1)
+
+	sctx.MarkJobPreempted("job-1")
+	sctx.MarkJobPreempted("job-2")
+	sctx.MarkJobPreempted("job-3")
+
+	assert.Less(t, sctx.FairsharePreemptionLimiter.TokensAt(sctx.Started), 0.0)
 }
 
 func TestCalculateFairnessError(t *testing.T) {
@@ -475,7 +519,7 @@ func TestCalculateFairnessError(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			fairnessCostProvider, err := fairness.NewDominantResourceFairness(tc.availableResources, "pool", configuration.SchedulingConfig{DominantResourceFairnessResourcesToConsider: []string{"cpu"}})
 			require.NoError(t, err)
-			sctx := NewSchedulingContext("pool", fairnessCostProvider, nil, tc.availableResources)
+			sctx := NewSchedulingContext("pool", fairnessCostProvider, nil, nil, tc.availableResources)
 			sctx.QueueSchedulingContexts = tc.queueCtxs
 			assert.InDelta(t, tc.expected, sctx.FairnessError(), 0.00001)
 		})
@@ -695,7 +739,7 @@ func createSchedulingContext(t *testing.T, jctx *JobSchedulingContext, isJobExis
 	fairnessCostProvider, err := fairness.NewDominantResourceFairness(
 		totalResources, "pool", configuration.SchedulingConfig{DominantResourceFairnessResourcesToConsider: []string{"cpu"}})
 	require.NoError(t, err)
-	sctx := NewSchedulingContext("pool", fairnessCostProvider, nil, totalResources)
+	sctx := NewSchedulingContext("pool", fairnessCostProvider, nil, nil, totalResources)
 
 	var initialAllocation map[string]internaltypes.ResourceList
 	demand := jctx.Job.AllResourceRequirements()

--- a/internal/scheduler/scheduling/gang_scheduler.go
+++ b/internal/scheduler/scheduling/gang_scheduler.go
@@ -183,7 +183,8 @@ func (sch *GangScheduler) trySchedule(ctx *armadacontext.Context, gctx *context.
 		}
 		addNodeSelectorToGctx(gctx, nodeUniformity, value)
 		txn := sch.nodeDb.Txn(true)
-		ok, unschedulableReason, err = sch.tryScheduleGangWithTxn(ctx, txn, gctx)
+		var preemptedJobs []*nodedb.JobPreemptionInfo
+		ok, unschedulableReason, preemptedJobs, err = sch.tryScheduleGangWithTxn(ctx, txn, gctx)
 		if err != nil {
 			txn.Abort()
 			return ok, unschedulableReason, err
@@ -195,6 +196,7 @@ func (sch *GangScheduler) trySchedule(ctx *armadacontext.Context, gctx *context.
 				// Store the selected label value in all job contexts
 				gctx.SetGangNodeUniformityValues(nodeUniformity, value)
 				txn.Commit()
+				sch.applyPreemptions(preemptedJobs)
 				return true, "", nil
 			}
 			if bestValue == "" || bestFit.Less(currentFit) {
@@ -203,6 +205,7 @@ func (sch *GangScheduler) trySchedule(ctx *armadacontext.Context, gctx *context.
 					// Store the selected label value in all job contexts
 					gctx.SetGangNodeUniformityValues(nodeUniformity, value)
 					txn.Commit()
+					sch.applyPreemptions(preemptedJobs)
 					return true, "", nil
 				}
 				// Record the best value seen so far.
@@ -226,21 +229,26 @@ func (sch *GangScheduler) trySchedule(ctx *armadacontext.Context, gctx *context.
 func (sch *GangScheduler) tryScheduleGang(ctx *armadacontext.Context, gctx *context.GangSchedulingContext) (bool, string, error) {
 	var ok bool
 	var unschedulableReason string
+	var preemptedJobs []*nodedb.JobPreemptionInfo
 	var err error
 	txn := sch.nodeDb.Txn(true)
 	defer txn.Abort()
-	ok, unschedulableReason, err = sch.tryScheduleGangWithTxn(ctx, txn, gctx)
+	ok, unschedulableReason, preemptedJobs, err = sch.tryScheduleGangWithTxn(ctx, txn, gctx)
 	if ok && err == nil {
 		txn.Commit()
+		// Only apply preemptions once the scheduling transaction has committed, so that aborted
+		// attempts (e.g. rejected node-uniformity values) never leak preemptions.
+		sch.applyPreemptions(preemptedJobs)
 	}
 	return ok, unschedulableReason, err
 }
 
-func (sch *GangScheduler) tryScheduleGangWithTxn(_ *armadacontext.Context, txn *memdb.Txn, gctx *context.GangSchedulingContext) (bool, string, error) {
+func (sch *GangScheduler) tryScheduleGangWithTxn(_ *armadacontext.Context, txn *memdb.Txn, gctx *context.GangSchedulingContext) (bool, string, []*nodedb.JobPreemptionInfo, error) {
 	var ok bool
 	var unschedulableReason string
+	var preemptedJobs []*nodedb.JobPreemptionInfo
 	var err error
-	if ok, err = sch.nodeDb.ScheduleManyWithTxn(txn, gctx); err == nil {
+	if ok, preemptedJobs, err = sch.nodeDb.ScheduleManyWithTxn(txn, gctx); err == nil {
 		if !ok {
 			if gctx.Cardinality() > 1 {
 				unschedulableReason = schedulerconstraints.GangDoesNotFitUnschedulableReason
@@ -248,9 +256,20 @@ func (sch *GangScheduler) tryScheduleGangWithTxn(_ *armadacontext.Context, txn *
 				unschedulableReason = schedulerconstraints.JobDoesNotFitUnschedulableReason
 			}
 		}
-		return ok, unschedulableReason, err
+		return ok, unschedulableReason, preemptedJobs, err
 	}
-	return ok, unschedulableReason, err
+	return ok, unschedulableReason, preemptedJobs, err
+}
+
+// applyPreemptions applies the preemptions reported by the NodeDb to the scheduling context.
+// NodeDb reports preemptions but does not mutate the preempted jobs' scheduling contexts; that is
+// done here, once the caller has committed the scheduling transaction. It records the preempting
+// job on each preempted job's context and marks the job as preempted so it is not re-scheduled.
+func (sch *GangScheduler) applyPreemptions(preemptedJobs []*nodedb.JobPreemptionInfo) {
+	for _, preemption := range preemptedJobs {
+		preemption.PreemptedJob.PreemptingJob = preemption.PreemptingJob
+		sch.schedulingContext.MarkJobPreempted(preemption.PreemptedJob.JobId)
+	}
 }
 
 func addNodeSelectorToGctx(gctx *context.GangSchedulingContext, nodeSelectorKey, nodeSelectorValue string) {

--- a/internal/scheduler/scheduling/gang_scheduler_test.go
+++ b/internal/scheduler/scheduling/gang_scheduler_test.go
@@ -727,6 +727,91 @@ func TestGangScheduler(t *testing.T) {
 	}
 }
 
+func TestGangScheduler_MarksPreemptedJobs(t *testing.T) {
+	schedulingConfig := testfixtures.TestSchedulingConfig()
+	node := testfixtures.Test32CpuNode(testfixtures.TestPriorities)
+
+	nodeDb, err := nodedb.NewNodeDb(
+		schedulingConfig.PriorityClasses,
+		schedulingConfig.IndexedResources,
+		schedulingConfig.IndexedTaints,
+		schedulingConfig.IndexedNodeLabels,
+		schedulingConfig.WellKnownNodeTypes,
+		testfixtures.TestResourceListFactory,
+	)
+	require.NoError(t, err)
+
+	// Fully allocate the node with a low-priority incumbent job.
+	txn := nodeDb.Txn(true)
+	incumbentJobs := testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 32)
+	require.NoError(t, nodeDb.CreateAndInsertWithJobDbJobsWithTxn(txn, incumbentJobs, node.DeepCopyNilKeys()))
+	txn.Commit()
+
+	// Evict the incumbents and register them so they are candidates for fair-share preemption.
+	dbNode, err := nodeDb.GetNode(node.GetId())
+	require.NoError(t, err)
+	evictedNode, err := nodeDb.EvictJobsFromNode(incumbentJobs, dbNode)
+	require.NoError(t, err)
+	txn = nodeDb.Txn(true)
+	require.NoError(t, nodeDb.UpsertWithTxn(txn, evictedNode))
+	evictedJctxByJobId := make(map[string]*context.JobSchedulingContext, len(incumbentJobs))
+	for i, job := range incumbentJobs {
+		evictedJctx := context.JobSchedulingContextFromJob(job)
+		evictedJctx.SetAssignedNode(evictedNode)
+		evictedJctxByJobId[job.Id()] = evictedJctx
+		require.NoError(t, nodeDb.AddEvictedJobSchedulingContextWithTxn(txn, i, evictedJctx))
+	}
+	txn.Commit()
+
+	totalResources := nodeDb.TotalKubernetesResources()
+	fairnessCostProvider, err := fairness.NewDominantResourceFairness(totalResources, testfixtures.TestPool, schedulingConfig)
+	require.NoError(t, err)
+	sctx := context.NewSchedulingContext(
+		"pool",
+		fairnessCostProvider,
+		rate.NewLimiter(rate.Limit(schedulingConfig.MaximumSchedulingRate), schedulingConfig.MaximumSchedulingBurst),
+		totalResources,
+	)
+	for _, queue := range []string{"A", "B"} {
+		require.NoError(t, sctx.AddQueueSchedulingContext(
+			queue, 1, 1, nil,
+			internaltypes.ResourceList{}, internaltypes.ResourceList{}, internaltypes.ResourceList{},
+			rate.NewLimiter(rate.Limit(schedulingConfig.MaximumPerQueueSchedulingRate), schedulingConfig.MaximumPerQueueSchedulingBurst),
+		))
+	}
+	constraints := schedulerconstraints.NewSchedulingConstraints("pool", totalResources, schedulingConfig,
+		[]*api.Queue{{Name: "A"}, {Name: "B"}})
+	floatingResourceTypes, err := floatingresources.NewFloatingResourceTypes(schedulingConfig.FloatingResources, testfixtures.TestResourceListFactory)
+	require.NoError(t, err)
+	sch, err := NewGangScheduler(sctx, constraints, floatingResourceTypes, nodeDb, false)
+	require.NoError(t, err)
+
+	// Schedule a single higher-priority job that only fits if an incumbent is preempted.
+	incoming := testfixtures.N1Cpu4GiJobs("B", testfixtures.PriorityClass1, 1)[0]
+	incomingJctx := context.JobSchedulingContextFromJob(incoming)
+	gctx := context.NewGangSchedulingContext([]*context.JobSchedulingContext{incomingJctx})
+
+	ok, reason, err := sch.Schedule(armadacontext.Background(), gctx)
+	require.NoError(t, err)
+	require.True(t, ok, "expected incoming job to schedule via fair-share preemption")
+	require.Empty(t, reason)
+	require.Equal(t, context.ScheduledWithFairSharePreemption, incomingJctx.PodSchedulingContext.SchedulingMethod)
+
+	// Exactly one incumbent should have been preempted, marked in both the jctx and the sctx.
+	preemptedCount := 0
+	for jobId, evictedJctx := range evictedJctxByJobId {
+		markedInSctx := sctx.IsJobPreempted(jobId)
+		markedInJctx := evictedJctx.PreemptingJob != nil
+		// The two markings must agree for a given job.
+		require.Equal(t, markedInSctx, markedInJctx, "sctx and jctx preemption marking disagree for job %s", jobId)
+		if markedInJctx {
+			preemptedCount++
+			require.Equal(t, incoming.Id(), evictedJctx.PreemptingJob.Id(), "preempting job should be the incoming job")
+		}
+	}
+	require.Equal(t, 1, preemptedCount, "expected exactly one incumbent to be preempted")
+}
+
 func createAwayJob() *jobdb.Job {
 	return testfixtures.Test1Cpu4GiJob(testfixtures.TestQueue, testfixtures.PriorityClass2).WithNewRun("executor-1", "node-1", "node-1", "away", 1)
 }

--- a/internal/scheduler/scheduling/gang_scheduler_test.go
+++ b/internal/scheduler/scheduling/gang_scheduler_test.go
@@ -629,6 +629,7 @@ func TestGangScheduler(t *testing.T) {
 					rate.Limit(tc.SchedulingConfig.MaximumSchedulingRate),
 					tc.SchedulingConfig.MaximumSchedulingBurst,
 				),
+				nil,
 				tc.TotalResources,
 			)
 			for queue, priorityFactor := range priorityFactorByQueue {
@@ -770,6 +771,7 @@ func TestGangScheduler_MarksPreemptedJobs(t *testing.T) {
 		"pool",
 		fairnessCostProvider,
 		rate.NewLimiter(rate.Limit(schedulingConfig.MaximumSchedulingRate), schedulingConfig.MaximumSchedulingBurst),
+		nil,
 		totalResources,
 	)
 	for _, queue := range []string{"A", "B"} {
@@ -810,6 +812,83 @@ func TestGangScheduler_MarksPreemptedJobs(t *testing.T) {
 		}
 	}
 	require.Equal(t, 1, preemptedCount, "expected exactly one incumbent to be preempted")
+}
+
+func TestGangScheduler_ConsumesPreemptionLimiterTokens(t *testing.T) {
+	schedulingConfig := testfixtures.TestSchedulingConfig()
+	node := testfixtures.Test32CpuNode(testfixtures.TestPriorities)
+
+	nodeDb, err := nodedb.NewNodeDb(
+		schedulingConfig.PriorityClasses,
+		schedulingConfig.IndexedResources,
+		schedulingConfig.IndexedTaints,
+		schedulingConfig.IndexedNodeLabels,
+		schedulingConfig.WellKnownNodeTypes,
+		testfixtures.TestResourceListFactory,
+	)
+	require.NoError(t, err)
+
+	// Fully allocate the node with a low-priority incumbent job.
+	txn := nodeDb.Txn(true)
+	incumbentJobs := testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 32)
+	require.NoError(t, nodeDb.CreateAndInsertWithJobDbJobsWithTxn(txn, incumbentJobs, node.DeepCopyNilKeys()))
+	txn.Commit()
+
+	// Evict the incumbents and register them so they are candidates for fair-share preemption.
+	dbNode, err := nodeDb.GetNode(node.GetId())
+	require.NoError(t, err)
+	evictedNode, err := nodeDb.EvictJobsFromNode(incumbentJobs, dbNode)
+	require.NoError(t, err)
+	txn = nodeDb.Txn(true)
+	require.NoError(t, nodeDb.UpsertWithTxn(txn, evictedNode))
+	for i, job := range incumbentJobs {
+		evictedJctx := context.JobSchedulingContextFromJob(job)
+		evictedJctx.SetAssignedNode(evictedNode)
+		require.NoError(t, nodeDb.AddEvictedJobSchedulingContextWithTxn(txn, i, evictedJctx))
+	}
+	txn.Commit()
+
+	totalResources := nodeDb.TotalKubernetesResources()
+	fairnessCostProvider, err := fairness.NewDominantResourceFairness(totalResources, testfixtures.TestPool, schedulingConfig)
+	require.NoError(t, err)
+	sctx := context.NewSchedulingContext(
+		"pool",
+		fairnessCostProvider,
+		rate.NewLimiter(rate.Limit(schedulingConfig.MaximumSchedulingRate), schedulingConfig.MaximumSchedulingBurst),
+		nil,
+		totalResources,
+	)
+	// Preemption limiter with a small, known budget so we can observe consumption.
+	sctx.FairsharePreemptionLimiter = rate.NewLimiter(rate.Limit(1), 5)
+	tokensBefore := sctx.FairsharePreemptionLimiter.TokensAt(sctx.Started)
+	for _, queue := range []string{"A", "B"} {
+		require.NoError(t, sctx.AddQueueSchedulingContext(
+			queue, 1, 1, nil,
+			internaltypes.ResourceList{}, internaltypes.ResourceList{}, internaltypes.ResourceList{},
+			rate.NewLimiter(rate.Limit(schedulingConfig.MaximumPerQueueSchedulingRate), schedulingConfig.MaximumPerQueueSchedulingBurst),
+		))
+	}
+	constraints := schedulerconstraints.NewSchedulingConstraints("pool", totalResources, schedulingConfig,
+		[]*api.Queue{{Name: "A"}, {Name: "B"}})
+	floatingResourceTypes, err := floatingresources.NewFloatingResourceTypes(schedulingConfig.FloatingResources, testfixtures.TestResourceListFactory)
+	require.NoError(t, err)
+	sch, err := NewGangScheduler(sctx, constraints, floatingResourceTypes, nodeDb, false)
+	require.NoError(t, err)
+
+	// Schedule a single higher-priority job that only fits if an incumbent is preempted.
+	incoming := testfixtures.N1Cpu4GiJobs("B", testfixtures.PriorityClass1, 1)[0]
+	incomingJctx := context.JobSchedulingContextFromJob(incoming)
+	gctx := context.NewGangSchedulingContext([]*context.JobSchedulingContext{incomingJctx})
+
+	ok, reason, err := sch.Schedule(armadacontext.Background(), gctx)
+	require.NoError(t, err)
+	require.True(t, ok, "expected incoming job to schedule via fair-share preemption")
+	require.Empty(t, reason)
+	require.Equal(t, context.ScheduledWithFairSharePreemption, incomingJctx.PodSchedulingContext.SchedulingMethod)
+
+	// One incumbent was preempted, so exactly one token should have been consumed.
+	tokensAfter := sctx.FairsharePreemptionLimiter.TokensAt(sctx.Started)
+	assert.InDelta(t, tokensBefore-1, tokensAfter, 1e-9, "expected one preemption token consumed per preempted job")
 }
 
 func createAwayJob() *jobdb.Job {

--- a/internal/scheduler/scheduling/idealised_value.go
+++ b/internal/scheduler/scheduling/idealised_value.go
@@ -47,6 +47,7 @@ func CalculateIdealisedValue(
 		sctx.Pool,
 		sctx.FairnessCostProvider,
 		noOpRateLimiter,
+		nil, // no fairshare preemption rate limit for idealised (dry-run) scheduling
 		sctx.TotalResources)
 
 	for _, qctx := range sctx.QueueSchedulingContexts {

--- a/internal/scheduler/scheduling/idealised_value_scheduler.go
+++ b/internal/scheduler/scheduling/idealised_value_scheduler.go
@@ -184,6 +184,10 @@ func (s staticRequirementsIgnoringIterator) OnlyYieldEvicted() {
 	s.iter.OnlyYieldEvicted()
 }
 
+func (s staticRequirementsIgnoringIterator) ResumeNonEvicted() {
+	s.iter.ResumeNonEvicted()
+}
+
 func (s staticRequirementsIgnoringIterator) Next() (*schedulercontext.JobSchedulingContext, error) {
 	next, err := s.iter.Next()
 	if err != nil {

--- a/internal/scheduler/scheduling/idealised_value_test.go
+++ b/internal/scheduler/scheduling/idealised_value_test.go
@@ -143,6 +143,7 @@ func TestCalculateIdealisedValue(t *testing.T) {
 				testfixtures.TestPool,
 				fairnessCostProvider,
 				noOpRateLimiter,
+				nil,
 				totalResources)
 
 			for _, q := range tc.queues {

--- a/internal/scheduler/scheduling/jobiteration.go
+++ b/internal/scheduler/scheduling/jobiteration.go
@@ -14,6 +14,9 @@ import (
 type JobContextIterator interface {
 	Next() (*schedulercontext.JobSchedulingContext, error)
 	OnlyYieldEvicted()
+	// ResumeNonEvicted reverses OnlyYieldEvicted, allowing non-evicted (new) jobs to be yielded again.
+	// New jobs paused by OnlyYieldEvicted are resumed from where iteration left off.
+	ResumeNonEvicted()
 }
 
 type InMemoryJobIterator struct {
@@ -48,7 +51,17 @@ func (it *InMemoryJobIterator) Next() (*schedulercontext.JobSchedulingContext, e
 }
 
 func (it *InMemoryJobIterator) OnlyYieldEvicted() {
+	if it.onlyYieldEvicted {
+		return
+	}
 	it.onlyYieldEvicted = true
+}
+
+func (it *InMemoryJobIterator) ResumeNonEvicted() {
+	if !it.onlyYieldEvicted {
+		return
+	}
+	it.onlyYieldEvicted = false
 }
 
 type InMemoryJobRepository struct {
@@ -147,13 +160,26 @@ func (it *QueuedJobsIterator) Next() (*schedulercontext.JobSchedulingContext, er
 }
 
 func (it *QueuedJobsIterator) OnlyYieldEvicted() {
+	if it.onlyYieldEvicted {
+		return
+	}
 	it.onlyYieldEvicted = true
+}
+
+func (it *QueuedJobsIterator) ResumeNonEvicted() {
+	if !it.onlyYieldEvicted {
+		return
+	}
+	// The underlying jobIter cursor is untouched while paused, so clearing the flag resumes
+	// yielding new jobs from where iteration left off.
+	it.onlyYieldEvicted = false
 }
 
 // MultiJobsIterator chains several JobIterators together in the order provided.
 type MultiJobsIterator struct {
-	i   int
-	its []JobContextIterator
+	i                int
+	onlyYieldEvicted bool
+	its              []JobContextIterator
 }
 
 func NewMultiJobsIterator(its ...JobContextIterator) *MultiJobsIterator {
@@ -178,16 +204,35 @@ func (it *MultiJobsIterator) Next() (*schedulercontext.JobSchedulingContext, err
 }
 
 func (it *MultiJobsIterator) OnlyYieldEvicted() {
+	if it.onlyYieldEvicted {
+		return
+	}
+	it.onlyYieldEvicted = true
 	for _, iter := range it.its {
 		iter.OnlyYieldEvicted()
 	}
 }
 
+func (it *MultiJobsIterator) ResumeNonEvicted() {
+	if !it.onlyYieldEvicted {
+		return
+	}
+	it.onlyYieldEvicted = false
+	for _, iter := range it.its {
+		iter.ResumeNonEvicted()
+	}
+	// Re-scan from the first sub-iterator. Already-drained sub-iterators (e.g. the evicted-jobs
+	// iterator) return nil immediately and are skipped, so iteration continues with the resumed
+	// new-jobs iterator.
+	it.i = 0
+}
+
 // MarketDrivenMultiJobsIterator combines two iterators by price
 type MarketDrivenMultiJobsIterator struct {
-	it1  JobContextIterator
-	it2  JobContextIterator
-	pool string
+	it1              JobContextIterator
+	it2              JobContextIterator
+	pool             string
+	onlyYieldEvicted bool
 
 	// TODO: ideally we add peek() to JobContextIterator and remove these
 	it1Value *schedulercontext.JobSchedulingContext
@@ -249,6 +294,10 @@ func (it *MarketDrivenMultiJobsIterator) Next() (*schedulercontext.JobScheduling
 }
 
 func (it *MarketDrivenMultiJobsIterator) OnlyYieldEvicted() {
+	if it.onlyYieldEvicted {
+		return
+	}
+	it.onlyYieldEvicted = true
 	it.it1.OnlyYieldEvicted()
 	if it.it1Value != nil && !it.it1Value.IsEvicted {
 		it.it1Value = nil
@@ -257,4 +306,16 @@ func (it *MarketDrivenMultiJobsIterator) OnlyYieldEvicted() {
 	if it.it2Value != nil && !it.it2Value.IsEvicted {
 		it.it2Value = nil
 	}
+}
+
+// ResumeNonEvicted reverses OnlyYieldEvicted. Note: the preemption rate limit that drives the
+// drain/resume flow is not applied on market-driven pools (see QueueScheduler.Schedule), so this
+// is provided only to satisfy the interface.
+func (it *MarketDrivenMultiJobsIterator) ResumeNonEvicted() {
+	if !it.onlyYieldEvicted {
+		return
+	}
+	it.onlyYieldEvicted = false
+	it.it1.ResumeNonEvicted()
+	it.it2.ResumeNonEvicted()
 }

--- a/internal/scheduler/scheduling/jobiteration_test.go
+++ b/internal/scheduler/scheduling/jobiteration_test.go
@@ -122,6 +122,31 @@ func TestMultiJobsIterator_OnlyYieldEvicted(t *testing.T) {
 	require.Nil(t, v)
 }
 
+func TestMultiJobsIterator_ResumeNonEvictedIsNoopWhenNotRestricted(t *testing.T) {
+	// New jobs come from a jobdb-backed iterator (pauses without consuming); evicted from in-memory.
+	evictedRepo := NewInMemoryJobRepository(testfixtures.TestPool, jobdb.JobPriorityComparer{})
+	evictedRepo.EnqueueMany([]*schedulercontext.JobSchedulingContext{
+		createJctxCreatedTimeAndPriority("B", 0, 1, true),
+	})
+	newRepo := newMockJobRepository()
+	for _, req := range testfixtures.N1CpuPodReqs(2) {
+		newRepo.Enqueue(jobFromPodSpec("A", req))
+	}
+	newIt := NewQueuedJobsIterator("A", testfixtures.TestPool, jobdb.FairShareOrder, newRepo)
+	multiIt := NewMultiJobsIterator(evictedRepo.GetJobIterator("B"), newIt)
+
+	// Consume the first job, then ResumeNonEvicted without ever restricting to evicted-only.
+	// This must be a no-op: it must NOT rewind the iterator back to the start.
+	first, err := multiIt.Next()
+	require.NoError(t, err)
+	require.NotNil(t, first)
+	multiIt.ResumeNonEvicted()
+
+	// Iteration continues after `first`, without re-yielding it.
+	rest := getAllJobIdsFromIterator(t, multiIt)
+	assert.NotContains(t, rest, first.JobId, "ResumeNonEvicted must not rewind the iterator")
+}
+
 func TestMarketDrivenMultiJobsIterator(t *testing.T) {
 	newJctxs := []*schedulercontext.JobSchedulingContext{
 		createJctxWithPrice("A", bidstore.PriceBand_PRICE_BAND_H, false),
@@ -229,6 +254,25 @@ func TestQueuedJobsIterator_OnlyYieldEvicted(t *testing.T) {
 	expected := make([]string, 0)
 	actual := getAllJobIdsFromIterator(t, it)
 	assert.Equal(t, expected, actual)
+}
+
+func TestQueuedJobsIterator_ResumeNonEvicted(t *testing.T) {
+	repo := newMockJobRepository()
+	expected := make([]string, 0)
+	for _, req := range testfixtures.N1CpuPodReqs(10) {
+		job := jobFromPodSpec("A", req)
+		repo.Enqueue(job)
+		expected = append(expected, job.Id())
+	}
+	it := NewQueuedJobsIterator("A", testfixtures.TestPool, jobdb.FairShareOrder, repo)
+
+	// Pause new jobs: nothing is yielded and the underlying cursor is not advanced.
+	it.OnlyYieldEvicted()
+	assert.Empty(t, getAllJobIdsFromIterator(t, it))
+
+	// Resume: all new jobs are yielded from where iteration left off (none were consumed while paused).
+	it.ResumeNonEvicted()
+	assert.Equal(t, expected, getAllJobIdsFromIterator(t, it))
 }
 
 func TestQueuedJobsIterator_ExceedsBufferSize(t *testing.T) {

--- a/internal/scheduler/scheduling/market_driven_indicative_pricer_test.go
+++ b/internal/scheduler/scheduling/market_driven_indicative_pricer_test.go
@@ -353,6 +353,7 @@ func createSctx(t *testing.T, totalResource internaltypes.ResourceList, queues [
 		testfixtures.TestPool,
 		fairnessCostProvider,
 		nil,
+		nil,
 		totalResource,
 	)
 	for _, q := range queues {

--- a/internal/scheduler/scheduling/market_driven_preempting_queue_scheduler_test.go
+++ b/internal/scheduler/scheduling/market_driven_preempting_queue_scheduler_test.go
@@ -384,7 +384,7 @@ func TestMarketDrivenPreemptingQueueScheduler(t *testing.T) {
 				},
 				{
 					// Schedule a gang filling the remaining space on both node
-					// Queue A is preeempted despite having a higher price, because the jobs are scheduled as away jobs
+					// Queue A is preempted despite having a higher price, because the jobs are scheduled as away jobs
 					JobsByQueue: map[string][]*jobdb.Job{
 						"B": testfixtures.N1GpuJobsWithPriceBandAndPriorityClass("B", bidstore.PriceBand_PRICE_BAND_A, testfixtures.PriorityClass6Preemptible, 16),
 					},

--- a/internal/scheduler/scheduling/market_driven_preempting_queue_scheduler_test.go
+++ b/internal/scheduler/scheduling/market_driven_preempting_queue_scheduler_test.go
@@ -722,6 +722,7 @@ func TestMarketDrivenPreemptingQueueScheduler(t *testing.T) {
 					testfixtures.TestPool,
 					fairnessCostProvider,
 					limiter,
+					nil,
 					totalResources,
 				)
 				sctx.Started = schedulingStarted.Add(time.Duration(i) * schedulingInterval)

--- a/internal/scheduler/scheduling/market_iterator.go
+++ b/internal/scheduler/scheduling/market_iterator.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/armadaproject/armada/internal/scheduler/internaltypes"
 	schedulercontext "github.com/armadaproject/armada/internal/scheduler/scheduling/context"
 	"github.com/armadaproject/armada/internal/scheduler/scheduling/fairness"
@@ -167,6 +169,13 @@ func (it *MarketBasedCandidateGangIterator) OnlyYieldEvicted() error {
 	}
 	it.onlyYieldEvicted = true
 	return nil
+}
+
+// ResumeNonEvicted is not supported for market-driven scheduling. The preemption rate limit that
+// drives the drain/resume flow is rejected at config validation for market-scheduled pools
+// (see PreemptionRateLimitWithMarketSchedulingErrorMessage), so this should never be called.
+func (it *MarketBasedCandidateGangIterator) ResumeNonEvicted() error {
+	return errors.New("ResumeNonEvicted is not supported for market-driven scheduling")
 }
 
 func (it *MarketBasedCandidateGangIterator) OnlyYieldEvictedForQueue(queue string) error {

--- a/internal/scheduler/scheduling/market_iterator_test.go
+++ b/internal/scheduler/scheduling/market_iterator_test.go
@@ -115,6 +115,7 @@ func createSchedulingContext(t *testing.T) *context.SchedulingContext {
 			rate.Limit(testfixtures.TestSchedulingConfig().MaximumSchedulingRate),
 			testfixtures.TestSchedulingConfig().MaximumSchedulingBurst,
 		),
+		nil,
 		testfixtures.Cpu("1"),
 	)
 }

--- a/internal/scheduler/scheduling/optimiser/gang_scheduler_test.go
+++ b/internal/scheduler/scheduling/optimiser/gang_scheduler_test.go
@@ -447,6 +447,7 @@ func createSctx(t *testing.T, totalResource internaltypes.ResourceList, queues [
 		testfixtures.TestPool,
 		fairnessCostProvider,
 		nil,
+		nil,
 		totalResource,
 	)
 	for _, q := range queues {

--- a/internal/scheduler/scheduling/optimiser/node_scheduler_test.go
+++ b/internal/scheduler/scheduling/optimiser/node_scheduler_test.go
@@ -217,6 +217,7 @@ func setUpSctx(t *testing.T, queues []*api.Queue, existingJobs []*jobdb.Job, tot
 		testfixtures.TestPool,
 		fairnessCostProvider,
 		nil,
+		nil,
 		totalResource,
 	)
 

--- a/internal/scheduler/scheduling/optimising_queue_scheduler_test.go
+++ b/internal/scheduler/scheduling/optimising_queue_scheduler_test.go
@@ -240,6 +240,7 @@ func TestOptimisingQueueScheduler_Schedule(t *testing.T) {
 					rate.Limit(tc.SchedulingConfig.MaximumSchedulingRate),
 					tc.SchedulingConfig.MaximumSchedulingBurst,
 				),
+				nil,
 				tc.TotalSchedulingCapacity,
 			)
 			for _, q := range tc.Queues {

--- a/internal/scheduler/scheduling/preempting_queue_scheduler.go
+++ b/internal/scheduler/scheduling/preempting_queue_scheduler.go
@@ -6,7 +6,6 @@ import (
 	"reflect"
 	"time"
 
-	log "github.com/armadaproject/armada/internal/common/logging"
 	"github.com/benbjohnson/immutable"
 	"github.com/hashicorp/go-memdb"
 	"github.com/pkg/errors"
@@ -15,6 +14,7 @@ import (
 	"k8s.io/utils/clock"
 
 	"github.com/armadaproject/armada/internal/common/armadacontext"
+	log "github.com/armadaproject/armada/internal/common/logging"
 	armadamaps "github.com/armadaproject/armada/internal/common/maps"
 	armadaslices "github.com/armadaproject/armada/internal/common/slices"
 	"github.com/armadaproject/armada/internal/scheduler/configuration"

--- a/internal/scheduler/scheduling/preempting_queue_scheduler.go
+++ b/internal/scheduler/scheduling/preempting_queue_scheduler.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"time"
 
+	log "github.com/armadaproject/armada/internal/common/logging"
 	"github.com/benbjohnson/immutable"
 	"github.com/hashicorp/go-memdb"
 	"github.com/pkg/errors"
@@ -196,6 +197,7 @@ func (sch *PreemptingQueueScheduler) Schedule(ctx *armadacontext.Context) (*Sche
 	// Only necessary if a non-zero number of jobs were evicted.
 	if len(reevictResult.EvictedJctxsByJobId) > 0 {
 		ctx.Logger().WithField("stage", "scheduling-algo").Info("Performing second scheduling ")
+		log.Info("####################")
 		rescheduleSchedulerResult, rescheduleErr := sch.schedule(
 			armadacontext.WithLogField(ctx, "stage", "schedule after oversubscribed eviction"),
 			inMemoryJobRepo,

--- a/internal/scheduler/scheduling/preempting_queue_scheduler_test.go
+++ b/internal/scheduler/scheduling/preempting_queue_scheduler_test.go
@@ -56,7 +56,7 @@ func TestEvict_JobsEvictedInFairshareOrder(t *testing.T) {
 	fairnessCostProvider, err := fairness.NewDominantResourceFairness(totalResources, testfixtures.TestPool, config)
 	require.NoError(t, err)
 	sctx := schedulingcontext.NewSchedulingContext(
-		testfixtures.TestPool, fairnessCostProvider, rate.NewLimiter(rate.Inf, 1000), totalResources,
+		testfixtures.TestPool, fairnessCostProvider, rate.NewLimiter(rate.Inf, 1000), nil, totalResources,
 	)
 
 	var allJobs []*jobdb.Job
@@ -2248,6 +2248,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 					testfixtures.TestPool,
 					fairnessCostProvider,
 					limiter,
+					nil,
 					totalResources,
 				)
 				sctx.Started = schedulingStarted.Add(time.Duration(i) * schedulingInterval)
@@ -2600,6 +2601,7 @@ func BenchmarkPreemptingQueueScheduler(b *testing.B) {
 				testfixtures.TestPool,
 				fairnessCostProvider,
 				limiter,
+				nil,
 				nodeDb.TotalKubernetesResources(),
 			)
 			for queue, priorityFactor := range priorityFactorByQueue {
@@ -2670,6 +2672,7 @@ func BenchmarkPreemptingQueueScheduler(b *testing.B) {
 					"pool",
 					fairnessCostProvider,
 					limiter,
+					nil,
 					nodeDb.TotalKubernetesResources(),
 				)
 				for queue, priorityFactor := range priorityFactorByQueue {
@@ -2748,6 +2751,7 @@ func TestPreemptingQueueSchedulerTimeouts(t *testing.T) {
 			testfixtures.TestPool,
 			fairnessCostProvider,
 			rate.NewLimiter(rate.Limit(config.MaximumSchedulingRate), config.MaximumSchedulingBurst),
+			nil,
 			totalResources,
 		)
 
@@ -2819,6 +2823,7 @@ func TestPreemptingQueueSchedulerTimeouts(t *testing.T) {
 			testfixtures.TestPool,
 			fairnessCostProvider,
 			rate.NewLimiter(rate.Limit(config.MaximumSchedulingRate), config.MaximumSchedulingBurst),
+			nil,
 			totalResources,
 		)
 		demand := testfixtures.TestResourceListFactory.MakeAllZero()
@@ -2887,6 +2892,7 @@ func setupGangEvictionTest(t *testing.T, numNodes int) *gangEvictionTestFixture 
 		testfixtures.TestPool,
 		fairnessCostProvider,
 		rate.NewLimiter(rate.Limit(config.MaximumSchedulingRate), config.MaximumSchedulingBurst),
+		nil,
 		totalResources,
 	)
 
@@ -3264,7 +3270,7 @@ func TestPreemptingQueueScheduler_RespectNodePodLimits(t *testing.T) {
 				allocatedByPriorityClass[j.PriorityClassName()] = allocatedByPriorityClass[j.PriorityClassName()].Add(j.AllResourceRequirements())
 			}
 
-			sctx := schedulingcontext.NewSchedulingContext(testfixtures.TestPool, fairnessCostProvider, rate.NewLimiter(rate.Inf, 1000), totalResources)
+			sctx := schedulingcontext.NewSchedulingContext(testfixtures.TestPool, fairnessCostProvider, rate.NewLimiter(rate.Inf, 1000), nil, totalResources)
 			require.NoError(t, sctx.AddQueueSchedulingContext(
 				"A", 1, 1,
 				allocatedByPriorityClass,
@@ -3376,7 +3382,7 @@ func TestPreemptingQueueScheduler_NonPreemptibleOverPack(t *testing.T) {
 		allocatedByPriorityClass[j.PriorityClassName()] = allocatedByPriorityClass[j.PriorityClassName()].Add(j.AllResourceRequirements())
 	}
 
-	sctx := schedulingcontext.NewSchedulingContext(testfixtures.TestPool, fairnessCostProvider, rate.NewLimiter(rate.Inf, 1000), totalResources)
+	sctx := schedulingcontext.NewSchedulingContext(testfixtures.TestPool, fairnessCostProvider, rate.NewLimiter(rate.Inf, 1000), nil, totalResources)
 	require.NoError(t, sctx.AddQueueSchedulingContext(
 		"A", 1, 1,
 		allocatedByPriorityClass,

--- a/internal/scheduler/scheduling/preempting_queue_scheduler_test.go
+++ b/internal/scheduler/scheduling/preempting_queue_scheduler_test.go
@@ -771,7 +771,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 			Nodes:            testfixtures.N32CpuNodes(2, testfixtures.TestPriorities),
 			Rounds: []SchedulingRound{
 				{
-					// Fill half of node 1 and half of node 2.
+					// Fill half capacity with jobs from queues A and B
 					JobsByQueue: map[string][]*jobdb.Job{
 						"A": testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 16),
 						"B": testfixtures.N1Cpu4GiJobs("B", testfixtures.PriorityClass0, 16),
@@ -782,7 +782,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 					},
 				},
 				{
-					// Schedule a gang filling the remaining space on both nodes.
+					// Schedule a gang filling the remaining space
 					JobsByQueue: map[string][]*jobdb.Job{
 						"C": testfixtures.WithGangAnnotationsJobs(testfixtures.N1Cpu4GiJobs("C", testfixtures.PriorityClass0, 32)),
 					},
@@ -2300,6 +2300,7 @@ func TestPreemptingQueueScheduler(t *testing.T) {
 						m = make(map[string]internaltypes.ResourceList)
 						allocatedByQueueAndPriorityClass[job.Queue()] = m
 					}
+
 					m[job.PriorityClassName()] = m[job.PriorityClassName()].Subtract(job.AllResourceRequirements())
 				}
 				for _, jctx := range result.ScheduledJobs {

--- a/internal/scheduler/scheduling/preemption_description.go
+++ b/internal/scheduler/scheduling/preemption_description.go
@@ -9,35 +9,29 @@ import (
 )
 
 const (
-	unknownPreemptionCause            = "Preempted by scheduler due to the job failing to reschedule - possibly node resource changed causing this job to be unschedulable\nNode Summary:\n%s"
-	unknownGangPreemptionCause        = "Preempted by scheduler due to the job failing to reschedule - possibly another job in the gang was preempted or the node resource changed causing this job to be unschedulable"
-	fairSharePreemptionTemplate       = "Preempted by scheduler using fair share preemption - preempting job %s"
-	marketBasedPreemptionTemplate     = "Preempted by scheduler using market based preemption - current job has a bid of %f - preempting job %s has a bid of %f"
-	urgencyPreemptionTemplate         = "Preempted by scheduler using urgency preemption - preempting job %s"
-	urgencyPreemptionMultiJobTemplate = "Preempted by scheduler using urgency preemption - preemption caused by one of the following jobs %s"
+	unknownPreemptionCause                 = "Preempted by scheduler due to the job failing to reschedule - possibly node resource changed causing this job to be unschedulable\nNode Summary:\n%s"
+	unknownGangPreemptionCause             = "Preempted by scheduler due to the job failing to reschedule - possibly another job in the gang was preempted or the node resource changed causing this job to be unschedulable"
+	gangSiblingFairSharePreemptionTemplate = "Preempted by scheduler using fair share preemption because the following gang members were preempted: %s"
+	fairSharePreemptionTemplate            = "Preempted by scheduler using fair share preemption - preempting job %s"
+	marketBasedPreemptionTemplate          = "Preempted by scheduler using market based preemption - current job has a bid of %f - preempting job %s has a bid of %f"
+	urgencyPreemptionTemplate              = "Preempted by scheduler using urgency preemption - preempting job %s"
+	urgencyPreemptionMultiJobTemplate      = "Preempted by scheduler using urgency preemption - preemption caused by one of the following jobs %s"
 )
 
-func PopulatePreemptionDescriptions(marketBasedScheduling bool, pool string, preemptedJobs []*context.JobSchedulingContext, scheduledJobs []*context.JobSchedulingContext) {
-	jobsScheduledWithUrgencyBasedPreemptionByNode := map[string][]*context.JobSchedulingContext{}
-	for _, schedJctx := range scheduledJobs {
-		if schedJctx.PodSchedulingContext == nil {
-			continue
-		}
-		if schedJctx.PodSchedulingContext.SchedulingMethod != context.ScheduledWithUrgencyBasedPreemption {
-			continue
-		}
+type preemptionInfo struct {
+	preemptedJobId  string
+	preemptingJobId string
+}
 
-		nodeId := schedJctx.PodSchedulingContext.NodeId
-		if _, ok := jobsScheduledWithUrgencyBasedPreemptionByNode[nodeId]; !ok {
-			jobsScheduledWithUrgencyBasedPreemptionByNode[nodeId] = []*context.JobSchedulingContext{}
-		}
-		jobsScheduledWithUrgencyBasedPreemptionByNode[nodeId] = append(jobsScheduledWithUrgencyBasedPreemptionByNode[nodeId], schedJctx)
-	}
+func PopulatePreemptionDescriptions(marketBasedScheduling bool, pool string, preemptedJobs []*context.JobSchedulingContext, scheduledJobs []*context.JobSchedulingContext) {
+	preemptedGangMembersByGangKey := calculatePreemptedGangMembersByGangKey(preemptedJobs)
+	jobsScheduledWithUrgencyBasedPreemptionByNode := calculateJobsScheduledWithUrgencyBasedPreemptionByNode(scheduledJobs)
 
 	for _, preemptedJctx := range preemptedJobs {
 		if preemptedJctx.PreemptionDescription != "" {
 			continue
 		}
+		siblingPreemptions := gangSiblingPreemptions(preemptedGangMembersByGangKey, preemptedJctx)
 		if preemptedJctx.PreemptingJob != nil {
 			if marketBasedScheduling {
 				preemptedJctx.PreemptionDescription = fmt.Sprintf(marketBasedPreemptionTemplate,
@@ -47,12 +41,17 @@ func PopulatePreemptionDescriptions(marketBasedScheduling bool, pool string, pre
 				preemptedJctx.PreemptionDescription = fmt.Sprintf(fairSharePreemptionTemplate, preemptedJctx.PreemptingJob.Id())
 				preemptedJctx.PreemptionType = context.PreemptedWithFairsharePreemption
 			}
+		} else if preemptedJctx.Job.IsInGang() && len(siblingPreemptions) > 0 {
+			if siblingPreemptions := gangSiblingPreemptions(preemptedGangMembersByGangKey, preemptedJctx); len(siblingPreemptions) > 0 {
+				preemptedJctx.PreemptionDescription = fmt.Sprintf(gangSiblingFairSharePreemptionTemplate, describeGangMemberPreemptions(siblingPreemptions))
+				preemptedJctx.PreemptionType = context.PreemptedWithFairsharePreemption
+				continue
+			}
 		} else {
 			potentialPreemptingJobs := jobsScheduledWithUrgencyBasedPreemptionByNode[preemptedJctx.GetAssignedNodeId()]
-
 			if len(potentialPreemptingJobs) == 0 {
 				if preemptedJctx.Job.IsInGang() {
-					preemptedJctx.PreemptionDescription = fmt.Sprintf(unknownGangPreemptionCause)
+					preemptedJctx.PreemptionDescription = unknownGangPreemptionCause
 					preemptedJctx.PreemptionType = context.UnknownGangJob
 				} else {
 					preemptedJctx.PreemptionDescription = fmt.Sprintf(unknownPreemptionCause, preemptedJctx.GetAssignedNode().SummaryString())
@@ -70,4 +69,61 @@ func PopulatePreemptionDescriptions(marketBasedScheduling bool, pool string, pre
 			}
 		}
 	}
+}
+
+func calculatePreemptedGangMembersByGangKey(preemptedJobs []*context.JobSchedulingContext) map[gangKey][]preemptionInfo {
+	preemptedGangMembersByGangKey := map[gangKey][]preemptionInfo{}
+	for _, preemptedJctx := range preemptedJobs {
+		if preemptedJctx.PreemptingJob == nil || preemptedJctx.Job == nil || !preemptedJctx.Job.IsInGang() {
+			continue
+		}
+		key := gangKeyForJob(preemptedJctx)
+		preemptedGangMembersByGangKey[key] = append(preemptedGangMembersByGangKey[key], preemptionInfo{
+			preemptedJobId:  preemptedJctx.JobId,
+			preemptingJobId: preemptedJctx.PreemptingJob.Id(),
+		})
+	}
+	return preemptedGangMembersByGangKey
+}
+
+func calculateJobsScheduledWithUrgencyBasedPreemptionByNode(scheduledJobs []*context.JobSchedulingContext) map[string][]*context.JobSchedulingContext {
+	jobsScheduledWithUrgencyBasedPreemptionByNode := map[string][]*context.JobSchedulingContext{}
+	for _, schedJctx := range scheduledJobs {
+		if schedJctx.PodSchedulingContext == nil {
+			continue
+		}
+		if schedJctx.PodSchedulingContext.SchedulingMethod != context.ScheduledWithUrgencyBasedPreemption {
+			continue
+		}
+
+		nodeId := schedJctx.PodSchedulingContext.NodeId
+		jobsScheduledWithUrgencyBasedPreemptionByNode[nodeId] = append(jobsScheduledWithUrgencyBasedPreemptionByNode[nodeId], schedJctx)
+	}
+	return jobsScheduledWithUrgencyBasedPreemptionByNode
+}
+
+func gangSiblingPreemptions(preemptedGangMembersByGangKey map[gangKey][]preemptionInfo, jctx *context.JobSchedulingContext) []preemptionInfo {
+	if !jctx.Job.IsInGang() {
+		return nil
+	}
+	preemptions := preemptedGangMembersByGangKey[gangKeyForJob(jctx)]
+	siblingPreemptions := make([]preemptionInfo, 0, len(preemptions))
+	for _, preemption := range preemptions {
+		if preemption.preemptedJobId == jctx.JobId {
+			continue
+		}
+		siblingPreemptions = append(siblingPreemptions, preemption)
+	}
+	return siblingPreemptions
+}
+
+func gangKeyForJob(jctx *context.JobSchedulingContext) gangKey {
+	return gangKey{queue: jctx.Job.Queue(), gangId: jctx.Job.GetGangInfo().Id()}
+}
+
+func describeGangMemberPreemptions(preemptions []preemptionInfo) string {
+	descriptions := armadaslices.Map(preemptions, func(p preemptionInfo) string {
+		return fmt.Sprintf("%s (preempted by job %s)", p.preemptedJobId, p.preemptingJobId)
+	})
+	return strings.Join(descriptions, ", ")
 }

--- a/internal/scheduler/scheduling/preemption_description_test.go
+++ b/internal/scheduler/scheduling/preemption_description_test.go
@@ -34,100 +34,138 @@ func TestPopulatePreemptionDescriptions(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		marketBased                 bool
-		preemptedJobContext         *context.JobSchedulingContext
-		expectedPreemptedJobContext *context.JobSchedulingContext
+		marketBased                  bool
+		preemptedJobContexts         []*context.JobSchedulingContext
+		expectedPreemptedJobContexts []*context.JobSchedulingContext
 	}{
 		"unknown cause - basic job": {
-			preemptedJobContext: &context.JobSchedulingContext{
+			preemptedJobContexts: []*context.JobSchedulingContext{{
 				JobId:        "job-1",
 				AssignedNode: testfixtures.TestSimpleNode("node-3"),
 				Job:          makeJob(t, "job-1", false),
-			},
-			expectedPreemptedJobContext: &context.JobSchedulingContext{
+			}},
+			expectedPreemptedJobContexts: []*context.JobSchedulingContext{{
 				JobId:                 "job-1",
 				AssignedNode:          testfixtures.TestSimpleNode("node-3"),
 				Job:                   makeJob(t, "job-1", false),
 				PreemptionDescription: fmt.Sprintf(unknownPreemptionCause, testfixtures.TestSimpleNode("node-3").SummaryString()),
 				PreemptionType:        context.Unknown,
-			},
+			}},
 		},
 		"unknown cause - gang job": {
-			preemptedJobContext: &context.JobSchedulingContext{
+			preemptedJobContexts: []*context.JobSchedulingContext{{
 				JobId:        "job-1",
 				AssignedNode: testfixtures.TestSimpleNode("node-3"),
 				Job:          makeJob(t, "job-1", true),
-			},
-			expectedPreemptedJobContext: &context.JobSchedulingContext{
+			}},
+			expectedPreemptedJobContexts: []*context.JobSchedulingContext{{
 				JobId:                 "job-1",
 				AssignedNode:          testfixtures.TestSimpleNode("node-3"),
 				Job:                   makeJob(t, "job-1", true),
 				PreemptionDescription: unknownGangPreemptionCause,
 				PreemptionType:        context.UnknownGangJob,
-			},
+			}},
 		},
 		"urgency preemption - single preempting job": {
-			preemptedJobContext: &context.JobSchedulingContext{
+			preemptedJobContexts: []*context.JobSchedulingContext{{
 				JobId:        "job-1",
 				AssignedNode: testfixtures.TestSimpleNode("node-1"),
-			},
-			expectedPreemptedJobContext: &context.JobSchedulingContext{
+				Job:          makeJob(t, "job-1", false),
+			}},
+			expectedPreemptedJobContexts: []*context.JobSchedulingContext{{
 				JobId:                 "job-1",
 				AssignedNode:          testfixtures.TestSimpleNode("node-1"),
+				Job:                   makeJob(t, "job-1", false),
 				PreemptionDescription: fmt.Sprintf(urgencyPreemptionTemplate, "job-2"),
 				PreemptionType:        context.PreemptedWithUrgencyPreemption,
-			},
+			}},
 		},
 		"urgency preemption - multiple preempting jobs": {
-			preemptedJobContext: &context.JobSchedulingContext{
+			preemptedJobContexts: []*context.JobSchedulingContext{{
 				JobId:        "job-1",
 				AssignedNode: testfixtures.TestSimpleNode("node-2"),
-			},
-			expectedPreemptedJobContext: &context.JobSchedulingContext{
+				Job:          makeJob(t, "job-1", false),
+			}},
+			expectedPreemptedJobContexts: []*context.JobSchedulingContext{{
 				JobId:                 "job-1",
 				AssignedNode:          testfixtures.TestSimpleNode("node-2"),
+				Job:                   makeJob(t, "job-1", false),
 				PreemptionDescription: fmt.Sprintf(urgencyPreemptionMultiJobTemplate, "job-3,job-4"),
 				PreemptionType:        context.PreemptedWithUrgencyPreemption,
-			},
+			}},
 		},
 		"fairshare": {
-			preemptedJobContext: &context.JobSchedulingContext{
+			preemptedJobContexts: []*context.JobSchedulingContext{{
 				JobId:         "job-1",
 				AssignedNode:  testfixtures.TestSimpleNode("node-4"),
+				Job:           makeJob(t, "job-1", false),
 				PreemptingJob: makeJob(t, "job-7", false),
-			},
-			expectedPreemptedJobContext: &context.JobSchedulingContext{
+			}},
+			expectedPreemptedJobContexts: []*context.JobSchedulingContext{{
 				JobId:                 "job-1",
 				AssignedNode:          testfixtures.TestSimpleNode("node-4"),
+				Job:                   makeJob(t, "job-1", false),
 				PreemptingJob:         makeJob(t, "job-7", false),
 				PreemptionDescription: fmt.Sprintf(fairSharePreemptionTemplate, "job-7"),
 				PreemptionType:        context.PreemptedWithFairsharePreemption,
+			}},
+		},
+		"fairshare - gang": {
+			preemptedJobContexts: []*context.JobSchedulingContext{
+				{
+					JobId:        "job-1",
+					AssignedNode: testfixtures.TestSimpleNode("node-4"),
+					Job:          makeJob(t, "job-1", true),
+				},
+				{
+					JobId:         "job-8",
+					AssignedNode:  testfixtures.TestSimpleNode("node-3"),
+					Job:           makeJob(t, "job-8", true),
+					PreemptingJob: makeJob(t, "job-7", false),
+				},
+			},
+			expectedPreemptedJobContexts: []*context.JobSchedulingContext{
+				{
+					JobId:                 "job-1",
+					AssignedNode:          testfixtures.TestSimpleNode("node-4"),
+					Job:                   makeJob(t, "job-1", true),
+					PreemptionDescription: fmt.Sprintf(gangSiblingFairSharePreemptionTemplate, describeGangMemberPreemptions([]preemptionInfo{{"job-8", "job-7"}})),
+					PreemptionType:        context.PreemptedWithFairsharePreemption,
+				},
+				{
+					JobId:                 "job-8",
+					AssignedNode:          testfixtures.TestSimpleNode("node-3"),
+					Job:                   makeJob(t, "job-8", true),
+					PreemptingJob:         makeJob(t, "job-7", false),
+					PreemptionDescription: fmt.Sprintf(fairSharePreemptionTemplate, "job-7"),
+					PreemptionType:        context.PreemptedWithFairsharePreemption,
+				},
 			},
 		},
 		"fairshare - market based": {
 			marketBased: true,
-			preemptedJobContext: &context.JobSchedulingContext{
+			preemptedJobContexts: []*context.JobSchedulingContext{{
 				JobId:         "job-1",
 				Job:           makeJobWithPrice(t, "job-1", false, 0),
 				AssignedNode:  testfixtures.TestSimpleNode("node-4"),
 				PreemptingJob: makeJobWithPrice(t, "job-7", false, 5),
-			},
-			expectedPreemptedJobContext: &context.JobSchedulingContext{
+			}},
+			expectedPreemptedJobContexts: []*context.JobSchedulingContext{{
 				JobId:                 "job-1",
 				Job:                   makeJobWithPrice(t, "job-1", false, 0),
 				AssignedNode:          testfixtures.TestSimpleNode("node-4"),
 				PreemptingJob:         makeJobWithPrice(t, "job-7", false, 5),
 				PreemptionDescription: fmt.Sprintf(marketBasedPreemptionTemplate, float64(0), "job-7", float64(5)),
 				PreemptionType:        context.PreemptedWithFairsharePreemption,
-			},
+			}},
 		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			PopulatePreemptionDescriptions(tc.marketBased, testfixtures.TestPool, []*context.JobSchedulingContext{tc.preemptedJobContext}, scheduledJobContexts)
+			PopulatePreemptionDescriptions(tc.marketBased, testfixtures.TestPool, tc.preemptedJobContexts, scheduledJobContexts)
 			assert.Equal(t, expectedScheduleJobContexts, scheduledJobContexts)
-			assert.Equal(t, []*context.JobSchedulingContext{tc.expectedPreemptedJobContext}, []*context.JobSchedulingContext{tc.preemptedJobContext})
+			assert.Equal(t, tc.expectedPreemptedJobContexts, tc.preemptedJobContexts)
 		})
 	}
 }

--- a/internal/scheduler/scheduling/queue_scheduler.go
+++ b/internal/scheduler/scheduling/queue_scheduler.go
@@ -122,6 +122,14 @@ func (sch *QueueScheduler) Schedule(ctx *armadacontext.Context) (*SchedulingResu
 			}
 			continue
 		}
+
+		// Skip gangs containing a job already preempted this round; they must not be re-scheduled.
+		if gangContainsPreemptedJob(sctx, gctx.JobSchedulingContexts) {
+			if err := sch.candidateGangIterator.Clear(); err != nil {
+				return nil, err
+			}
+			continue
+		}
 		start := sch.clock.Now()
 		scheduledOk, unschedulableReason, err := sch.gangScheduler.Schedule(ctx, gctx)
 		if err != nil {
@@ -310,6 +318,15 @@ func (it *QueuedGangIterator) OnlyYieldEvicted() {
 
 func (it *QueuedGangIterator) Clear() {
 	it.next = nil
+}
+
+func gangContainsPreemptedJob(sctx *schedulercontext.SchedulingContext, gang []*schedulercontext.JobSchedulingContext) bool {
+	for _, jctx := range gang {
+		if sctx.IsJobPreempted(jctx.JobId) {
+			return true
+		}
+	}
+	return false
 }
 
 func (it *QueuedGangIterator) Peek() (*schedulercontext.GangSchedulingContext, error) {

--- a/internal/scheduler/scheduling/queue_scheduler.go
+++ b/internal/scheduler/scheduling/queue_scheduler.go
@@ -25,6 +25,8 @@ type CandidateGangIterator interface {
 	GetAllocationForQueue(queue string) (internaltypes.ResourceList, bool)
 	OnlyYieldEvicted() error
 	OnlyYieldEvictedForQueue(queue string) error
+	// ResumeNonEvicted reverses OnlyYieldEvicted, allowing non-evicted (new) jobs to be yielded again.
+	ResumeNonEvicted() error
 	SecondPrice(priceSettingQueue string) float64
 }
 
@@ -97,6 +99,8 @@ func (sch *QueueScheduler) Schedule(ctx *armadacontext.Context) (*SchedulingResu
 	scheduledResource := sch.schedulingContext.TotalResources.Factory().MakeAllZero()
 	statsPerQueue := map[string]QueueStats{}
 	loopNumber := 0
+	preemptionRateLimitHit := false
+	evictedJobsRescheduled := false
 	for {
 		// Hard timeout check via context - if exceeded, abort immediately with error.
 		select {
@@ -104,6 +108,15 @@ func (sch *QueueScheduler) Schedule(ctx *armadacontext.Context) (*SchedulingResu
 			sctx.TerminationReason = fmt.Sprintf("hard timeout: %s", ctx.Err().Error())
 			return nil, ctx.Err()
 		default:
+		}
+
+		// Once this pool's fairshare preemption budget is exhausted,
+		// reschedule all remaining evicted (preemptable) jobs before considering any more new jobs.
+		if !preemptionRateLimitHit && sctx.AtFairsharePreemptionRateLimit() {
+			preemptionRateLimitHit = true
+			if err := sch.candidateGangIterator.OnlyYieldEvicted(); err != nil {
+				return nil, err
+			}
 		}
 
 		// Peek() returns the next gang to try to schedule. Call Clear() before calling Peek() again.
@@ -114,6 +127,16 @@ func (sch *QueueScheduler) Schedule(ctx *armadacontext.Context) (*SchedulingResu
 			return nil, err
 		}
 		if gctx == nil {
+			// If we drained evicted jobs due to the preemption rate limit, bring back new jobs now that
+			// all preemptable jobs have been rescheduled. Skip this if a terminal reason (e.g. a global
+			// scheduling rate limit) ended scheduling, since new jobs should stay paused in that case.
+			if preemptionRateLimitHit && !evictedJobsRescheduled && sctx.TerminationReason == "" {
+				evictedJobsRescheduled = true
+				if err := sch.candidateGangIterator.ResumeNonEvicted(); err != nil {
+					return nil, err
+				}
+				continue
+			}
 			break
 		}
 		if gctx.Cardinality() == 0 {
@@ -295,7 +318,10 @@ type QueuedGangIterator struct {
 	jobsSeen uint
 	// If the iterator should only be yielding evicted jobs
 	onlyYieldEvicted bool
-	next             *schedulercontext.GangSchedulingContext
+	// A non-evicted gang that was already peeked (and so consumed from the underlying iterator) when
+	// OnlyYieldEvicted was set. Stashed rather than dropped so ResumeNonEvicted can yield it again.
+	stashedNonEvicted *schedulercontext.GangSchedulingContext
+	next              *schedulercontext.GangSchedulingContext
 }
 
 func NewQueuedGangIterator(sctx *schedulercontext.SchedulingContext, it JobContextIterator, maxLookback uint, skipKnownUnschedulableJobs bool) *QueuedGangIterator {
@@ -309,11 +335,28 @@ func NewQueuedGangIterator(sctx *schedulercontext.SchedulingContext, it JobConte
 }
 
 func (it *QueuedGangIterator) OnlyYieldEvicted() {
+	if it.onlyYieldEvicted {
+		return
+	}
 	it.onlyYieldEvicted = true
 	it.queuedJobsIterator.OnlyYieldEvicted()
 	if it.next != nil && !it.next.AllJobsEvicted {
+		// Stash the already-consumed non-evicted gang so ResumeNonEvicted can yield it again,
+		// rather than losing it (the underlying iterator's cursor has already advanced past it).
+		it.stashedNonEvicted = it.next
 		it.Clear()
 	}
+}
+
+func (it *QueuedGangIterator) ResumeNonEvicted() {
+	if !it.onlyYieldEvicted {
+		return
+	}
+	it.onlyYieldEvicted = false
+	it.queuedJobsIterator.ResumeNonEvicted()
+	// Restore any gang stashed by OnlyYieldEvicted so it is yielded before the iterator advances.
+	it.next = it.stashedNonEvicted
+	it.stashedNonEvicted = nil
 }
 
 func (it *QueuedGangIterator) Clear() {
@@ -411,6 +454,9 @@ type CostBasedCandidateGangIterator struct {
 	// If, e.g., onlyYieldEvictedByQueue["A"] is true,
 	// this iterator only yields gangs where all jobs are evicted for queue A.
 	onlyYieldEvictedByQueue map[string]bool
+	// All per-queue iterators, kept so the priority queue can be rebuilt by ResumeNonEvicted
+	// (OnlyYieldEvicted drops items for queues with no remaining evicted jobs).
+	iteratorsByQueue map[string]*QueuedGangIterator
 	// Priority queue containing per-queue iterators.
 	// Determines the order in which queues are processed.
 	pq QueueCandidateGangIteratorPQ
@@ -441,6 +487,7 @@ func NewCostBasedCandidateGangIterator(
 		queueRepository:         queueRepository,
 		fairnessCostProvider:    fairnessCostProvider,
 		onlyYieldEvictedByQueue: make(map[string]bool),
+		iteratorsByQueue:        iteratorsByQueue,
 		pq: QueueCandidateGangIteratorPQ{
 			considerPriority:     considerPriority,
 			prioritiseLargerJobs: prioritiseLargerJobs,
@@ -448,16 +495,24 @@ func NewCostBasedCandidateGangIterator(
 		},
 	}
 	for queue, queueIt := range iteratorsByQueue {
-		qctx, present := queueIt.schedulingContext.QueueSchedulingContexts[queue]
-		if !present {
-			return nil, fmt.Errorf("unable to find queue context for queue %s", queue)
-		}
-		queueBudget := qctx.DemandCappedAdjustedFairShare / qctx.Weight
-		if _, err := it.updateAndPushPQItem(it.newPQItem(queue, queueBudget, queueIt)); err != nil {
+		if err := it.pushQueue(queue, queueIt); err != nil {
 			return nil, err
 		}
 	}
 	return it, nil
+}
+
+// pushQueue adds a per-queue iterator's current head to the priority queue.
+func (it *CostBasedCandidateGangIterator) pushQueue(queue string, queueIt *QueuedGangIterator) error {
+	qctx, present := queueIt.schedulingContext.QueueSchedulingContexts[queue]
+	if !present {
+		return fmt.Errorf("unable to find queue context for queue %s", queue)
+	}
+	queueBudget := qctx.DemandCappedAdjustedFairShare / qctx.Weight
+	if _, err := it.updateAndPushPQItem(it.newPQItem(queue, queueBudget, queueIt)); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (it *CostBasedCandidateGangIterator) OnlyYieldEvicted() error {
@@ -504,6 +559,31 @@ func (it *CostBasedCandidateGangIterator) OnlyYieldEvictedForQueue(queue string)
 		}
 	}
 	it.onlyYieldEvictedByQueue[queue] = true
+	return nil
+}
+
+// ResumeNonEvicted reverses OnlyYieldEvicted, allowing non-evicted (new) jobs to be yielded again.
+// It rebuilds the priority queue from all per-queue iterators, since OnlyYieldEvicted drops items
+// for queues that had no remaining evicted jobs. Per-queue evicted-only state set by
+// OnlyYieldEvictedForQueue (e.g. from a per-queue scheduling rate limit) is preserved.
+func (it *CostBasedCandidateGangIterator) ResumeNonEvicted() error {
+	if !it.onlyYieldEvicted {
+		return nil
+	}
+	it.onlyYieldEvicted = false
+
+	// Rebuild the priority queue from scratch so previously-dropped queues are reconsidered.
+	it.pq.items = make([]*QueueCandidateGangIteratorItem, 0, len(it.iteratorsByQueue))
+	for queue, queueIt := range it.iteratorsByQueue {
+		// Leave queues that were individually restricted to evicted-only (e.g. hit their per-queue
+		// scheduling rate limit); only undo the global evicted-only drain.
+		if !it.onlyYieldEvictedByQueue[queue] {
+			queueIt.ResumeNonEvicted()
+		}
+		if err := it.pushQueue(queue, queueIt); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/internal/scheduler/scheduling/queue_scheduler_test.go
+++ b/internal/scheduler/scheduling/queue_scheduler_test.go
@@ -519,6 +519,7 @@ func TestQueueScheduler(t *testing.T) {
 					rate.Limit(tc.SchedulingConfig.MaximumSchedulingRate),
 					tc.SchedulingConfig.MaximumSchedulingBurst,
 				),
+				nil,
 				totalResources,
 			)
 			for _, q := range tc.Queues {
@@ -689,6 +690,7 @@ func newQueueSchedulerSctx(t *testing.T, config configuration.SchedulingConfig, 
 		"pool",
 		fairnessCostProvider,
 		rate.NewLimiter(rate.Limit(config.MaximumSchedulingRate), config.MaximumSchedulingBurst),
+		nil,
 		totalResources,
 	)
 	for _, q := range queues {
@@ -764,6 +766,150 @@ func TestQueueScheduler_PreemptedJobsGetMarkedInSctx(t *testing.T) {
 		}
 	}
 	require.Equal(t, 1, preemptedCount, "expected exactly one incumbent to be preempted")
+}
+
+func TestQueueScheduler_PreemptionRateLimit(t *testing.T) {
+	tests := map[string]struct {
+		node *internaltypes.Node
+		// These will all be evicted
+		existingJobsQueueA []*jobdb.Job
+		// These will all be evicted
+		existingJobsQueueB []*jobdb.Job
+		// New jobs to try scheduling
+		newJobsQueueB                  []*jobdb.Job
+		rateLimit                      *rate.Limiter
+		expectedNumberNewJobsScheduled int
+		expectedNumberPreemptedJobs    int
+	}{
+		"exhausted limit, full node: new job cannot preempt": {
+			node:                           testfixtures.Test32CpuNode(testfixtures.TestPriorities),
+			existingJobsQueueA:             testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 32),
+			newJobsQueueB:                  testfixtures.N1Cpu4GiJobs("B", testfixtures.PriorityClass0, 32),
+			rateLimit:                      rate.NewLimiter(rate.Limit(0), 0),
+			expectedNumberNewJobsScheduled: 0,
+			expectedNumberPreemptedJobs:    0,
+		},
+		"exhausted limit, free space: new job scheduled without preemption": {
+			node:                           testfixtures.Test32CpuNode(testfixtures.TestPriorities),
+			existingJobsQueueA:             testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 31),
+			newJobsQueueB:                  testfixtures.N1Cpu4GiJobs("B", testfixtures.PriorityClass0, 32),
+			rateLimit:                      rate.NewLimiter(rate.Limit(0), 0),
+			expectedNumberNewJobsScheduled: 1,
+			expectedNumberPreemptedJobs:    0,
+		},
+		"limited rate limit, full node: limited new jobs preempt via fairshare": {
+			node:                           testfixtures.Test32CpuNode(testfixtures.TestPriorities),
+			existingJobsQueueA:             testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 32),
+			newJobsQueueB:                  testfixtures.N1Cpu4GiJobs("B", testfixtures.PriorityClass0, 32),
+			rateLimit:                      rate.NewLimiter(rate.Limit(5), 5),
+			expectedNumberNewJobsScheduled: 5,
+			expectedNumberPreemptedJobs:    5,
+		},
+		"limited rate limit, partially full node: new jobs fill space perform limited fairshare preemption": {
+			node:                           testfixtures.Test32CpuNode(testfixtures.TestPriorities),
+			existingJobsQueueA:             testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 31),
+			newJobsQueueB:                  testfixtures.N1Cpu4GiJobs("B", testfixtures.PriorityClass0, 32),
+			rateLimit:                      rate.NewLimiter(rate.Limit(5), 5),
+			expectedNumberNewJobsScheduled: 6,
+			expectedNumberPreemptedJobs:    5,
+		},
+		"limited rate limit, queue with mix of new + evicted jobs - partially full node: new jobs fill space perform limited fairshare preemption": {
+			node:                           testfixtures.Test32CpuNode(testfixtures.TestPriorities),
+			existingJobsQueueA:             testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 25),
+			existingJobsQueueB:             testfixtures.N1Cpu4GiJobs("B", testfixtures.PriorityClass0, 5),
+			newJobsQueueB:                  testfixtures.N1Cpu4GiJobs("B", testfixtures.PriorityClass0, 32),
+			rateLimit:                      rate.NewLimiter(rate.Limit(5), 5),
+			expectedNumberNewJobsScheduled: 7,
+			expectedNumberPreemptedJobs:    5,
+		},
+		"unlimited rate limit, full node: new job preempts via fairshare": {
+			node:                           testfixtures.Test32CpuNode(testfixtures.TestPriorities),
+			existingJobsQueueA:             testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 32),
+			newJobsQueueB:                  testfixtures.N1Cpu4GiJobs("B", testfixtures.PriorityClass0, 32),
+			rateLimit:                      nil,
+			expectedNumberNewJobsScheduled: 16,
+			expectedNumberPreemptedJobs:    16,
+		},
+		"unlimited rate limit - queue with mix of new + evicted jobs - new job preempts via fairshare": {
+			node:                           testfixtures.Test32CpuNode(testfixtures.TestPriorities),
+			existingJobsQueueA:             testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 22),
+			existingJobsQueueB:             testfixtures.N1Cpu4GiJobs("B", testfixtures.PriorityClass0, 10),
+			newJobsQueueB:                  testfixtures.N1Cpu4GiJobs("B", testfixtures.PriorityClass0, 32),
+			rateLimit:                      nil,
+			expectedNumberNewJobsScheduled: 6,
+			expectedNumberPreemptedJobs:    6,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			config := testfixtures.TestSchedulingConfig()
+			nodeDb, err := NewNodeDb(config, stringinterner.New(1024))
+			require.NoError(t, err)
+
+			existingJobs := append(tc.existingJobsQueueA, tc.existingJobsQueueB...)
+			// candidates for fair-share preemption / rescheduling.
+			txn := nodeDb.Txn(true)
+			require.NoError(t, nodeDb.CreateAndInsertWithJobDbJobsWithTxn(txn, existingJobs, tc.node))
+			txn.Commit()
+
+			dbNode, err := nodeDb.GetNode(tc.node.GetId())
+			require.NoError(t, err)
+			evictedNode, err := nodeDb.EvictJobsFromNode(existingJobs, dbNode)
+			require.NoError(t, err)
+			txn = nodeDb.Txn(true)
+			require.NoError(t, nodeDb.UpsertWithTxn(txn, evictedNode))
+			evictedJctxs := make([]*context.JobSchedulingContext, len(existingJobs))
+			evictedJctxByQueue := make(map[string][]*context.JobSchedulingContext, 2)
+			for i, job := range existingJobs {
+				evictedJctx := context.JobSchedulingContextFromJob(job)
+				evictedJctx.SetAssignedNode(evictedNode)
+				evictedJctx.IsEvicted = true
+				evictedJctxs[i] = evictedJctx
+				evictedJctxByQueue[evictedJctx.Job.Queue()] = append(evictedJctxByQueue[evictedJctx.Job.Queue()], evictedJctx)
+				require.NoError(t, nodeDb.AddEvictedJobSchedulingContextWithTxn(txn, i, evictedJctx))
+			}
+			txn.Commit()
+
+			sctx := newQueueSchedulerSctx(t, config, nodeDb.TotalKubernetesResources(), []string{"A", "B"})
+			sctx.FairsharePreemptionLimiter = tc.rateLimit
+
+			constraints := schedulerconstraints.NewSchedulingConstraints("pool", nodeDb.TotalKubernetesResources(), config,
+				[]*api.Queue{{Name: "A"}, {Name: "B"}})
+
+			evictedRepoA := NewInMemoryJobIterator(evictedJctxByQueue["A"])
+			evictedRepoB := NewInMemoryJobIterator(evictedJctxByQueue["B"])
+
+			newRepo := newMockJobRepository()
+			newRepo.EnqueueMany(tc.newJobsQueueB)
+			jobIteratorByQueue := map[string]JobContextIterator{
+				"A": evictedRepoA,
+				"B": NewMultiJobsIterator(evictedRepoB, newRepo.GetJobIterator("B")),
+			}
+
+			sch, err := NewQueueScheduler(sctx, constraints, testfixtures.TestEmptyFloatingResources, nodeDb, jobIteratorByQueue, false, true, config.EnablePreferLargeJobOrdering, config.MaxQueueLookback, false, 0, clock.RealClock{})
+			require.NoError(t, err)
+
+			result, err := sch.Schedule(armadacontext.Background())
+			require.NoError(t, err)
+
+			newJobsScheduled := 0
+			for _, job := range result.ScheduledJobs {
+				if !job.IsEvicted {
+					newJobsScheduled++
+				}
+			}
+			assert.Equal(t, tc.expectedNumberNewJobsScheduled, newJobsScheduled)
+
+			numberPreemptedJobs := 0
+			for _, jctx := range evictedJctxs {
+				if jctx.PreemptingJob != nil {
+					numberPreemptedJobs++
+				}
+			}
+			assert.Equal(t, tc.expectedNumberPreemptedJobs, numberPreemptedJobs)
+		})
+	}
 }
 
 func TestQueueScheduler_SkipsPreemptedCandidate(t *testing.T) {
@@ -973,6 +1119,7 @@ func setupTimeoutTest(t *testing.T, queues []*api.Queue, jobsByQueue map[string]
 		testfixtures.TestPool,
 		fairnessCostProvider,
 		rate.NewLimiter(rate.Limit(config.MaximumSchedulingRate), config.MaximumSchedulingBurst),
+		nil,
 		totalResources,
 	)
 
@@ -1073,7 +1220,7 @@ func TestQueuedGangIterator(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			sctx := context.NewSchedulingContext("pool", nil, nil, testfixtures.TestResourceListFactory.MakeAllZero())
+			sctx := context.NewSchedulingContext("pool", nil, nil, nil, testfixtures.TestResourceListFactory.MakeAllZero())
 			it := NewQueuedGangIterator(sctx, NewInMemoryJobIterator(tc.jctxs), tc.maxLookback, false)
 			if tc.onlyYieldEvicted {
 				it.OnlyYieldEvicted()
@@ -1108,7 +1255,7 @@ func TestQueuedGangIterator_OnlyYieldEvicted_TopItemEvicted(t *testing.T) {
 		createJctx(true),
 	}
 
-	sctx := context.NewSchedulingContext("pool", nil, nil, testfixtures.TestResourceListFactory.MakeAllZero())
+	sctx := context.NewSchedulingContext("pool", nil, nil, nil, testfixtures.TestResourceListFactory.MakeAllZero())
 	it := NewQueuedGangIterator(sctx, NewInMemoryJobIterator(jctxs), 1, false)
 
 	gctx, err := it.Peek()
@@ -1132,7 +1279,7 @@ func TestQueuedGangIterator_OnlyYieldEvicted_TopItemNonEvicted(t *testing.T) {
 		createJctx(true),
 	}
 
-	sctx := context.NewSchedulingContext("pool", nil, nil, testfixtures.TestResourceListFactory.MakeAllZero())
+	sctx := context.NewSchedulingContext("pool", nil, nil, nil, testfixtures.TestResourceListFactory.MakeAllZero())
 	it := NewQueuedGangIterator(sctx, NewInMemoryJobIterator(jctxs), 1, false)
 
 	gctx, err := it.Peek()
@@ -1146,6 +1293,78 @@ func TestQueuedGangIterator_OnlyYieldEvicted_TopItemNonEvicted(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, gctx.JobSchedulingContexts, 1)
 	assert.Equal(t, jctxs[1].JobId, gctx.JobSchedulingContexts[0].JobId)
+}
+
+func TestQueuedGangIterator_ResumeNonEvicted(t *testing.T) {
+	evictedJob := testfixtures.Test1Cpu4GiJob("A", testfixtures.PriorityClass0)
+	evictedJctx := context.JobSchedulingContextFromJob(evictedJob)
+	evictedJctx.IsEvicted = true
+	evictedIt := NewInMemoryJobIterator([]*context.JobSchedulingContext{evictedJctx})
+
+	newRepo := newMockJobRepository()
+	newJob := jobFromPodSpec("A", testfixtures.N1CpuPodReqs(1)[0])
+	newRepo.Enqueue(newJob)
+	newIt := NewQueuedJobsIterator("A", testfixtures.TestPool, jobdb.FairShareOrder, newRepo)
+
+	combined := NewMultiJobsIterator(evictedIt, newIt)
+
+	sctx := context.NewSchedulingContext("pool", nil, nil, nil, testfixtures.TestResourceListFactory.MakeAllZero())
+	it := NewQueuedGangIterator(sctx, combined, 0, false)
+
+	// Peek gives evicted job prior to only yield evicted
+	gctx, err := it.Peek()
+	require.NoError(t, err)
+	assert.Equal(t, evictedJob.Id(), gctx.JobSchedulingContexts[0].JobId)
+
+	// Evicted-only mode: only the evicted job is yielded, the new job is paused.
+	it.OnlyYieldEvicted()
+	gctx, err = it.Peek()
+	require.NoError(t, err)
+	require.NotNil(t, gctx)
+	assert.Equal(t, evictedJob.Id(), gctx.JobSchedulingContexts[0].JobId)
+	it.Clear()
+	gctx, err = it.Peek()
+	require.NoError(t, err)
+	assert.Nil(t, gctx, "new job must stay paused while in evicted-only mode")
+
+	// Resume: the paused new job is now yielded.
+	it.ResumeNonEvicted()
+	gctx, err = it.Peek()
+	require.NoError(t, err)
+	require.NotNil(t, gctx)
+	assert.Equal(t, newJob.Id(), gctx.JobSchedulingContexts[0].JobId)
+}
+
+func TestQueuedGangIterator_ResumeNonEvicted_NoEvicted(t *testing.T) {
+	evictedIt := NewInMemoryJobIterator([]*context.JobSchedulingContext{})
+
+	newRepo := newMockJobRepository()
+	newJob := jobFromPodSpec("A", testfixtures.N1CpuPodReqs(1)[0])
+	newRepo.Enqueue(newJob)
+	newIt := NewQueuedJobsIterator("A", testfixtures.TestPool, jobdb.FairShareOrder, newRepo)
+
+	combined := NewMultiJobsIterator(evictedIt, newIt)
+
+	sctx := context.NewSchedulingContext("pool", nil, nil, nil, testfixtures.TestResourceListFactory.MakeAllZero())
+	it := NewQueuedGangIterator(sctx, combined, 0, false)
+
+	// Peek gives new job prior to only yield evicted
+	gctx, err := it.Peek()
+	require.NoError(t, err)
+	assert.Equal(t, newJob.Id(), gctx.JobSchedulingContexts[0].JobId)
+
+	// Evicted-only mode: only the evicted job is yielded, the new job is paused.
+	it.OnlyYieldEvicted()
+	gctx, err = it.Peek()
+	require.NoError(t, err)
+	assert.Nil(t, gctx, "new job must stay paused while in evicted-only mode")
+
+	// Resume: the paused new job is now yielded.
+	it.ResumeNonEvicted()
+	gctx, err = it.Peek()
+	require.NoError(t, err)
+	require.NotNil(t, gctx)
+	assert.Equal(t, newJob.Id(), gctx.JobSchedulingContexts[0].JobId)
 }
 
 func createJctx(evicted bool) *context.JobSchedulingContext {
@@ -1164,7 +1383,7 @@ func createGangJctx(gangId string, cardinality int) *context.JobSchedulingContex
 }
 
 func TestGangContainsPreemptedJob(t *testing.T) {
-	sctx := context.NewSchedulingContext("pool", nil, nil, testfixtures.TestResourceListFactory.MakeAllZero())
+	sctx := context.NewSchedulingContext("pool", nil, nil, nil, testfixtures.TestResourceListFactory.MakeAllZero())
 
 	gangJob1 := createGangJctx("gang-1", 2)
 	gangJob2 := createGangJctx("gang-1", 2)

--- a/internal/scheduler/scheduling/queue_scheduler_test.go
+++ b/internal/scheduler/scheduling/queue_scheduler_test.go
@@ -681,6 +681,123 @@ func TestQueueScheduler(t *testing.T) {
 	}
 }
 
+func newQueueSchedulerSctx(t *testing.T, config configuration.SchedulingConfig, totalResources internaltypes.ResourceList, queues []string) *context.SchedulingContext {
+	t.Helper()
+	fairnessCostProvider, err := fairness.NewDominantResourceFairness(totalResources, testfixtures.TestPool, config)
+	require.NoError(t, err)
+	sctx := context.NewSchedulingContext(
+		"pool",
+		fairnessCostProvider,
+		rate.NewLimiter(rate.Limit(config.MaximumSchedulingRate), config.MaximumSchedulingBurst),
+		totalResources,
+	)
+	for _, q := range queues {
+		require.NoError(t, sctx.AddQueueSchedulingContext(
+			q, 1, 1, nil,
+			internaltypes.ResourceList{}, internaltypes.ResourceList{}, internaltypes.ResourceList{},
+			rate.NewLimiter(rate.Limit(config.MaximumPerQueueSchedulingRate), config.MaximumPerQueueSchedulingBurst),
+		))
+	}
+	sctx.UpdateFairShares()
+	return sctx
+}
+
+func TestQueueScheduler_PreemptedJobsGetMarkedInSctx(t *testing.T) {
+	config := testfixtures.TestSchedulingConfig()
+	nodeDb, err := NewNodeDb(config, stringinterner.New(1024))
+	require.NoError(t, err)
+
+	// Fully allocate the node with a low-priority jobs in queue A.
+	node := testfixtures.Test32CpuNode(testfixtures.TestPriorities)
+	existingJobs := testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 32)
+	txn := nodeDb.Txn(true)
+	require.NoError(t, nodeDb.CreateAndInsertWithJobDbJobsWithTxn(txn, existingJobs, node.DeepCopyNilKeys()))
+	txn.Commit()
+
+	// Evict the existing jobs and register them so they are candidates for fair-share preemption.
+	dbNode, err := nodeDb.GetNode(node.GetId())
+	require.NoError(t, err)
+	evictedNode, err := nodeDb.EvictJobsFromNode(existingJobs, dbNode)
+	require.NoError(t, err)
+	txn = nodeDb.Txn(true)
+	require.NoError(t, nodeDb.UpsertWithTxn(txn, evictedNode))
+	evictedJctxByJobId := make(map[string]*context.JobSchedulingContext, len(existingJobs))
+	for i, job := range existingJobs {
+		evictedJctx := context.JobSchedulingContextFromJob(job)
+		evictedJctx.SetAssignedNode(evictedNode)
+		evictedJctxByJobId[job.Id()] = evictedJctx
+		require.NoError(t, nodeDb.AddEvictedJobSchedulingContextWithTxn(txn, i, evictedJctx))
+	}
+	txn.Commit()
+
+	sctx := newQueueSchedulerSctx(t, config, nodeDb.TotalKubernetesResources(), []string{"A", "B"})
+	constraints := schedulerconstraints.NewSchedulingConstraints("pool", nodeDb.TotalKubernetesResources(), config,
+		[]*api.Queue{{Name: "A"}, {Name: "B"}})
+
+	// New job must preempt one of the existing jobs to fit on
+	job := testfixtures.Test1Cpu4GiJob("B", testfixtures.PriorityClass1)
+	jobRepo := NewInMemoryJobRepository(testfixtures.TestPool, jobdb.JobPriorityComparer{})
+	jobRepo.EnqueueMany(context.JobSchedulingContextsFromJobs([]*jobdb.Job{job}))
+	jobIteratorByQueue := map[string]JobContextIterator{
+		"A": jobRepo.GetJobIterator("A"),
+		"B": jobRepo.GetJobIterator("B"),
+	}
+
+	sch, err := NewQueueScheduler(sctx, constraints, testfixtures.TestEmptyFloatingResources, nodeDb, jobIteratorByQueue, false, true, config.EnablePreferLargeJobOrdering, config.MaxQueueLookback, false, 0, clock.RealClock{})
+	require.NoError(t, err)
+
+	result, err := sch.Schedule(armadacontext.Background())
+	require.NoError(t, err)
+
+	require.Len(t, result.ScheduledJobs, 1)
+	require.Equal(t, job.Id(), result.ScheduledJobs[0].JobId)
+
+	// Exactly one incumbent should be preempted, marked in both the jctx and the sctx.
+	preemptedCount := 0
+	for jobId, evictedJctx := range evictedJctxByJobId {
+		markedInSctx := sctx.IsJobPreempted(jobId)
+		markedInJctx := evictedJctx.PreemptingJob != nil
+		require.Equal(t, markedInSctx, markedInJctx, "sctx and jctx preemption marking disagree for job %s", jobId)
+		if markedInJctx {
+			preemptedCount++
+			require.Equal(t, job.Id(), evictedJctx.PreemptingJob.Id())
+		}
+	}
+	require.Equal(t, 1, preemptedCount, "expected exactly one incumbent to be preempted")
+}
+
+func TestQueueScheduler_SkipsPreemptedCandidate(t *testing.T) {
+	config := testfixtures.TestSchedulingConfig()
+	nodeDb, err := NewNodeDb(config, stringinterner.New(1024))
+	require.NoError(t, err)
+
+	txn := nodeDb.Txn(true)
+	require.NoError(t, nodeDb.CreateAndInsertWithJobDbJobsWithTxn(txn, nil, testfixtures.Test32CpuNode(testfixtures.TestPriorities)))
+	txn.Commit()
+
+	sctx := newQueueSchedulerSctx(t, config, nodeDb.TotalKubernetesResources(), []string{"A"})
+	constraints := schedulerconstraints.NewSchedulingConstraints("pool", nodeDb.TotalKubernetesResources(), config,
+		[]*api.Queue{{Name: "A"}})
+
+	jobs := testfixtures.N1Cpu4GiJobs("A", testfixtures.PriorityClass0, 2)
+	jctxs := context.JobSchedulingContextsFromJobs(jobs)
+	// Mark the first job as already preempted this round; it must not be re-scheduled.
+	sctx.MarkJobPreempted(jobs[0].Id())
+
+	jobRepo := NewInMemoryJobRepository(testfixtures.TestPool, jobdb.JobPriorityComparer{})
+	jobRepo.EnqueueMany(jctxs)
+	jobIteratorByQueue := map[string]JobContextIterator{"A": jobRepo.GetJobIterator("A")}
+
+	sch, err := NewQueueScheduler(sctx, constraints, testfixtures.TestEmptyFloatingResources, nodeDb, jobIteratorByQueue, false, false, config.EnablePreferLargeJobOrdering, config.MaxQueueLookback, false, 0, clock.RealClock{})
+	require.NoError(t, err)
+
+	result, err := sch.Schedule(armadacontext.Background())
+	require.NoError(t, err)
+
+	assert.Len(t, result.ScheduledJobs, 1)
+	require.Equal(t, jobs[1].Id(), result.ScheduledJobs[0].JobId)
+}
+
 func NewNodeDb(config configuration.SchedulingConfig, stringInterner *stringinterner.StringInterner) (*nodedb.NodeDb, error) {
 	nodeDb, err := nodedb.NewNodeDb(
 		config.PriorityClasses,
@@ -1036,6 +1153,35 @@ func createJctx(evicted bool) *context.JobSchedulingContext {
 	jctx := context.JobSchedulingContextFromJob(job)
 	jctx.IsEvicted = evicted
 	return jctx
+}
+
+func createGangJctx(gangId string, cardinality int) *context.JobSchedulingContext {
+	job := testfixtures.Test1Cpu4GiJob("A", testfixtures.PriorityClass0).
+		WithGangInfo(jobdb.CreateGangInfo(gangId, cardinality, ""))
+	jctx := context.JobSchedulingContextFromJob(job)
+	jctx.IsEvicted = true
+	return jctx
+}
+
+func TestGangContainsPreemptedJob(t *testing.T) {
+	sctx := context.NewSchedulingContext("pool", nil, nil, testfixtures.TestResourceListFactory.MakeAllZero())
+
+	gangJob1 := createGangJctx("gang-1", 2)
+	gangJob2 := createGangJctx("gang-1", 2)
+	standalone := createJctx(true)
+
+	// No preempted jobs registered: nothing is skipped.
+	assert.False(t, gangContainsPreemptedJob(sctx, []*context.JobSchedulingContext{gangJob1, gangJob2}))
+	assert.False(t, gangContainsPreemptedJob(sctx, []*context.JobSchedulingContext{standalone}))
+
+	// A gang with any preempted member is considered preempted
+	sctx.MarkJobPreempted(gangJob1.JobId)
+	assert.True(t, gangContainsPreemptedJob(sctx, []*context.JobSchedulingContext{gangJob1, gangJob2}))
+	assert.False(t, gangContainsPreemptedJob(sctx, []*context.JobSchedulingContext{standalone}))
+
+	// A preempted standalone job marked as preempted is considered preempted
+	sctx.MarkJobPreempted(standalone.JobId)
+	assert.True(t, gangContainsPreemptedJob(sctx, []*context.JobSchedulingContext{standalone}))
 }
 
 func TestQueueSchedulerTimeouts(t *testing.T) {

--- a/internal/scheduler/scheduling/runner/async_test.go
+++ b/internal/scheduler/scheduling/runner/async_test.go
@@ -628,7 +628,7 @@ func createSctx(t *testing.T, scheduledJobs []*jobdb.Job, preemptedJobs []*jobdb
 	totalResources := testfixtures.TestResourceListFactory.MakeAllZero()
 	fairnessCostProvider, err := fairness.NewDominantResourceFairness(totalResources, reconcileTestPool, testfixtures.TestSchedulingConfig())
 	require.NoError(t, err)
-	sctx := schedulercontext.NewSchedulingContext(reconcileTestPool, fairnessCostProvider, nil, totalResources)
+	sctx := schedulercontext.NewSchedulingContext(reconcileTestPool, fairnessCostProvider, nil, nil, totalResources)
 
 	demand := internaltypes.ResourceList{}
 	for _, job := range append(scheduledJobs, preemptedJobs...) {

--- a/internal/scheduler/scheduling/scheduling_algo.go
+++ b/internal/scheduler/scheduling/scheduling_algo.go
@@ -52,7 +52,10 @@ type FairSchedulingAlgo struct {
 	// Global job scheduling rate-limiter.
 	limiter *rate.Limiter
 	// Per-queue job scheduling rate-limiters.
-	limiterByQueue               map[string]*rate.Limiter
+	limiterByQueue map[string]*rate.Limiter
+	// Per-pool fairshare preemption rate-limiters
+	// No rate limiter for a pool means no preemption limit
+	preemptionLimiterByPool      map[string]*rate.Limiter
 	lastOptimiserRoundTimeByPool map[string]time.Time
 	// Max amount of time each scheduling round is allowed to take (hard timeout).
 	maxSchedulingDuration time.Duration
@@ -88,6 +91,7 @@ func NewFairSchedulingAlgo(
 		schedulingContextRepository:  schedulingContextRepository,
 		limiter:                      rate.NewLimiter(rate.Limit(config.MaximumSchedulingRate), config.MaximumSchedulingBurst),
 		limiterByQueue:               make(map[string]*rate.Limiter),
+		preemptionLimiterByPool:      initialisePerPoolRateLimiters(config.Pools),
 		lastOptimiserRoundTimeByPool: make(map[string]time.Time, len(config.Pools)),
 		maxSchedulingDuration:        maxSchedulingDuration,
 		clock:                        clock.RealClock{},
@@ -710,7 +714,7 @@ func (l *FairSchedulingAlgo) constructSchedulingContext(
 	if err != nil {
 		return nil, err
 	}
-	sctx := schedulercontext.NewSchedulingContext(pool, fairnessCostProvider, l.limiter, totalCapacity)
+	sctx := schedulercontext.NewSchedulingContext(pool, fairnessCostProvider, l.limiter, l.preemptionLimiterByPool[pool], totalCapacity)
 	constraints := schedulerconstraints.NewSchedulingConstraints(pool, totalCapacity, l.schedulingConfig, maps.Values(queues))
 
 	for _, queue := range queues {
@@ -781,6 +785,20 @@ func (l *FairSchedulingAlgo) constructSchedulingContext(
 	sctx.UpdateFairShares()
 
 	return sctx, nil
+}
+
+func initialisePerPoolRateLimiters(pools []configuration.PoolConfig) map[string]*rate.Limiter {
+	limiterByPool := make(map[string]*rate.Limiter, len(pools))
+	for _, pool := range pools {
+		if pool.FairsharePreemptionRateLimit == nil {
+			continue
+		}
+		limiterByPool[pool.Name] = rate.NewLimiter(
+			rate.Limit(pool.FairsharePreemptionRateLimit.MaximumRate),
+			pool.FairsharePreemptionRateLimit.MaximumBurst,
+		)
+	}
+	return limiterByPool
 }
 
 // SchedulePool schedules jobs on nodes that belong to a given pool.

--- a/internal/scheduler/scheduling/scheduling_algo_test.go
+++ b/internal/scheduler/scheduling/scheduling_algo_test.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/mock/gomock"
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
+	"golang.org/x/time/rate"
 	v1 "k8s.io/api/core/v1"
 	k8sResource "k8s.io/apimachinery/pkg/api/resource"
 	clock "k8s.io/utils/clock/testing"
@@ -31,6 +32,57 @@ import (
 	"github.com/armadaproject/armada/internal/scheduler/testfixtures"
 	"github.com/armadaproject/armada/pkg/api"
 )
+
+func TestConstructSchedulingContext_SetsFairsharePreemptionLimiter(t *testing.T) {
+	tests := map[string]struct {
+		rateLimit     *configuration.RateLimit
+		expectLimiter bool
+		expectedRate  rate.Limit
+		expectedBurst int
+	}{
+		"configured": {
+			rateLimit:     &configuration.RateLimit{MaximumRate: 10, MaximumBurst: 20},
+			expectLimiter: true,
+			expectedRate:  rate.Limit(10),
+			expectedBurst: 20,
+		},
+		"configured with zero rate/burst": {
+			rateLimit:     &configuration.RateLimit{MaximumRate: 0, MaximumBurst: 0},
+			expectLimiter: true,
+			expectedRate:  rate.Limit(0),
+			expectedBurst: 0,
+		},
+		"unconfigured means no limiter": {
+			rateLimit:     nil,
+			expectLimiter: false,
+		},
+	}
+
+	totalResources := testfixtures.TestResourceListFactory.FromNodeProto(
+		map[string]*k8sResource.Quantity{"cpu": pointer.MustParseResource("1")},
+	)
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			config := testfixtures.TestSchedulingConfig()
+			config.Pools = []configuration.PoolConfig{{Name: "pool", FairsharePreemptionRateLimit: tc.rateLimit}}
+			l := &FairSchedulingAlgo{
+				schedulingConfig:        config,
+				preemptionLimiterByPool: initialisePerPoolRateLimiters(config.Pools),
+			}
+
+			sctx, err := l.constructSchedulingContext("pool", totalResources, nil, nil, nil, nil, map[string]*api.Queue{})
+			require.NoError(t, err)
+
+			if !tc.expectLimiter {
+				assert.Nil(t, sctx.FairsharePreemptionLimiter)
+				return
+			}
+			require.NotNil(t, sctx.FairsharePreemptionLimiter)
+			assert.Equal(t, tc.expectedRate, sctx.FairsharePreemptionLimiter.Limit())
+			assert.Equal(t, tc.expectedBurst, sctx.FairsharePreemptionLimiter.Burst())
+		})
+	}
+}
 
 type scheduledJobs struct {
 	jobs         []*jobdb.Job

--- a/internal/scheduler/simulator/simulator.go
+++ b/internal/scheduler/simulator/simulator.go
@@ -565,6 +565,7 @@ func (s *Simulator) handleScheduleEvent(ctx *armadacontext.Context) error {
 			pool,
 			fairnessCostProvider,
 			s.limiter,
+			nil, // no fairshare preemption rate limit in the simulator
 			totalResources,
 		)
 

--- a/internal/scheduler/submitcheck.go
+++ b/internal/scheduler/submitcheck.go
@@ -360,7 +360,7 @@ poolStart:
 			})
 
 			txn := ex.nodeDb.Txn(true)
-			ok, err := ex.nodeDb.ScheduleManyWithTxn(txn, gctx)
+			ok, _, err := ex.nodeDb.ScheduleManyWithTxn(txn, gctx)
 			txn.Abort()
 
 			sb.WriteString(ex.id)


### PR DESCRIPTION
Right now Armada works on instantaneous fair share, meaning when a new queue comes along, Armada will immediately preempt as much out the way as it needs to (within rate limit) to achieve fair share instantly

The problem with this is that it is very wasteful, often farms have a high churn of jobs so simply slowing the rate Armada tries to achieve fair share can be a big efficiency gain. As jobs will often get on without preemption in a reasonable amount of time.

This PR adds a fair share preemption rate limit, to enact this control albeit in a relatively basic fashion.

It allows admins to control how much Armada will preempt jobs out the way to achieve fair share
 - Having a strict limit will mean better usage of natural churn, likely less job wastage, but will take longer to reach fair share
 - Having a generous limit will mean users reach fair share faster at the expense of wastage

We'll no doubt need to add much smarter mechanisms to adjust how fast Armada should reach fair share / how wasteful it should be to do so. However this is a simple control that will likely deliver a large value in terms of reduced wastage while we come up with better mechanisms
