### PR TITLE
Add promtool unit tests for the scheduler recording rules

### DIFF
--- a/deployment/scheduler/tests/scheduler-prometheusrule_test.yaml
+++ b/deployment/scheduler/tests/scheduler-prometheusrule_test.yaml
@@ -1,0 +1,96 @@
+# Unit tests for the scheduler recording rules. Run with validate-rules.sh.
+#
+# The classification counters carry the labels `category` and `subcategory`,
+# all lowercase, as defined in internal/scheduler/metrics/constants.go. PromQL
+# label names are case-sensitive, and a `by (...)` label that matches nothing
+# silently collapses the dimension instead of producing an error, so the
+# assertions below check that the recorded series keep the `subcategory`
+# label with distinct values.
+#
+# The job state counters (armada_scheduler_job_state_counter_by_*) carry no
+# classification labels, so the succeeded-jobs series are dimensioned by
+# queue or cluster only.
+rule_files:
+  - scheduler-prometheusrule.rules.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      # Failures per queue: two subcategories at different rates (4/min and 2/min).
+      - series: 'armada_scheduler_job_error_classification_by_queue{namespace="default",queue="q1",pool="p1",category="infrastructure",subcategory="oom"}'
+        values: '0+4x70'
+      - series: 'armada_scheduler_job_error_classification_by_queue{namespace="default",queue="q1",pool="p1",category="infrastructure",subcategory="eviction"}'
+        values: '0+2x70'
+      # Failures per node (3/min).
+      - series: 'armada_scheduler_job_error_classification_by_node{namespace="default",node="n1",pool="p1",cluster="c1",category="infrastructure",subcategory="oom"}'
+        values: '0+3x70'
+      # Successes per queue (14/min). With 6 failures/min the queue total is 20/min.
+      - series: 'armada_scheduler_job_state_counter_by_queue{namespace="default",queue="q1",pool="p1",state="succeeded",priorState="running"}'
+        values: '0+14x70'
+      # Successes (6/min) and failures (4/min) per node. The node failure ratio is 4/10.
+      - series: 'armada_scheduler_job_state_counter_by_node{namespace="default",node="n1",pool="p1",cluster="c1",state="succeeded",priorState="running"}'
+        values: '0+6x70'
+      - series: 'armada_scheduler_job_state_counter_by_node{namespace="default",node="n1",pool="p1",cluster="c1",state="failed",priorState="running"}'
+        values: '0+4x70'
+
+    promql_expr_test:
+      # 1. The per-queue failure rule keeps distinct subcategory values.
+      - expr: queue_category_subcategory:armada_scheduler_failed_jobs
+        eval_time: 60m
+        exp_samples:
+          - labels: 'queue_category_subcategory:armada_scheduler_failed_jobs{namespace="default",queue="q1",category="infrastructure",subcategory="oom"}'
+            value: 240
+          - labels: 'queue_category_subcategory:armada_scheduler_failed_jobs{namespace="default",queue="q1",category="infrastructure",subcategory="eviction"}'
+            value: 120
+
+      # 2. The per-cluster failure rule reads the metric that exists.
+      - expr: cluster_category_subcategory:armada_scheduler_failed_jobs
+        eval_time: 60m
+        exp_samples:
+          - labels: 'cluster_category_subcategory:armada_scheduler_failed_jobs{namespace="default",cluster="c1",category="infrastructure",subcategory="oom"}'
+            value: 180
+
+      # 3. The per-node failure rule returns data.
+      - expr: node:armada_scheduler_failed_jobs
+        eval_time: 60m
+        exp_samples:
+          - labels: 'node:armada_scheduler_failed_jobs{namespace="default",node="n1"}'
+            value: 240
+
+      # 4. The per-queue success rule returns data under its queue-only name.
+      - expr: queue:armada_scheduler_succeeded_jobs
+        eval_time: 60m
+        exp_samples:
+          - labels: 'queue:armada_scheduler_succeeded_jobs{namespace="default",queue="q1"}'
+            value: 840
+
+      # 5. increase10m and increase1h use different windows: 14/min over 10m and over 1h.
+      - expr: queue:armada_scheduler_succeeded_jobs:increase10m
+        eval_time: 60m
+        exp_samples:
+          - labels: 'queue:armada_scheduler_succeeded_jobs:increase10m{namespace="default",queue="q1"}'
+            value: 140
+      - expr: queue:armada_scheduler_succeeded_jobs:increase1h
+        eval_time: 60m
+        exp_samples:
+          - labels: 'queue:armada_scheduler_succeeded_jobs:increase1h{namespace="default",queue="q1"}'
+            value: 840
+
+      # 6. Node failure ratio over 1h: 240 failed / (240 failed + 360 succeeded).
+      - expr: node:armada_scheduler_failed_rate_jobs:increase1h
+        eval_time: 60m
+        exp_samples:
+          - labels: 'node:armada_scheduler_failed_rate_jobs:increase1h{namespace="default",node="n1"}'
+            value: 0.4
+
+      # 7. Per-queue failure ratio keeps the classification dimensions in the
+      #    numerator while the denominator is the queue total: 360 failed + 840 succeeded.
+      - expr: queue_category_subcategory:armada_scheduler_failed_rate_jobs:increase1h
+        eval_time: 60m
+        exp_samples:
+          - labels: 'queue_category_subcategory:armada_scheduler_failed_rate_jobs:increase1h{namespace="default",queue="q1",category="infrastructure",subcategory="oom"}'
+            value: 0.2
+          - labels: 'queue_category_subcategory:armada_scheduler_failed_rate_jobs:increase1h{namespace="default",queue="q1",category="infrastructure",subcategory="eviction"}'
+            value: 0.1

--- a/deployment/scheduler/tests/validate-rules.sh
+++ b/deployment/scheduler/tests/validate-rules.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Validates the scheduler PrometheusRule recording rules.
+#
+# Recording rules fail silently. A metric name that does not exist and a
+# `sum by (...)` on a label that does not exist are both valid PromQL.
+# Prometheus returns no series, or one collapsed series, and reports no error.
+# `promtool check rules` reports SUCCESS on such rules, so a lint pass alone
+# is insufficient. Only unit tests that assert the recorded output detect
+# this class of bug. This script renders the chart, lints the rendered rules,
+# and then runs every *_test.yaml in this directory against them.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART_DIR="$(dirname "${SCRIPT_DIR}")"
+RULES_FILE="scheduler-prometheusrule.rules.yaml"
+
+for tool in helm yq promtool; do
+  if ! command -v "${tool}" >/dev/null 2>&1; then
+    echo "validate-rules.sh: required tool not found: ${tool}" >&2
+    exit 1
+  fi
+done
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
+# The chart requires image tags, an ingress class, cluster issuers and
+# hostnames to render at all. The values below are placeholders. Only the
+# PrometheusRule template is emitted, and its .spec is a plain Prometheus
+# rules file. The namespace is pinned because the test fixtures select
+# namespace="default".
+helm template armada-scheduler "${CHART_DIR}" \
+  --namespace default \
+  --show-only templates/scheduler-prometheusrule.yaml \
+  --set scheduler.prometheus.enabled=true \
+  --set scheduler.prometheus.scrapeInterval=30s \
+  --set scheduler.image.tag=test \
+  --set ingester.image.tag=test \
+  --set scheduler.ingressClass=nginx \
+  --set scheduler.clusterIssuer=test-issuer \
+  --set 'scheduler.hostnames={scheduler.example.test}' \
+  --set scheduler.applicationConfig.profiling.clusterIssuer=test-issuer \
+  --set 'scheduler.applicationConfig.profiling.hostnames={scheduler-profiling.example.test}' \
+  --set ingester.applicationConfig.profiling.clusterIssuer=test-issuer \
+  --set 'ingester.applicationConfig.profiling.hostnames={ingester-profiling.example.test}' \
+  | yq '.spec' > "${WORK_DIR}/${RULES_FILE}"
+
+promtool check rules "${WORK_DIR}/${RULES_FILE}"
+
+# promtool resolves rule_files relative to the test file, so the tests run
+# from a copy next to the rendered rules.
+for test_file in "${SCRIPT_DIR}"/*_test.yaml; do
+  cp "${test_file}" "${WORK_DIR}/"
+  promtool test rules "${WORK_DIR}/$(basename "${test_file}")"
+done


### PR DESCRIPTION
No test in the repository validates a PrometheusRule. `git grep -l 'promql_expr_test\|rule_files' -- '*.yaml'` returns nothing on master. That is why the defects in #4983 went unnoticed. A metric name that does not exist and a `sum by (...)` on a label that does not exist are both valid PromQL. Prometheus returns no series, or one collapsed series, and reports no error. `promtool check rules` reports SUCCESS on such rules. Only a unit test that asserts the recorded output detects this class of bug.

This PR adds `deployment/scheduler/tests/` with two files.

`validate-rules.sh` renders `templates/scheduler-prometheusrule.yaml` with `helm template` and pipes the output through `yq '.spec'`. The result is a plain Prometheus rules file. The script runs `promtool check rules` on it, then `promtool test rules` for each `*_test.yaml` next to the script. It pins `--namespace default`, because the fixtures select that namespace. It supplies placeholder values for the image tags, ingress class, cluster issuers and hostnames that the chart requires. It works in a `mktemp -d` directory, removes that directory on exit, and uses `set -euo pipefail`.

`scheduler-prometheusrule_test.yaml` feeds ramped counters for the four metrics the scheduler exports and asserts the recorded series at `eval_time: 60m`. The assertions check that:

- the per-queue failure rule keeps distinct `subcategory` values
- the per-cluster and per-node failure rules return data
- the per-queue success rule returns data under its `queue:` name
- `increase10m` and `increase1h` return different values (140 and 840 for a 14/min ramp)
- the node failure ratio is 0.4
- the per-queue failure ratio keeps the classification labels (0.2 and 0.1) over the queue total

Results:

- current rules on master: `promtool check` SUCCESS (33 rules), `promtool test` fails, exit code 1
- rules from #4983: `promtool check` SUCCESS (33 rules), `promtool test` SUCCESS, exit code 0

This PR is independent of #4983. The script fails on master until that fix merges. CI does not run the script yet.

Run it with `bash deployment/scheduler/tests/validate-rules.sh`. It needs `helm`, `yq` and `promtool`.
