### PR TITLE
Add configuration to set job defaults per pool 

### DIFF
--- a/internal/scheduler/configuration/configuration.go
+++ b/internal/scheduler/configuration/configuration.go
@@ -434,6 +434,18 @@ type PoolConfig struct {
 	// Set to true to fall back to the legacy behaviour
 	//  where preemption ordering is determined purely by scheduled-at priority.
 	DisablePreemptCrossPoolJobsFirst bool
+	JobDefaults                      *JobDefaults
+}
+
+func (p PoolConfig) GetDefaultJobTolerations() []v1.Toleration {
+	if p.JobDefaults == nil || p.JobDefaults.Tolerations == nil {
+		return nil
+	}
+	return p.JobDefaults.Tolerations
+}
+
+type JobDefaults struct {
+	Tolerations []v1.Toleration
 }
 
 // RateLimit The rate at which an action can happen using a token bucket approach

--- a/internal/scheduler/nodedb/nodedb.go
+++ b/internal/scheduler/nodedb/nodedb.go
@@ -180,6 +180,8 @@ type NodeDb struct {
 	disableFairshareScheduling bool
 	disableUrgencyScheduling   bool
 
+	defaultTolerations []v1.Toleration
+
 	// pool is the pool this NodeDb is scheduling for.
 	// When set (non-empty), jobs whose run pool differs from it (cross-pool "away" jobs)
 	// are accounted at CrossPoolPriority so any home job can urgency-preempt them ahead of home jobs.
@@ -378,6 +380,7 @@ type SchedulingOptions struct {
 	DisableFairshareScheduling bool
 	DisableUrgencyScheduling   bool
 	DisallowedJobResources     []string
+	DefaultTolerations         []v1.Toleration
 }
 
 func (nodeDb *NodeDb) ConfigureScheduling(opts SchedulingOptions) {
@@ -387,6 +390,7 @@ func (nodeDb *NodeDb) ConfigureScheduling(opts SchedulingOptions) {
 	nodeDb.disableFairshareScheduling = opts.DisableFairshareScheduling
 	nodeDb.disableUrgencyScheduling = opts.DisableUrgencyScheduling
 	nodeDb.disallowedJobResources = opts.DisallowedJobResources
+	nodeDb.defaultTolerations = opts.DefaultTolerations
 }
 
 func (nodeDb *NodeDb) GetNodes() ([]*internaltypes.Node, error) {
@@ -554,6 +558,8 @@ func (nodeDb *NodeDb) SelectNodeForJobWithTxn(txn *memdb.Txn, jctx *context.JobS
 		NumNodes:                 int(nodeDb.numNodes),
 		NumExcludedNodesByReason: make(map[string]int),
 	}
+	originalNumberOfTolerations := len(jctx.AdditionalTolerations)
+	jctx.AdditionalTolerations = append(jctx.AdditionalTolerations, nodeDb.defaultTolerations...)
 	jctx.PodSchedulingContext = pctx
 
 	// For pods that failed to schedule, add an exclusion reason for implicitly excluded nodes.
@@ -561,6 +567,8 @@ func (nodeDb *NodeDb) SelectNodeForJobWithTxn(txn *memdb.Txn, jctx *context.JobS
 		if pctx.NodeId != "" {
 			return
 		}
+		// Remove added tolerations if not scheduled
+		jctx.AdditionalTolerations = jctx.AdditionalTolerations[:originalNumberOfTolerations]
 		numExplicitlyExcludedNodes := 0
 		for _, count := range pctx.NumExcludedNodesByReason {
 			numExplicitlyExcludedNodes += count

--- a/internal/scheduler/nodedb/nodedb_test.go
+++ b/internal/scheduler/nodedb/nodedb_test.go
@@ -800,6 +800,7 @@ func TestDisallowedJobResources(t *testing.T) {
 func TestHomeNodeScheduling(t *testing.T) {
 	tests := map[string]struct {
 		disableHomeScheduling bool
+		defaultToleration     *v1.Toleration
 		addNodeTaint          bool
 		addJobToleration      bool
 		jobPriorityClassName  string
@@ -808,6 +809,24 @@ func TestHomeNodeScheduling(t *testing.T) {
 	}{
 		"should schedule home jobs": {
 			expectSuccess: true,
+		},
+		"should schedule home jobs - when default toleration matches node taint": {
+			addNodeTaint: true,
+			defaultToleration: &v1.Toleration{
+				Key:      "largeJobsOnly",
+				Operator: v1.TolerationOpExists,
+				Effect:   v1.TaintEffectNoSchedule,
+			},
+			expectSuccess: true,
+		},
+		"should schedule home jobs - when default toleration does not match node taint": {
+			addNodeTaint: true,
+			defaultToleration: &v1.Toleration{
+				Key:      "non-matching",
+				Operator: v1.TolerationOpExists,
+				Effect:   v1.TaintEffectNoSchedule,
+			},
+			expectSuccess: false,
 		},
 		"should schedule home jobs - when job toleration matches node taint": {
 			expectSuccess:    true,
@@ -844,8 +863,15 @@ func TestHomeNodeScheduling(t *testing.T) {
 				testfixtures.TestResourceListFactory,
 			)
 			require.NoError(t, err)
-			if tc.disableHomeScheduling {
-				nodeDb.ConfigureScheduling(SchedulingOptions{DisableHomeScheduling: true})
+			if tc.disableHomeScheduling || tc.defaultToleration != nil {
+				options := SchedulingOptions{}
+				if tc.disableHomeScheduling {
+					options.DisableHomeScheduling = true
+				}
+				if tc.defaultToleration != nil {
+					options.DefaultTolerations = []v1.Toleration{*tc.defaultToleration}
+				}
+				nodeDb.ConfigureScheduling(options)
 			}
 
 			nodeDbTxn := nodeDb.Txn(true)
@@ -880,6 +906,9 @@ func TestHomeNodeScheduling(t *testing.T) {
 				assert.NotNil(t, jctx.PodSchedulingContext)
 				assert.True(t, jctx.PodSchedulingContext.IsSuccessful())
 				assert.Equal(t, node.GetId(), jctx.PodSchedulingContext.NodeId)
+				if tc.defaultToleration != nil {
+					assert.Equal(t, *tc.defaultToleration, jctx.AdditionalTolerations[0])
+				}
 				if tc.expectScheduledAway {
 					assert.Equal(t, context.ScheduledAsAwayJob, jctx.PodSchedulingContext.SchedulingMethod)
 					assert.Equal(t, int32(29000), jctx.PodSchedulingContext.ScheduledAtPriority)

--- a/internal/scheduler/scheduling/context/pod.go
+++ b/internal/scheduler/scheduling/context/pod.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 	"text/tabwriter"
 	"time"
-
-	v1 "k8s.io/api/core/v1"
 )
 
 type SchedulingType string
@@ -55,8 +53,6 @@ type PodSchedulingContext struct {
 	ScheduledAway bool
 	// The method of scheduling that was used to schedule this job
 	SchedulingMethod SchedulingType
-	// Additional tolerations used just for this scheduling round
-	AdditionalTolerations []v1.Toleration
 }
 
 func (pctx *PodSchedulingContext) IsSuccessful() bool {

--- a/internal/scheduler/scheduling/context/pod.go
+++ b/internal/scheduler/scheduling/context/pod.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"text/tabwriter"
 	"time"
+
+	v1 "k8s.io/api/core/v1"
 )
 
 type SchedulingType string
@@ -53,6 +55,8 @@ type PodSchedulingContext struct {
 	ScheduledAway bool
 	// The method of scheduling that was used to schedule this job
 	SchedulingMethod SchedulingType
+	// Additional tolerations used just for this scheduling round
+	AdditionalTolerations []v1.Toleration
 }
 
 func (pctx *PodSchedulingContext) IsSuccessful() bool {

--- a/internal/scheduler/scheduling/scheduling_algo.go
+++ b/internal/scheduler/scheduling/scheduling_algo.go
@@ -755,6 +755,7 @@ func ConstructNodeDb(
 		DisableFairshareScheduling: poolConfig.DisableFairshareScheduling,
 		DisableUrgencyScheduling:   poolConfig.DisableUrgencyScheduling,
 		DisallowedJobResources:     poolConfig.ExperimentalUnscheduledResources,
+		DefaultTolerations:         poolConfig.GetDefaultJobTolerations(),
 	})
 
 	if err := populateNodeDb(poolConfig, nodeDb, currentPoolJobs, otherPoolsJobs, nodes); err != nil {


### PR DESCRIPTION
This change allows setting job defaults per pool, specifically in this case adding tolerations

This is specifically useful when the pool is a mix of home and cross-pool away nodes (tainted) but you want jobs to be scheduled as home across all nodes
 - This is more efficient and allows for better scheduling placement. As away nodes are considered strictly after home nodes, meaning without this you can get preemptions on home nodes even when there is empty space on the away nodes.
