### PR TITLE
Classify delete-action failed pods with the pod-level failure reason

### DIFF
--- a/internal/executor/service/pod_issue_handler.go
+++ b/internal/executor/service/pod_issue_handler.go
@@ -194,7 +194,11 @@ func (p *PodIssueHandler) DetectAndRegisterDeleteActionIssue(pod *v1.Pod) (bool,
 	if !util.IsManagedPod(pod) || pod.Status.Phase != v1.PodFailed {
 		return false, nil
 	}
-	classification := p.classifier.ClassifyContainerError(pod)
+	// Classify with the extracted failure reason. This lets onPodError rules
+	// match pods that never started a container, for example kubelet admission
+	// rejections. Such pods have no exit codes and no termination messages.
+	failedReason := util.ExtractPodFailedReason(pod)
+	classification := p.classifier.ClassifyPodError(pod, failedReason)
 	if classification.Action != categorizer.PodFailureActionDelete {
 		return false, nil
 	}
@@ -211,7 +215,7 @@ func (p *PodIssueHandler) DetectAndRegisterDeleteActionIssue(pod *v1.Pod) (bool,
 		RunId: util.ExtractJobRunId(pod),
 		PodIssue: &podIssue{
 			OriginalPodState: pod.DeepCopy(),
-			Message:          util.ExtractPodFailedReason(pod),
+			Message:          failedReason,
 			DebugMessage:     reporter.CreateDebugMessage(podEvents),
 			Retryable:        false,
 			Type:             DeleteActionFailure,

--- a/internal/executor/service/pod_issue_handler_test.go
+++ b/internal/executor/service/pod_issue_handler_test.go
@@ -923,20 +923,58 @@ func TestDetectAndRegisterDeleteActionIssue(t *testing.T) {
 		deleteAction     bool
 		phase            v1.PodPhase
 		podEventsErr     bool
+		classifier       func(t *testing.T) *categorizer.Classifier
+		pod              func(t *testing.T) *v1.Pod
 		expectRegistered bool
 	}{
 		"failed pod in a delete-action category":  {deleteAction: true, phase: v1.PodFailed, expectRegistered: true},
 		"failed pod in a retain category":         {deleteAction: false, phase: v1.PodFailed, expectRegistered: false},
 		"running pod in a delete-action category": {deleteAction: true, phase: v1.PodRunning, expectRegistered: false},
 		"pod events unavailable still registers":  {deleteAction: true, phase: v1.PodFailed, podEventsErr: true, expectRegistered: true},
+		// A kubelet admission rejection has no container statuses. Only the
+		// pod-level failure message can classify it.
+		"rejected pod matches an onPodError delete rule": {
+			phase: v1.PodFailed,
+			classifier: func(t *testing.T) *categorizer.Classifier {
+				c, err := categorizer.NewClassifier(categorizer.ErrorCategoriesConfig{
+					Categories: []categorizer.CategoryConfig{
+						{
+							Name:   "pih-rejected-cat",
+							Action: categorizer.PodFailureActionDelete,
+							Rules:  []categorizer.CategoryRule{{OnPodError: &errormatch.RegexMatcher{Pattern: "Pod was rejected.*"}}},
+						},
+					},
+				})
+				require.NoError(t, err)
+				return c
+			},
+			pod: func(t *testing.T) *v1.Pod {
+				return makeTestPod(v1.PodStatus{
+					Phase:   v1.PodFailed,
+					Reason:  "UnexpectedAdmissionError",
+					Message: "Pod was rejected: not enough cpus available to satisfy request",
+				})
+			},
+			expectRegistered: true,
+		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			classifier := classifierForExitCode(t, "pih-del-cat", "pih-del-sub", 42, tc.deleteAction)
+			var classifier *categorizer.Classifier
+			if tc.classifier != nil {
+				classifier = tc.classifier(t)
+			} else {
+				classifier = classifierForExitCode(t, "pih-del-cat", "pih-del-sub", 42, tc.deleteAction)
+			}
 			podIssueService, _, fakeClusterContext, _, err := setupTestComponentsWithClassifier([]*job.RunState{}, classifier)
 			require.NoError(t, err)
-			pod := makeFailedPodWithExitCode(t, 42)
-			pod.Status.Phase = tc.phase
+			var pod *v1.Pod
+			if tc.pod != nil {
+				pod = tc.pod(t)
+			} else {
+				pod = makeFailedPodWithExitCode(t, 42)
+				pod.Status.Phase = tc.phase
+			}
 			addPod(t, fakeClusterContext, pod)
 			if tc.podEventsErr {
 				fakeClusterContext.GetPodEventsErr = fmt.Errorf("events unavailable")


### PR DESCRIPTION
The delete-action detection classified failed pods with ClassifyContainerError. That call passes an empty pod-error message. As a result, onPodError rules could never match on this path. Pods that never started a container were unclassifiable. Such pods have no exit codes, no termination messages, and no matching conditions.

The concrete case: the scheduler places a job on a node with a GPU that just became unhealthy. The kubelet rejects the pod at admission with "Allocate failed due to requested number of devices unavailable for nvidia.com/gpu". No container ever existed. The pod-level status message is the only description of the failure. Other admission rejections have the same shape, for example resource races with DaemonSet pods, or DiskPressure that appears after scheduling. Kubelet evictions have it too. There, the message separates a node that ran low on a resource from a pod that exceeded its own limit. The coarse Evicted condition cannot make that distinction.

The detection now classifies with ClassifyPodError. It passes the same extracted failure reason that it already stores on the issue. ExtractPodFailedReason returns pod.Status.Message first, so these messages become matchable with onPodError rules. ClassifyPodError evaluates all other rule types exactly as before. Existing categories behave identically. onPodError rules simply become reachable on this path.

This closes one of the two categorizer gaps that block the migration of failedPodChecks to Delete-action categories. A pod-status check migrates like this:

```yaml
# legacy failedPodChecks entry
podStatuses:
  - regexp: "Pod was rejected.*"
    reason: "UnexpectedAdmissionError"

# becomes a category (paired with a scheduler retry policy for it)
errorCategories:
  categories:
    - name: node_admission_failure
      action: Delete
      rules:
        - onPodError: { pattern: "Pod was rejected.*" }
```

We validated the change on a live cluster. An onPodError rule matched an evicted pod. The executor deleted the pod and reported the categorized failure only after the pod was gone. It emitted exactly one terminal event.
