### PR TITLE
Ingesters: redeliver messages when context canceled

### DIFF
--- a/internal/common/ingest/ingestion_pipeline.go
+++ b/internal/common/ingest/ingestion_pipeline.go
@@ -2,12 +2,12 @@ package ingest
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/apache/pulsar-client-go/pulsar"
-	"github.com/pkg/errors"
 
 	"github.com/armadaproject/armada/internal/common/armadacontext"
 	commonconfig "github.com/armadaproject/armada/internal/common/config"
@@ -128,7 +128,7 @@ func (i *IngestionPipeline[T, U]) Run(ctx *armadacontext.Context) error {
 		if i.pulsarConfig.DelayMonitor.Enabled {
 			err := i.startProcessingDelayMonitor(ctx, client)
 			if err != nil {
-				return errors.WithMessage(err, "error starting topic delay monitoring")
+				return fmt.Errorf("error starting topic delay monitoring: %w", err)
 			}
 		}
 	}
@@ -225,7 +225,7 @@ func (i *IngestionPipeline[T, U]) Run(ctx *armadacontext.Context) error {
 			} else {
 				log.Infof("%s - Inserted %d pulsar messages in %dms", i.pulsarTopic, len(msg.GetMessageIDs()), taken.Milliseconds())
 			}
-			if errors.Is(err, context.DeadlineExceeded) {
+			if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
 				// This occurs when we're shutting down- it's a signal to stop processing immediately
 				break
 			} else {
@@ -258,13 +258,13 @@ func (i *IngestionPipeline[T, U]) startProcessingDelayMonitor(ctx *armadacontext
 	}
 	pulsarAdminClient, err := pulsarutils.NewPulsarAdminClient(&i.pulsarConfig)
 	if err != nil {
-		return errors.WithMessage(err, "error creating pulsar admin client")
+		return fmt.Errorf("error creating pulsar admin client: %w", err)
 	}
 
 	topicDelayMonitor := NewTopicProcessingDelayMonitor(pulsarClient, pulsarAdminClient, i.pulsarTopic, i.pulsarSubscriptionName, i.pulsarConfig.DelayMonitor.Interval, i.metrics)
 	err = topicDelayMonitor.Initialise(ctx)
 	if err != nil {
-		return errors.WithMessage(err, "failed to initialise topic delay monitor")
+		return fmt.Errorf("failed to initialise topic delay monitor: %w", err)
 	}
 	go func() {
 		log.Infof("starting topic delay monitor")
@@ -283,7 +283,7 @@ func (i *IngestionPipeline[T, U]) subscribe() (pulsar.Client, pulsar.Consumer, f
 	// Subscribe to Pulsar and receive messages
 	pulsarClient, err := pulsarutils.NewPulsarClient(&i.pulsarConfig)
 	if err != nil {
-		return nil, nil, nil, errors.WithMessage(err, "error creating pulsar client")
+		return nil, nil, nil, fmt.Errorf("error creating pulsar client: %w", err)
 	}
 
 	consumer, err := pulsarClient.Subscribe(pulsar.ConsumerOptions{
@@ -294,7 +294,7 @@ func (i *IngestionPipeline[T, U]) subscribe() (pulsar.Client, pulsar.Consumer, f
 		SubscriptionInitialPosition: pulsar.SubscriptionPositionEarliest,
 	})
 	if err != nil {
-		return nil, nil, nil, errors.WithMessage(err, "error creating pulsar consumer")
+		return nil, nil, nil, fmt.Errorf("error creating pulsar consumer: %w", err)
 	}
 
 	return pulsarClient, consumer, func() {

--- a/internal/common/ingest/ingestion_pipeline_test.go
+++ b/internal/common/ingest/ingestion_pipeline_test.go
@@ -1,6 +1,7 @@
 package ingest
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
@@ -402,6 +403,60 @@ func (s *simpleSink) assertDidProcess(messages []pulsar.Message) {
 func (s *simpleSink) assertProcessedMessageCount(count int) {
 	s.t.Helper()
 	assert.Len(s.t, s.simpleMessages, count)
+}
+
+// erroringSink always returns the configured error from Store, and records how many times it was called.
+type erroringSink struct {
+	err   error
+	calls int
+	mutex sync.Mutex
+}
+
+func (s *erroringSink) Store(_ *armadacontext.Context, _ *simpleMessages) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.calls++
+	return s.err
+}
+
+func (s *erroringSink) callCount() int {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	return s.calls
+}
+
+func TestRun_ContextCanceled_StopsProcessingWithoutAcking(t *testing.T) {
+	ctx, cancel := armadacontext.WithCancel(armadacontext.Background())
+	defer cancel()
+	messages := []pulsar.Message{
+		pulsarutils.NewPulsarMessage(1, baseTime, marshal(t, succeeded)),
+	}
+	// Since the sink always errors with context.Canceled, the mock consumer's AckID is never
+	// called, so nothing will cancel the context on our behalf. We do it ourselves once the sink
+	// has been invoked, mirroring what happens when the caller's context is cancelled during shutdown.
+	sink := &erroringSink{err: context.Canceled}
+	mockConsumer := newMockPulsarConsumer(t, messages, func() {})
+	converter := newSimpleEventSequenceConverter(t)
+
+	pipeline := testJobSetEventsPipeline(mockConsumer, converter, sink)
+	pipeline.pulsarBatchDuration = 10 * time.Millisecond
+
+	done := make(chan error, 1)
+	go func() {
+		done <- pipeline.Run(ctx)
+	}()
+
+	assert.Eventually(t, func() bool { return sink.callCount() > 0 }, 5*time.Second, 10*time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("pipeline did not stop processing after sink returned context.Canceled")
+	}
+
+	assert.Empty(t, mockConsumer.acked)
 }
 
 func TestRun_JobSetEvents_HappyPath_SingleMessage(t *testing.T) {


### PR DESCRIPTION
Currently, when the ingesters' stores return an error which is context canceled, the messages to be processed are acked, and thus could be dropped.

This change makes it so that in the case of such an error, the messages which failed to be stored are redelivered and so retried on restart.

Also migrate away from the package github.com/pkg/errors to use Golang's built-in functionality.