### PR TITLE
Make submit check use same code as scheduling_algo to construct nodedb

### DIFF
--- a/internal/scheduler/configuration/configuration.go
+++ b/internal/scheduler/configuration/configuration.go
@@ -445,6 +445,10 @@ type RateLimit struct {
 	MaximumBurst int `validate:"gte=0"`
 }
 
+func (p PoolConfig) ShouldPreemptCrossPoolJobsFirst() bool {
+	return !p.DisablePreemptCrossPoolJobsFirst
+}
+
 func (p PoolConfig) GetSubmissionGroup() string {
 	if p.ExperimentalSubmissionGroup == "" {
 		return p.Name

--- a/internal/scheduler/scheduling/scheduling_algo.go
+++ b/internal/scheduler/scheduling/scheduling_algo.go
@@ -746,7 +746,7 @@ func ConstructNodeDb(
 	// Only set the pool when cross-pool preemption ordering is enabled for this pool.
 	// Setting this causes nodeDb to consider cross-pool jobs to be scheduled at CrossPoolPriority
 	//  resulting in them being preempted ahead of home jobs
-	if !poolConfig.DisablePreemptCrossPoolJobsFirst {
+	if !poolConfig.ShouldPreemptCrossPoolJobsFirst() {
 		nodeDb.SetPool(poolConfig.Name)
 	}
 

--- a/internal/scheduler/scheduling/scheduling_algo.go
+++ b/internal/scheduler/scheduling/scheduling_algo.go
@@ -243,15 +243,6 @@ func (l *FairSchedulingAlgo) runPoolSchedulingRound(
 			}, nil
 	}
 
-	fsctx.nodeDb.ConfigureScheduling(nodedb.SchedulingOptions{
-		DisableHomeScheduling:      pool.DisableHomeScheduling,
-		DisableAwayScheduling:      pool.DisableAwayScheduling,
-		DisableGangAwayScheduling:  pool.DisableGangAwayScheduling,
-		DisableFairshareScheduling: pool.DisableFairshareScheduling,
-		DisableUrgencyScheduling:   pool.DisableUrgencyScheduling,
-		DisallowedJobResources:     pool.ExperimentalUnscheduledResources,
-	})
-
 	start := time.Now()
 	schedulingResult, sctx, err := l.SchedulePool(ctx, fsctx, pool)
 	if err != nil {
@@ -713,23 +704,61 @@ func (l *FairSchedulingAlgo) constructNodeDb(
 	otherPoolsJobs []*jobdb.Job,
 	nodes []*internaltypes.Node,
 ) (*nodedb.NodeDb, error) {
+	nodeDbConfig := NodeDbIndexConfiguration{
+		IndexedResources:   l.schedulingConfig.IndexedResources,
+		IndexedTaints:      l.schedulingConfig.IndexedTaints,
+		IndexedNodeLabels:  l.schedulingConfig.IndexedNodeLabels,
+		WellKnownNodeTypes: l.schedulingConfig.WellKnownNodeTypes,
+	}
+
+	return ConstructNodeDb(nodeDbConfig, l.resourceListFactory, priorityClasses, poolConfig, nodeFactory, currentPoolJobs, otherPoolsJobs, nodes)
+}
+
+type NodeDbIndexConfiguration struct {
+	IndexedResources   []configuration.ResourceType
+	IndexedTaints      []string
+	IndexedNodeLabels  []string
+	WellKnownNodeTypes []configuration.WellKnownNodeType
+}
+
+func ConstructNodeDb(
+	config NodeDbIndexConfiguration,
+	resourceListFactory *internaltypes.ResourceListFactory,
+	priorityClasses map[string]types.PriorityClass,
+	poolConfig configuration.PoolConfig,
+	nodeFactory *internaltypes.NodeFactory,
+	currentPoolJobs []*jobdb.Job,
+	otherPoolsJobs []*jobdb.Job,
+	nodes []*internaltypes.Node,
+) (*nodedb.NodeDb, error) {
 	nodeDb, err := nodedb.NewNodeDb(
 		priorityClasses,
-		l.schedulingConfig.IndexedResources,
-		l.schedulingConfig.IndexedTaints,
-		l.schedulingConfig.IndexedNodeLabels,
-		l.schedulingConfig.WellKnownNodeTypes,
-		l.resourceListFactory,
+		config.IndexedResources,
+		config.IndexedTaints,
+		config.IndexedNodeLabels,
+		config.WellKnownNodeTypes,
+		resourceListFactory,
 	)
 	if err != nil {
 		return nil, err
 	}
+
 	// Only set the pool when cross-pool preemption ordering is enabled for this pool.
 	// Setting this causes nodeDb to consider cross-pool jobs to be scheduled at CrossPoolPriority
 	//  resulting in them being preempted ahead of home jobs
-	if l.schedulingConfig.GetPreemptCrossPoolJobsFirst(poolConfig.Name) {
+	if !poolConfig.DisablePreemptCrossPoolJobsFirst {
 		nodeDb.SetPool(poolConfig.Name)
 	}
+
+	nodeDb.ConfigureScheduling(nodedb.SchedulingOptions{
+		DisableHomeScheduling:      poolConfig.DisableHomeScheduling,
+		DisableAwayScheduling:      poolConfig.DisableAwayScheduling,
+		DisableGangAwayScheduling:  poolConfig.DisableGangAwayScheduling,
+		DisableFairshareScheduling: poolConfig.DisableFairshareScheduling,
+		DisableUrgencyScheduling:   poolConfig.DisableUrgencyScheduling,
+		DisallowedJobResources:     poolConfig.ExperimentalUnscheduledResources,
+	})
+
 	if err := populateNodeDb(poolConfig, nodeFactory, nodeDb, currentPoolJobs, otherPoolsJobs, nodes); err != nil {
 		return nil, err
 	}

--- a/internal/scheduler/submitcheck.go
+++ b/internal/scheduler/submitcheck.go
@@ -20,6 +20,7 @@ import (
 	"github.com/armadaproject/armada/internal/scheduler/nodedb"
 	"github.com/armadaproject/armada/internal/scheduler/queue"
 	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
+	"github.com/armadaproject/armada/internal/scheduler/scheduling"
 	"github.com/armadaproject/armada/internal/scheduler/scheduling/constraints"
 	"github.com/armadaproject/armada/internal/scheduler/scheduling/context"
 )
@@ -49,7 +50,7 @@ type executor struct {
 }
 
 type schedulerState struct {
-	executorsByPoolAndId      map[string]map[string]*executor
+	nodeDbByPool              map[string]*nodedb.NodeDb
 	constraintsByPool         map[string]constraints.SchedulingConstraints
 	jobSchedulingResultsCache *lru.Cache
 }
@@ -148,48 +149,48 @@ func (srv *SubmitChecker) updateExecutors(ctx *armadacontext.Context) error {
 		srv.schedulingConfig.PriorityClasses,
 		srv.resourceListFactory)
 
-	executorsByPoolAndId := map[string]map[string]*executor{}
-	totalResourcesByPool := map[string]internaltypes.ResourceList{}
+	nodeDbByPool := map[string]*nodedb.NodeDb{}
+	constraintsByPool := map[string]constraints.SchedulingConstraints{}
+
+	allNodes := []*internaltypes.Node{}
 	for _, ex := range executors {
 		nodes := nodeFactory.FromSchedulerObjectsExecutors(
 			[]*schedulerobjects.Executor{ex},
 			func(s string) { ctx.Error(s) })
 		// Treat cordoned nodes as available.
 		nodes = nodeFactory.RemoveCordonTaint(nodes)
-		nodesByPool := armadaslices.GroupByFunc(nodes, func(n *internaltypes.Node) string {
-			return n.GetPool()
-		})
-		for pool, nodes := range nodesByPool {
+		allNodes = append(allNodes, nodes...)
+	}
 
-			nodeDb, err := srv.constructNodeDb(nodes)
+	nodesByPool := armadaslices.GroupByFunc(allNodes, func(n *internaltypes.Node) string {
+		return n.GetPool()
+	})
 
-			if _, present := executorsByPoolAndId[pool]; !present {
-				executorsByPoolAndId[pool] = map[string]*executor{}
-			}
+	for _, pool := range srv.schedulingConfig.Pools {
+		poolNodes := nodesByPool[pool.Name]
 
-			if err == nil {
-				totalResourcesByPool[pool] = totalResourcesByPool[pool].Add(nodeDb.TotalKubernetesResources())
-
-				executorsByPoolAndId[pool][ex.Id] = &executor{
-					id:     ex.Id,
-					nodeDb: nodeDb,
-				}
-			} else {
-				ctx.Logger().
-					WithStacktrace(err).
-					Warnf("Error constructing nodedb for executor: %s", ex.Id)
-			}
+		for _, awayPool := range pool.AwayPools {
+			poolNodes = append(poolNodes, nodesByPool[awayPool.Name]...)
 		}
-	}
 
-	for _, pool := range srv.floatingResourceTypes.AllPools() {
-		totalResourcesByPool[pool] = totalResourcesByPool[pool].Add(srv.floatingResourceTypes.GetTotalAvailableForPool(pool))
-	}
+		nodeDbConfig := scheduling.NodeDbIndexConfiguration{
+			IndexedResources:   srv.schedulingConfig.IndexedResources,
+			IndexedNodeLabels:  srv.schedulingConfig.IndexedNodeLabels,
+			IndexedTaints:      srv.schedulingConfig.IndexedTaints,
+			WellKnownNodeTypes: srv.schedulingConfig.WellKnownNodeTypes,
+		}
 
-	constraintsByPool := map[string]constraints.SchedulingConstraints{}
-	for pool, totalResources := range totalResourcesByPool {
-		constraintsByPool[pool] = constraints.NewSchedulingConstraints(
-			pool,
+		nodeDb, err := scheduling.ConstructNodeDb(nodeDbConfig, srv.resourceListFactory, srv.schedulingConfig.PriorityClasses, pool, nodeFactory, nil, nil, poolNodes)
+		if err != nil {
+			return fmt.Errorf("failed constructing nodedb for pool %s - %s", pool.Name, err)
+		}
+
+		nodeDbByPool[pool.Name] = nodeDb
+
+		totalResources := nodeDb.TotalKubernetesResources()
+		totalResources = totalResources.Add(srv.floatingResourceTypes.GetTotalAvailableForPool(pool.Name))
+		constraintsByPool[pool.Name] = constraints.NewSchedulingConstraints(
+			pool.Name,
 			totalResources,
 			srv.schedulingConfig,
 			queues,
@@ -197,7 +198,7 @@ func (srv *SubmitChecker) updateExecutors(ctx *armadacontext.Context) error {
 	}
 
 	srv.state.Store(&schedulerState{
-		executorsByPoolAndId:      executorsByPoolAndId,
+		nodeDbByPool:              nodeDbByPool,
 		constraintsByPool:         constraintsByPool,
 		jobSchedulingResultsCache: jobSchedulingResultsCache,
 	})
@@ -299,7 +300,6 @@ func (srv *SubmitChecker) getGangSchedulingResult(gangJobs []*jobdb.Job, state *
 
 // Check if a set of jobs can be scheduled onto some cluster.
 // TODO: there are a number of things this won't catch:
-//   - Node Uniformity Label (although it will work if this is per cluster)
 //   - Gang jobs that will use more than the allowed capacity limit
 func (srv *SubmitChecker) getSchedulingResult(originalGangCtx *context.GangSchedulingContext, state *schedulerState) schedulingResult {
 	successfulPools := map[string]bool{}
@@ -318,10 +318,11 @@ poolStart:
 			}
 		}
 
+		sb.WriteString(fmt.Sprintf("pool %s:\n", pool.Name))
+
 		if originalGangCtx.RequestsFloatingResources {
 			rr := originalGangCtx.TotalResourceRequests
 			if ok, reason := srv.floatingResourceTypes.WithinLimits(pool.Name, rr); !ok {
-				sb.WriteString(fmt.Sprintf("pool %s:\n", pool.Name))
 				sb.WriteString(fmt.Sprintf("job/gang requests floating resources %s but %s\n", rr.OfType(internaltypes.Floating).String(), reason))
 				sb.WriteString("\n---\n")
 				continue
@@ -332,78 +333,57 @@ poolStart:
 		if c != nil {
 			queueLimit := c.GetQueueResourceLimit(originalGangCtx.Queue, originalGangCtx.PriorityClassName())
 			if !queueLimit.IsEmpty() && originalGangCtx.TotalResourceRequests.Exceeds(queueLimit) {
-				sb.WriteString(fmt.Sprintf("pool %s:\n", pool.Name))
 				sb.WriteString(fmt.Sprintf("job/gang requests resources %s which exceeds the total limit of %s for its queue/priority class\n", originalGangCtx.TotalResourceRequests, queueLimit))
 				sb.WriteString("\n---\n")
 				continue
 			}
 		}
 
-		executors := maps.Values(state.executorsByPoolAndId[pool.Name])
-		for _, awayPool := range pool.AwayPools {
-			executors = append(executors, maps.Values(state.executorsByPoolAndId[awayPool.Name])...)
+		gctx := copyGangContext(originalGangCtx)
+		nodeDb := state.nodeDbByPool[pool.Name]
+
+		txn := nodeDb.Txn(true)
+		ok, _, err := nodeDb.ScheduleManyWithTxn(txn, gctx)
+		txn.Abort()
+
+		if err != nil {
+			sb.WriteString(err.Error())
+			sb.WriteString("\n")
+			continue
 		}
 
-		for _, ex := range executors {
+		if ok {
+			if !gctx.JobSchedulingContexts[0].PodSchedulingContext.ScheduledAway || len(pool.AwayPools) > 0 {
+				for _, pool := range srv.getPoolsBySubmissionGroup(pool.GetSubmissionGroup()) {
+					successfulPools[pool] = true
+				}
+			}
+			continue
+		}
 
-			// copy the gctx here, as we are going to mutate it
-			gctx := copyGangContext(originalGangCtx)
+		numSuccessfullyScheduled := 0
+		for _, jctx := range gctx.JobSchedulingContexts {
+			if jctx.PodSchedulingContext.IsSuccessful() {
+				numSuccessfullyScheduled++
+			}
+		}
 
-			// TODO construct nodedb per synthetic pool to avoid needing to set this dynamically
-			ex.nodeDb.ConfigureScheduling(nodedb.SchedulingOptions{
-				DisableHomeScheduling:      pool.DisableHomeScheduling,
-				DisableAwayScheduling:      pool.DisableAwayScheduling,
-				DisableGangAwayScheduling:  pool.DisableGangAwayScheduling,
-				DisableFairshareScheduling: pool.DisableFairshareScheduling,
-				DisableUrgencyScheduling:   pool.DisableUrgencyScheduling,
-				DisallowedJobResources:     pool.ExperimentalUnscheduledResources,
-			})
-
-			txn := ex.nodeDb.Txn(true)
-			ok, _, err := ex.nodeDb.ScheduleManyWithTxn(txn, gctx)
-			txn.Abort()
-
-			sb.WriteString(ex.id)
-			if err != nil {
-				sb.WriteString(err.Error())
-				sb.WriteString("\n")
+		if len(gctx.JobSchedulingContexts) == 1 {
+			pctx := gctx.JobSchedulingContexts[0].PodSchedulingContext
+			if pctx == nil {
 				continue
 			}
-
-			if ok {
-				if !gctx.JobSchedulingContexts[0].PodSchedulingContext.ScheduledAway || len(pool.AwayPools) > 0 {
-					for _, pool := range srv.getPoolsBySubmissionGroup(pool.GetSubmissionGroup()) {
-						successfulPools[pool] = true
-					}
-				}
-				continue
-			}
-
-			numSuccessfullyScheduled := 0
-			for _, jctx := range gctx.JobSchedulingContexts {
-				if jctx.PodSchedulingContext.IsSuccessful() {
-					numSuccessfullyScheduled++
-				}
-			}
-
-			if len(gctx.JobSchedulingContexts) == 1 {
-				sb.WriteString(":\n")
-				pctx := gctx.JobSchedulingContexts[0].PodSchedulingContext
-				if pctx == nil {
-					continue
-				}
-				sb.WriteString(pctx.String())
-				sb.WriteString("\n")
-				sb.WriteString("---")
-				sb.WriteString("\n")
-			} else {
-				sb.WriteString(
-					fmt.Sprintf(
-						": %d out of %d pods schedulable\n",
-						numSuccessfullyScheduled, len(gctx.JobSchedulingContexts),
-					),
-				)
-			}
+			sb.WriteString(pctx.String())
+			sb.WriteString("\n")
+			sb.WriteString("---")
+			sb.WriteString("\n")
+		} else {
+			sb.WriteString(
+				fmt.Sprintf(
+					": %d out of %d pods schedulable\n",
+					numSuccessfullyScheduled, len(gctx.JobSchedulingContexts),
+				),
+			)
 		}
 	}
 	if len(successfulPools) > 0 {

--- a/internal/scheduler/submitcheck.go
+++ b/internal/scheduler/submitcheck.go
@@ -44,11 +44,6 @@ func (d deadline) exceeded(now time.Time) bool {
 	return !time.Time(d).IsZero() && now.After(time.Time(d))
 }
 
-type executor struct {
-	id     string
-	nodeDb *nodedb.NodeDb
-}
-
 type schedulerState struct {
 	nodeDbByPool              map[string]*nodedb.NodeDb
 	constraintsByPool         map[string]constraints.SchedulingConstraints
@@ -183,6 +178,11 @@ func (srv *SubmitChecker) updateExecutors(ctx *armadacontext.Context) error {
 		nodeDb, err := scheduling.ConstructNodeDb(nodeDbConfig, srv.resourceListFactory, srv.schedulingConfig.PriorityClasses, pool, nodeFactory, nil, nil, poolNodes)
 		if err != nil {
 			return fmt.Errorf("failed constructing nodedb for pool %s - %s", pool.Name, err)
+		}
+
+		err = nodeDb.ClearAllocated()
+		if err != nil {
+			return fmt.Errorf("failed clearing nodedb for pool %s - %s", pool.Name, err)
 		}
 
 		nodeDbByPool[pool.Name] = nodeDb
@@ -390,36 +390,6 @@ poolStart:
 		return schedulingResult{isSchedulable: true, pools: maps.Keys(successfulPools)}
 	}
 	return schedulingResult{isSchedulable: false, reason: sb.String()}
-}
-
-func (srv *SubmitChecker) constructNodeDb(nodes []*internaltypes.Node) (*nodedb.NodeDb, error) {
-	nodeDb, err := nodedb.NewNodeDb(
-		srv.schedulingConfig.PriorityClasses,
-		srv.schedulingConfig.IndexedResources,
-		srv.schedulingConfig.IndexedTaints,
-		srv.schedulingConfig.IndexedNodeLabels,
-		srv.schedulingConfig.WellKnownNodeTypes,
-		srv.resourceListFactory,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	txn := nodeDb.Txn(true)
-	defer txn.Abort()
-	for _, node := range nodes {
-		if err = nodeDb.CreateAndInsertWithJobDbJobsWithTxn(txn, nil, node); err != nil {
-			return nil, err
-		}
-	}
-	txn.Commit()
-
-	err = nodeDb.ClearAllocated()
-	if err != nil {
-		return nil, err
-	}
-
-	return nodeDb, nil
 }
 
 func copyGangContext(gctx *context.GangSchedulingContext) *context.GangSchedulingContext {

--- a/internal/scheduler/submitcheck_test.go
+++ b/internal/scheduler/submitcheck_test.go
@@ -240,6 +240,17 @@ func TestSubmitChecker_CheckJobDbJobs(t *testing.T) {
 				largeGangJob[3].Id(): {isSchedulable: true, pools: []string{"cpu"}},
 			},
 		},
+		"Gang Schedules - multiple cluster": {
+			executorTimeout: defaultTimeout,
+			executors:       []*schedulerobjects.Executor{Executor(SmallNode("cpu")), Executor(SmallNode("cpu"))},
+			jobs:            largeGangJob,
+			expectedResult: map[string]schedulingResult{
+				largeGangJob[0].Id(): {isSchedulable: true, pools: []string{"cpu"}},
+				largeGangJob[1].Id(): {isSchedulable: true, pools: []string{"cpu"}},
+				largeGangJob[2].Id(): {isSchedulable: true, pools: []string{"cpu"}},
+				largeGangJob[3].Id(): {isSchedulable: true, pools: []string{"cpu"}},
+			},
+		},
 		"Individual jobs fit but gang doesn't": {
 			executorTimeout: defaultTimeout,
 			executors:       []*schedulerobjects.Executor{Executor(SmallNode("cpu"))},


### PR DESCRIPTION
The submitcheck needs a nodedb to see if a job is considered schedulable by the scheduler

However currently it gets this nodedb in a bespoke way which is sub-optimal:
 - Builds a nodedb per executor (rather than per pool as the scheduler does)
 - Has to reconfigure the nodedb constantly, as different pools set different nodedb scheduling configs
 - Cannot check if some valid gangs are schedulable, submitcheck does not allow cross-cluster gangs  but the scheduler does
 - We always need to remember any changes to building the nodedb for the scheduler also need to be applied to the submitcheck

Now we do away with these problems by:
 - Using the same code to build the nodedb in the submitcheck and the core scheduler
 - Create a nodedb per pool to match how the scheduler does it

This should keep the 2 paths more inline and reduce burden going forward
 - We should probably improve the current code path for instantiating a nodedb, but that is one for a separate PR

