### PR TITLE
Add onPodEvents rule matcher to the error categorizer

### DIFF
--- a/internal/common/errormatch/types.go
+++ b/internal/common/errormatch/types.go
@@ -19,6 +19,17 @@ type RegexMatcher struct {
 	Pattern string `yaml:"pattern"`
 }
 
+// PodEventMatcher matches one Kubernetes event on the pod. The fields mirror
+// the failedPodChecks PodEventCheck so existing check configs migrate by copy.
+type PodEventMatcher struct {
+	// Regexp must match the event message.
+	Regexp string `yaml:"regexp"`
+	// Reason, when set, must equal the event reason exactly.
+	Reason string `yaml:"reason,omitempty"`
+	// Type must equal the event type: Normal or Warning.
+	Type string `yaml:"type"`
+}
+
 // Condition constants derived from KubernetesReason.
 // OOMKilled is a container-level condition (container.State.Terminated.Reason).
 // Evicted and DeadlineExceeded are pod-level conditions (pod.Status.Reason).

--- a/internal/executor/categorizer/classifier.go
+++ b/internal/executor/categorizer/classifier.go
@@ -28,9 +28,17 @@ type rule struct {
 	onExitCodes          *errormatch.ExitCodeMatcher
 	onTerminationMessage *regexp.Regexp
 	onPodError           *regexp.Regexp
+	onPodEvents          *podEventRule
 	onConditions         []string
 	subcategory          string
 	hint                 string
+}
+
+// podEventRule is a compiled OnPodEvents matcher.
+type podEventRule struct {
+	message   *regexp.Regexp
+	reason    string
+	eventType string
 }
 
 // ClassifyResult holds the classification output for a failed pod.
@@ -140,11 +148,14 @@ func buildRule(cfg CategoryRule) (rule, error) {
 	if cfg.OnPodError != nil {
 		matcherCount++
 	}
+	if cfg.OnPodEvents != nil {
+		matcherCount++
+	}
 	if matcherCount == 0 {
-		return rule{}, fmt.Errorf("rule must specify one of onConditions, onExitCodes, onTerminationMessage, or onPodError")
+		return rule{}, fmt.Errorf("rule must specify one of onConditions, onExitCodes, onTerminationMessage, onPodError, or onPodEvents")
 	}
 	if matcherCount > 1 {
-		return rule{}, fmt.Errorf("rule must specify only one of onConditions, onExitCodes, onTerminationMessage, or onPodError")
+		return rule{}, fmt.Errorf("rule must specify only one of onConditions, onExitCodes, onTerminationMessage, onPodError, or onPodEvents")
 	}
 
 	for _, cond := range cfg.OnConditions {
@@ -185,12 +196,26 @@ func buildRule(cfg CategoryRule) (rule, error) {
 		podErrorRegex = re
 	}
 
+	var podEvents *podEventRule
+	if cfg.OnPodEvents != nil {
+		re, err := regexp.Compile(cfg.OnPodEvents.Regexp)
+		if err != nil {
+			return rule{}, fmt.Errorf("invalid onPodEvents regexp %q: %w", cfg.OnPodEvents.Regexp, err)
+		}
+		if cfg.OnPodEvents.Type != v1.EventTypeNormal && cfg.OnPodEvents.Type != v1.EventTypeWarning {
+			return rule{}, fmt.Errorf("invalid onPodEvents type %q, must be %q or %q",
+				cfg.OnPodEvents.Type, v1.EventTypeNormal, v1.EventTypeWarning)
+		}
+		podEvents = &podEventRule{message: re, reason: cfg.OnPodEvents.Reason, eventType: cfg.OnPodEvents.Type}
+	}
+
 	return rule{
 		containerName:        cfg.ContainerName,
 		onExitCodes:          cfg.OnExitCodes,
 		onConditions:         cfg.OnConditions,
 		onTerminationMessage: terminationRegex,
 		onPodError:           podErrorRegex,
+		onPodEvents:          podEvents,
 		subcategory:          cfg.Subcategory,
 		hint:                 cfg.Hint,
 	}, nil
@@ -202,22 +227,24 @@ func buildRule(cfg CategoryRule) (rule, error) {
 // Returns empty result if the receiver is nil or the pod is nil.
 // Returns (defaultCategory, defaultSubcategory) if no rules match.
 func (c *Classifier) ClassifyContainerError(pod *v1.Pod) ClassifyResult {
-	return c.classify(pod, "")
+	return c.classify(pod, "", nil)
 }
 
 // ClassifyPodError returns the category and subcategory for a pod-level failure
 // captured by the executor (image pull, missing volume, stuck terminating,
-// active deadline exceeded, etc.). It additionally matches podErrorMessage
-// against onPodError rules (see CategoryRule.OnPodError); all other rule types
-// are evaluated against pod state, preserving first-match-wins across config order.
+// active deadline exceeded, etc.). It also matches podErrorMessage against
+// onPodError rules and podEvents against onPodEvents rules. All other rule
+// types evaluate against pod state as before, and first-match-wins across
+// config order is unchanged. Pass nil podEvents on paths where the events are
+// unavailable. onPodEvents rules then never match.
 // Returns empty result if the receiver is nil or the pod is nil.
 // Returns (defaultCategory, defaultSubcategory) if no rules match.
-func (c *Classifier) ClassifyPodError(pod *v1.Pod, podErrorMessage string) ClassifyResult {
-	return c.classify(pod, podErrorMessage)
+func (c *Classifier) ClassifyPodError(pod *v1.Pod, podErrorMessage string, podEvents []*v1.Event) ClassifyResult {
+	return c.classify(pod, podErrorMessage, podEvents)
 }
 
 // Rules are evaluated in config order; the first matching rule wins.
-func (c *Classifier) classify(pod *v1.Pod, podErrorMessage string) ClassifyResult {
+func (c *Classifier) classify(pod *v1.Pod, podErrorMessage string, podEvents []*v1.Event) ClassifyResult {
 	if c == nil || pod == nil {
 		return ClassifyResult{Action: PodFailureActionRetain}
 	}
@@ -227,7 +254,7 @@ func (c *Classifier) classify(pod *v1.Pod, podErrorMessage string) ClassifyResul
 	for _, cat := range c.categories {
 		for _, r := range cat.rules {
 			start := time.Now()
-			matched := ruleMatches(r, containers, podReason, podErrorMessage)
+			matched := ruleMatches(r, containers, podReason, podErrorMessage, podEvents)
 			metrics.RecordRuleEvaluationDuration(cat.name, r.subcategory, time.Since(start))
 			if matched {
 				return ClassifyResult{Category: cat.name, Subcategory: r.subcategory, Hint: r.hint, Action: cat.action}
@@ -238,10 +265,10 @@ func (c *Classifier) classify(pod *v1.Pod, podErrorMessage string) ClassifyResul
 }
 
 // ruleMatches evaluates a single rule. Container-level matchers honor the
-// rule's containerName scope (when set); onPodError ignores it because the
-// pod-level error has no container attribution. Exactly one matcher is set
-// per rule (validated at NewClassifier).
-func ruleMatches(r rule, containers []containerInfo, podReason, podErrorMessage string) bool {
+// rule's containerName scope (when set). onPodError and onPodEvents ignore it
+// because pod-level failures have no container attribution. Exactly one
+// matcher is set per rule (validated at NewClassifier).
+func ruleMatches(r rule, containers []containerInfo, podReason, podErrorMessage string, podEvents []*v1.Event) bool {
 	filtered := containers
 	if r.containerName != "" {
 		filtered = filterByName(containers, r.containerName)
@@ -257,6 +284,27 @@ func ruleMatches(r rule, containers []containerInfo, podReason, podErrorMessage 
 	}
 	if r.onPodError != nil {
 		return podErrorMessage != "" && errormatch.MatchPattern(r.onPodError, podErrorMessage)
+	}
+	if r.onPodEvents != nil {
+		return matchesPodEvents(r.onPodEvents, podEvents)
+	}
+	return false
+}
+
+// matchesPodEvents mirrors the legacy failedPodChecks event checker. An event
+// matches when its type equals the rule's, its reason equals the rule's (when
+// set), and its message matches the regex.
+func matchesPodEvents(matcher *podEventRule, podEvents []*v1.Event) bool {
+	for _, event := range podEvents {
+		if matcher.reason != "" && matcher.reason != event.Reason {
+			continue
+		}
+		if matcher.eventType != event.Type {
+			continue
+		}
+		if errormatch.MatchPattern(matcher.message, event.Message) {
+			return true
+		}
 	}
 	return false
 }

--- a/internal/executor/categorizer/classifier_test.go
+++ b/internal/executor/categorizer/classifier_test.go
@@ -18,10 +18,59 @@ func TestClassify(t *testing.T) {
 		config              ErrorCategoriesConfig
 		pod                 *v1.Pod
 		podErrorMessage     string
+		podEvents           []*v1.Event
 		expectedCategory    string
 		expectedSubcategory string
 		expectedAction      PodFailureAction
 	}{
+		"onPodEvents matches a warning event by message and type": {
+			config: ErrorCategoriesConfig{Categories: []CategoryConfig{
+				{Name: "gpu_unavailable", Action: PodFailureActionDelete, Rules: []CategoryRule{
+					{OnPodEvents: &errormatch.PodEventMatcher{
+						Regexp: "Pod Allocate failed due to requested number of devices unavailable for nvidia.com/gpu.*",
+						Type:   v1.EventTypeWarning,
+					}, Subcategory: "device_plugin"},
+				}},
+			}},
+			pod: &v1.Pod{Status: v1.PodStatus{Phase: v1.PodFailed}},
+			podEvents: []*v1.Event{
+				{Type: v1.EventTypeNormal, Message: "Successfully assigned default/pod to node"},
+				{Type: v1.EventTypeWarning, Reason: "UnexpectedAdmissionError", Message: "Pod Allocate failed due to requested number of devices unavailable for nvidia.com/gpu. Requested: 1, Available: 0"},
+			},
+			expectedCategory:    "gpu_unavailable",
+			expectedSubcategory: "device_plugin",
+			expectedAction:      PodFailureActionDelete,
+		},
+		"onPodEvents reason filter rejects a different reason": {
+			config: ErrorCategoriesConfig{Categories: []CategoryConfig{
+				{Name: "gpu_unavailable", Rules: []CategoryRule{
+					{OnPodEvents: &errormatch.PodEventMatcher{Regexp: ".*", Reason: "UnexpectedAdmissionError", Type: v1.EventTypeWarning}},
+				}},
+			}},
+			pod:              &v1.Pod{Status: v1.PodStatus{Phase: v1.PodFailed}},
+			podEvents:        []*v1.Event{{Type: v1.EventTypeWarning, Reason: "FailedScheduling", Message: "anything"}},
+			expectedCategory: "",
+		},
+		"onPodEvents does not match an event of a different type": {
+			config: ErrorCategoriesConfig{Categories: []CategoryConfig{
+				{Name: "gpu_unavailable", Rules: []CategoryRule{
+					{OnPodEvents: &errormatch.PodEventMatcher{Regexp: ".*", Type: v1.EventTypeWarning}},
+				}},
+			}},
+			pod:              &v1.Pod{Status: v1.PodStatus{Phase: v1.PodFailed}},
+			podEvents:        []*v1.Event{{Type: v1.EventTypeNormal, Message: "anything"}},
+			expectedCategory: "",
+		},
+		"onPodEvents does not match without events": {
+			config: ErrorCategoriesConfig{Categories: []CategoryConfig{
+				{Name: "gpu_unavailable", Rules: []CategoryRule{
+					{OnPodEvents: &errormatch.PodEventMatcher{Regexp: ".*", Type: v1.EventTypeWarning}},
+				}},
+			}},
+			pod:              podWithTerminatedContainer(1, "Error", ""),
+			podErrorMessage:  "some pod error",
+			expectedCategory: "",
+		},
 		"action propagates from the matched category": {
 			config: ErrorCategoriesConfig{Categories: []CategoryConfig{
 				{Name: "infra", Action: PodFailureActionDelete, Rules: []CategoryRule{
@@ -379,10 +428,10 @@ func TestClassify(t *testing.T) {
 			classifier, err := NewClassifier(tc.config)
 			require.NoError(t, err)
 			var result ClassifyResult
-			if tc.podErrorMessage == "" {
+			if tc.podErrorMessage == "" && tc.podEvents == nil {
 				result = classifier.ClassifyContainerError(tc.pod)
 			} else {
-				result = classifier.ClassifyPodError(tc.pod, tc.podErrorMessage)
+				result = classifier.ClassifyPodError(tc.pod, tc.podErrorMessage, tc.podEvents)
 			}
 			assert.Equal(t, tc.expectedCategory, result.Category)
 			assert.Equal(t, tc.expectedSubcategory, result.Subcategory)
@@ -467,6 +516,30 @@ func TestNewClassifier_ValidationErrors(t *testing.T) {
 				}},
 			}},
 			errContains: "invalid action",
+		},
+		"invalid onPodEvents regexp": {
+			config: ErrorCategoriesConfig{Categories: []CategoryConfig{
+				{Name: "bad", Rules: []CategoryRule{
+					{OnPodEvents: &errormatch.PodEventMatcher{Regexp: "([invalid", Type: v1.EventTypeWarning}},
+				}},
+			}},
+			errContains: "invalid onPodEvents regexp",
+		},
+		"invalid onPodEvents type": {
+			config: ErrorCategoriesConfig{Categories: []CategoryConfig{
+				{Name: "bad", Rules: []CategoryRule{
+					{OnPodEvents: &errormatch.PodEventMatcher{Regexp: ".*", Type: "Info"}},
+				}},
+			}},
+			errContains: "invalid onPodEvents type",
+		},
+		"onPodEvents type is required": {
+			config: ErrorCategoriesConfig{Categories: []CategoryConfig{
+				{Name: "bad", Rules: []CategoryRule{
+					{OnPodEvents: &errormatch.PodEventMatcher{Regexp: ".*"}},
+				}},
+			}},
+			errContains: "invalid onPodEvents type",
 		},
 		"invalid exit code operator": {
 			config: ErrorCategoriesConfig{Categories: []CategoryConfig{

--- a/internal/executor/categorizer/doc.go
+++ b/internal/executor/categorizer/doc.go
@@ -72,7 +72,8 @@
 //	// Terminated pod: container state carries the relevant termination signals.
 //	result := classifier.ClassifyContainerError(pod)
 //
-//	// Pre-terminal failure: an executor-captured error message is matched
-//	// against onPodError rules in addition to pod state.
-//	result = classifier.ClassifyPodError(pod, podErrorMessage)
+//	// Pod-level failure: an executor-captured error message and the pod's
+//	// Kubernetes events are matched against onPodError and onPodEvents rules
+//	// in addition to pod state. Pass nil events when they are unavailable.
+//	result = classifier.ClassifyPodError(pod, podErrorMessage, podEvents)
 package categorizer

--- a/internal/executor/categorizer/types.go
+++ b/internal/executor/categorizer/types.go
@@ -55,11 +55,18 @@ const (
 // missing volume, missing config) and Armada-detected conditions (stuck
 // terminating, active deadline exceeded, externally deleted). ContainerName
 // is ignored for OnPodError because the message has no container attribution.
+//
+// OnPodEvents is also pod-level: it matches the pod's Kubernetes events.
+// Events carry failures that often do not reach pod or container status, for
+// example kubelet admission and device-plugin errors. The rule matches only
+// on classification paths that receive the events (failed pod detection). On
+// other paths it never matches. ContainerName is ignored for OnPodEvents.
 type CategoryRule struct {
 	ContainerName        string                      `yaml:"containerName,omitempty"`
 	OnExitCodes          *errormatch.ExitCodeMatcher `yaml:"onExitCodes,omitempty"`
 	OnTerminationMessage *errormatch.RegexMatcher    `yaml:"onTerminationMessage,omitempty"`
 	OnPodError           *errormatch.RegexMatcher    `yaml:"onPodError,omitempty"`
+	OnPodEvents          *errormatch.PodEventMatcher `yaml:"onPodEvents,omitempty"`
 	OnConditions         []string                    `yaml:"onConditions,omitempty"`
 	Subcategory          string                      `yaml:"subcategory,omitempty"`
 	// Hint is operator-supplied user-facing copy describing this failure mode.

--- a/internal/executor/service/pod_issue_handler.go
+++ b/internal/executor/service/pod_issue_handler.go
@@ -194,21 +194,23 @@ func (p *PodIssueHandler) DetectAndRegisterDeleteActionIssue(pod *v1.Pod) (bool,
 	if !util.IsManagedPod(pod) || pod.Status.Phase != v1.PodFailed {
 		return false, nil
 	}
-	// Classify with the extracted failure reason. This lets onPodError rules
-	// match pods that never started a container, for example kubelet admission
-	// rejections. Such pods have no exit codes and no termination messages.
-	failedReason := util.ExtractPodFailedReason(pod)
-	classification := p.classifier.ClassifyPodError(pod, failedReason)
-	if classification.Action != categorizer.PodFailureActionDelete {
-		return false, nil
-	}
 	podEvents, err := p.clusterContext.GetPodEvents(pod)
 	if err != nil {
-		// The debug message is best effort, the delete-first ordering is not.
-		// Register without the events rather than let the caller report the
-		// failure while the pod still holds its name.
+		// The events feed the debug message and the onPodEvents rules. Both
+		// are best effort. The delete-first ordering is not. If the fetch
+		// fails, classify and register without the events. The caller must
+		// not report the failure while the pod still holds its name.
 		log.Warnf("Failed retrieving pod events for pod %s: %v", pod.Name, err)
 		podEvents = nil
+	}
+	// Classify with the extracted failure reason and the pod events. This
+	// lets onPodError and onPodEvents rules match pods that never started a
+	// container, for example kubelet admission rejections. Such pods have no
+	// exit codes and no termination messages.
+	failedReason := util.ExtractPodFailedReason(pod)
+	classification := p.classifier.ClassifyPodError(pod, failedReason, podEvents)
+	if classification.Action != categorizer.PodFailureActionDelete {
+		return false, nil
 	}
 	return p.registerIssue(&runIssue{
 		JobId: util.ExtractJobId(pod),
@@ -469,7 +471,7 @@ func (p *PodIssueHandler) handleNonRetryableJobIssue(issue *issue) {
 			failureCategory, failureSubcategory = errormatch.CategoryInternal, sub
 			message = podIssue.Message
 		} else {
-			result := p.classifier.ClassifyPodError(podIssue.OriginalPodState, podIssue.Message)
+			result := p.classifier.ClassifyPodError(podIssue.OriginalPodState, podIssue.Message, nil)
 			failureCategory, failureSubcategory = result.Category, result.Subcategory
 			message = result.AppendHint(podIssue.Message)
 		}
@@ -637,7 +639,7 @@ func (p *PodIssueHandler) handleRetryableJobIssue(issue *issue) {
 		// When we have our own internal state - we don't need to wait for the pod deletion to complete
 		// We can just mark is to delete in our state and return the lease
 		jobRunAttempted := issue.RunIssue.PodIssue.Type != UnableToSchedule
-		result := p.classifier.ClassifyPodError(issue.RunIssue.PodIssue.OriginalPodState, issue.RunIssue.PodIssue.Message)
+		result := p.classifier.ClassifyPodError(issue.RunIssue.PodIssue.OriginalPodState, issue.RunIssue.PodIssue.Message, nil)
 
 		returnLeaseEvent, err := reporter.CreateReturnLeaseEvent(
 			issue.RunIssue.PodIssue.OriginalPodState,

--- a/internal/executor/service/pod_issue_handler_test.go
+++ b/internal/executor/service/pod_issue_handler_test.go
@@ -925,6 +925,7 @@ func TestDetectAndRegisterDeleteActionIssue(t *testing.T) {
 		podEventsErr     bool
 		classifier       func(t *testing.T) *categorizer.Classifier
 		pod              func(t *testing.T) *v1.Pod
+		podEvents        []*v1.Event
 		expectRegistered bool
 	}{
 		"failed pod in a delete-action category":  {deleteAction: true, phase: v1.PodFailed, expectRegistered: true},
@@ -957,6 +958,36 @@ func TestDetectAndRegisterDeleteActionIssue(t *testing.T) {
 			},
 			expectRegistered: true,
 		},
+		// A device-plugin admission failure surfaces only as a Warning event.
+		// Pod and container status carry nothing to classify by.
+		"rejected pod matches an onPodEvents delete rule": {
+			phase: v1.PodFailed,
+			classifier: func(t *testing.T) *categorizer.Classifier {
+				c, err := categorizer.NewClassifier(categorizer.ErrorCategoriesConfig{
+					Categories: []categorizer.CategoryConfig{
+						{
+							Name:   "pih-gpu-cat",
+							Action: categorizer.PodFailureActionDelete,
+							Rules: []categorizer.CategoryRule{{OnPodEvents: &errormatch.PodEventMatcher{
+								Regexp: "devices unavailable for nvidia.com/gpu",
+								Type:   v1.EventTypeWarning,
+							}}},
+						},
+					},
+				})
+				require.NoError(t, err)
+				return c
+			},
+			pod: func(t *testing.T) *v1.Pod {
+				return makeTestPod(v1.PodStatus{Phase: v1.PodFailed})
+			},
+			podEvents: []*v1.Event{{
+				Type:    v1.EventTypeWarning,
+				Reason:  "UnexpectedAdmissionError",
+				Message: "Pod Allocate failed due to requested number of devices unavailable for nvidia.com/gpu. Requested: 1, Available: 0",
+			}},
+			expectRegistered: true,
+		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -976,6 +1007,9 @@ func TestDetectAndRegisterDeleteActionIssue(t *testing.T) {
 				pod.Status.Phase = tc.phase
 			}
 			addPod(t, fakeClusterContext, pod)
+			if tc.podEvents != nil {
+				addPodEvents(fakeClusterContext, pod, tc.podEvents)
+			}
 			if tc.podEventsErr {
 				fakeClusterContext.GetPodEventsErr = fmt.Errorf("events unavailable")
 			}


### PR DESCRIPTION
The categorizer could not match Kubernetes pod events. Kubelet admission and device-plugin failures appear most reliably as events. Examples: GPU allocation failures, DiskPressure rejections, and ephemeral-storage warnings. Some of these failures also appear in the pod status message, with slightly different wording. The event stream is often the richer or the only signal. The event-based entries in failedPodChecks had no equivalent category rule. They could not migrate.

This PR adds an onPodEvents matcher to CategoryRule. Its fields are the same as the legacy PodEventCheck fields: a regexp on the event message, an exact type (Normal or Warning), and an optional exact reason. Existing check configs migrate by copy:

```yaml
# legacy failedPodChecks entry
events:
  - regexp: "Pod Allocate failed due to requested number of devices unavailable for nvidia.com/gpu."
    type: Warning

# becomes a category (paired with a scheduler retry policy for it)
errorCategories:
  categories:
    - name: gpu_unavailable
      action: Delete
      rules:
        - onPodEvents:
            regexp: "Pod Allocate failed due to requested number of devices unavailable for nvidia.com/gpu."
            type: Warning
```

The matching semantics are the same as the legacy checker's. A rule matches when any event passes the type, reason, and message filters. First-match-wins across config order is unchanged.

ClassifyPodError gains a podEvents parameter. The delete-action detection now fetches pod events before classification and passes them in. The fetch stays best effort. On error, the detection classifies the pod without events, and event rules do not match. The legacy path degrades the same way: an events fetch failure there also ends in a terminal failure. The two report-time reclassification sites pass nil events. That matches the legacy scope, where event checks only influenced failed pod detection.

