### PR TITLE
Remove away-pool skip from submit check

### DIFF
--- a/internal/scheduler/submitcheck.go
+++ b/internal/scheduler/submitcheck.go
@@ -305,17 +305,10 @@ func (srv *SubmitChecker) getSchedulingResult(originalGangCtx *context.GangSched
 	successfulPools := map[string]bool{}
 	var sb strings.Builder
 
-poolStart:
 	for _, pool := range srv.schedulingConfig.Pools {
 
 		if successfulPools[pool.Name] {
 			continue
-		}
-
-		for _, awayPool := range pool.AwayPools {
-			if successfulPools[awayPool.Name] {
-				continue poolStart
-			}
 		}
 
 		sb.WriteString(fmt.Sprintf("pool %s:\n", pool.Name))

--- a/internal/scheduler/submitcheck_test.go
+++ b/internal/scheduler/submitcheck_test.go
@@ -33,6 +33,7 @@ func TestSubmitChecker_CheckJobDbJobs(t *testing.T) {
 	smallJob2 := testfixtures.Test1Cpu4GiJob("queue", testfixtures.PriorityClass1)
 	smallGpuJob := testfixtures.Test1GpuJob("queue", testfixtures.PriorityClass4PreemptibleAway)
 	smallAwayJob := testfixtures.Test1Cpu4GiJob("queue", testfixtures.PriorityClass4PreemptibleAway)
+	gpuTolerantCpuJob := testfixtures.Test1Cpu4GiJobWithGpuToleration("queue", testfixtures.PriorityClass4PreemptibleAway)
 	largeJob1 := testfixtures.Test32Cpu256GiJobWithLargeJobToleration("queue", testfixtures.PriorityClass1)
 
 	// This Gang job will fit
@@ -51,7 +52,11 @@ func TestSubmitChecker_CheckJobDbJobs(t *testing.T) {
 		{Name: "cpu2"},
 		{Name: "cpu-disallowed-resources", ExperimentalUnscheduledResources: []string{"cpu"}},
 		{Name: "gpu"},
-		{Name: "cpu-away", AwayPools: []configuration.AwayPoolConfig{{Name: "gpu"}}},
+		{
+			Name:                             "cpu-away",
+			AwayPools:                        []configuration.AwayPoolConfig{{Name: "gpu"}},
+			ExperimentalUnscheduledResources: []string{"nvidia.com/gpu"},
+		},
 		{Name: "cpu-grouped-1", ExperimentalSubmissionGroup: "group-1"},
 		{Name: "cpu-grouped-2", ExperimentalSubmissionGroup: "group-1"},
 	}
@@ -130,8 +135,22 @@ func TestSubmitChecker_CheckJobDbJobs(t *testing.T) {
 				// The job can theoretically schedule:
 				// - On the "gpu" pool as a home job
 				// - On the "cpu-away" pool, which has "gpu" as an away pool
-				// Jobs shouldn't get assigned to pools with away pools they are already home jobs on
+				// It is kept off "cpu-away" by that pool banning nvidia.com/gpu, not by
+				// anything in the pool sweep itself.
 				smallGpuJob.Id(): {isSchedulable: true, pools: []string{"gpu"}},
+			},
+		},
+		"One job schedulable, home job on an away pool, borrowing pool also viable": {
+			executorTimeout: defaultTimeout,
+			executors: []*schedulerobjects.Executor{
+				Executor(GpuNode("gpu")),
+			},
+			jobs: []*jobdb.Job{gpuTolerantCpuJob},
+			expectedResult: map[string]schedulingResult{
+				// This job requests no GPU but tolerates the gpu taint, so it is a home
+				// job on the "gpu" pool and is not excluded from "cpu-away" by that
+				// pool's nvidia.com/gpu ban. It is therefore eligible for both.
+				gpuTolerantCpuJob.Id(): {isSchedulable: true, pools: []string{"cpu-away", "gpu"}},
 			},
 		},
 		"One job schedulable, away pools": {

--- a/internal/scheduler/testfixtures/testfixtures.go
+++ b/internal/scheduler/testfixtures/testfixtures.go
@@ -749,6 +749,11 @@ func Test1Cpu4GiJob(queue string, priorityClassName string) *jobdb.Job {
 	return TestJob(queue, jobId, priorityClassName, Test1Cpu4GiPodReqs())
 }
 
+func Test1Cpu4GiJobWithGpuToleration(queue string, priorityClassName string) *jobdb.Job {
+	jobId := util.ULID()
+	return TestJob(queue, jobId, priorityClassName, Test1Cpu4GiPodReqsWithGpuToleration())
+}
+
 func Test1Cpu4GiJobQueuedWithPrice(queue string, priorityClassName string, price float64) *jobdb.Job {
 	jobId := util.ULID()
 	return TestJobQueuedWithPrice(queue, jobId, priorityClassName, price, Test1Cpu4GiPodReqs())
@@ -820,6 +825,19 @@ func Test1Cpu4GiPodReqs() *internaltypes.PodRequirements {
 		"cpu":    resource.MustParse("1"),
 		"memory": resource.MustParse("4Gi"),
 	})
+}
+
+// Test1Cpu4GiPodReqsWithGpuToleration requests no GPU but tolerates the gpu taint, so it
+// can be placed on a GPU node as a home job rather than as an away job.
+func Test1Cpu4GiPodReqsWithGpuToleration() *internaltypes.PodRequirements {
+	req := Test1Cpu4GiPodReqs()
+	req.Tolerations = []v1.Toleration{
+		{
+			Key:   "gpu",
+			Value: "true",
+		},
+	}
+	return req
 }
 
 func Test1Cpu16GiPodReqs() *internaltypes.PodRequirements {


### PR DESCRIPTION
Removes the away-pool skip, and the now-unused poolStart label, in getSchedulingResult in submitcheck.go. This behaviour can instead be controlled by setting ExperimentalUnscheduledResources in the scheduler config.

Test changes:

test cpu-away pool now bans nvidia.com/gpu, enforcing the behaviour via config rather than in the submitcheck logic.
add Test1Cpu4GiJobWithGpuToleration and a case pinning that a zero-GPU job tolerating the gpu taint gets both the away pool and the cpu pool.
