### PR TITLE
Lookout UI - allow resetting column configuration

### DIFF
--- a/internal/lookoutui/src/analytics/types.ts
+++ b/internal/lookoutui/src/analytics/types.ts
@@ -11,6 +11,7 @@ export const ANALYTICS_EVENTS = {
   LIGHT_MODE_SELECTED: "Light Mode Selected",
   DARK_MODE_SELECTED: "Dark Mode Selected",
   COLUMN_CONFIGURATION_DIALOG_CLOSED: "Column Configuration Dialog Closed",
+  COLUMN_CONFIGURATION_RESET: "Column Configuration Reset",
   CUSTOM_VIEW_CREATED: "Custom View Created",
   CUSTOM_VIEW_LOADED: "Custom View Loaded",
   CUSTOM_VIEW_DELETED: "Custom View Deleted",

--- a/internal/lookoutui/src/components/hooks/useCustomSnackbar.tsx
+++ b/internal/lookoutui/src/components/hooks/useCustomSnackbar.tsx
@@ -1,8 +1,10 @@
 import { Close } from "@mui/icons-material"
-import { IconButton } from "@mui/material"
+import { Button, IconButton } from "@mui/material"
 import { OptionsObject, useSnackbar, VariantType } from "notistack"
 
 export type OpenSnackbarFn = (message: string, variant: VariantType, options?: OptionsObject) => void
+
+export type OpenUndoableSnackbarFn = (message: string, onUndo: () => void, options?: OptionsObject) => void
 
 export const useCustomSnackbar = (): OpenSnackbarFn => {
   const { enqueueSnackbar, closeSnackbar } = useSnackbar()
@@ -14,6 +16,32 @@ export const useCustomSnackbar = (): OpenSnackbarFn => {
         <IconButton style={{ flex: "0" }} onClick={() => closeSnackbar(snackbarKey)}>
           <Close style={{ color: "white" }} />
         </IconButton>
+      ),
+    })
+  }
+}
+
+export const useUndoableSnackbar = (): OpenUndoableSnackbarFn => {
+  const { enqueueSnackbar, closeSnackbar } = useSnackbar()
+  return (message: string, onUndo: () => void, options?: OptionsObject) => {
+    enqueueSnackbar(message, {
+      variant: "info",
+      ...options,
+      action: (snackbarKey) => (
+        <>
+          <Button
+            style={{ color: "white" }}
+            onClick={() => {
+              onUndo()
+              closeSnackbar(snackbarKey)
+            }}
+          >
+            Undo
+          </Button>
+          <IconButton style={{ flex: "0" }} onClick={() => closeSnackbar(snackbarKey)}>
+            <Close style={{ color: "white" }} />
+          </IconButton>
+        </>
       ),
     })
   }

--- a/internal/lookoutui/src/pages/jobs/components/ColumnConfigurationDialog/index.tsx
+++ b/internal/lookoutui/src/pages/jobs/components/ColumnConfigurationDialog/index.tsx
@@ -3,11 +3,13 @@ import { PointerEvent, useCallback, useMemo, useRef, useState } from "react"
 import { DndContext, DragEndEvent, KeyboardSensor, PointerSensor, useSensor, useSensors } from "@dnd-kit/core"
 import { restrictToWindowEdges, restrictToVerticalAxis } from "@dnd-kit/modifiers"
 import { arrayMove, SortableContext } from "@dnd-kit/sortable"
-import { ArrowDownward, Close } from "@mui/icons-material"
+import { ArrowDownward, Close, RestartAlt } from "@mui/icons-material"
 import {
   Alert,
+  Button,
   Chip,
   Dialog,
+  DialogActions,
   DialogContent,
   DialogContentText,
   DialogTitle,
@@ -40,7 +42,7 @@ const ScrollToAddAnnotationColumnChip = styled(Chip)({
 
   position: "absolute",
   left: "50%",
-  bottom: 10,
+  bottom: 62,
   transform: "translate(-50%, 0)",
 })
 
@@ -85,6 +87,7 @@ export interface ColumnConfigurationDialogProps {
   columnOrderIds: ColumnId[]
   setColumnOrder: (columnOrder: ColumnId[]) => void
   toggleColumnVisibility: (columnId: ColumnId) => void
+  onResetColumnConfiguration: () => void
   onAddAnnotationColumn: (annotationKey: string) => void
   onRemoveAnnotationColumn: (colId: ColumnId) => void
   onEditAnnotationColumn: (colId: ColumnId, annotationKey: string) => void
@@ -101,6 +104,7 @@ export const ColumnConfigurationDialog = ({
   columnOrderIds,
   setColumnOrder,
   toggleColumnVisibility,
+  onResetColumnConfiguration,
   onAddAnnotationColumn,
   onRemoveAnnotationColumn,
   onEditAnnotationColumn,
@@ -172,6 +176,13 @@ export const ColumnConfigurationDialog = ({
       }
     }
   }, [])
+
+  const handleReset = useCallback(() => {
+    trackAnalyticsEvent(ANALYTICS_EVENTS.COLUMN_CONFIGURATION_RESET, {
+      visibleColumnIds: visibleColumnIds.join(","),
+    })
+    onResetColumnConfiguration()
+  }, [onResetColumnConfiguration, visibleColumnIds])
 
   const handleClose = useCallback(() => {
     trackAnalyticsEvent(ANALYTICS_EVENTS.COLUMN_CONFIGURATION_DIALOG_CLOSED, {
@@ -263,6 +274,11 @@ export const ColumnConfigurationDialog = ({
           </Stack>
         </ErrorBoundary>
       </DialogContent>
+      <DialogActions>
+        <Button onClick={handleReset} color="secondary" startIcon={<RestartAlt />}>
+          Reset to defaults
+        </Button>
+      </DialogActions>
     </Dialog>
   )
 }

--- a/internal/lookoutui/src/pages/jobs/components/JobsTableActionBar.tsx
+++ b/internal/lookoutui/src/pages/jobs/components/JobsTableActionBar.tsx
@@ -36,6 +36,7 @@ export interface JobsTableActionBarProps {
   onRemoveAnnotationColumn: (colId: ColumnId) => void
   onEditAnnotationColumn: (colId: ColumnId, annotationKey: string) => void
   toggleColumnVisibility: (columnId: ColumnId) => void
+  onResetColumnConfiguration: () => void
   onGroupsChanged: (newGroups: ColumnId[]) => void
   onClearFilters: () => void
   onClearSorting: () => void
@@ -69,6 +70,7 @@ export const JobsTableActionBar = memo(
     onRemoveAnnotationColumn,
     onEditAnnotationColumn,
     toggleColumnVisibility,
+    onResetColumnConfiguration,
     onGroupsChanged,
     onClearFilters,
     onClearSorting,
@@ -112,6 +114,7 @@ export const JobsTableActionBar = memo(
           columnOrderIds={columnOrder}
           setColumnOrder={setColumnOrder}
           toggleColumnVisibility={toggleColumnVisibility}
+          onResetColumnConfiguration={onResetColumnConfiguration}
           onAddAnnotationColumn={onAddAnnotationColumn}
           onEditAnnotationColumn={onEditAnnotationColumn}
           onRemoveAnnotationColumn={onRemoveAnnotationColumn}

--- a/internal/lookoutui/src/pages/jobs/components/JobsTableContainer.tsx
+++ b/internal/lookoutui/src/pages/jobs/components/JobsTableContainer.tsx
@@ -40,6 +40,8 @@ import {
   COLUMN_PARSE_TYPES,
   ColumnId,
   createAnnotationColumn,
+  DEFAULT_COLUMN_ORDER,
+  DEFAULT_COLUMN_VISIBILITY,
   getAnnotationKeyCols,
   INPUT_PARSERS,
   GET_JOB_COLUMNS,
@@ -68,7 +70,7 @@ import {
   useFormatIsoTimestampWithUserSettings,
   useDisplayedTimeZoneWithUserSettings,
 } from "../../../components/hooks/formatTimeWithUserSettings"
-import { useCustomSnackbar } from "../../../components/hooks/useCustomSnackbar"
+import { useCustomSnackbar, useUndoableSnackbar } from "../../../components/hooks/useCustomSnackbar"
 import { columnIsAggregatable, useFetchJobsTableData } from "../../../components/hooks/useJobsTableData"
 import { CommandSpec } from "../../../config"
 import { isJobGroupRow, JobRow, JobTableRow } from "../../../models/jobsTableModels"
@@ -118,6 +120,7 @@ function fromLookoutOrder(lookoutOrder: LookoutColumnOrder): SortingState {
 
 export const JobsTableContainer = ({ debug, autoRefreshMs, commandSpecs }: JobsTableContainerProps) => {
   const openSnackbar = useCustomSnackbar()
+  const openUndoableSnackbar = useUndoableSnackbar()
   const groupJobs = useGroupJobs()
 
   const router = useStableRouter()
@@ -436,6 +439,43 @@ export const JobsTableContainer = ({ debug, autoRefreshMs, commandSpecs }: JobsT
       setRowsToFetch(pendingDataForAllVisibleData(expanded, data, pageSize, pageIndex * pageSize))
     }
   }
+
+  const resetColumnConfiguration = useCallback(() => {
+    const annotationColumnIds = getAnnotationKeyCols(allColumns).map((key) => toAnnotationColId(key))
+    const mustRemainVisible = [
+      ...grouping,
+      ...(grouping.length > 0 ? [StandardColumnId.Count] : []),
+      ...columnFilterState.map(({ id }) => toColId(id)),
+      toColId(lookoutOrder.id),
+    ]
+    setColumnOrder([...DEFAULT_COLUMN_ORDER, ...annotationColumnIds])
+    setColumnVisibility({
+      ...DEFAULT_COLUMN_VISIBILITY,
+      ...Object.fromEntries(annotationColumnIds.map((colId) => [colId, false])),
+      ...Object.fromEntries(mustRemainVisible.map((colId) => [colId, true])),
+    })
+    setColumnSizing({})
+    jobsTablePreferencesService.clearLegacyColumnSizingFromLocalStorage()
+
+    const previousColumnOrder = columnOrder
+    const previousColumnVisibility = columnVisibility
+    const previousColumnSizing = columnSizing
+    openUndoableSnackbar("Column configuration reset to defaults.", () => {
+      setColumnOrder(previousColumnOrder)
+      setColumnVisibility(previousColumnVisibility)
+      setColumnSizing(previousColumnSizing)
+    })
+  }, [
+    allColumns,
+    grouping,
+    columnFilterState,
+    lookoutOrder,
+    columnOrder,
+    columnVisibility,
+    columnSizing,
+    jobsTablePreferencesService,
+    openUndoableSnackbar,
+  ])
 
   const colIsVisible = (column: ColumnId): boolean => {
     return column in columnVisibility && columnVisibility[column]
@@ -849,6 +889,7 @@ export const JobsTableContainer = ({ debug, autoRefreshMs, commandSpecs }: JobsT
               onEditAnnotationColumn={editAnnotationCol}
               onGroupsChanged={onGroupingChange}
               toggleColumnVisibility={onColumnVisibilityChange}
+              onResetColumnConfiguration={resetColumnConfiguration}
               onClearFilters={clearFilters}
               onClearSorting={clearSorting}
               customSortingApplied={customSortingApplied}

--- a/internal/lookoutui/src/pages/jobs/components/JobsTableContainer.tsx
+++ b/internal/lookoutui/src/pages/jobs/components/JobsTableContainer.tsx
@@ -448,14 +448,25 @@ export const JobsTableContainer = ({ debug, autoRefreshMs, commandSpecs }: JobsT
       ...columnFilterState.map(({ id }) => toColId(id)),
       toColId(lookoutOrder.id),
     ]
-    setColumnOrder([...DEFAULT_COLUMN_ORDER, ...annotationColumnIds])
-    setColumnVisibility({
+    const newColumnVisibility = {
       ...DEFAULT_COLUMN_VISIBILITY,
       ...Object.fromEntries(annotationColumnIds.map((colId) => [colId, false])),
       ...Object.fromEntries(mustRemainVisible.map((colId) => [colId, true])),
-    })
+    }
+    const revealsNewAggregateColumn =
+      grouping.length > 0 &&
+      Object.entries(newColumnVisibility).some(([rawColId, isVisible]) => {
+        const colId = toColId(rawColId)
+        return isVisible && columnIsAggregatable(colId) && !visibleColumnIds.includes(colId)
+      })
+
+    setColumnOrder([...DEFAULT_COLUMN_ORDER, ...annotationColumnIds])
+    setColumnVisibility(newColumnVisibility)
     setColumnSizing({})
     jobsTablePreferencesService.clearLegacyColumnSizingFromLocalStorage()
+    if (revealsNewAggregateColumn) {
+      setRowsToFetch(pendingDataForAllVisibleData(expanded, data, pageSize, pageIndex * pageSize))
+    }
 
     const previousColumnOrder = columnOrder
     const previousColumnVisibility = columnVisibility
@@ -473,7 +484,13 @@ export const JobsTableContainer = ({ debug, autoRefreshMs, commandSpecs }: JobsT
     columnOrder,
     columnVisibility,
     columnSizing,
+    visibleColumnIds,
+    expanded,
+    data,
+    pageSize,
+    pageIndex,
     jobsTablePreferencesService,
+    setRowsToFetch,
     openUndoableSnackbar,
   ])
 

--- a/internal/lookoutui/src/services/lookout/JobsTablePreferencesService.ts
+++ b/internal/lookoutui/src/services/lookout/JobsTablePreferencesService.ts
@@ -459,6 +459,10 @@ export class JobsTablePreferencesService {
     return obj
   }
 
+  clearLegacyColumnSizingFromLocalStorage() {
+    localStorage.removeItem(COLUMN_SIZING_KEY)
+  }
+
   private getColumnSizingFromLocalStorage(): Record<string, number> | undefined {
     const json = localStorage.getItem(COLUMN_SIZING_KEY)
     if (stringIsInvalid(json)) {


### PR DESCRIPTION
In the column configuration dialog, add a button, "Reset to defaults", which resets the order, visibility and width of columns in the jobs table.

<img width="649" height="209" alt="image" src="https://github.com/user-attachments/assets/9096e74a-3016-4a64-b94f-329a17033807" />
