### PR TITLE
Lookout UI - download logs from start

### DIFF
--- a/internal/lookoutui/src/pages/jobs/components/sidebar/SidebarTabJobLogs.tsx
+++ b/internal/lookoutui/src/pages/jobs/components/sidebar/SidebarTabJobLogs.tsx
@@ -192,11 +192,6 @@ export const SidebarTabJobLogs = ({ job }: SidebarTabJobLogsProps) => {
       return
     }
 
-    if (loadFromStart) {
-      downloadLogLines(logLines)
-      return
-    }
-
     setDownloadingLogs(true)
     try {
       const allLogLines = await fetchAllLogsFromStart(cluster, namespace, job.jobId, selectedContainer)
@@ -208,8 +203,6 @@ export const SidebarTabJobLogs = ({ job }: SidebarTabJobLogsProps) => {
     }
   }, [
     getLogsResult.status,
-    loadFromStart,
-    logLines,
     downloadLogLines,
     fetchAllLogsFromStart,
     cluster,

--- a/internal/lookoutui/src/pages/jobs/components/sidebar/SidebarTabJobLogs.tsx
+++ b/internal/lookoutui/src/pages/jobs/components/sidebar/SidebarTabJobLogs.tsx
@@ -22,12 +22,13 @@ import {
 import { Analytics, ANALYTICS_EVENTS } from "../../../../analytics"
 import { downloadTextFile } from "../../../../common/downloadTextFile"
 import { SPACING } from "../../../../common/spacing"
+import { getErrorMessage } from "../../../../common/utils"
 import { JobRunLogsTextSizeToggle } from "../../../../components/JobRunLogsTextSizeToggle"
 import { useFormatIsoTimestampWithUserSettings } from "../../../../components/hooks/formatTimeWithUserSettings"
 import { useCustomSnackbar } from "../../../../components/hooks/useCustomSnackbar"
 import { Job } from "../../../../models/lookoutModels"
 import { useGetJobSpec } from "../../../../services/lookout/useGetJobSpec"
-import { LogLine, useGetLogs } from "../../../../services/lookout/useGetLogs"
+import { LogLine, useFetchAllLogsFromStart, useGetLogs } from "../../../../services/lookout/useGetLogs"
 import {
   JobRunLogsTextSize,
   useJobRunLogsShowTimestamps,
@@ -37,11 +38,24 @@ import {
 
 import { NoRunsAlert } from "./NoRunsAlert"
 
+const LogsControlsContainer = styled("div")(({ theme }) => ({
+  display: "flex",
+  flexDirection: "row",
+  justifyContent: "space-between",
+  alignContent: "center",
+  gap: theme.spacing(SPACING.sm),
+  flexWrap: "wrap",
+}))
+
+const DownloadLogsButtonContainer = styled("div")({
+  alignContent: "center",
+})
+
 const LogsSettingsContainer = styled("div")(({ theme }) => ({
   display: "flex",
   flexDirection: "row",
   alignItems: "center",
-  justifyContent: "end",
+  justifyContent: "space-apart",
   gap: theme.spacing(SPACING.sm),
   flexWrap: "wrap",
 }))
@@ -157,17 +171,53 @@ export const SidebarTabJobLogs = ({ job }: SidebarTabJobLogsProps) => {
   const [showTimestamps, setShowTimestamps] = useJobRunLogsShowTimestamps()
   const [wrapLines, setWrapLines] = useJobRunLogsWrapLines()
 
-  const downloadLogs = useCallback(() => {
+  const fetchAllLogsFromStart = useFetchAllLogsFromStart()
+  const [downloadingLogs, setDownloadingLogs] = useState(false)
+
+  const downloadLogLines = useCallback(
+    (logLinesToDownload: LogLine[]) => {
+      downloadTextFile(
+        logLinesToDownload
+          .flatMap(({ line, timestamp }) => (showTimestamps ? `${timestamp}\t${line}` : line))
+          .join("\n"),
+        `${job.jobId}-${runIndex}-${selectedContainer}.txt`,
+        "text/plain",
+      )
+    },
+    [showTimestamps, job.jobId, runIndex, selectedContainer],
+  )
+
+  const downloadLogs = useCallback(async () => {
     if (getLogsResult.status !== "success") {
       return
     }
 
-    downloadTextFile(
-      logLines.flatMap(({ line, timestamp }) => (showTimestamps ? `${timestamp}\t${line}` : line)).join("\n"),
-      `${job.jobId}-${runIndex}-${selectedContainer}.txt`,
-      "text/plain",
-    )
-  }, [getLogsResult.status, logLines, showTimestamps, job.jobId, runIndex, selectedContainer])
+    if (loadFromStart) {
+      downloadLogLines(logLines)
+      return
+    }
+
+    setDownloadingLogs(true)
+    try {
+      const allLogLines = await fetchAllLogsFromStart(cluster, namespace, job.jobId, selectedContainer)
+      downloadLogLines(allLogLines)
+    } catch (e) {
+      openSnackbar(`Failed to download logs for Job with ID: ${job.jobId}: ${await getErrorMessage(e)}`, "error")
+    } finally {
+      setDownloadingLogs(false)
+    }
+  }, [
+    getLogsResult.status,
+    loadFromStart,
+    logLines,
+    downloadLogLines,
+    fetchAllLogsFromStart,
+    cluster,
+    namespace,
+    job.jobId,
+    selectedContainer,
+    openSnackbar,
+  ])
 
   if (job.runs.length === 0) {
     return <NoRunsAlert jobState={job.state} />
@@ -249,7 +299,9 @@ export const SidebarTabJobLogs = ({ job }: SidebarTabJobLogsProps) => {
             />
           </FormGroup>
         </div>
-        <div>
+      </RunContainerSelectors>
+      <LogsControlsContainer>
+        <DownloadLogsButtonContainer>
           <Tooltip
             arrow
             title={`The file ${showTimestamps ? "will include" : "will not include"} timestamps for each log line. Toggle the 'show timestamps' switch below to change this.`}
@@ -257,40 +309,40 @@ export const SidebarTabJobLogs = ({ job }: SidebarTabJobLogsProps) => {
             <Analytics
               component={Button}
               eventName={ANALYTICS_EVENTS.DOWNLOAD_LOGS_CLICKED}
-              aria-label="download logs"
-              loading={getLogsResult.status === "pending"}
+              aria-label="download logs from start"
+              loading={getLogsResult.status === "pending" || downloadingLogs}
               disabled={getLogsResult.status !== "success"}
               startIcon={<Download />}
               variant="outlined"
               size="small"
               onClick={downloadLogs}
             >
-              Download logs
+              Download logs from start
             </Analytics>
           </Tooltip>
-        </div>
-      </RunContainerSelectors>
-      <LogsSettingsContainer>
-        <div>
-          <FormGroup>
-            <FormControlLabel
-              control={
-                <Switch checked={showTimestamps} onChange={({ target: { checked } }) => setShowTimestamps(checked)} />
-              }
-              label="Show timestamps"
-            />
-          </FormGroup>
-        </div>
-        <div>
-          <FormGroup>
-            <FormControlLabel
-              control={<Switch checked={wrapLines} onChange={({ target: { checked } }) => setWrapLines(checked)} />}
-              label="Wrap lines"
-            />
-          </FormGroup>
-        </div>
-        <JobRunLogsTextSizeToggle compact />
-      </LogsSettingsContainer>
+        </DownloadLogsButtonContainer>
+        <LogsSettingsContainer>
+          <div>
+            <FormGroup>
+              <FormControlLabel
+                control={
+                  <Switch checked={showTimestamps} onChange={({ target: { checked } }) => setShowTimestamps(checked)} />
+                }
+                label="Show timestamps"
+              />
+            </FormGroup>
+          </div>
+          <div>
+            <FormGroup>
+              <FormControlLabel
+                control={<Switch checked={wrapLines} onChange={({ target: { checked } }) => setWrapLines(checked)} />}
+                label="Wrap lines"
+              />
+            </FormGroup>
+          </div>
+          <JobRunLogsTextSizeToggle compact />
+        </LogsSettingsContainer>
+      </LogsControlsContainer>
       {getJobSpecResult.status === "pending" ||
         (getLogsResult.status === "pending" && (
           <LogsContainer textSize={textSize}>

--- a/internal/lookoutui/src/services/lookout/mocks/fakeData.ts
+++ b/internal/lookoutui/src/services/lookout/mocks/fakeData.ts
@@ -35,6 +35,7 @@ heavyweight:
 `.trim()
 
 const NUM_LOG_LINES = 4
+const TOTAL_FAKE_LOG_LINES = 40
 
 export const createFakeLogs = (
   cluster: string,
@@ -42,11 +43,21 @@ export const createFakeLogs = (
   jobId: string,
   container: string,
   sinceTime: string,
-): BinocularsLogLine[] =>
-  [...Array(NUM_LOG_LINES)].map((_, i) => ({
-    timestamp: new Date(Date.parse(sinceTime || twoMinutesAgo.toISOString()) + i * 100).toISOString(),
+): BinocularsLogLine[] => {
+  const startTime = twoMinutesAgo.getTime()
+  const linesAlreadyReturned = sinceTime ? Math.round((Date.parse(sinceTime) - startTime) / 100) + 1 : 0
+
+  if (linesAlreadyReturned >= TOTAL_FAKE_LOG_LINES) {
+    return []
+  }
+
+  const numLines = Math.min(NUM_LOG_LINES, TOTAL_FAKE_LOG_LINES - linesAlreadyReturned)
+
+  return [...Array(numLines)].map((_, i) => ({
+    timestamp: new Date(startTime + (linesAlreadyReturned + i) * 100).toISOString(),
     line: `${jobId} - ${container} - ${namespace} - ${cluster}`,
   }))
+}
 
 export const fakeRunError =
   /* eslint-disable @cspell/spellchecker */

--- a/internal/lookoutui/src/services/lookout/useGetLogs.ts
+++ b/internal/lookoutui/src/services/lookout/useGetLogs.ts
@@ -1,4 +1,6 @@
-import { InfiniteData, useInfiniteQuery } from "@tanstack/react-query"
+import { useCallback } from "react"
+
+import { InfiniteData, useInfiniteQuery, useQueryClient } from "@tanstack/react-query"
 
 import { getErrorMessage } from "../../common/utils"
 import { getConfig } from "../../config"
@@ -12,6 +14,52 @@ const INITIAL_TAIL_LINES = 1000
 export type LogLine = {
   timestamp: string
   line: string
+}
+
+const fetchLogsFromStartPage = async (
+  getBinocularsApi: ReturnType<typeof useApiClients>["getBinocularsApi"],
+  cluster: string,
+  namespace: string,
+  jobId: string,
+  container: string,
+  sinceTime: string,
+): Promise<LogLine[]> => {
+  const config = getConfig()
+  try {
+    const logLinesRaw = config.fakeDataEnabled
+      ? createFakeLogs(cluster, namespace, jobId, container, sinceTime)
+      : (
+          await getBinocularsApi(cluster).logs({
+            body: {
+              jobId,
+              podNumber: 0,
+              podNamespace: namespace,
+              sinceTime,
+              logOptions: {
+                container: container,
+                tailLines: undefined,
+              },
+            },
+          })
+        ).log
+
+    const logLines = (logLinesRaw ?? []).map((l) => ({
+      timestamp: l.timestamp ?? "",
+      line: l.line ?? "",
+    }))
+
+    let sliceIndex = 0
+    for (let i = 0; i < logLines.length; i++) {
+      if (logLines[i].timestamp > sinceTime) {
+        break
+      }
+      sliceIndex = i + 1
+    }
+
+    return logLines.slice(sliceIndex)
+  } catch (e) {
+    throw await getErrorMessage(e)
+  }
 }
 
 export const useGetLogs = (
@@ -78,4 +126,30 @@ export const useGetLogs = (
     getNextPageParam: (_, allPages) => allPages.flat().at(-1)?.timestamp ?? "",
     enabled,
   })
+}
+
+export const useFetchAllLogsFromStart = () => {
+  const queryClient = useQueryClient()
+  const { getBinocularsApi } = useApiClients()
+
+  return useCallback(
+    async (cluster: string, namespace: string, jobId: string, container: string): Promise<LogLine[]> => {
+      const allLogLines: LogLine[] = []
+      let sinceTime = ""
+      for (;;) {
+        const page = await queryClient.fetchQuery({
+          // eslint-disable-next-line @tanstack/query/exhaustive-deps -- getBinocularsApi is a stable, memoised reference and does not vary the fetched data
+          queryKey: ["getLogsFromStartPage", cluster, namespace, jobId, container, sinceTime],
+          queryFn: () => fetchLogsFromStartPage(getBinocularsApi, cluster, namespace, jobId, container, sinceTime),
+        })
+        if (page.length === 0) {
+          break
+        }
+        allLogLines.push(...page)
+        sinceTime = page[page.length - 1].timestamp
+      }
+      return allLogLines
+    },
+    [queryClient, getBinocularsApi],
+  )
 }


### PR DESCRIPTION
Currently, the "Download logs" button for a job's particular container donwloads only the logs which have been loaded. Unless the user has checked the "Load from start" checkbox, this is the latest 1,000 lines.

This changes the button to download all the logs from the start - not just the latest 1,000 lines - regardless of whether the checkbox has been checked.

It also moves the button down onto the row below, aligned to the left, to make better use of space.

<img width="1024" height="330" alt="image" src="https://github.com/user-attachments/assets/391322d9-187f-452e-915c-8896a07469d6" />
