### PR TITLE
Stop hiding scheduling type for away jobs

### DIFF
--- a/internal/scheduler/metrics/cycle_metrics.go
+++ b/internal/scheduler/metrics/cycle_metrics.go
@@ -33,6 +33,8 @@ var (
 	poolAndOutcomeLabels                   = []string{poolLabel, outcomeLabel, terminationReasonLabel}
 	nodeLabels                             = []string{poolLabel, nodeLabel, clusterLabel, nodeTypeLabel, resourceLabel, reservationLabel, schedulableLabel, overAllocatedLabel, physicalPoolLabel, capacityClassLabel, scalableUnitLabel}
 	defaultType                            = "unknown"
+	homePlacementType                      = "home"
+	awayPlacementType                      = "away"
 	reconcilerFailureType                  = "reconciler"
 )
 
@@ -398,7 +400,7 @@ func newCycleMetrics(publisher pulsarutils.Publisher[*metricevents.Event], scala
 			Name: ArmadaSchedulerMetricsPrefix + "scheduled_jobs",
 			Help: "Number of events scheduled",
 		},
-		poolAndQueueAndPriorityClassTypeLabels,
+		append(poolAndQueueAndPriorityClassTypeLabels, "placement_type"),
 	)
 
 	preemptedJobs := prometheus.NewCounterVec(
@@ -695,10 +697,18 @@ func (m *cycleMetrics) ReportSchedulerResult(ctx *armadacontext.Context, result 
 
 			for _, jobCtx := range schedulingResult.ScheduledJobs {
 				schedulingType := defaultType
-				if jobCtx.PodSchedulingContext != nil && jobCtx.PodSchedulingContext.SchedulingMethod != "" {
-					schedulingType = string(jobCtx.PodSchedulingContext.SchedulingMethod)
+				placementType := defaultType
+				if jobCtx.PodSchedulingContext != nil {
+					if jobCtx.PodSchedulingContext.SchedulingMethod != "" {
+						schedulingType = string(jobCtx.PodSchedulingContext.SchedulingMethod)
+					}
+					placementType = homePlacementType
+					if jobCtx.PodSchedulingContext.ScheduledAway {
+						placementType = awayPlacementType
+					}
 				}
-				m.scheduledJobs.WithLabelValues(pool, jobCtx.Job.Queue(), jobCtx.Job.PriorityClassName(), schedulingType).Inc()
+
+				m.scheduledJobs.WithLabelValues(pool, jobCtx.Job.Queue(), jobCtx.Job.PriorityClassName(), schedulingType, placementType).Inc()
 			}
 
 			for _, jobCtx := range schedulingResult.PreemptedJobs {

--- a/internal/scheduler/metrics/cycle_metrics_test.go
+++ b/internal/scheduler/metrics/cycle_metrics_test.go
@@ -176,7 +176,7 @@ func TestResetLeaderMetrics_Counters(t *testing.T) {
 		assert.Equal(t, 0.0, counterVal)
 	}
 
-	testResetCounter(m.scheduledJobs, poolAndQueueAndPriorityClassTypeLabels)
+	testResetCounter(m.scheduledJobs, append(poolAndQueueAndPriorityClassTypeLabels, homePlacementType))
 	testResetCounter(m.preemptedJobs, poolAndQueueAndPriorityClassTypeLabels)
 	testResetCounter(m.failedJobs, poolAndQueueAndPriorityClassTypeLabels)
 }
@@ -234,7 +234,7 @@ func TestDisableLeaderMetrics(t *testing.T) {
 	poolAndQueueAndPriorityClassTypeLabels := []string{"pool1", "queue1", "priorityClass1", "type1"}
 
 	collect := func(m *cycleMetrics) []prometheus.Metric {
-		m.scheduledJobs.WithLabelValues(poolAndQueueAndPriorityClassTypeLabels...).Inc()
+		m.scheduledJobs.WithLabelValues(append(poolAndQueueAndPriorityClassTypeLabels, homePlacementType)...).Inc()
 		m.preemptedJobs.WithLabelValues(poolAndQueueAndPriorityClassTypeLabels...).Inc()
 		m.latestCycleMetrics.Load().consideredJobs.WithLabelValues(poolQueueLabelValues...).Inc()
 		m.latestCycleMetrics.Load().fairShare.WithLabelValues(poolQueueLabelValues...).Inc()

--- a/internal/scheduler/nodedb/nodedb.go
+++ b/internal/scheduler/nodedb/nodedb.go
@@ -619,7 +619,6 @@ func (nodeDb *NodeDb) SelectNodeForJobWithTxn(txn *memdb.Txn, jctx *context.JobS
 			}
 			if node != nil {
 				pctx.WellKnownNodeTypeName = awayNodeType.WellKnownNodeTypeName
-				pctx.SchedulingMethod = context.ScheduledAsAwayJob
 				pctx.ScheduledAway = true
 				return node, preemptedJobs, nil
 			}

--- a/internal/scheduler/nodedb/nodedb_test.go
+++ b/internal/scheduler/nodedb/nodedb_test.go
@@ -909,11 +909,12 @@ func TestHomeNodeScheduling(t *testing.T) {
 				if tc.defaultToleration != nil {
 					assert.Equal(t, *tc.defaultToleration, jctx.AdditionalTolerations[0])
 				}
+				assert.Equal(t, context.ScheduledWithoutPreemption, jctx.PodSchedulingContext.SchedulingMethod)
 				if tc.expectScheduledAway {
-					assert.Equal(t, context.ScheduledAsAwayJob, jctx.PodSchedulingContext.SchedulingMethod)
+					assert.True(t, jctx.PodSchedulingContext.ScheduledAway)
 					assert.Equal(t, int32(29000), jctx.PodSchedulingContext.ScheduledAtPriority)
 				} else {
-					assert.Equal(t, context.ScheduledWithoutPreemption, jctx.PodSchedulingContext.SchedulingMethod)
+					assert.False(t, jctx.PodSchedulingContext.ScheduledAway)
 					assert.Equal(t, int32(30000), jctx.PodSchedulingContext.ScheduledAtPriority)
 				}
 			} else {
@@ -1282,7 +1283,8 @@ func TestConditionalAwayNodeScheduling(t *testing.T) {
 			if tc.expectScheduled {
 				assert.NotNil(t, node)
 				assert.Equal(t, node.GetId(), jctx.PodSchedulingContext.NodeId)
-				assert.Equal(t, context.ScheduledAsAwayJob, jctx.PodSchedulingContext.SchedulingMethod)
+				assert.True(t, jctx.PodSchedulingContext.ScheduledAway)
+				assert.Equal(t, context.ScheduledWithoutPreemption, jctx.PodSchedulingContext.SchedulingMethod)
 			} else {
 				assert.Nil(t, node)
 			}
@@ -1405,7 +1407,8 @@ func TestAwayNodeScheduling(t *testing.T) {
 				assert.NotNil(t, jctx.PodSchedulingContext)
 				assert.True(t, jctx.PodSchedulingContext.IsSuccessful())
 				assert.Equal(t, node.GetId(), jctx.PodSchedulingContext.NodeId)
-				assert.Equal(t, context.ScheduledAsAwayJob, jctx.PodSchedulingContext.SchedulingMethod)
+				assert.True(t, jctx.PodSchedulingContext.ScheduledAway)
+				assert.Equal(t, context.ScheduledWithoutPreemption, jctx.PodSchedulingContext.SchedulingMethod)
 				assert.Equal(t, int32(29000), jctx.PodSchedulingContext.ScheduledAtPriority)
 				if tc.wellKnownNodeTypeTaint.Value == schedulerconfig.WildCardWellKnownNodeTypeValue {
 					require.Equal(

--- a/internal/scheduler/scheduling/context/pod.go
+++ b/internal/scheduler/scheduling/context/pod.go
@@ -15,7 +15,6 @@ const (
 	ScheduledWithoutPreemption          SchedulingType = "no-preemption"
 	ScheduledWithFairSharePreemption    SchedulingType = "fairshare"
 	ScheduledWithUrgencyBasedPreemption SchedulingType = "urgency"
-	ScheduledAsAwayJob                  SchedulingType = "away"
 	ScheduledWithFairnessOptimiser      SchedulingType = "optimiser"
 )
 


### PR DESCRIPTION
Currently we mark all jobs scheduled away as SchedulingType="away", however this means the actual scheduling type is lost (i.e was it scheduled was preemption or not?)

I've now removed the ScheduleAsAwayJob SchedulingType and we now leverage the existing ScheduledAway flag

This is now reflected in metrics with a new label 'placement_type' which determines if the scheduling was home or away

