### PR TITLE
fix(lookout): use kubectl exec `--` separator in default command template

### DIFF
--- a/config/lookout/config.yaml
+++ b/config/lookout/config.yaml
@@ -37,7 +37,7 @@ uiConfig:
     - name: Logs
       template: "kubectl --context {{ runs[runs.length - 1].cluster }} -n {{ namespace }} logs armada-{{ jobId }}-0"
     - name: Exec
-      template: "kubectl --context {{ runs[runs.length - 1].cluster }} -n {{ namespace }} exec -it armada-{{ jobId }}-0 /bin/sh"
+      template: "kubectl --context {{ runs[runs.length - 1].cluster }} -n {{ namespace }} exec -it armada-{{ jobId }}-0 -- /bin/sh"
       descriptionMd: Execute a command on the job's container.
       alertMessageMd: |
         This will only work if the container is still running.

--- a/config/lookouthc/config.yaml
+++ b/config/lookouthc/config.yaml
@@ -33,7 +33,7 @@ uiConfig:
     - name: Logs
       template: "kubectl --context {{ runs[runs.length - 1].cluster }} -n {{ namespace }} logs armada-{{ jobId }}-0"
     - name: Exec
-      template: "kubectl --context {{ runs[runs.length - 1].cluster }} -n {{ namespace }} exec -it armada-{{ jobId }}-0 /bin/sh"
+      template: "kubectl --context {{ runs[runs.length - 1].cluster }} -n {{ namespace }} exec -it armada-{{ jobId }}-0 -- /bin/sh"
       descriptionMd: Execute a command on the job's container.
       alertMessageMd: |
         This will only work if the container is still running.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you: -->

#### What type of PR is this?

Bug fix

#### What this PR does / why we need it

Lookout's default "Exec" command template (in `config/lookout/config.yaml` and
`config/lookouthc/config.yaml`) generates a command of the form:

```
kubectl --context <cluster> -n <namespace> exec -it armada-<jobId>-0 /bin/sh
```

The `exec [POD] [COMMAND]` syntax (without `--` separating kubectl's own
arguments from the in-container command) was deprecated and has since been
removed from kubectl. Running the suggested command on any current kubectl
release fails with:

```
error: exec [POD] [COMMAND] is not supported anymore. Use exec [POD] -- [COMMAND] instead
```

This PR inserts `--` before `/bin/sh` in both templates so the generated
command uses the syntax current kubectl requires.

#### Which issue(s) this PR fixes

Fixes #

#### Special notes for your reviewer

This is a two-line config change (one line per file) with no code paths
affected. Validation performed:
- `python3 -c "import yaml; yaml.safe_load(open(...))"` on both edited files
  to confirm they remain valid YAML.
- Repo-wide grep for the old template string and for other occurrences of
  `exec -it armada-` / `bin/sh` to confirm no other config file, doc, or test
  contains the same stale syntax.
- Confirmed no Go or TypeScript test hardcodes or snapshots this template
  string.

These files are default/example configs (used by the local dev quickstack)
and are not wired into any `go build`/`go test`/lint CI job, so there is no
additional local build/test command applicable beyond the YAML syntax check
above.

Fixes #5150