### PR TITLE
Categorize preempted jobs under a static preemption category

### DIFF
--- a/internal/common/errormatch/doc.go
+++ b/internal/common/errormatch/doc.go
@@ -10,4 +10,10 @@
 // for config validation. Non-pod conditions ([ConditionPreempted],
 // [ConditionLeaseReturned], [ConditionLeaseExpired], [ConditionAppError]) are also defined here
 // for use by the retry engine but are not included in [KnownConditions].
+//
+// The failure-category constants ([CategoryInternal], [CategoryPreemption])
+// and the Subcategory constants name the classifications that Armada
+// hard-codes on self-generated errors. The operator categorizer never
+// assigns them. Errors in [CategoryPreemption] carry the scheduler's
+// preemption type string as their subcategory.
 package errormatch

--- a/internal/common/errormatch/types.go
+++ b/internal/common/errormatch/types.go
@@ -60,10 +60,12 @@ var KnownConditions = map[string]bool{
 	ConditionDeadlineExceeded: true,
 }
 
-// CategoryInternal is the failure category for Armada-generated failures.
-// It is hard-coded at the Error-construction site,
-// not assigned by the operator categorizer.
-const CategoryInternal = "internal"
+// Failure categories that Armada hard-codes at the Error-construction
+// site. The operator categorizer does not assign them.
+const (
+	CategoryInternal   = "internal"   // Armada-generated failures
+	CategoryPreemption = "preemption" // runs that Armada preempts
+)
 
 const (
 	SubcategoryJobCreationFailed = "job-creation-failed" // executor failed to build the runnable job from the lease

--- a/internal/lookoutingester/instructions/instructions.go
+++ b/internal/lookoutingester/instructions/instructions.go
@@ -472,8 +472,21 @@ func (c *InstructionConverter) handleJobRunErrors(ts time.Time, event *armadaeve
 			}
 			jobRunUpdate.ExitCode = pointer.Int32(exitCode)
 		case *armadaevents.Error_JobRunPreemptedError:
-			// This case is already handled by the JobRunPreempted event
-			// When we formalise that as a terminal event, we'll remove this JobRunError getting produced
+			// The JobRunPreempted event sets the run state and the error text.
+			// This case persists only the failure classification.
+			category := e.GetFailureCategory()
+			subcategory := e.GetFailureSubcategory()
+			wasClassified := category != "" || subcategory != ""
+			if e.Terminal && wasClassified {
+				classification := &model.UpdateJobRunInstruction{RunId: event.RunId}
+				if category != "" {
+					classification.FailureCategory = pointer.String(category)
+				}
+				if subcategory != "" {
+					classification.FailureSubcategory = pointer.String(subcategory)
+				}
+				update.JobRunsToUpdate = append(update.JobRunsToUpdate, classification)
+			}
 			continue
 		case *armadaevents.Error_PodLeaseReturned:
 			jobRunUpdate.JobRunState = pointer.Int32(lookout.JobRunLeaseReturnedOrdinal)

--- a/internal/lookoutingester/instructions/instructions_test.go
+++ b/internal/lookoutingester/instructions/instructions_test.go
@@ -510,6 +510,38 @@ func TestConvert(t *testing.T) {
 				MessageIds:      []pulsar.MessageID{pulsarutils.NewMessageId(1)},
 			},
 		},
+		"job run preempted error carries failure classification": {
+			events: &utils.EventsWithIds[*armadaevents.EventSequence]{
+				Events: []*armadaevents.EventSequence{testfixtures.NewEventSequence(&armadaevents.EventSequence_Event{
+					Created: testfixtures.BaseTimeProto,
+					Event: &armadaevents.EventSequence_Event_JobRunErrors{
+						JobRunErrors: &armadaevents.JobRunErrors{
+							JobId: testfixtures.JobId,
+							RunId: testfixtures.RunId,
+							Errors: []*armadaevents.Error{
+								{
+									Terminal:           true,
+									FailureCategory:    "preemption",
+									FailureSubcategory: "api",
+									Reason: &armadaevents.Error_JobRunPreemptedError{
+										JobRunPreemptedError: &armadaevents.JobRunPreemptedError{},
+									},
+								},
+							},
+						},
+					},
+				})},
+				MessageIds: []pulsar.MessageID{pulsarutils.NewMessageId(1)},
+			},
+			expected: &model.InstructionSet{
+				JobRunsToUpdate: []*model.UpdateJobRunInstruction{{
+					RunId:              testfixtures.RunId,
+					FailureCategory:    pointer.String("preemption"),
+					FailureSubcategory: pointer.String("api"),
+				}},
+				MessageIds: []pulsar.MessageID{pulsarutils.NewMessageId(1)},
+			},
+		},
 		"job run preempted (fair-share)": {
 			events: &utils.EventsWithIds[*armadaevents.EventSequence]{
 				Events:     []*armadaevents.EventSequence{testfixtures.NewEventSequence(testfixtures.JobRunPreemptedFairShare)},

--- a/internal/scheduler/retry_policy_test.go
+++ b/internal/scheduler/retry_policy_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/armadaproject/armada/internal/scheduler/pricing"
 	"github.com/armadaproject/armada/internal/scheduler/retry"
 	"github.com/armadaproject/armada/internal/scheduler/schedulerobjects"
+	schedulercontext "github.com/armadaproject/armada/internal/scheduler/scheduling/context"
 	"github.com/armadaproject/armada/internal/scheduler/scheduling/runner"
 	"github.com/armadaproject/armada/internal/scheduler/testfixtures"
 	"github.com/armadaproject/armada/pkg/api"
@@ -836,6 +837,7 @@ func TestRetryPolicy_FFOff_ApiPreemptionIdentity(t *testing.T) {
 		job.Id(), job.LatestRun().Id(), "",
 		"Preempted - preemption requested via API",
 		requestor,
+		schedulercontext.PreemptedViaApi,
 		sched.clock.Now(),
 	)
 	assert.Equal(t, expected, events.Events)

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -815,6 +815,7 @@ func AppendEventSequencesFromPreemptedJobs(eventSequences []*armadaevents.EventS
 				preemptingJobId(jctx.GetPreemptingJob()),
 				jctx.PreemptionDescription,
 				requestor,
+				jctx.PreemptionType,
 				time,
 			),
 		})
@@ -901,7 +902,10 @@ func createEventsForLeaseExpiredRetry(job *jobdb.Job, leaseExpiredError *armadae
 	}
 }
 
-func createEventsForPreemptedJob(jobId string, runId string, preemptingJobId string, reason string, requestor string, time time.Time) []*armadaevents.EventSequence_Event {
+func createEventsForPreemptedJob(jobId string, runId string, preemptingJobId string, reason string, requestor string, preemptionType schedulercontext.PreemptionType, time time.Time) []*armadaevents.EventSequence_Event {
+	if preemptionType == "" {
+		preemptionType = schedulercontext.Unknown
+	}
 	return []*armadaevents.EventSequence_Event{
 		{
 			Created: protoutil.ToTimestamp(time),
@@ -923,7 +927,9 @@ func createEventsForPreemptedJob(jobId string, runId string, preemptingJobId str
 					JobId: jobId,
 					Errors: []*armadaevents.Error{
 						{
-							Terminal: true,
+							Terminal:           true,
+							FailureCategory:    errormatch.CategoryPreemption,
+							FailureSubcategory: string(preemptionType),
 							Reason: &armadaevents.Error_JobRunPreemptedError{
 								JobRunPreemptedError: &armadaevents.JobRunPreemptedError{
 									Reason: reason,
@@ -941,7 +947,9 @@ func createEventsForPreemptedJob(jobId string, runId string, preemptingJobId str
 					JobId: jobId,
 					Errors: []*armadaevents.Error{
 						{
-							Terminal: true,
+							Terminal:           true,
+							FailureCategory:    errormatch.CategoryPreemption,
+							FailureSubcategory: string(preemptionType),
 							Reason: &armadaevents.Error_JobRunPreemptedError{
 								JobRunPreemptedError: &armadaevents.JobRunPreemptedError{
 									Reason: reason,
@@ -990,7 +998,7 @@ func AppendEventSequencesFromReconciliationFailureJobs(eventSequences []*armadae
 			Queue:      jobInfo.Job.Queue(),
 			JobSetName: jobInfo.Job.Jobset(),
 			UserId:     requestor,
-			Events:     createEventsForPreemptedJob(jobInfo.Job.Id(), run.Id(), "", jobInfo.Reason, requestor, time),
+			Events:     createEventsForPreemptedJob(jobInfo.Job.Id(), run.Id(), "", jobInfo.Reason, requestor, schedulercontext.PreemptedViaNodeReconciler, time),
 		}
 		eventSequences = append(eventSequences, es)
 	}
@@ -1485,7 +1493,7 @@ func (s *Scheduler) generateUpdateMessagesFromJob(ctx *armadacontext.Context, jo
 				reason = *lastRun.PreemptReason()
 			}
 			requestor := ptr.Deref(lastRun.PreemptUser(), "")
-			events = append(events, createEventsForPreemptedJob(job.Id(), lastRun.Id(), "", reason, requestor, s.clock.Now())...)
+			events = append(events, createEventsForPreemptedJob(job.Id(), lastRun.Id(), "", reason, requestor, schedulercontext.PreemptedViaApi, s.clock.Now())...)
 			s.metrics.ReportJobPreemptedStateTransition(job, schedulercontext.PreemptedViaApi)
 			s.metrics.ReportJobPreemptedWithType(job, schedulercontext.PreemptedViaApi)
 		}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -3589,7 +3589,9 @@ func TestCycleConsistency(t *testing.T) {
 									RunId: testfixtures.UUIDFromInt(1).String(),
 									Errors: []*armadaevents.Error{
 										{
-											Terminal: true,
+											Terminal:           true,
+											FailureCategory:    errormatch.CategoryPreemption,
+											FailureSubcategory: string(schedulercontext.Unknown),
 											Reason: &armadaevents.Error_JobRunPreemptedError{
 												JobRunPreemptedError: &armadaevents.JobRunPreemptedError{},
 											},
@@ -3605,7 +3607,9 @@ func TestCycleConsistency(t *testing.T) {
 									JobId: queuedJobA.JobID,
 									Errors: []*armadaevents.Error{
 										{
-											Terminal: true,
+											Terminal:           true,
+											FailureCategory:    errormatch.CategoryPreemption,
+											FailureSubcategory: string(schedulercontext.Unknown),
 											Reason: &armadaevents.Error_JobRunPreemptedError{
 												JobRunPreemptedError: &armadaevents.JobRunPreemptedError{},
 											},


### PR DESCRIPTION
The scheduler stamps `FailureCategory: "preemption"` on both terminal errors of a preempted run, and the preemption type string as the `FailureSubcategory`: `fairshare`, `urgency`, `optimiser`, `api`, `reconciler`, `unknown`, or `unknown-gang`. One function, `createEventsForPreemptedJob`, builds those errors for all three preemption paths: the scheduling round passes the job context's preemption type, the node reconciler passes `reconciler`, and a preemption request through the API passes `api`. An empty type falls back to `unknown`, the same default the preemption metrics use. The category constant lives in `internal/common/errormatch`, next to the `internal` category, and follows the same rule: the Error-construction site sets it, and the operator categorizer never does.

The Lookout ingester needs its own change, because `handleJobRunErrors` skips run-level preemption errors: the `JobRunPreempted` event owns the run state and the error text. The preempted-error case now appends an update that carries only the failure classification, so the `job_run` row gets the category and subcategory without touching state or error.

The subcategory reuses the scheduler's `PreemptionType` strings, the same values the preemption metrics expose, so one vocabulary covers the metrics and the Lookout rows.

Verification: unit tests cover the scheduler events, the type fallback, and the ingester passthrough. On a local stack with a real executor on a kind cluster, `armadactl preempt job` on a running job produced a Lookout run row with `failure_category=preemption` and `failure_subcategory=api`, run state `RUN_PREEMPTED`, and job state `PREEMPTED`. A second scenario saturated the cluster from one queue with preemptible jobs and submitted a non-preemptible job from another queue. The scheduler evicted a running pod by fair-share preemption, and the evicted run's row read `failure_category=preemption` and `failure_subcategory=fairshare`.
