### PR TITLE
Remove nodedb.ClearAllocated func

### DIFF
--- a/internal/scheduler/nodedb/nodedb.go
+++ b/internal/scheduler/nodedb/nodedb.go
@@ -1173,38 +1173,6 @@ func (nodeDb *NodeDb) UpsertWithTxn(txn *memdb.Txn, node *internaltypes.Node) er
 	return nil
 }
 
-// ClearAllocated zeroes out allocated resources on all nodes in the NodeDb.
-func (nodeDb *NodeDb) ClearAllocated() error {
-	txn := nodeDb.db.Txn(true)
-	defer txn.Abort()
-	it, err := NewNodesIterator(txn)
-	if err != nil {
-		return err
-	}
-	newNodes := make([]*internaltypes.Node, 0)
-	for node := it.NextNode(); node != nil; node = it.NextNode() {
-		node = node.DeepCopyNilKeys()
-		node.AllocatableByPriority = newAllocatableByPriorityAndResourceType(
-			nodeDb.nodeDbPriorities,
-			node.GetAllocatableResources(),
-		)
-		newNodes = append(newNodes, node)
-	}
-	if err := nodeDb.UpsertManyWithTxn(txn, newNodes); err != nil {
-		return err
-	}
-	txn.Commit()
-	return nil
-}
-
-func newAllocatableByPriorityAndResourceType(priorities []int32, rl internaltypes.ResourceList) map[int32]internaltypes.ResourceList {
-	rv := make(map[int32]internaltypes.ResourceList, len(priorities))
-	for _, priority := range priorities {
-		rv[priority] = rl
-	}
-	return rv
-}
-
 func (nodeDb *NodeDb) AddEvictedJobSchedulingContextWithTxn(txn *memdb.Txn, index int, jctx *context.JobSchedulingContext) error {
 	if it, err := txn.Get(EvictedJobsTable, IdIndex, jctx.JobId); err != nil {
 		return errors.WithStack(err)

--- a/internal/scheduler/submitcheck.go
+++ b/internal/scheduler/submitcheck.go
@@ -180,11 +180,6 @@ func (srv *SubmitChecker) updateExecutors(ctx *armadacontext.Context) error {
 			return fmt.Errorf("failed constructing nodedb for pool %s - %s", pool.Name, err)
 		}
 
-		err = nodeDb.ClearAllocated()
-		if err != nil {
-			return fmt.Errorf("failed clearing nodedb for pool %s - %s", pool.Name, err)
-		}
-
 		nodeDbByPool[pool.Name] = nodeDb
 
 		totalResources := nodeDb.TotalKubernetesResources()


### PR DESCRIPTION
This function clears out allocation on the nodedb.

However it is only used in the submitcheck which never sets any allocation, even worse it only uses it right after the nodedb was just created and will have no allocation

I think this is just adding unnecessary complexity without any benefit