### PR TITLE
Remove the 'all-priority-classes' flag from armadactl commands

### DIFF
--- a/cmd/armadactl/cmd/cancel.go
+++ b/cmd/armadactl/cmd/cancel.go
@@ -20,9 +20,9 @@ func cancelCmd() *cobra.Command {
 	cmd.AddCommand(
 		cancelJobCmd(),
 		cancelJobSetCmd(),
-		cancelExecutorCmd(),
-		cancelNodeCmd(),
-		cancelQueueCmd(),
+		cancelExecutorCmd(armadactl.New()),
+		cancelNodeCmd(armadactl.New()),
+		cancelQueueCmd(armadactl.New()),
 	)
 	return cmd
 }
@@ -66,8 +66,7 @@ func cancelJobSetCmd() *cobra.Command {
 	return cmd
 }
 
-func cancelExecutorCmd() *cobra.Command {
-	a := armadactl.New()
+func cancelExecutorCmd(a *armadactl.App) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "executor <executor>",
 		Short: "Cancels jobs on executor.",
@@ -118,8 +117,7 @@ func cancelExecutorCmd() *cobra.Command {
 	return cmd
 }
 
-func cancelNodeCmd() *cobra.Command {
-	a := armadactl.New()
+func cancelNodeCmd(a *armadactl.App) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "node <name>",
 		Short: "Cancels jobs on node for specified executor.",
@@ -174,8 +172,7 @@ func cancelNodeCmd() *cobra.Command {
 	return cmd
 }
 
-func cancelQueueCmd() *cobra.Command {
-	a := armadactl.New()
+func cancelQueueCmd(a *armadactl.App) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "queues <queue_1> <queue_2> <queue_3> ...",
 		Short:   "Cancels jobs on queues.",

--- a/cmd/armadactl/cmd/cancel.go
+++ b/cmd/armadactl/cmd/cancel.go
@@ -74,15 +74,6 @@ func cancelExecutorCmd() *cobra.Command {
 		Long:  `Cancels jobs on executor with provided executor name, priority classes, queues, and pools.`,
 		Args:  cobra.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			all, err := cmd.Flags().GetBool("all-priority-classes")
-			if err != nil {
-				return fmt.Errorf("error reading all-priority-classes flag: %s", err)
-			}
-			if !all {
-				if err := cmd.MarkFlagRequired("priority-classes"); err != nil {
-					return fmt.Errorf("error marking priority-class flag as required: %s", err)
-				}
-			}
 			return initParams(cmd, a.Params)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -91,10 +82,6 @@ func cancelExecutorCmd() *cobra.Command {
 			priorityClasses, err := cmd.Flags().GetStringSlice("priority-classes")
 			if err != nil {
 				return fmt.Errorf("error reading priority-class selection: %s", err)
-			}
-			allPriorityClasses, _ := cmd.Flags().GetBool("all-priority-classes")
-			if allPriorityClasses {
-				priorityClasses = nil
 			}
 
 			queues, err := cmd.Flags().GetStringSlice("queues")
@@ -121,13 +108,7 @@ func cancelExecutorCmd() *cobra.Command {
 		"priority-classes",
 		"p",
 		[]string{},
-		"Cancel jobs on executor matching the specified priority classes. Provided priority classes should be comma separated, as in the following example: armada-default,armada-preemptible.",
-	)
-	cmd.Flags().BoolP(
-		"all-priority-classes",
-		"a",
-		false,
-		"Cancel jobs on executor for all priority classes.",
+		"Cancel jobs on executor matching the specified priority classes, comma separated (e.g. armada-default,armada-preemptible). If no priority classes are provided, jobs across all priority classes will be cancelled.",
 	)
 	cmd.Flags().StringSlice(
 		"pools",
@@ -145,15 +126,6 @@ func cancelNodeCmd() *cobra.Command {
 		Long:  `Cancels jobs on node for executor with provided executor name, priority classes and queues.`,
 		Args:  cobra.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			all, err := cmd.Flags().GetBool("all-priority-classes")
-			if err != nil {
-				return fmt.Errorf("error reading all-priority-classes flag: %s", err)
-			}
-			if !all {
-				if err := cmd.MarkFlagRequired("priority-classes"); err != nil {
-					return fmt.Errorf("error marking priority-class flag as required: %s", err)
-				}
-			}
 			if err := cmd.MarkFlagRequired("executor"); err != nil {
 				return fmt.Errorf("error marking executor flag as required: %s", err)
 			}
@@ -165,10 +137,6 @@ func cancelNodeCmd() *cobra.Command {
 			priorityClasses, err := cmd.Flags().GetStringSlice("priority-classes")
 			if err != nil {
 				return fmt.Errorf("error reading priority-class selection: %s", err)
-			}
-			allPriorityClasses, _ := cmd.Flags().GetBool("all-priority-classes")
-			if allPriorityClasses {
-				priorityClasses = nil
 			}
 
 			queues, err := cmd.Flags().GetStringSlice("queues")
@@ -195,13 +163,7 @@ func cancelNodeCmd() *cobra.Command {
 		"priority-classes",
 		"p",
 		[]string{},
-		"Cancel jobs on node for specified executor matching the specified priority classes. Provided priority classes should be comma separated, as in the following example: armada-default,armada-preemptible.",
-	)
-	cmd.Flags().BoolP(
-		"all-priority-classes",
-		"a",
-		false,
-		"Preempt jobs on executor for all priority classes.",
+		"Cancel jobs on node for specified executor matching the specified priority classes, comma separated (e.g. armada-default,armada-preemptible). If no priority classes are provided, jobs across all priority classes will be cancelled.",
 	)
 	cmd.Flags().StringP(
 		"executor",
@@ -222,15 +184,6 @@ func cancelQueueCmd() *cobra.Command {
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := cmd.MarkFlagRequired("job-states"); err != nil {
 				return err
-			}
-			all, err := cmd.Flags().GetBool("all-priority-classes")
-			if err != nil {
-				return fmt.Errorf("error reading all-priority-classes flag: %s", err)
-			}
-			if !all {
-				if err := cmd.MarkFlagRequired("priority-classes"); err != nil {
-					return fmt.Errorf("error marking priority-class flag as required: %s", err)
-				}
 			}
 			return initParams(cmd, a.Params)
 		},
@@ -273,10 +226,6 @@ func cancelQueueCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("error reading priority-classes flag: %s", err)
 			}
-			allPriorityClasses, _ := cmd.Flags().GetBool("all-priority-classes")
-			if allPriorityClasses {
-				priorityClasses = nil
-			}
 
 			pools, err := cmd.Flags().GetStringSlice("pools")
 			if err != nil {
@@ -313,13 +262,7 @@ func cancelQueueCmd() *cobra.Command {
 		"priority-classes",
 		"p",
 		[]string{},
-		"Jobs matching the provided priority classes will be cancelled.",
-	)
-	cmd.Flags().BoolP(
-		"all-priority-classes",
-		"a",
-		false,
-		"Preempt jobs on executor for all priority classes.",
+		"Jobs matching the provided priority classes will be cancelled. If no priority classes are provided, jobs across all priority classes will be cancelled.",
 	)
 	cmd.Flags().StringSlice(
 		"pools",

--- a/cmd/armadactl/cmd/cancel_test.go
+++ b/cmd/armadactl/cmd/cancel_test.go
@@ -120,158 +120,86 @@ func TestCancelQueue(t *testing.T) {
 	}
 }
 
-func TestCancelExecutorAllPriorityClasses(t *testing.T) {
+func TestCancelExecutor(t *testing.T) {
 	tests := map[string]struct {
-		flags       []flag
-		expectError bool
+		flags               []flag
+		wantPriorityClasses []string
 	}{
-		"with all-priority-classes flag set": {
-			flags:       []flag{{"all-priority-classes", "true"}},
-			expectError: false,
+		// Omitting priority-classes means all priority classes, which the
+		// executor API represents as an empty slice.
+		"without priority-classes": {
+			flags:               nil,
+			wantPriorityClasses: []string{},
 		},
-		"without all-priority-classes and without priority-classes": {
-			flags:       nil,
-			expectError: true,
+		"with a single priority class": {
+			flags:               []flag{{"priority-classes", "armada-default"}},
+			wantPriorityClasses: []string{"armada-default"},
 		},
-		"without all-priority-classes but with priority-classes": {
-			flags:       []flag{{"priority-classes", "armada-default"}},
-			expectError: false,
+		"with multiple priority classes": {
+			flags:               []flag{{"priority-classes", "armada-default,armada-preemptible"}},
+			wantPriorityClasses: []string{"armada-default", "armada-preemptible"},
 		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			cmd := cancelExecutorCmd()
-			cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
-				all, err := cmd.Flags().GetBool("all-priority-classes")
-				if err != nil {
-					return err
-				}
-				if !all {
-					if err := cmd.MarkFlagRequired("priority-classes"); err != nil {
-						return err
-					}
-				}
-				return nil
-			}
+
+			var gotPriorityClasses []string
 			cmd.RunE = func(cmd *cobra.Command, args []string) error {
-				return nil
+				var err error
+				gotPriorityClasses, err = cmd.Flags().GetStringSlice("priority-classes")
+				return err
 			}
+
 			cmd.SetArgs([]string{"test-executor"})
 			for _, f := range tc.flags {
 				require.NoError(t, cmd.Flags().Set(f.name, f.value))
 			}
-			err := cmd.Execute()
-			if tc.expectError {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
+
+			require.NoError(t, cmd.Execute())
+			require.Equal(t, tc.wantPriorityClasses, gotPriorityClasses)
 		})
 	}
 }
 
-func TestCancelNodeAllPriorityClasses(t *testing.T) {
+func TestCancelNode(t *testing.T) {
 	tests := map[string]struct {
-		flags       []flag
-		expectError bool
+		flags               []flag
+		wantPriorityClasses []string
 	}{
-		"with all-priority-classes flag set": {
-			flags:       []flag{{"all-priority-classes", "true"}, {"executor", "test-exec"}},
-			expectError: false,
+		// Omitting priority-classes means all priority classes, which the
+		// node API represents as an empty slice.
+		"without priority-classes": {
+			flags:               []flag{{"executor", "test-executor"}},
+			wantPriorityClasses: []string{},
 		},
-		"without all-priority-classes and without priority-classes": {
-			flags:       []flag{{"executor", "test-exec"}},
-			expectError: true,
+		"with a single priority class": {
+			flags:               []flag{{"executor", "test-executor"}, {"priority-classes", "armada-default"}},
+			wantPriorityClasses: []string{"armada-default"},
 		},
-		"without all-priority-classes but with priority-classes": {
-			flags:       []flag{{"priority-classes", "armada-default"}, {"executor", "test-exec"}},
-			expectError: false,
+		"with multiple priority classes": {
+			flags:               []flag{{"executor", "test-executor"}, {"priority-classes", "armada-default,armada-preemptible"}},
+			wantPriorityClasses: []string{"armada-default", "armada-preemptible"},
 		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			cmd := cancelNodeCmd()
-			cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
-				all, err := cmd.Flags().GetBool("all-priority-classes")
-				if err != nil {
-					return err
-				}
-				if !all {
-					if err := cmd.MarkFlagRequired("priority-classes"); err != nil {
-						return err
-					}
-				}
-				if err := cmd.MarkFlagRequired("executor"); err != nil {
-					return err
-				}
-				return nil
-			}
+
+			var gotPriorityClasses []string
 			cmd.RunE = func(cmd *cobra.Command, args []string) error {
-				return nil
+				var err error
+				gotPriorityClasses, err = cmd.Flags().GetStringSlice("priority-classes")
+				return err
 			}
+
 			cmd.SetArgs([]string{"test-node"})
 			for _, f := range tc.flags {
 				require.NoError(t, cmd.Flags().Set(f.name, f.value))
 			}
-			err := cmd.Execute()
-			if tc.expectError {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
-}
 
-func TestCancelQueueAllPriorityClasses(t *testing.T) {
-	tests := map[string]struct {
-		flags       []flag
-		expectError bool
-	}{
-		"with all-priority-classes flag set": {
-			flags:       []flag{{"all-priority-classes", "true"}, {"job-states", "queued"}},
-			expectError: false,
-		},
-		"without all-priority-classes and without priority-classes": {
-			flags:       []flag{{"job-states", "queued"}},
-			expectError: true,
-		},
-		"without all-priority-classes but with priority-classes": {
-			flags:       []flag{{"priority-classes", "armada-default"}, {"job-states", "queued"}},
-			expectError: false,
-		},
-	}
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			cmd := cancelQueueCmd()
-			cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
-				if err := cmd.MarkFlagRequired("job-states"); err != nil {
-					return err
-				}
-				all, err := cmd.Flags().GetBool("all-priority-classes")
-				if err != nil {
-					return err
-				}
-				if !all {
-					if err := cmd.MarkFlagRequired("priority-classes"); err != nil {
-						return err
-					}
-				}
-				return nil
-			}
-			cmd.RunE = func(cmd *cobra.Command, args []string) error {
-				return nil
-			}
-			cmd.SetArgs([]string{"test-queue"})
-			for _, f := range tc.flags {
-				require.NoError(t, cmd.Flags().Set(f.name, f.value))
-			}
-			err := cmd.Execute()
-			if tc.expectError {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
+			require.NoError(t, cmd.Execute())
+			require.Equal(t, tc.wantPriorityClasses, gotPriorityClasses)
 		})
 	}
 }

--- a/cmd/armadactl/cmd/cancel_test.go
+++ b/cmd/armadactl/cmd/cancel_test.go
@@ -1,155 +1,72 @@
 package cmd
 
 import (
-	"io"
 	"testing"
 
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 
 	"github.com/armadaproject/armada/internal/armadactl"
+	"github.com/armadaproject/armada/pkg/api"
 )
-
-func TestCancel(t *testing.T) {
-	tests := map[string]struct {
-		Flags  []flag
-		jobId  string
-		queue  string
-		jobSet string
-	}{
-		"default flags": {nil, "", "", ""},
-		"valid job-id":  {[]flag{{"job-id", "jobId1"}}, "jobId1", "", ""},
-		"valid queue":   {[]flag{{"queue", "queue1,jobSet1"}}, "", "queue1", "jobSet1"},
-		"valid job-set": {[]flag{{"job-set", "jobSet1"}}, "", "", "jobSet1"},
-	}
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			a := armadactl.New()
-			cmd := cancelCmd()
-
-			cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
-				a.Out = io.Discard
-
-				if len(test.jobId) > 0 {
-					jobIdFlag, err1 := cmd.Flags().GetString("job-id")
-					require.Error(t, err1)
-					require.Equal(t, test.jobId, jobIdFlag)
-				}
-				if len(test.queue) > 0 {
-					queueFlag, err1 := cmd.Flags().GetString("queue")
-					jobSetFlag, err2 := cmd.Flags().GetString("job-set")
-					require.Error(t, err1)
-					require.Error(t, err2)
-					require.Equal(t, test.queue, queueFlag)
-					require.Equal(t, test.jobSet, jobSetFlag)
-				}
-				if len(test.jobSet) > 0 {
-					jobSetFlag, err1 := cmd.Flags().GetString("job-set")
-					require.Error(t, err1)
-					require.Equal(t, test.jobSet, jobSetFlag)
-				}
-				return nil
-			}
-		})
-	}
-}
-
-func TestCancelQueue(t *testing.T) {
-	tests := map[string]struct {
-		Flags           []flag
-		jobStates       []string
-		selectors       []string
-		priorityClasses []string
-		inverse         bool
-		onlyCordoned    bool
-		dryRun          bool
-	}{
-		"default flags":            {nil, []string{}, []string{}, []string{}, false, false, false},
-		"valid selectors":          {[]flag{{"selectors", "armadaproject.io/priority=high,armadaproject.io/category=critical"}}, []string{}, []string{"armadaproject.io/priority=high", "armadaproject.io/category=critical"}, []string{}, false, false, false},
-		"valid job-states 1":       {[]flag{{"job-states", "queued"}}, []string{"queued"}, []string{}, []string{}, false, false, false},
-		"valid job-states 2":       {[]flag{{"job-states", "queued,leased,pending,running"}}, []string{"queued", "leased", "pending", "running"}, []string{}, []string{}, false, false, false},
-		"valid priority-classes 1": {[]flag{{"priority-classes", "armada-default"}}, []string{}, []string{}, []string{"armada-default"}, false, false, false},
-		"valid priority-classes 2": {[]flag{{"priority-classes", "armada-default,armada-preemptible"}}, []string{}, []string{}, []string{"armada-default", "armada-preemptible"}, false, false, false},
-		"valid multiple flags": {
-			[]flag{{"selectors", "armadaproject.io/priority=high,armadaproject.io/category=critical"}, {"job-states", "queued,leased,pending,running"}, {"priority-classes", "armada-default,armada-preemptible"}},
-			[]string{"queued", "leased", "pending", "running"},
-			[]string{"armadaproject.io/priority=high", "armadaproject.io/category=critical"},
-			[]string{"armada-default", "armada-preemptible"},
-			true, true, true,
-		},
-	}
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			a := armadactl.New()
-			cmd := cancelQueueCmd()
-
-			cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
-				a.Out = io.Discard
-
-				if len(test.jobStates) > 0 {
-					jobStatesFlag, err := cmd.Flags().GetString("job-states")
-					require.NoError(t, err)
-					require.Equal(t, test.jobStates, jobStatesFlag)
-				}
-				if len(test.selectors) > 0 {
-					selectorsFlag, err := cmd.Flags().GetString("selectors")
-					require.Error(t, err)
-					require.Equal(t, test.selectors, selectorsFlag)
-				}
-				if len(test.priorityClasses) > 0 {
-					priorityClassesFlag, err := cmd.Flags().GetString("priority-classes")
-					require.Error(t, err)
-					require.Equal(t, test.priorityClasses, priorityClassesFlag)
-				}
-
-				inverseValue, err := cmd.Flags().GetBool("inverse")
-				require.NoError(t, err)
-				require.Equal(t, test, inverseValue)
-
-				onlyCordonedValue, err := cmd.Flags().GetBool("only-cordoned")
-				require.NoError(t, err)
-				require.Equal(t, test, onlyCordonedValue)
-
-				dryRunValue, err := cmd.Flags().GetBool("dry-run")
-				require.NoError(t, err)
-				require.Equal(t, test, dryRunValue)
-
-				return nil
-			}
-		})
-	}
-}
 
 func TestCancelExecutor(t *testing.T) {
 	tests := map[string]struct {
-		flags               []flag
-		wantPriorityClasses []string
+		flags []flag
+		want  executorCall
 	}{
 		// Omitting priority-classes means all priority classes, which the
-		// executor API represents as an empty slice.
+		// executor API represents as an empty slice. An unnarrowed queue
+		// selection expands to every queue.
 		"without priority-classes": {
-			flags:               nil,
-			wantPriorityClasses: []string{},
+			flags: nil,
+			want: executorCall{
+				executor:        "test-executor",
+				queues:          []string{"queue-a", "queue-b"},
+				priorityClasses: []string{},
+				pools:           []string{},
+			},
 		},
 		"with a single priority class": {
-			flags:               []flag{{"priority-classes", "armada-default"}},
-			wantPriorityClasses: []string{"armada-default"},
+			flags: []flag{{"priority-classes", "armada-default"}},
+			want: executorCall{
+				executor:        "test-executor",
+				queues:          []string{"queue-a", "queue-b"},
+				priorityClasses: []string{"armada-default"},
+				pools:           []string{},
+			},
 		},
 		"with multiple priority classes": {
-			flags:               []flag{{"priority-classes", "armada-default,armada-preemptible"}},
-			wantPriorityClasses: []string{"armada-default", "armada-preemptible"},
+			flags: []flag{{"priority-classes", "armada-default,armada-preemptible"}},
+			want: executorCall{
+				executor:        "test-executor",
+				queues:          []string{"queue-a", "queue-b"},
+				priorityClasses: []string{"armada-default", "armada-preemptible"},
+				pools:           []string{},
+			},
+		},
+		"with queues and pools": {
+			flags: []flag{{"queues", "queue-a"}, {"pools", "pool-1,pool-2"}},
+			want: executorCall{
+				executor:        "test-executor",
+				queues:          []string{"queue-a"},
+				priorityClasses: []string{},
+				pools:           []string{"pool-1", "pool-2"},
+			},
 		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			cmd := cancelExecutorCmd()
+			a := armadactl.New()
+			cmd := cancelExecutorCmd(a)
 
-			var gotPriorityClasses []string
-			cmd.RunE = func(cmd *cobra.Command, args []string) error {
-				var err error
-				gotPriorityClasses, err = cmd.Flags().GetStringSlice("priority-classes")
-				return err
-			}
+			var got []executorCall
+			withFakeAPIs(t, a, cmd, func() {
+				a.Params.QueueAPI.GetAll = func() ([]*api.Queue, error) { return testQueues(), nil }
+				a.Params.ExecutorAPI.CancelOnExecutor = func(executor string, queues, priorityClasses, pools []string) error {
+					got = append(got, executorCall{executor, queues, priorityClasses, pools})
+					return nil
+				}
+			})
 
 			cmd.SetArgs([]string{"test-executor"})
 			for _, f := range tc.flags {
@@ -157,41 +74,68 @@ func TestCancelExecutor(t *testing.T) {
 			}
 
 			require.NoError(t, cmd.Execute())
-			require.Equal(t, tc.wantPriorityClasses, gotPriorityClasses)
+			require.Equal(t, []executorCall{tc.want}, got)
 		})
 	}
 }
 
 func TestCancelNode(t *testing.T) {
 	tests := map[string]struct {
-		flags               []flag
-		wantPriorityClasses []string
+		flags []flag
+		want  nodeCall
 	}{
-		// Omitting priority-classes means all priority classes, which the
-		// node API represents as an empty slice.
+		// Omitting priority-classes means all priority classes, which the node
+		// API represents as an empty slice.
 		"without priority-classes": {
-			flags:               []flag{{"executor", "test-executor"}},
-			wantPriorityClasses: []string{},
+			flags: []flag{{"executor", "test-executor"}},
+			want: nodeCall{
+				node:            "test-node",
+				executor:        "test-executor",
+				queues:          []string{"queue-a", "queue-b"},
+				priorityClasses: []string{},
+			},
 		},
 		"with a single priority class": {
-			flags:               []flag{{"executor", "test-executor"}, {"priority-classes", "armada-default"}},
-			wantPriorityClasses: []string{"armada-default"},
+			flags: []flag{{"executor", "test-executor"}, {"priority-classes", "armada-default"}},
+			want: nodeCall{
+				node:            "test-node",
+				executor:        "test-executor",
+				queues:          []string{"queue-a", "queue-b"},
+				priorityClasses: []string{"armada-default"},
+			},
 		},
 		"with multiple priority classes": {
-			flags:               []flag{{"executor", "test-executor"}, {"priority-classes", "armada-default,armada-preemptible"}},
-			wantPriorityClasses: []string{"armada-default", "armada-preemptible"},
+			flags: []flag{{"executor", "test-executor"}, {"priority-classes", "armada-default,armada-preemptible"}},
+			want: nodeCall{
+				node:            "test-node",
+				executor:        "test-executor",
+				queues:          []string{"queue-a", "queue-b"},
+				priorityClasses: []string{"armada-default", "armada-preemptible"},
+			},
+		},
+		"with queues": {
+			flags: []flag{{"executor", "test-executor"}, {"queues", "queue-a"}},
+			want: nodeCall{
+				node:            "test-node",
+				executor:        "test-executor",
+				queues:          []string{"queue-a"},
+				priorityClasses: []string{},
+			},
 		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			cmd := cancelNodeCmd()
+			a := armadactl.New()
+			cmd := cancelNodeCmd(a)
 
-			var gotPriorityClasses []string
-			cmd.RunE = func(cmd *cobra.Command, args []string) error {
-				var err error
-				gotPriorityClasses, err = cmd.Flags().GetStringSlice("priority-classes")
-				return err
-			}
+			var got []nodeCall
+			withFakeAPIs(t, a, cmd, func() {
+				a.Params.QueueAPI.GetAll = func() ([]*api.Queue, error) { return testQueues(), nil }
+				a.Params.NodeAPI.CancelOnNode = func(node, executor string, queues, priorityClasses []string) error {
+					got = append(got, nodeCall{node, executor, queues, priorityClasses})
+					return nil
+				}
+			})
 
 			cmd.SetArgs([]string{"test-node"})
 			for _, f := range tc.flags {
@@ -199,7 +143,138 @@ func TestCancelNode(t *testing.T) {
 			}
 
 			require.NoError(t, cmd.Execute())
-			require.Equal(t, tc.wantPriorityClasses, gotPriorityClasses)
+			require.Equal(t, []nodeCall{tc.want}, got)
 		})
 	}
+}
+
+func TestCancelQueues(t *testing.T) {
+	// job-states is required by this command, so every case sets it.
+	tests := map[string]struct {
+		args  []string
+		flags []flag
+		want  []queueCall
+	}{
+		// Omitting priority-classes means all priority classes, which the
+		// queue API represents as an empty slice.
+		"without priority-classes": {
+			args:  []string{"queue-a"},
+			flags: []flag{{"job-states", "queued"}},
+			want: []queueCall{
+				{
+					queue:           "queue-a",
+					priorityClasses: []string{},
+					jobStates:       []api.JobState{api.JobState_QUEUED},
+					pools:           []string{},
+				},
+			},
+		},
+		"with a single priority class": {
+			args:  []string{"queue-a"},
+			flags: []flag{{"job-states", "queued"}, {"priority-classes", "armada-default"}},
+			want: []queueCall{
+				{
+					queue:           "queue-a",
+					priorityClasses: []string{"armada-default"},
+					jobStates:       []api.JobState{api.JobState_QUEUED},
+					pools:           []string{},
+				},
+			},
+		},
+		"with multiple priority classes": {
+			args:  []string{"queue-a"},
+			flags: []flag{{"job-states", "queued"}, {"priority-classes", "armada-default,armada-preemptible"}},
+			want: []queueCall{
+				{
+					queue:           "queue-a",
+					priorityClasses: []string{"armada-default", "armada-preemptible"},
+					jobStates:       []api.JobState{api.JobState_QUEUED},
+					pools:           []string{},
+				},
+			},
+		},
+		"with multiple job states and pools": {
+			args:  []string{"queue-a"},
+			flags: []flag{{"job-states", "queued,running"}, {"pools", "pool-1"}},
+			want: []queueCall{
+				{
+					queue:           "queue-a",
+					priorityClasses: []string{},
+					jobStates:       []api.JobState{api.JobState_QUEUED, api.JobState_RUNNING},
+					pools:           []string{"pool-1"},
+				},
+			},
+		},
+		"cancels each selected queue": {
+			args:  []string{"queue-a", "queue-b"},
+			flags: []flag{{"job-states", "queued"}},
+			want: []queueCall{
+				{
+					queue:           "queue-a",
+					priorityClasses: []string{},
+					jobStates:       []api.JobState{api.JobState_QUEUED},
+					pools:           []string{},
+				},
+				{
+					queue:           "queue-b",
+					priorityClasses: []string{},
+					jobStates:       []api.JobState{api.JobState_QUEUED},
+					pools:           []string{},
+				},
+			},
+		},
+		// dry-run reports what would happen without calling the API.
+		"dry-run calls nothing": {
+			args:  []string{"queue-a"},
+			flags: []flag{{"job-states", "queued"}, {"dry-run", "true"}},
+			want:  nil,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			a := armadactl.New()
+			cmd := cancelQueueCmd(a)
+
+			var got []queueCall
+			withFakeAPIs(t, a, cmd, func() {
+				a.Params.QueueAPI.GetAll = func() ([]*api.Queue, error) { return testQueues(), nil }
+				a.Params.QueueAPI.Cancel = func(queue string, priorityClasses []string, jobStates []api.JobState, pools []string) error {
+					got = append(got, queueCall{queue, priorityClasses, jobStates, pools})
+					return nil
+				}
+			})
+
+			cmd.SetArgs(tc.args)
+			for _, f := range tc.flags {
+				require.NoError(t, cmd.Flags().Set(f.name, f.value))
+			}
+
+			require.NoError(t, cmd.Execute())
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestCancelQueuesRequiresQueueSelection(t *testing.T) {
+	// Guards against accidentally cancelling every queue: selection must be
+	// narrowed by name or by label.
+	a := armadactl.New()
+	cmd := cancelQueueCmd(a)
+
+	called := false
+	withFakeAPIs(t, a, cmd, func() {
+		a.Params.QueueAPI.GetAll = func() ([]*api.Queue, error) { return testQueues(), nil }
+		a.Params.QueueAPI.Cancel = func(queue string, priorityClasses []string, jobStates []api.JobState, pools []string) error {
+			called = true
+			return nil
+		}
+	})
+
+	// Must be non-nil: cobra falls back to os.Args[1:] when args are nil.
+	cmd.SetArgs([]string{})
+	require.NoError(t, cmd.Flags().Set("job-states", "queued"))
+	cmd.SilenceUsage = true
+
+	require.Error(t, cmd.Execute())
+	require.False(t, called, "no queue should be cancelled without a selection")
 }

--- a/cmd/armadactl/cmd/preempt.go
+++ b/cmd/armadactl/cmd/preempt.go
@@ -18,9 +18,9 @@ func preemptCmd() *cobra.Command {
 	}
 	cmd.AddCommand(
 		preemptJobCmd(),
-		preemptExecutorCmd(),
-		preemptNodeCmd(),
-		preemptQueuesCmd(),
+		preemptExecutorCmd(armadactl.New()),
+		preemptNodeCmd(armadactl.New()),
+		preemptQueuesCmd(armadactl.New()),
 	)
 	return cmd
 }
@@ -46,8 +46,7 @@ func preemptJobCmd() *cobra.Command {
 	return cmd
 }
 
-func preemptExecutorCmd() *cobra.Command {
-	a := armadactl.New()
+func preemptExecutorCmd(a *armadactl.App) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "executor <executor>",
 		Short: "Preempts jobs on executor.",
@@ -97,8 +96,7 @@ func preemptExecutorCmd() *cobra.Command {
 	return cmd
 }
 
-func preemptNodeCmd() *cobra.Command {
-	a := armadactl.New()
+func preemptNodeCmd(a *armadactl.App) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "node <name>",
 		Short: "Preempts jobs on node for specified executor.",
@@ -152,8 +150,7 @@ func preemptNodeCmd() *cobra.Command {
 	return cmd
 }
 
-func preemptQueuesCmd() *cobra.Command {
-	a := armadactl.New()
+func preemptQueuesCmd(a *armadactl.App) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "queues <queue_1> <queue_2> <queue_3> ...",
 		Short:   "Preempts jobs on queues.",

--- a/cmd/armadactl/cmd/preempt.go
+++ b/cmd/armadactl/cmd/preempt.go
@@ -54,15 +54,6 @@ func preemptExecutorCmd() *cobra.Command {
 		Long:  `Preempts jobs on executor with provided executor name, priority classes, queues, and pools.`,
 		Args:  cobra.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			all, err := cmd.Flags().GetBool("all-priority-classes")
-			if err != nil {
-				return fmt.Errorf("error reading all-priority-classes flag: %s", err)
-			}
-			if !all {
-				if err := cmd.MarkFlagRequired("priority-classes"); err != nil {
-					return fmt.Errorf("error marking priority-class flag as required: %s", err)
-				}
-			}
 			return initParams(cmd, a.Params)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -71,11 +62,6 @@ func preemptExecutorCmd() *cobra.Command {
 			priorityClasses, err := cmd.Flags().GetStringSlice("priority-classes")
 			if err != nil {
 				return fmt.Errorf("error reading priority-class selection: %s", err)
-			}
-
-			allPriorityClasses, _ := cmd.Flags().GetBool("all-priority-classes")
-			if allPriorityClasses {
-				priorityClasses = nil
 			}
 
 			queues, err := cmd.Flags().GetStringSlice("queues")
@@ -101,13 +87,7 @@ func preemptExecutorCmd() *cobra.Command {
 		"priority-classes",
 		"p",
 		[]string{},
-		"Preempt jobs on executor matching the specified priority classes. Provided priority classes should be comma separated, as in the following example: armada-default,armada-preemptible.",
-	)
-	cmd.Flags().BoolP(
-		"all-priority-classes",
-		"a",
-		false,
-		"Preempt jobs on executor for all priority classes.",
+		"Preempt jobs on executor matching the specified priority classes, comma separated (e.g. armada-default,armada-preemptible). If no priority classes are provided, jobs across all priority classes will be preempted.",
 	)
 	cmd.Flags().StringSlice(
 		"pools",
@@ -125,15 +105,6 @@ func preemptNodeCmd() *cobra.Command {
 		Long:  `Preempts jobs on node for specified executor with provided node name, executor name, priority classes and queues.`,
 		Args:  cobra.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			all, err := cmd.Flags().GetBool("all-priority-classes")
-			if err != nil {
-				return fmt.Errorf("error reading all-priority-classes flag: %s", err)
-			}
-			if !all {
-				if err := cmd.MarkFlagRequired("priority-classes"); err != nil {
-					return fmt.Errorf("error marking priority-class flag as required: %s", err)
-				}
-			}
 			if err := cmd.MarkFlagRequired("executor"); err != nil {
 				return fmt.Errorf("error marking executor flag as required: %s", err)
 			}
@@ -145,11 +116,6 @@ func preemptNodeCmd() *cobra.Command {
 			priorityClasses, err := cmd.Flags().GetStringSlice("priority-classes")
 			if err != nil {
 				return fmt.Errorf("error reading priority-class selection: %s", err)
-			}
-
-			allPriorityClasses, _ := cmd.Flags().GetBool("all-priority-classes")
-			if allPriorityClasses {
-				priorityClasses = nil
 			}
 
 			queues, err := cmd.Flags().GetStringSlice("queues")
@@ -175,13 +141,7 @@ func preemptNodeCmd() *cobra.Command {
 		"priority-classes",
 		"p",
 		[]string{},
-		"Preempt jobs on node for specified executor matching the specified priority classes. Provided priority classes should be comma separated, as in the following example: armada-default,armada-preemptible.",
-	)
-	cmd.Flags().BoolP(
-		"all-priority-classes",
-		"a",
-		false,
-		"Preempt jobs on node for specified executor for all priority classes.",
+		"Preempt jobs on node for specified executor matching the specified priority classes, comma separated (e.g. armada-default,armada-preemptible). If no priority classes are provided, jobs across all priority classes will be preempted.",
 	)
 	cmd.Flags().StringP(
 		"executor",
@@ -200,15 +160,6 @@ func preemptQueuesCmd() *cobra.Command {
 		Long:    `Preempts jobs on selected queues in specified priority classes and pools. Allows selecting of queues by label or name, one of which must be provided. All flags with multiple values must be comma separated.`,
 		Aliases: []string{"queue"},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			all, err := cmd.Flags().GetBool("all-priority-classes")
-			if err != nil {
-				return fmt.Errorf("error reading all-priority-classes flag: %s", err)
-			}
-			if !all {
-				if err := cmd.MarkFlagRequired("priority-classes"); err != nil {
-					return fmt.Errorf("error marking priority-class flag as required: %s", err)
-				}
-			}
 			return initParams(cmd, a.Params)
 		},
 		RunE: func(cmd *cobra.Command, queues []string) error {
@@ -235,11 +186,6 @@ func preemptQueuesCmd() *cobra.Command {
 			priorityClasses, err := cmd.Flags().GetStringSlice("priority-classes")
 			if err != nil {
 				return fmt.Errorf("error reading priority-classes flag: %s", err)
-			}
-
-			allPriorityClasses, _ := cmd.Flags().GetBool("all-priority-classes")
-			if allPriorityClasses {
-				priorityClasses = nil
 			}
 
 			pools, err := cmd.Flags().GetStringSlice("pools")
@@ -271,13 +217,7 @@ func preemptQueuesCmd() *cobra.Command {
 		"priority-classes",
 		"p",
 		[]string{},
-		"Jobs matching the provided priority classes will be preempted.",
-	)
-	cmd.Flags().BoolP(
-		"all-priority-classes",
-		"a",
-		false,
-		"Preempt jobs in all priority classes. Cannot be used with the priority-classes flag.",
+		"Jobs matching the provided priority classes will be preempted. If no priority classes are provided, jobs across all priority classes will be preempted.",
 	)
 	cmd.Flags().StringSliceP(
 		"selector",

--- a/cmd/armadactl/cmd/preempt_test.go
+++ b/cmd/armadactl/cmd/preempt_test.go
@@ -8,95 +8,117 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/armadaproject/armada/internal/armadactl"
+	"github.com/armadaproject/armada/pkg/api"
 )
 
-func TestPreemptQueue(t *testing.T) {
-	tests := map[string]struct {
-		Flags           []flag
-		selectors       []string
-		priorityClasses []string
-		inverse         bool
-		onlyCordoned    bool
-		dryRun          bool
-	}{
-		"default flags":            {nil, []string{}, []string{}, false, false, false},
-		"valid selectors":          {[]flag{{"selectors", "armadaproject.io/priority=high,armadaproject.io/category=critical"}}, []string{"armadaproject.io/priority=high", "armadaproject.io/category=critical"}, []string{}, false, false, false},
-		"valid priority-classes 1": {[]flag{{"priority-classes", "armada-default"}}, []string{}, []string{"armada-default"}, false, false, false},
-		"valid priority-classes 2": {[]flag{{"priority-classes", "armada-default,armada-preemptible"}}, []string{}, []string{"armada-default", "armada-preemptible"}, false, false, false},
-		"valid multiple flags": {
-			[]flag{{"selectors", "armadaproject.io/priority=high,armadaproject.io/category=critical"}, {"priority-classes", "armada-default,armada-preemptible"}},
-			[]string{"armadaproject.io/priority=high", "armadaproject.io/category=critical"},
-			[]string{"armada-default", "armada-preemptible"},
-			true, true, true,
-		},
-	}
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			a := armadactl.New()
-			cmd := preemptQueuesCmd()
+// executorCall records the arguments armadactl passes to the executor API.
+type executorCall struct {
+	executor        string
+	queues          []string
+	priorityClasses []string
+	pools           []string
+}
 
-			cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
-				a.Out = io.Discard
+// nodeCall records the arguments armadactl passes to the node API.
+type nodeCall struct {
+	node            string
+	executor        string
+	queues          []string
+	priorityClasses []string
+}
 
-				if len(test.selectors) > 0 {
-					selectorsFlag, err := cmd.Flags().GetString("selectors")
-					require.Error(t, err)
-					require.Equal(t, test.selectors, selectorsFlag)
-				}
-				if len(test.priorityClasses) > 0 {
-					priorityClassesFlag, err := cmd.Flags().GetString("priority-classes")
-					require.Error(t, err)
-					require.Equal(t, test.priorityClasses, priorityClassesFlag)
-				}
+// queueCall records the arguments armadactl passes to the queue API.
+type queueCall struct {
+	queue           string
+	priorityClasses []string
+	jobStates       []api.JobState
+	pools           []string
+}
 
-				inverseValue, err := cmd.Flags().GetBool("inverse")
-				require.NoError(t, err)
-				require.Equal(t, test, inverseValue)
+// testQueues is the set of queues the faked GetAll returns. Commands that are
+// not narrowed by queue expand to all of them.
+func testQueues() []*api.Queue {
+	return []*api.Queue{{Name: "queue-a"}, {Name: "queue-b"}}
+}
 
-				onlyCordonedValue, err := cmd.Flags().GetBool("only-cordoned")
-				require.NoError(t, err)
-				require.Equal(t, test, onlyCordonedValue)
-
-				dryRunValue, err := cmd.Flags().GetBool("dry-run")
-				require.NoError(t, err)
-				require.Equal(t, test, dryRunValue)
-
-				return nil
-			}
-		})
+// withFakeAPIs runs the command's real PreRunE and then replaces the API
+// functions that initParams just installed, so the command executes its real
+// RunE all the way to the API boundary without making network calls.
+//
+// installFakes must overwrite the APIs *after* initParams has run, since
+// initParams assigns every function pointer in Params.
+func withFakeAPIs(t *testing.T, a *armadactl.App, cmd *cobra.Command, installFakes func()) {
+	t.Helper()
+	a.Out = io.Discard
+	realPreRunE := cmd.PreRunE
+	require.NotNil(t, realPreRunE, "expected the command to define a PreRunE")
+	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+		if err := realPreRunE(cmd, args); err != nil {
+			return err
+		}
+		installFakes()
+		return nil
 	}
 }
 
 func TestPreemptExecutor(t *testing.T) {
 	tests := map[string]struct {
-		flags               []flag
-		wantPriorityClasses []string
+		flags []flag
+		want  executorCall
 	}{
 		// Omitting priority-classes means all priority classes, which the
-		// executor API represents as an empty slice.
+		// executor API represents as an empty slice. An unnarrowed queue
+		// selection expands to every queue.
 		"without priority-classes": {
-			flags:               nil,
-			wantPriorityClasses: []string{},
+			flags: nil,
+			want: executorCall{
+				executor:        "test-executor",
+				queues:          []string{"queue-a", "queue-b"},
+				priorityClasses: []string{},
+				pools:           []string{},
+			},
 		},
 		"with a single priority class": {
-			flags:               []flag{{"priority-classes", "armada-default"}},
-			wantPriorityClasses: []string{"armada-default"},
+			flags: []flag{{"priority-classes", "armada-default"}},
+			want: executorCall{
+				executor:        "test-executor",
+				queues:          []string{"queue-a", "queue-b"},
+				priorityClasses: []string{"armada-default"},
+				pools:           []string{},
+			},
 		},
 		"with multiple priority classes": {
-			flags:               []flag{{"priority-classes", "armada-default,armada-preemptible"}},
-			wantPriorityClasses: []string{"armada-default", "armada-preemptible"},
+			flags: []flag{{"priority-classes", "armada-default,armada-preemptible"}},
+			want: executorCall{
+				executor:        "test-executor",
+				queues:          []string{"queue-a", "queue-b"},
+				priorityClasses: []string{"armada-default", "armada-preemptible"},
+				pools:           []string{},
+			},
+		},
+		"with queues and pools": {
+			flags: []flag{{"queues", "queue-a"}, {"pools", "pool-1,pool-2"}},
+			want: executorCall{
+				executor:        "test-executor",
+				queues:          []string{"queue-a"},
+				priorityClasses: []string{},
+				pools:           []string{"pool-1", "pool-2"},
+			},
 		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			cmd := preemptExecutorCmd()
+			a := armadactl.New()
+			cmd := preemptExecutorCmd(a)
 
-			var gotPriorityClasses []string
-			cmd.RunE = func(cmd *cobra.Command, args []string) error {
-				var err error
-				gotPriorityClasses, err = cmd.Flags().GetStringSlice("priority-classes")
-				return err
-			}
+			var got []executorCall
+			withFakeAPIs(t, a, cmd, func() {
+				a.Params.QueueAPI.GetAll = func() ([]*api.Queue, error) { return testQueues(), nil }
+				a.Params.ExecutorAPI.PreemptOnExecutor = func(executor string, queues, priorityClasses, pools []string) error {
+					got = append(got, executorCall{executor, queues, priorityClasses, pools})
+					return nil
+				}
+			})
 
 			cmd.SetArgs([]string{"test-executor"})
 			for _, f := range tc.flags {
@@ -104,41 +126,68 @@ func TestPreemptExecutor(t *testing.T) {
 			}
 
 			require.NoError(t, cmd.Execute())
-			require.Equal(t, tc.wantPriorityClasses, gotPriorityClasses)
+			require.Equal(t, []executorCall{tc.want}, got)
 		})
 	}
 }
 
 func TestPreemptNode(t *testing.T) {
 	tests := map[string]struct {
-		flags               []flag
-		wantPriorityClasses []string
+		flags []flag
+		want  nodeCall
 	}{
-		// Omitting priority-classes means all priority classes, which the
-		// node API represents as an empty slice.
+		// Omitting priority-classes means all priority classes, which the node
+		// API represents as an empty slice.
 		"without priority-classes": {
-			flags:               []flag{{"executor", "test-executor"}},
-			wantPriorityClasses: []string{},
+			flags: []flag{{"executor", "test-executor"}},
+			want: nodeCall{
+				node:            "test-node",
+				executor:        "test-executor",
+				queues:          []string{"queue-a", "queue-b"},
+				priorityClasses: []string{},
+			},
 		},
 		"with a single priority class": {
-			flags:               []flag{{"executor", "test-executor"}, {"priority-classes", "armada-default"}},
-			wantPriorityClasses: []string{"armada-default"},
+			flags: []flag{{"executor", "test-executor"}, {"priority-classes", "armada-default"}},
+			want: nodeCall{
+				node:            "test-node",
+				executor:        "test-executor",
+				queues:          []string{"queue-a", "queue-b"},
+				priorityClasses: []string{"armada-default"},
+			},
 		},
 		"with multiple priority classes": {
-			flags:               []flag{{"executor", "test-executor"}, {"priority-classes", "armada-default,armada-preemptible"}},
-			wantPriorityClasses: []string{"armada-default", "armada-preemptible"},
+			flags: []flag{{"executor", "test-executor"}, {"priority-classes", "armada-default,armada-preemptible"}},
+			want: nodeCall{
+				node:            "test-node",
+				executor:        "test-executor",
+				queues:          []string{"queue-a", "queue-b"},
+				priorityClasses: []string{"armada-default", "armada-preemptible"},
+			},
+		},
+		"with queues": {
+			flags: []flag{{"executor", "test-executor"}, {"queues", "queue-a"}},
+			want: nodeCall{
+				node:            "test-node",
+				executor:        "test-executor",
+				queues:          []string{"queue-a"},
+				priorityClasses: []string{},
+			},
 		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			cmd := preemptNodeCmd()
+			a := armadactl.New()
+			cmd := preemptNodeCmd(a)
 
-			var gotPriorityClasses []string
-			cmd.RunE = func(cmd *cobra.Command, args []string) error {
-				var err error
-				gotPriorityClasses, err = cmd.Flags().GetStringSlice("priority-classes")
-				return err
-			}
+			var got []nodeCall
+			withFakeAPIs(t, a, cmd, func() {
+				a.Params.QueueAPI.GetAll = func() ([]*api.Queue, error) { return testQueues(), nil }
+				a.Params.NodeAPI.PreemptOnNode = func(node, executor string, queues, priorityClasses []string) error {
+					got = append(got, nodeCall{node, executor, queues, priorityClasses})
+					return nil
+				}
+			})
 
 			cmd.SetArgs([]string{"test-node"})
 			for _, f := range tc.flags {
@@ -146,7 +195,104 @@ func TestPreemptNode(t *testing.T) {
 			}
 
 			require.NoError(t, cmd.Execute())
-			require.Equal(t, tc.wantPriorityClasses, gotPriorityClasses)
+			require.Equal(t, []nodeCall{tc.want}, got)
 		})
 	}
+}
+
+func TestPreemptQueues(t *testing.T) {
+	tests := map[string]struct {
+		args  []string
+		flags []flag
+		want  []queueCall
+	}{
+		// Omitting priority-classes means all priority classes, which the
+		// queue API represents as an empty slice.
+		"without priority-classes": {
+			args:  []string{"queue-a"},
+			flags: nil,
+			want: []queueCall{
+				{queue: "queue-a", priorityClasses: []string{}, pools: []string{}},
+			},
+		},
+		"with a single priority class": {
+			args:  []string{"queue-a"},
+			flags: []flag{{"priority-classes", "armada-default"}},
+			want: []queueCall{
+				{queue: "queue-a", priorityClasses: []string{"armada-default"}, pools: []string{}},
+			},
+		},
+		"with multiple priority classes": {
+			args:  []string{"queue-a"},
+			flags: []flag{{"priority-classes", "armada-default,armada-preemptible"}},
+			want: []queueCall{
+				{queue: "queue-a", priorityClasses: []string{"armada-default", "armada-preemptible"}, pools: []string{}},
+			},
+		},
+		"with pools": {
+			args:  []string{"queue-a"},
+			flags: []flag{{"pools", "pool-1"}},
+			want: []queueCall{
+				{queue: "queue-a", priorityClasses: []string{}, pools: []string{"pool-1"}},
+			},
+		},
+		"preempts each selected queue": {
+			args:  []string{"queue-a", "queue-b"},
+			flags: nil,
+			want: []queueCall{
+				{queue: "queue-a", priorityClasses: []string{}, pools: []string{}},
+				{queue: "queue-b", priorityClasses: []string{}, pools: []string{}},
+			},
+		},
+		// dry-run reports what would happen without calling the API.
+		"dry-run calls nothing": {
+			args:  []string{"queue-a"},
+			flags: []flag{{"dry-run", "true"}},
+			want:  nil,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			a := armadactl.New()
+			cmd := preemptQueuesCmd(a)
+
+			var got []queueCall
+			withFakeAPIs(t, a, cmd, func() {
+				a.Params.QueueAPI.GetAll = func() ([]*api.Queue, error) { return testQueues(), nil }
+				a.Params.QueueAPI.Preempt = func(queue string, priorityClasses, pools []string) error {
+					got = append(got, queueCall{queue: queue, priorityClasses: priorityClasses, pools: pools})
+					return nil
+				}
+			})
+
+			cmd.SetArgs(tc.args)
+			for _, f := range tc.flags {
+				require.NoError(t, cmd.Flags().Set(f.name, f.value))
+			}
+
+			require.NoError(t, cmd.Execute())
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestPreemptQueuesRequiresQueueSelection(t *testing.T) {
+	a := armadactl.New()
+	cmd := preemptQueuesCmd(a)
+
+	called := false
+	withFakeAPIs(t, a, cmd, func() {
+		a.Params.QueueAPI.GetAll = func() ([]*api.Queue, error) { return testQueues(), nil }
+		a.Params.QueueAPI.Preempt = func(queue string, priorityClasses, pools []string) error {
+			called = true
+			return nil
+		}
+	})
+
+	// Must be non-nil: cobra falls back to os.Args[1:] when args are nil.
+	cmd.SetArgs([]string{})
+	cmd.SilenceUsage = true
+
+	require.Error(t, cmd.Execute())
+	require.False(t, called, "no queue should be preempted without a selection")
 }

--- a/cmd/armadactl/cmd/preempt_test.go
+++ b/cmd/armadactl/cmd/preempt_test.go
@@ -67,155 +67,86 @@ func TestPreemptQueue(t *testing.T) {
 	}
 }
 
-func TestPreemptExecutorAllPriorityClasses(t *testing.T) {
+func TestPreemptExecutor(t *testing.T) {
 	tests := map[string]struct {
-		flags       []flag
-		expectError bool
+		flags               []flag
+		wantPriorityClasses []string
 	}{
-		"with all-priority-classes flag set": {
-			flags:       []flag{{"all-priority-classes", "true"}},
-			expectError: false,
+		// Omitting priority-classes means all priority classes, which the
+		// executor API represents as an empty slice.
+		"without priority-classes": {
+			flags:               nil,
+			wantPriorityClasses: []string{},
 		},
-		"without all-priority-classes and without priority-classes": {
-			flags:       nil,
-			expectError: true,
+		"with a single priority class": {
+			flags:               []flag{{"priority-classes", "armada-default"}},
+			wantPriorityClasses: []string{"armada-default"},
 		},
-		"without all-priority-classes but with priority-classes": {
-			flags:       []flag{{"priority-classes", "armada-default"}},
-			expectError: false,
+		"with multiple priority classes": {
+			flags:               []flag{{"priority-classes", "armada-default,armada-preemptible"}},
+			wantPriorityClasses: []string{"armada-default", "armada-preemptible"},
 		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			cmd := preemptExecutorCmd()
-			cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
-				all, err := cmd.Flags().GetBool("all-priority-classes")
-				if err != nil {
-					return err
-				}
-				if !all {
-					if err := cmd.MarkFlagRequired("priority-classes"); err != nil {
-						return err
-					}
-				}
-				return nil
-			}
+
+			var gotPriorityClasses []string
 			cmd.RunE = func(cmd *cobra.Command, args []string) error {
-				return nil
+				var err error
+				gotPriorityClasses, err = cmd.Flags().GetStringSlice("priority-classes")
+				return err
 			}
+
 			cmd.SetArgs([]string{"test-executor"})
 			for _, f := range tc.flags {
 				require.NoError(t, cmd.Flags().Set(f.name, f.value))
 			}
-			err := cmd.Execute()
-			if tc.expectError {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
+
+			require.NoError(t, cmd.Execute())
+			require.Equal(t, tc.wantPriorityClasses, gotPriorityClasses)
 		})
 	}
 }
 
-func TestPreemptNodeAllPriorityClasses(t *testing.T) {
+func TestPreemptNode(t *testing.T) {
 	tests := map[string]struct {
-		flags       []flag
-		expectError bool
+		flags               []flag
+		wantPriorityClasses []string
 	}{
-		"with all-priority-classes flag set": {
-			flags:       []flag{{"all-priority-classes", "true"}, {"executor", "test-exec"}},
-			expectError: false,
+		// Omitting priority-classes means all priority classes, which the
+		// node API represents as an empty slice.
+		"without priority-classes": {
+			flags:               []flag{{"executor", "test-executor"}},
+			wantPriorityClasses: []string{},
 		},
-		"without all-priority-classes and without priority-classes": {
-			flags:       []flag{{"executor", "test-exec"}},
-			expectError: true,
+		"with a single priority class": {
+			flags:               []flag{{"executor", "test-executor"}, {"priority-classes", "armada-default"}},
+			wantPriorityClasses: []string{"armada-default"},
 		},
-		"without all-priority-classes but with priority-classes": {
-			flags:       []flag{{"priority-classes", "armada-default"}, {"executor", "test-exec"}},
-			expectError: false,
+		"with multiple priority classes": {
+			flags:               []flag{{"executor", "test-executor"}, {"priority-classes", "armada-default,armada-preemptible"}},
+			wantPriorityClasses: []string{"armada-default", "armada-preemptible"},
 		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			cmd := preemptNodeCmd()
-			cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
-				all, err := cmd.Flags().GetBool("all-priority-classes")
-				if err != nil {
-					return err
-				}
-				if !all {
-					if err := cmd.MarkFlagRequired("priority-classes"); err != nil {
-						return err
-					}
-				}
-				if err := cmd.MarkFlagRequired("executor"); err != nil {
-					return err
-				}
-				return nil
-			}
+
+			var gotPriorityClasses []string
 			cmd.RunE = func(cmd *cobra.Command, args []string) error {
-				return nil
+				var err error
+				gotPriorityClasses, err = cmd.Flags().GetStringSlice("priority-classes")
+				return err
 			}
+
 			cmd.SetArgs([]string{"test-node"})
 			for _, f := range tc.flags {
 				require.NoError(t, cmd.Flags().Set(f.name, f.value))
 			}
-			err := cmd.Execute()
-			if tc.expectError {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
-}
 
-func TestPreemptQueuesAllPriorityClasses(t *testing.T) {
-	tests := map[string]struct {
-		flags       []flag
-		expectError bool
-	}{
-		"with all-priority-classes flag set": {
-			flags:       []flag{{"all-priority-classes", "true"}},
-			expectError: false,
-		},
-		"without all-priority-classes and without priority-classes": {
-			flags:       nil,
-			expectError: true,
-		},
-		"without all-priority-classes but with priority-classes": {
-			flags:       []flag{{"priority-classes", "armada-default"}},
-			expectError: false,
-		},
-	}
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			cmd := preemptQueuesCmd()
-			cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
-				all, err := cmd.Flags().GetBool("all-priority-classes")
-				if err != nil {
-					return err
-				}
-				if !all {
-					if err := cmd.MarkFlagRequired("priority-classes"); err != nil {
-						return err
-					}
-				}
-				return nil
-			}
-			cmd.RunE = func(cmd *cobra.Command, args []string) error {
-				return nil
-			}
-			cmd.SetArgs([]string{"test-queue"})
-			for _, f := range tc.flags {
-				require.NoError(t, cmd.Flags().Set(f.name, f.value))
-			}
-			err := cmd.Execute()
-			if tc.expectError {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
+			require.NoError(t, cmd.Execute())
+			require.Equal(t, tc.wantPriorityClasses, gotPriorityClasses)
 		})
 	}
 }


### PR DESCRIPTION
For cancel/preempt queue/node/executor, we now simply default to all priority classes unless a priority class filter is provided

The 'all-priority-classes' was cumbersome and users typically always wanted 'all-priority-classes'

Making it default aligns the command with user expectation and makes it easier to use, while keeping the optional filter of priority classes if users need it

I've also reworked the tests - so we don't override RunE etc and let that use the real production code
 - This means the tests now run the actual production code and just assert the outputs, which I think is much more robust

