### PR TITLE
Add doc links to the retry and categorizer package overviews

### DIFF
--- a/internal/executor/categorizer/doc.go
+++ b/internal/executor/categorizer/doc.go
@@ -6,24 +6,29 @@
 // # Configuration
 //
 // Categories are defined in the executor config under application.errorCategories.
-// Each category has a name and one or more rules. Rules are evaluated in config
-// order across all categories; the first matching rule wins, setting both the
-// category name and the rule's optional subcategory.
+// Each category has a name and one or more rules. The classifier evaluates
+// rules in config order across all categories. The first matching rule wins
+// and sets both the category name and the rule's optional subcategory.
 //
 // Each rule uses exactly one matcher:
-//   - OnConditions: matches Kubernetes failure signals (OOMKilled, Evicted, DeadlineExceeded)
-//   - OnExitCodes: matches non-zero container exit codes using In/NotIn set operators
-//   - OnTerminationMessage: matches container termination messages against a regex
-//   - OnPodError: matches a pod-level error message captured by the executor
-//     against a regex; covers failures with no useful container terminationMessage
-//     (image pull, missing volume, stuck terminating, deadline exceeded, etc.)
+//   - [CategoryRule.OnConditions]: matches Kubernetes failure signals (OOMKilled, Evicted, DeadlineExceeded)
+//   - [CategoryRule.OnExitCodes]: matches non-zero container exit codes using In/NotIn set operators
+//   - [CategoryRule.OnTerminationMessage]: matches container termination messages against a regex
+//   - [CategoryRule.OnPodError]: matches a regex against the pod-level error
+//     message the executor captured. It covers failures with no useful
+//     container terminationMessage (image pull, missing volume, stuck
+//     terminating, etc.)
+//   - [CategoryRule.OnPodEvents]: matches the pod's Kubernetes events, where
+//     kubelet admission and device-plugin failures appear most reliably
 //
-// Container-level matchers honor ContainerName scoping when set. OnPodError
-// ignores it because pod-level error text has no container attribution.
+// Container-level matchers honor [CategoryRule.ContainerName] scoping when
+// set. OnPodError and OnPodEvents ignore it because pod-level failures have
+// no container attribution.
 //
-// Each rule may also set Hint, an optional user-facing string that the executor
-// appends to the failure message. Hints land in lookoutdb.job_run.error and
-// are surfaced to users in Lookout alongside the raw runtime error.
+// Each rule may also set [CategoryRule.Hint], an optional user-facing string
+// that the executor appends to the failure message. Hints go into
+// lookoutdb.job_run.error, and Lookout shows them to users alongside the raw
+// runtime error.
 //
 // Exit code 0 is always skipped. Both regular and init containers are checked.
 //

--- a/internal/scheduler/retry/doc.go
+++ b/internal/scheduler/retry/doc.go
@@ -8,13 +8,13 @@
 // on a subcategory that narrows the match. The first rule that matches wins.
 // If no rule matches, the policy's default action applies.
 //
-// Engine.Evaluate makes the decision. It is a pure function of the compiled
-// policy, the run error, and the job's failure counts; its doc comment
-// defines the check order and the exact limit semantics.
+// [Engine.Evaluate] makes the decision. It is a pure function of the
+// compiled policy, the run error, and the job's failure counts. Its doc
+// comment defines the check order and the exact limit semantics.
 //
-// ConvertPolicy compiles api.RetryPolicy protos into the Policy type the
-// engine evaluates. ApiPolicyCache keeps the compiled policies in memory,
-// refreshed from the Armada API, and NoopPolicyCache stands in when the
+// [ConvertPolicy] compiles api.RetryPolicy protos into the [Policy] type the
+// engine evaluates. [ApiPolicyCache] keeps the compiled policies in memory,
+// refreshed from the Armada API, and [NoopPolicyCache] stands in when the
 // retry policy feature is disabled.
 //
 // A Retry rule can carry a Mutation that changes the job when that rule


### PR DESCRIPTION
The retry and categorizer package overviews on pkg.go.dev name their symbols in plain prose. The rendered pages therefore show no links. A Go doc comment links a symbol only when it appears in brackets, for example [Engine.Evaluate] or [CategoryRule.OnPodEvents].

This PR brackets the same-package symbol references in both doc.go files. Cross-package mentions such as api.RetryPolicy stay plain text. A cross-package doc link must spell out the full import path, and that reads worse than no link.

This PR also makes three more comment-only fixes. The categorizer matcher list gains the onPodEvents entry: #5081 updated the usage example in the same file but missed the list. Three semicolon chains become separate sentences. Two passive sentences in the categorizer overview become active.