### PR TITLE
[Bug] Fix setting nodedb pool incorrectly based on config

### DIFF
--- a/internal/scheduler/scheduling/scheduling_algo.go
+++ b/internal/scheduler/scheduling/scheduling_algo.go
@@ -759,7 +759,7 @@ func ConstructNodeDb(
 	// Only set the pool when cross-pool preemption ordering is enabled for this pool.
 	// Setting this causes nodeDb to consider cross-pool jobs to be scheduled at CrossPoolPriority
 	//  resulting in them being preempted ahead of home jobs
-	if !poolConfig.ShouldPreemptCrossPoolJobsFirst() {
+	if poolConfig.ShouldPreemptCrossPoolJobsFirst() {
 		nodeDb.SetPool(poolConfig.Name)
 	}
 


### PR DESCRIPTION
This was accidentally negated when we swapped the negation logic into the function
 - This is purely a rollout flag and will be removed soon anyways

The functionality now matches the comment above the code, we set pool when cross-pool preemption ordering is enabled

