### PR TITLE
Replace deprecated strings.Title in scheduler metrics

### DIFF
--- a/internal/scheduler/metrics.go
+++ b/internal/scheduler/metrics.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/exp/maps"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	"k8s.io/utils/clock"
 
 	"github.com/armadaproject/armada/internal/common/armadacontext"
@@ -372,6 +374,14 @@ func (c *MetricsCollector) updateClusterMetrics(ctx *armadacontext.Context) ([]p
 		return nil, err
 	}
 
+	// Created per call rather than shared at package level: cases.Caser is
+	// documented as potentially stateful and must not be shared between
+	// goroutines, and Collect may be called concurrently by the Prometheus
+	// registry. Sharing one silently corrupts its output rather than failing
+	// loudly; Alertmanager shipped that bug in its templates (prometheus/
+	// alertmanager#3278) and it produced garbled text in production.
+	phaseTitleCaser := cases.Title(language.English)
+
 	cordonedStatusByCluster := map[string]*clusterCordonedStatus{}
 	phaseCountByQueue := map[queuePhaseMetricKey]int{}
 	allocatedResourceByQueue := map[queuePriceBandMetricKey]resource.ComputeResources{}
@@ -503,7 +513,7 @@ func (c *MetricsCollector) updateClusterMetrics(ctx *armadacontext.Context) ([]p
 						nodeType:    node.ReportingNodeType,
 						reservation: reservation,
 						// Convert to string with first letter capitalised
-						phase: strings.Title(strings.ToLower(phase)),
+						phase: phaseTitleCaser.String(strings.ToLower(phase)),
 					}
 					phaseCountByQueue[key]++
 
@@ -512,7 +522,7 @@ func (c *MetricsCollector) updateClusterMetrics(ctx *armadacontext.Context) ([]p
 						nodeJobsMetricCounts[nodeJobPhaseMetricKey{
 							node:    node.Name,
 							cluster: executor.Id,
-							phase:   strings.Title(strings.ToLower(phase)),
+							phase:   phaseTitleCaser.String(strings.ToLower(phase)),
 						}]++
 					}
 


### PR DESCRIPTION
strings.Title has been deprecated since Go 1.18. Replace both call sites in internal/scheduler/metrics.go with cases.Title(language.English) from golang.org/x/text/cases. These are the only two uses of strings.Title in the repository.

The caser is created once per updateClusterMetrics call rather than at package level. cases.Caser is documented as potentially stateful and not safe for sharing between goroutines, and MetricsCollector.Collect may be called concurrently by the Prometheus registry. The x/text authors note concurrency safety only for cases.Fold, and deliberately not for Title, Upper or Lower; cases.titleCaser does mutate its embedded context on every Transform, and sharing one across goroutines is reported by the race detector.

This matters more than it looks, because sharing a caser corrupts output silently rather than failing loudly. Alertmanager shipped exactly this bug in its template FuncMap and it garbled user-visible notification text in production for months before it was tracked down; see prometheus/alertmanager#3278, fixed the same way, with a separate caser per call. Here the affected strings are Prometheus label values, where corruption would fragment time series rather than merely look wrong.

Creating the caser outside the node/executor loops also avoids reallocating it on every iteration.

Because these values are public Prometheus label values, output was verified unchanged for every JobRunState_name value - UNKNOWN, PENDING, RUNNING, SUCCEEDED and FAILED all produce byte-identical results under both implementations.

golang.org/x/text was already a direct dependency, so go.mod is unchanged.

Fixes #4776
