### PR TITLE
Airflow handle AF 3.x changes (#501)

### DIFF
--- a/third_party/airflow/armada/_compat.py
+++ b/third_party/airflow/armada/_compat.py
@@ -36,12 +36,12 @@ try:
 except ImportError:
     from airflow.exceptions import AirflowFailException  # Airflow 2.x
 
-# Context moved to airflow.sdk.definitions.context in Airflow 3.0. The shim at
+# Context moved to the Task SDK in Airflow 3.0. The shim at
 # airflow.utils.context.Context still resolves on 3.x, but it is exposed via a
 # module-level __getattr__ that returns the *module*, not the class - which
 # breaks Sphinx autodoc rendering. Import the real class directly.
 try:
-    from airflow.sdk.definitions.context import Context  # Airflow >= 3.0
+    from airflow.sdk import Context  # Airflow >= 3.0
 except ImportError:
     from airflow.utils.context import Context  # Airflow 2.x
 

--- a/third_party/airflow/armada/triggers.py
+++ b/third_party/airflow/armada/triggers.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+from http import HTTPStatus
 from typing import Any, AsyncIterator, ClassVar
 
-from airflow.exceptions import AirflowException
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 from airflow.utils.state import TaskInstanceState
 from pendulum import DateTime
@@ -13,11 +13,26 @@ from .hooks import ArmadaHook
 from .utils import log_exceptions, xcom_pull_for_ti
 
 # Terminal task states in which a lingering Armada job must be cancelled on
-# trigger cleanup. Any other state (notably DEFERRED) means the triggerer is
-# handing off the trigger, not that the task finished, so the job is left alone.
+# trigger cleanup. Any other state means the task did not finish: DEFERRED is the
+# triggerer handing off the trigger, and REMOVED is the attempt this trigger
+# belongs to having been superseded (cleared). In both cases the job is left alone.
 CANCEL_JOBS_WHEN_TASK_IN_STATE: frozenset[TaskInstanceState] = frozenset(
     {TaskInstanceState.SUCCESS, TaskInstanceState.FAILED}
 )
+
+
+def _is_task_instance_not_found(error: Exception) -> bool:
+    """
+    True when an Execution API error reports the task instance as not found.
+
+    ``AirflowRuntimeError`` carries the failed call's HTTP status in
+    ``error.error.detail``; a 404 there is the API server saying it cannot
+    resolve the task instance, as opposed to the call itself having gone wrong.
+    """
+    detail = getattr(getattr(error, "error", None), "detail", None)
+    if not isinstance(detail, dict):
+        return False
+    return detail.get("status_code") == HTTPStatus.NOT_FOUND
 
 
 class ArmadaPollJobTrigger(BaseTrigger):
@@ -82,10 +97,11 @@ class ArmadaPollJobTrigger(BaseTrigger):
         """
         Cancel the Armada job only when the task has reached a terminal state.
 
-        A task that is not in a terminal state on trigger exit (most importantly
-        DEFERRED) means the triggerer is restarting / handing off the trigger,
-        not that the task has finished — cancelling in that case would kill a
-        perfectly healthy job. Morally equivalent to
+        A task that is not in a terminal state on trigger exit means the task did
+        not finish: DEFERRED is the triggerer restarting / handing off the trigger,
+        and REMOVED is this attempt having been cleared. Cancelling in either case
+        would kill a job that is either perfectly healthy or already owned by the
+        replacement attempt. Morally equivalent to
         KubernetesPodTrigger.safe_to_cancel().
         """
         try:
@@ -101,28 +117,62 @@ class ArmadaPollJobTrigger(BaseTrigger):
         return state in CANCEL_JOBS_WHEN_TASK_IN_STATE
 
     async def _get_task_state(self) -> Any:
+        """
+        State of the task instance this trigger was created for.
+
+        Reports REMOVED when the task instance can no longer be resolved.
+        Clearing a task supersedes the attempt the trigger belongs to: the
+        Execution API then either answers the state lookup with 404 (the task
+        instance record is gone) or reports no state for it (its state is reset
+        to NULL, or it is absent from the response). That is the normal
+        consequence of clearing rather than a failed lookup, and REMOVED is not
+        a terminal state, so cleanup logs one line and leaves the job alone.
+        """
         if not AIRFLOW_V_3_0_PLUS:
             return await sync_to_async(self.task_instance.current_state)()
 
+        from airflow.sdk.exceptions import AirflowRuntimeError
         from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
 
         ti = self.task_instance
         map_index = getattr(ti, "map_index", -1)
-        response = await sync_to_async(RuntimeTaskInstance.get_task_states)(
-            dag_id=ti.dag_id,
-            task_ids=[ti.task_id],
-            run_ids=[ti.run_id],
-            map_index=map_index,
+        ti_description = (
+            f"dag_id={ti.dag_id}, task_id={ti.task_id}, "
+            f"run_id={ti.run_id}, map_index={map_index}"
         )
+        try:
+            response = await sync_to_async(RuntimeTaskInstance.get_task_states)(
+                dag_id=ti.dag_id,
+                task_ids=[ti.task_id],
+                run_ids=[ti.run_id],
+                map_index=map_index,
+            )
+        except AirflowRuntimeError as e:
+            if not _is_task_instance_not_found(e):
+                raise
+            return self._removed_task_instance(
+                ti_description, "the Execution API answered the state lookup with 404"
+            )
+
         # The /states endpoint suffixes the response key with
         # ``_{map_index}`` for mapped TIs and uses the bare task_id
         # otherwise.
         ti_key = f"{ti.task_id}_{map_index}" if map_index >= 0 else ti.task_id
-        try:
-            return response[ti.run_id][ti_key]
-        except KeyError:
-            raise AirflowException(
-                "TaskInstance not found for "
-                f"dag_id={ti.dag_id}, task_id={ti.task_id}, "
-                f"run_id={ti.run_id}, map_index={map_index}"
+        state = response.get(ti.run_id, {}).get(ti_key)
+        if state is None:
+            return self._removed_task_instance(
+                ti_description, "the Execution API reports no state for it"
             )
+        return state
+
+    def _removed_task_instance(
+        self, ti_description: str, reason: str
+    ) -> TaskInstanceState:
+        self.log.info(
+            "TaskInstance (%s) can no longer be resolved: %s. It was most likely "
+            "cleared while the trigger was running; treating it as %s.",
+            ti_description,
+            reason,
+            TaskInstanceState.REMOVED,
+        )
+        return TaskInstanceState.REMOVED

--- a/third_party/airflow/pyproject.toml
+++ b/third_party/airflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "armada_airflow"
-version = "1.1.2"
+version = "1.1.3"
 description = "Armada Airflow Operator"
 readme='README.md'
 authors = [{name = "Armada-GROSS", email = "armada@armadaproject.io"}]

--- a/third_party/airflow/test/unit/test_triggers.py
+++ b/third_party/airflow/test/unit/test_triggers.py
@@ -3,11 +3,33 @@ from unittest.mock import MagicMock, patch
 import grpc
 import pytest
 from airflow.utils.state import TaskInstanceState
-from armada._compat import deserialize, serialize
+from armada._compat import AIRFLOW_V_3_0_PLUS, deserialize, serialize
 from armada.model import GrpcChannelArgs, RunningJobContext
 from armada.triggers import CANCEL_JOBS_WHEN_TASK_IN_STATE, ArmadaPollJobTrigger
 from armada_client.typings import JobState
 from pendulum import DateTime
+
+GET_TASK_STATES = (
+    "airflow.sdk.execution_time.task_runner.RuntimeTaskInstance.get_task_states"
+)
+
+airflow_3_only = pytest.mark.skipif(
+    not AIRFLOW_V_3_0_PLUS,
+    reason="The Execution API state lookup only exists on Airflow 3",
+)
+
+
+def _api_server_error(status_code: int) -> Exception:
+    """Build the error the Execution API raises when a call fails."""
+    from airflow.sdk.exceptions import AirflowRuntimeError, ErrorType
+    from airflow.sdk.execution_time.comms import ErrorResponse
+
+    return AirflowRuntimeError(
+        ErrorResponse(
+            error=ErrorType.API_SERVER_ERROR,
+            detail={"status_code": status_code, "message": "Not Found"},
+        )
+    )
 
 
 def test_trigger_serialize_roundtrip_preserves_moment():
@@ -101,6 +123,84 @@ async def test_do_not_cancels_running_job_when_trigger_is_suspended():
         await trigger.cleanup()
 
     hook.cancel_job.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_do_not_cancels_running_job_when_task_instance_was_removed():
+    # Clearing a task supersedes the attempt this trigger belongs to. REMOVED says
+    # nothing about the job having finished, and the replacement attempt owns the
+    # xcom job context by then, so cleanup must leave the job running.
+    trigger = _make_trigger_with_task_state(TaskInstanceState.REMOVED)
+    hook = MagicMock()
+
+    with (
+        patch.object(
+            ArmadaPollJobTrigger,
+            "_get_task_state",
+            return_value=TaskInstanceState.REMOVED,
+        ),
+        patch.object(
+            ArmadaPollJobTrigger,
+            "hook",
+            new_callable=lambda: property(lambda self: hook),
+        ),
+    ):
+        await trigger.cleanup()
+
+    hook.cancel_job.assert_not_called()
+
+
+@pytest.mark.asyncio
+@airflow_3_only
+async def test_task_state_lookup_reports_removed_when_lookup_returns_404():
+    trigger = _make_trigger_with_task_state(TaskInstanceState.DEFERRED)
+
+    with patch(GET_TASK_STATES, side_effect=_api_server_error(404)):
+        assert await trigger._get_task_state() == TaskInstanceState.REMOVED
+
+
+@pytest.mark.asyncio
+@airflow_3_only
+@pytest.mark.parametrize(
+    "response",
+    [
+        pytest.param({"run": {}}, id="task_instance_absent_from_response"),
+        pytest.param({}, id="dag_run_absent_from_response"),
+        # Clearing a deferred task resets its state to NULL, which the Execution
+        # API reports as a null state for the task instance.
+        pytest.param({"run": {"task": None}}, id="state_reset_to_null_by_clear"),
+    ],
+)
+async def test_task_state_lookup_reports_removed_when_state_is_unresolvable(response):
+    trigger = _make_trigger_with_task_state(TaskInstanceState.DEFERRED)
+
+    with patch(GET_TASK_STATES, return_value=response):
+        assert await trigger._get_task_state() == TaskInstanceState.REMOVED
+
+
+@pytest.mark.asyncio
+@airflow_3_only
+async def test_task_state_lookup_re_raises_non_404_api_errors():
+    trigger = _make_trigger_with_task_state(TaskInstanceState.DEFERRED)
+    api_error = _api_server_error(500)
+
+    with patch(GET_TASK_STATES, side_effect=api_error):
+        with pytest.raises(type(api_error)):
+            await trigger._get_task_state()
+
+
+@pytest.mark.asyncio
+@airflow_3_only
+@pytest.mark.parametrize("map_index, ti_key", [(-1, "task"), (3, "task_3")])
+async def test_task_state_lookup_reads_state_from_response(map_index, ti_key):
+    trigger = _make_trigger_with_task_state(TaskInstanceState.RUNNING)
+    trigger.task_instance.map_index = map_index
+
+    with patch(
+        GET_TASK_STATES,
+        return_value={"run": {ti_key: TaskInstanceState.RUNNING}},
+    ):
+        assert await trigger._get_task_state() == TaskInstanceState.RUNNING
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- Use public API for backcompat code
- Handle case where API server response throws error, when deferred task state is cleared during runtime