### PR TITLE
Add preemption type to job_resource_seconds_lost_to_preemption metric

### DIFF
--- a/internal/scheduler/metrics/state_metrics.go
+++ b/internal/scheduler/metrics/state_metrics.go
@@ -9,6 +9,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/armadaproject/armada/internal/scheduler/jobdb"
+	"github.com/armadaproject/armada/internal/scheduler/scheduling/context"
 	"github.com/armadaproject/armada/pkg/armadaevents"
 )
 
@@ -107,7 +108,7 @@ func newJobStateMetrics(
 			Name: ArmadaSchedulerMetricsPrefix + "job_resource_seconds_lost_to_preemption",
 			Help: "Resource seconds lost to preemption",
 		},
-		[]string{queueLabel, poolLabel, checkpointLabel, resourceLabel},
+		[]string{queueLabel, poolLabel, checkpointLabel, resourceLabel, typeLabel},
 	)
 	retryPolicyDecisionsByQueue := prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -169,24 +170,24 @@ func (m *jobStateMetrics) collect(ch chan<- prometheus.Metric) {
 	}
 }
 
-// ReportJobLeased reports the job as being leased. This has to be reported separately because the state transition
-// logic does work for job leased!
-func (m *jobStateMetrics) ReportJobLeased(job *jobdb.Job) {
+// ReportJobLeasedStateTransition reports the job as being leased. This has to be reported separately because the state transition
+// logic does not work for job leased!
+func (m *jobStateMetrics) ReportJobLeasedStateTransition(job *jobdb.Job) {
 	run := job.LatestRun()
 	duration, priorState := stateDuration(job, run, run.LeaseTime())
 	m.updateStateDuration(job, leased, priorState, duration)
 }
 
-// ReportJobPreempted reports the job as being preempted. This has to be reported separately because the state transition
-// logic does work for job preempted!
-func (m *jobStateMetrics) ReportJobPreempted(job *jobdb.Job) {
+// ReportJobPreemptedStateTransition reports the job as being preempted. This has to be reported separately because the state transition
+// logic does not work for job preempted!
+func (m *jobStateMetrics) ReportJobPreemptedStateTransition(job *jobdb.Job, preemptionType context.PreemptionType) {
 	run := job.LatestRun()
 	duration, priorState := stateDuration(job, run, run.PreemptedTime())
 	m.updateStateDuration(job, preempted, priorState, duration)
-	m.recordPreemptedSecondsLost(job, duration, noCheckpointLabelValue)
+	m.recordPreemptedSecondsLost(job, duration, preemptionType, noCheckpointLabelValue)
 	for _, checkpointDuration := range m.jobCheckpointIntervals {
 		timeSinceCheckpoint := math.Min(duration, checkpointDuration.Seconds())
-		m.recordPreemptedSecondsLost(job, timeSinceCheckpoint, durationToShortString(checkpointDuration))
+		m.recordPreemptedSecondsLost(job, timeSinceCheckpoint, preemptionType, durationToShortString(checkpointDuration))
 	}
 }
 
@@ -198,7 +199,7 @@ func (m *jobStateMetrics) ReportRetryPolicyDecision(job *jobdb.Job, policyName s
 	m.retryPolicyDecisionsByQueue.WithLabelValues(job.Queue(), run.Pool(), policyName, decision).Inc()
 }
 
-func (m *jobStateMetrics) recordPreemptedSecondsLost(job *jobdb.Job, duration float64, checkpointLabel string) {
+func (m *jobStateMetrics) recordPreemptedSecondsLost(job *jobdb.Job, duration float64, preemptionType context.PreemptionType, checkpointLabel string) {
 	run := job.LatestRun()
 	requests := job.AllResourceRequirements()
 
@@ -206,7 +207,7 @@ func (m *jobStateMetrics) recordPreemptedSecondsLost(job *jobdb.Job, duration fl
 		resQty := requests.GetByNameZeroIfMissing(string(res))
 		resSeconds := duration * float64(resQty.MilliValue()) / 1000
 		m.jobResourceSecondsLostToPreemptionByQueue.
-			WithLabelValues(job.Queue(), run.Pool(), checkpointLabel, res.String()).Add(resSeconds)
+			WithLabelValues(job.Queue(), run.Pool(), checkpointLabel, res.String(), string(preemptionType)).Add(resSeconds)
 	}
 }
 

--- a/internal/scheduler/metrics/state_metrics_test.go
+++ b/internal/scheduler/metrics/state_metrics_test.go
@@ -463,7 +463,7 @@ func TestDisable(t *testing.T) {
 	byNodeLabels := []string{testNode, testPool, testCluster, "running", "pending"}
 	byQueueResourceLabels := append(byQueueAndStateLabels, "cpu")
 	byNodeResourceLabels := append(byNodeLabels, "cpu")
-	resourceSecondsLostToPreemptionLabels := append(byQueueLabels, "none", "cpu")
+	resourceSecondsLostToPreemptionLabels := append(byQueueLabels, "none", "cpu", "urgency")
 
 	collect := func(m *jobStateMetrics) []prometheus.Metric {
 		m.jobStateCounterByQueue.WithLabelValues(byQueueAndStateLabels...).Inc()

--- a/internal/scheduler/metrics/state_metrics_test.go
+++ b/internal/scheduler/metrics/state_metrics_test.go
@@ -12,6 +12,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/armadaproject/armada/internal/scheduler/jobdb"
+	schedulingcontext "github.com/armadaproject/armada/internal/scheduler/scheduling/context"
 	"github.com/armadaproject/armada/internal/scheduler/testfixtures"
 	"github.com/armadaproject/armada/pkg/armadaevents"
 )
@@ -341,7 +342,7 @@ func TestReportJobStateTransitions(t *testing.T) {
 	}
 }
 
-func TestReportJobPreempted(t *testing.T) {
+func TestReportJobPreemptedStateTransition(t *testing.T) {
 	baseTimePlusSeconds := func(numSeconds int) *time.Time {
 		newTime := baseTime.Add(time.Duration(numSeconds) * time.Second)
 		return &newTime
@@ -359,13 +360,14 @@ func TestReportJobPreempted(t *testing.T) {
 	jobCheckpointIntervals := []time.Duration{time.Second * 5, time.Second * 30, time.Minute * 5}
 
 	metrics := newJobStateMetrics([]v1.ResourceName{"cpu"}, jobCheckpointIntervals, 12*time.Hour)
-	metrics.ReportJobPreempted(job)
+	preemptionType := schedulingcontext.PreemptedWithUrgencyPreemption
+	metrics.ReportJobPreemptedStateTransition(job, preemptionType)
 
-	expectedJobResourceSecondsLostToPreemptionByQueue := map[[4]string]float64{
-		{testQueue, testPool, noCheckpointLabelValue, "cpu"}: 60 * 16,
-		{testQueue, testPool, "5s", "cpu"}:                   5 * 16,
-		{testQueue, testPool, "30s", "cpu"}:                  30 * 16,
-		{testQueue, testPool, "5m", "cpu"}:                   60 * 16,
+	expectedJobResourceSecondsLostToPreemptionByQueue := map[[5]string]float64{
+		{testQueue, testPool, noCheckpointLabelValue, "cpu", string(preemptionType)}: 60 * 16,
+		{testQueue, testPool, "5s", "cpu", string(preemptionType)}:                   5 * 16,
+		{testQueue, testPool, "30s", "cpu", string(preemptionType)}:                  30 * 16,
+		{testQueue, testPool, "5m", "cpu", string(preemptionType)}:                   60 * 16,
 	}
 	for k, v := range expectedJobResourceSecondsLostToPreemptionByQueue {
 		actualJobStateSeconds := testutil.ToFloat64(metrics.jobResourceSecondsLostToPreemptionByQueue.WithLabelValues(k[:]...))
@@ -432,7 +434,7 @@ func TestReset(t *testing.T) {
 	byNodeLabels := []string{testNode, testPool, testCluster, "running", "pending"}
 	byQueueResourceLabels := append(byQueueAndStateLabels, "cpu")
 	byNodeResourceLabels := append(byNodeLabels, "cpu")
-	resourceSecondsLostToPreemptionLabels := append(byQueueLabels, "none", "cpu")
+	resourceSecondsLostToPreemptionLabels := append(byQueueLabels, "none", "cpu", "urgency")
 	m := newJobStateMetrics(nil, []time.Duration{}, 12*time.Hour)
 
 	testReset := func(vec *prometheus.CounterVec, labels []string) {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -1475,7 +1475,8 @@ func (s *Scheduler) generateUpdateMessagesFromJob(ctx *armadacontext.Context, jo
 				events = append(events, jobErrors)
 			}
 		} else if lastRun.PreemptRequested() && job.PriorityClass().Preemptible {
-			job = job.WithQueued(false).WithFailed(true).WithUpdatedRun(lastRun.WithoutTerminal().WithFailed(true))
+			now := s.clock.Now()
+			job = job.WithQueued(false).WithFailed(true).WithUpdatedRun(lastRun.WithoutTerminal().WithFailed(true).WithPreemptedTime(&now))
 			reason := "Preempted - preemption requested via API"
 			if lastRun.PreemptReason() != nil && *lastRun.PreemptReason() != "" {
 				reason = *lastRun.PreemptReason()

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -460,13 +460,13 @@ func (s *Scheduler) cycle(ctx *armadacontext.Context, updateAll bool, leaderToke
 		s.metrics.ReportSchedulerResult(ctx, *schedulerResult)
 
 		for _, jctx := range schedulerResult.GetAllScheduledJobs() {
-			s.metrics.ReportJobLeased(jctx.Job)
+			s.metrics.ReportJobLeasedStateTransition(jctx.Job)
 		}
 		for _, jctx := range schedulerResult.GetAllPreemptedJobs() {
-			s.metrics.ReportJobPreempted(jctx.Job)
+			s.metrics.ReportJobPreemptedStateTransition(jctx.Job, jctx.PreemptionType)
 		}
 		for _, jctx := range schedulerResult.GetCombinedReconciliationResult().PreemptedJobs {
-			s.metrics.ReportJobPreempted(jctx.Job)
+			s.metrics.ReportJobPreemptedStateTransition(jctx.Job, schedulercontext.PreemptedViaNodeReconciler)
 		}
 	}
 
@@ -1482,6 +1482,7 @@ func (s *Scheduler) generateUpdateMessagesFromJob(ctx *armadacontext.Context, jo
 			}
 			requestor := ptr.Deref(lastRun.PreemptUser(), "")
 			events = append(events, createEventsForPreemptedJob(job.Id(), lastRun.Id(), "", reason, requestor, s.clock.Now())...)
+			s.metrics.ReportJobPreemptedStateTransition(job, schedulercontext.PreemptedViaApi)
 			s.metrics.ReportJobPreemptedWithType(job, schedulercontext.PreemptedViaApi)
 		}
 	}


### PR DESCRIPTION
This just allows us to see which type of preemption is having the biggest impact on time lost

