### PR TITLE
Lookout hot/cold split: add (queue, job_id) index

### DIFF
--- a/internal/lookouthc/schema/doc.go
+++ b/internal/lookouthc/schema/doc.go
@@ -2,8 +2,9 @@
 // hot-cold phase of Lookout. The partitioner converts the unpartitioned
 // job table (produced by the lookout migration chain) into a LIST-partitioned
 // shape with job_active and job_terminated partitions, in a single
-// PostgreSQL transaction. On an already-partitioned database it is a no-op.
-// On an unexpected shape it refuses.
+// PostgreSQL transaction. On an already-partitioned database it backfills
+// any indexes added to the partitioned shape since that database was first
+// partitioned, then returns. On an unexpected shape it refuses.
 //
 // Callers should apply the lookout migration chain first, then call
 // ApplyPartitioner.

--- a/internal/lookouthc/schema/doc.go
+++ b/internal/lookouthc/schema/doc.go
@@ -6,7 +6,17 @@
 // On an unexpected shape it refuses.
 //
 // Callers should apply the lookout migration chain first, then call
-// ApplyPartitioner. The package is scaffolding for the experimental phase
+// ApplyPartitioner.
+//
+// The partitioned shape carries one index that the unpartitioned chain does
+// not need: idx_job_queue_job_id, on (queue, job_id). The unpartitioned job
+// table gets an ordered job_id scan for free from its PRIMARY KEY, but
+// partitioning forces the primary key to (job_id, state), which cannot
+// provide a single ordered scan across partitions. Lookout's default job
+// view filters by queue and sorts by job_id, so this index keeps that query
+// an index scan instead of a full scan of the table.
+//
+// The package is scaffolding for the experimental phase
 // and is deleted at graduation (when the partitioner SQL is lifted into a
 // real lookout-chain migration).
 package schema

--- a/internal/lookouthc/schema/schema.go
+++ b/internal/lookouthc/schema/schema.go
@@ -251,6 +251,7 @@ func findShapeMismatch(ctx *armadacontext.Context, q pgx.Tx) (string, error) {
 
 	expectedParentIndexes := []string{
 		"idx_job_queue_last_transition_time_seconds",
+		"idx_job_queue_job_id",
 		"idx_job_queue_jobset_state",
 		"idx_job_state",
 		"idx_job_submitted",
@@ -367,6 +368,7 @@ func convertUnpartitionedToPartitioned(ctx *armadacontext.Context, tx pgx.Tx) er
 		`ALTER TABLE job_new_terminated RENAME TO job_terminated`,
 		`ALTER INDEX job_new_pkey RENAME TO job_pkey`,
 		`ALTER INDEX idx_job_new_queue_last_transition_time_seconds RENAME TO idx_job_queue_last_transition_time_seconds`,
+		`ALTER INDEX idx_job_new_queue_job_id RENAME TO idx_job_queue_job_id`,
 		`ALTER INDEX idx_job_new_queue_jobset_state RENAME TO idx_job_queue_jobset_state`,
 		`ALTER INDEX idx_job_new_state RENAME TO idx_job_state`,
 		`ALTER INDEX idx_job_new_submitted RENAME TO idx_job_submitted`,

--- a/internal/lookouthc/schema/schema.go
+++ b/internal/lookouthc/schema/schema.go
@@ -53,6 +53,9 @@ func ApplyPartitioner(ctx *armadacontext.Context, db TxBeginner) error {
 
 		switch state {
 		case jobStateAlreadyPartitioned:
+			if err := backfillQueueJobIDIndex(ctx, tx); err != nil {
+				return errors.Wrap(err, "backfill idx_job_queue_job_id")
+			}
 			return nil
 		case jobStateUnpartitioned:
 			if err := convertUnpartitionedToPartitioned(ctx, tx); err != nil {
@@ -251,7 +254,6 @@ func findShapeMismatch(ctx *armadacontext.Context, q pgx.Tx) (string, error) {
 
 	expectedParentIndexes := []string{
 		"idx_job_queue_last_transition_time_seconds",
-		"idx_job_queue_job_id",
 		"idx_job_queue_jobset_state",
 		"idx_job_state",
 		"idx_job_submitted",
@@ -307,6 +309,18 @@ func extractInts(s string) ([]int, error) {
 		result = append(result, n)
 	}
 	return result, nil
+}
+
+// backfillQueueJobIDIndex creates idx_job_queue_job_id on an already
+// partitioned job table if it is missing. This index was added after the
+// partitioner had already shipped, so a database partitioned by an earlier
+// version of this package would otherwise be rejected as the wrong shape on
+// every subsequent run. It is intentionally excluded from
+// expectedParentIndexes for that reason.
+func backfillQueueJobIDIndex(ctx *armadacontext.Context, tx pgx.Tx) error {
+	_, err := tx.Exec(ctx,
+		`CREATE INDEX IF NOT EXISTS idx_job_queue_job_id ON job (queue, job_id) WITH (fillfactor = 80)`)
+	return err
 }
 
 // convertUnpartitionedToPartitioned is the conversion branch: it creates

--- a/internal/lookouthc/schema/schema_test.go
+++ b/internal/lookouthc/schema/schema_test.go
@@ -94,6 +94,31 @@ func TestApplyPartitioner_AlreadyPartitionedIsNoOp(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestApplyPartitioner_BackfillsMissingQueueJobIDIndex verifies that a job
+// table partitioned before idx_job_queue_job_id existed is not rejected as
+// the wrong shape, and instead gets the index backfilled in place.
+func TestApplyPartitioner_BackfillsMissingQueueJobIDIndex(t *testing.T) {
+	err := withLookoutChainAppliedDb(func(db *pgxpool.Pool) error {
+		ctx := armadacontext.Background()
+
+		require.NoError(t, ApplyPartitioner(ctx, db))
+
+		_, err := db.Exec(ctx, `DROP INDEX idx_job_queue_job_id`)
+		require.NoError(t, err)
+
+		require.NoError(t, ApplyPartitioner(ctx, db))
+
+		var exists bool
+		require.NoError(t, db.QueryRow(ctx,
+			`SELECT EXISTS (SELECT 1 FROM pg_indexes WHERE tablename = 'job' AND indexname = 'idx_job_queue_job_id')`,
+		).Scan(&exists))
+		assert.True(t, exists, "idx_job_queue_job_id should be backfilled")
+
+		return nil
+	})
+	require.NoError(t, err)
+}
+
 func TestApplyPartitioner_WrongShapeRefuses(t *testing.T) {
 	err := withLookoutChainAppliedDb(func(db *pgxpool.Pool) error {
 		ctx := armadacontext.Background()

--- a/internal/lookouthc/schema/target_schema.sql
+++ b/internal/lookouthc/schema/target_schema.sql
@@ -17,6 +17,15 @@
 -- The PRIMARY KEY is (job_id, state) because PostgreSQL requires the
 -- partition key in any unique constraint. job_id alone is still globally
 -- unique (ULIDs) -- the state addition is a technical requirement only.
+--
+-- Because the primary key is partitioned, it cannot serve as a globally
+-- ordered access path on job_id: Postgres cannot produce a single ordered
+-- scan across partitions from a partitioned index alone. Lookout's default
+-- job view filters by queue and sorts by job_id descending, so without
+-- idx_{{TABLE}}_queue_job_id below, that query falls back to scanning each
+-- partition in job_id order and filtering out non-matching queues row by
+-- row -- for a large table this means scanning millions of rows to return
+-- a single page of results.
 
 CREATE TABLE {{TABLE}} (
     job_id                       varchar(32)   NOT NULL,
@@ -58,6 +67,9 @@ ALTER TABLE {{TABLE}}_terminated ALTER COLUMN job_spec SET STORAGE EXTERNAL;
 
 CREATE INDEX idx_{{TABLE}}_queue_last_transition_time_seconds
     ON {{TABLE}} (queue, last_transition_time_seconds)
+    WITH (fillfactor = 80);
+CREATE INDEX idx_{{TABLE}}_queue_job_id
+    ON {{TABLE}} (queue, job_id)
     WITH (fillfactor = 80);
 CREATE INDEX idx_{{TABLE}}_queue_jobset_state
     ON {{TABLE}} (queue, jobset, state)


### PR DESCRIPTION
This new index fixes slow queue-filtered job queries observed in production.

The unpartitioned `job` table gets an ordered scan on `job_id` for free given that is its primary key. Lookout's UI sorts by `job_id` descending by default (and so puts the most recently-submitted jobs at the top). However, partitioning it forces the primary key to become `(job_id, state)`, which cannot produce an ordered scan across partitions on `job_id` alone.

This new index prevents scans of each partition in its entireity when filtering by `queue` and ordering by `job_id`.