### PR TITLE
Lookout UI: clear dependent job filters when prerequisites are removed

### DIFF
--- a/internal/lookoutui/src/common/jobsTableColumns.tsx
+++ b/internal/lookoutui/src/common/jobsTableColumns.tsx
@@ -98,34 +98,26 @@ export const isStandardColId = (columnId: string): columnId is StandardColumnId 
 export const getColumnMetadata = (column: JobTableColumn) => (column.meta ?? {}) as JobTableColumnMetadata
 
 // Some standard columns may only be filtered on if there are active filters on other columns.
-// PREREQUISITE_FILTER_COLUMNS defines these relationships.
-export const PREREQUISITE_FILTER_COLUMNS: Record<StandardColumnId, StandardColumnId[]> = {
+// PREREQUISITE_FILTER_COLUMNS defines these relationships. Columns absent from this record have no
+// prerequisites.
+export const PREREQUISITE_FILTER_COLUMNS: Partial<Record<StandardColumnId, StandardColumnId[]>> = {
   [StandardColumnId.JobSet]: [StandardColumnId.Queue],
-  [StandardColumnId.JobID]: [],
-  [StandardColumnId.Queue]: [],
-  [StandardColumnId.State]: [],
-  [StandardColumnId.Priority]: [],
-  [StandardColumnId.Owner]: [],
   [StandardColumnId.Namespace]: [StandardColumnId.Queue],
-  [StandardColumnId.CPU]: [],
-  [StandardColumnId.Memory]: [],
-  [StandardColumnId.EphemeralStorage]: [],
-  [StandardColumnId.GPU]: [],
-  [StandardColumnId.PriorityClass]: [],
-  [StandardColumnId.TimeSubmittedUtc]: [],
-  [StandardColumnId.TimeSubmittedAgo]: [],
-  [StandardColumnId.LastTransitionTimeUtc]: [],
-  [StandardColumnId.TimeInState]: [],
-  [StandardColumnId.SelectorCol]: [],
-  [StandardColumnId.Count]: [],
-  [StandardColumnId.Node]: [],
-  [StandardColumnId.Cluster]: [],
-  [StandardColumnId.Pool]: [],
-  [StandardColumnId.ExitCode]: [],
-  [StandardColumnId.RuntimeSeconds]: [],
-  [StandardColumnId.FailureCategory]: [],
-  [StandardColumnId.FailureSubcategory]: [],
 }
+
+// Some standard columns may only be grouped by if other columns are also grouped by. This is kept
+// separate from PREREQUISITE_FILTER_COLUMNS so that the filtering and grouping relationships may
+// diverge.
+export const PREREQUISITE_GROUPING_COLUMNS: Partial<Record<StandardColumnId, StandardColumnId[]>> = {
+  [StandardColumnId.JobSet]: [StandardColumnId.Queue],
+  [StandardColumnId.Namespace]: [StandardColumnId.Queue],
+}
+
+export const prerequisiteFilterColumns = (columnId: string): StandardColumnId[] =>
+  (isStandardColId(columnId) ? PREREQUISITE_FILTER_COLUMNS[columnId] : undefined) ?? []
+
+export const prerequisiteGroupingColumns = (columnId: string): StandardColumnId[] =>
+  (isStandardColId(columnId) ? PREREQUISITE_GROUPING_COLUMNS[columnId] : undefined) ?? []
 
 export const STANDARD_COLUMN_DISPLAY_NAMES: Record<StandardColumnId, string> = {
   [StandardColumnId.JobID]: "Job ID",

--- a/internal/lookoutui/src/common/jobsTableFormatters.ts
+++ b/internal/lookoutui/src/common/jobsTableFormatters.ts
@@ -4,3 +4,8 @@ export const formatJobState = (state?: JobState): string => (state ? (jobStateDi
 
 export const formatJobRunState = (state?: JobRunState): string =>
   state !== undefined ? (jobRunStateDisplayInfo[state]?.displayName ?? state) : ""
+
+export const formatColumnList = (displayNames: string[]): string =>
+  displayNames.length < 2
+    ? (displayNames[0] ?? "")
+    : `${displayNames.slice(0, -1).join(", ")} and ${displayNames[displayNames.length - 1]}`

--- a/internal/lookoutui/src/common/jobsTableUtils.test.ts
+++ b/internal/lookoutui/src/common/jobsTableUtils.test.ts
@@ -2,7 +2,12 @@ import { JobFilter, JobFiltersWithExcludes, JobState, Match } from "../models/lo
 
 import { StandardColumnId, toAnnotationColId } from "./jobsTableColumns"
 import { LookoutColumnFilter } from "./jobsTableUtils"
-import { diffOfKeys, getFiltersForRowsSelection, pruneUnsatisfiedFilters } from "./jobsTableUtils"
+import {
+  changedFilterColumnIds,
+  diffOfKeys,
+  getFiltersForRowsSelection,
+  pruneUnsatisfiedFilters,
+} from "./jobsTableUtils"
 import { RowId } from "./reactTableUtils"
 
 describe("JobsTableUtils", () => {
@@ -65,6 +70,31 @@ describe("JobsTableUtils", () => {
 
       expect(pruned).toEqual(filters)
       expect(removedColumnIds).toEqual([])
+    })
+  })
+
+  describe("changedFilterColumnIds", () => {
+    it("returns nothing when the filter states match", () => {
+      const filters = [{ id: StandardColumnId.Queue, value: ["queue-1"] }]
+
+      expect(changedFilterColumnIds(filters, filters)).toEqual([])
+    })
+
+    it("detects added, removed and modified filters, ignoring unchanged ones", () => {
+      const before = [
+        { id: StandardColumnId.Queue, value: ["queue-1"] },
+        { id: StandardColumnId.Owner, value: "owner-1" },
+        { id: StandardColumnId.JobSet, value: "job-set-1" },
+      ]
+      const after = [
+        { id: StandardColumnId.Queue, value: ["queue-2"] },
+        { id: StandardColumnId.Owner, value: "owner-1" },
+        { id: StandardColumnId.State, value: ["QUEUED"] },
+      ]
+
+      expect(changedFilterColumnIds(before, after).sort()).toEqual(
+        [StandardColumnId.Queue, StandardColumnId.JobSet, StandardColumnId.State].sort(),
+      )
     })
   })
 

--- a/internal/lookoutui/src/common/jobsTableUtils.test.ts
+++ b/internal/lookoutui/src/common/jobsTableUtils.test.ts
@@ -2,10 +2,72 @@ import { JobFilter, JobFiltersWithExcludes, JobState, Match } from "../models/lo
 
 import { StandardColumnId, toAnnotationColId } from "./jobsTableColumns"
 import { LookoutColumnFilter } from "./jobsTableUtils"
-import { diffOfKeys, getFiltersForRowsSelection } from "./jobsTableUtils"
+import { diffOfKeys, getFiltersForRowsSelection, pruneUnsatisfiedFilters } from "./jobsTableUtils"
 import { RowId } from "./reactTableUtils"
 
 describe("JobsTableUtils", () => {
+  describe("pruneUnsatisfiedFilters", () => {
+    it("keeps filters which have no prerequisites", () => {
+      const filters = [{ id: StandardColumnId.Queue, value: ["queue-1"] }]
+
+      const { filters: pruned, removedColumnIds } = pruneUnsatisfiedFilters(filters)
+
+      expect(pruned).toEqual(filters)
+      expect(removedColumnIds).toEqual([])
+    })
+
+    it("keeps a dependent filter when its prerequisite is filtered on", () => {
+      const filters = [
+        { id: StandardColumnId.Queue, value: ["queue-1"] },
+        { id: StandardColumnId.JobSet, value: "job-set-1" },
+      ]
+
+      const { filters: pruned, removedColumnIds } = pruneUnsatisfiedFilters(filters)
+
+      expect(pruned).toEqual(filters)
+      expect(removedColumnIds).toEqual([])
+    })
+
+    it("removes a dependent filter when its prerequisite is absent", () => {
+      const { filters: pruned, removedColumnIds } = pruneUnsatisfiedFilters([
+        { id: StandardColumnId.JobSet, value: "job-set-1" },
+      ])
+
+      expect(pruned).toEqual([])
+      expect(removedColumnIds).toEqual([StandardColumnId.JobSet])
+    })
+
+    it("removes a dependent filter when its prerequisite is present but empty", () => {
+      const { filters: pruned, removedColumnIds } = pruneUnsatisfiedFilters([
+        { id: StandardColumnId.Queue, value: [] },
+        { id: StandardColumnId.JobSet, value: "job-set-1" },
+      ])
+
+      expect(pruned).toEqual([{ id: StandardColumnId.Queue, value: [] }])
+      expect(removedColumnIds).toEqual([StandardColumnId.JobSet])
+    })
+
+    it("removes every dependent filter sharing an absent prerequisite", () => {
+      const { filters: pruned, removedColumnIds } = pruneUnsatisfiedFilters([
+        { id: StandardColumnId.JobSet, value: "job-set-1" },
+        { id: StandardColumnId.Namespace, value: "namespace-1" },
+        { id: StandardColumnId.Owner, value: "owner-1" },
+      ])
+
+      expect(pruned).toEqual([{ id: StandardColumnId.Owner, value: "owner-1" }])
+      expect(removedColumnIds).toEqual([StandardColumnId.JobSet, StandardColumnId.Namespace])
+    })
+
+    it("keeps annotation filters, which have no prerequisites", () => {
+      const filters = [{ id: toAnnotationColId("hyperparameter"), value: "some-value" }]
+
+      const { filters: pruned, removedColumnIds } = pruneUnsatisfiedFilters(filters)
+
+      expect(pruned).toEqual(filters)
+      expect(removedColumnIds).toEqual([])
+    })
+  })
+
   describe("diffOfKeys", () => {
     it("detects added keys", () => {
       const newObject = {

--- a/internal/lookoutui/src/common/jobsTableUtils.ts
+++ b/internal/lookoutui/src/common/jobsTableUtils.ts
@@ -60,6 +60,22 @@ export const pruneUnsatisfiedFilters = <T extends { id: string; value: unknown }
   }
 }
 
+// The IDs of the columns whose filter differs between two filter states.
+export const changedFilterColumnIds = (
+  before: { id: string; value: unknown }[],
+  after: { id: string; value: unknown }[],
+): string[] =>
+  _.union(
+    before.map(({ id }) => id),
+    after.map(({ id }) => id),
+  ).filter(
+    (columnId) =>
+      !_.isEqual(
+        before.find(({ id }) => id === columnId),
+        after.find(({ id }) => id === columnId),
+      ),
+  )
+
 export const pendingDataForAllVisibleData = (
   expanded: ExpandedStateList,
   data: JobTableRow[],

--- a/internal/lookoutui/src/common/jobsTableUtils.ts
+++ b/internal/lookoutui/src/common/jobsTableUtils.ts
@@ -12,6 +12,7 @@ import {
   DEFAULT_COLUMN_MATCHES,
   fromAnnotationColId,
   isStandardColId,
+  prerequisiteFilterColumns,
   StandardColumnId,
   TIME_RANGE_FILTER_COLUMNS,
   VALID_COLUMN_MATCHES,
@@ -28,6 +29,35 @@ export interface PendingData {
   skip: number
   take?: number
   append?: boolean
+}
+
+export const isEmptyFilterValue = (value: unknown): boolean =>
+  value === undefined || value === null || value === "" || (Array.isArray(value) && value.length === 0)
+
+// Whether a column may be filtered on, i.e. every one of its prerequisite columns is itself
+// filtered on by a non-empty filter.
+export const canFilterOnColumn = (columnId: string, filters: { id: string; value: unknown }[]): boolean =>
+  prerequisiteFilterColumns(columnId).every((prerequisiteId) =>
+    filters.some(({ id, value }) => id === prerequisiteId && !isEmptyFilterValue(value)),
+  )
+
+// A filter on a column is only meaningful if every one of that column's prerequisite columns is
+// itself filtered on. Filters which do not meet this condition are removed, along with any filters
+// which in turn depend on them.
+export const pruneUnsatisfiedFilters = <T extends { id: string; value: unknown }>(
+  filters: T[],
+): { filters: T[]; removedColumnIds: string[] } => {
+  const removedColumnIds: string[] = []
+  let remaining = filters
+
+  for (;;) {
+    const kept = remaining.filter((filter) => canFilterOnColumn(filter.id, remaining))
+    if (kept.length === remaining.length) {
+      return { filters: remaining, removedColumnIds }
+    }
+    removedColumnIds.push(...remaining.filter((filter) => !kept.includes(filter)).map(({ id }) => id))
+    remaining = kept
+  }
 }
 
 export const pendingDataForAllVisibleData = (

--- a/internal/lookoutui/src/components/ActionableValueOnHover.tsx
+++ b/internal/lookoutui/src/components/ActionableValueOnHover.tsx
@@ -65,6 +65,7 @@ export const ActionableValueOnHover = ({
           <StyledIconButton
             size="small"
             hidden={!hovering}
+            aria-label="Filter by this value"
             onClick={(e) => {
               if (stopPropagationOnActionClick) {
                 e.stopPropagation()

--- a/internal/lookoutui/src/components/hooks/useCustomSnackbar.tsx
+++ b/internal/lookoutui/src/components/hooks/useCustomSnackbar.tsx
@@ -1,10 +1,12 @@
 import { Close } from "@mui/icons-material"
 import { Button, IconButton } from "@mui/material"
-import { OptionsObject, useSnackbar, VariantType } from "notistack"
+import { OptionsObject, SnackbarKey, useSnackbar, VariantType } from "notistack"
 
 export type OpenSnackbarFn = (message: string, variant: VariantType, options?: OptionsObject) => void
 
-export type OpenUndoableSnackbarFn = (message: string, onUndo: () => void, options?: OptionsObject) => void
+export type OpenUndoableSnackbarFn = (message: string, onUndo: () => void, options?: OptionsObject) => SnackbarKey
+
+export type CloseSnackbarFn = (key: SnackbarKey) => void
 
 export const useCustomSnackbar = (): OpenSnackbarFn => {
   const { enqueueSnackbar, closeSnackbar } = useSnackbar()
@@ -23,7 +25,7 @@ export const useCustomSnackbar = (): OpenSnackbarFn => {
 
 export const useUndoableSnackbar = (): OpenUndoableSnackbarFn => {
   const { enqueueSnackbar, closeSnackbar } = useSnackbar()
-  return (message: string, onUndo: () => void, options?: OptionsObject) => {
+  return (message: string, onUndo: () => void, options?: OptionsObject) =>
     enqueueSnackbar(message, {
       variant: "info",
       ...options,
@@ -44,5 +46,6 @@ export const useUndoableSnackbar = (): OpenUndoableSnackbarFn => {
         </>
       ),
     })
-  }
 }
+
+export const useCloseSnackbar = (): CloseSnackbarFn => useSnackbar().closeSnackbar

--- a/internal/lookoutui/src/pages/jobs/components/GroupBySelect.tsx
+++ b/internal/lookoutui/src/pages/jobs/components/GroupBySelect.tsx
@@ -14,12 +14,12 @@ import {
 import {
   ColumnId,
   getColumnMetadata,
-  isStandardColId,
   JobTableColumn,
-  PREREQUISITE_FILTER_COLUMNS,
+  prerequisiteGroupingColumns,
   STANDARD_COLUMN_DISPLAY_NAMES,
   toColId,
 } from "../../../common/jobsTableColumns"
+import { formatColumnList } from "../../../common/jobsTableFormatters"
 
 const DIVIDER_WIDTH = 10
 
@@ -81,9 +81,9 @@ function GroupColumnSelect({ columns, groups, currentlySelected, onSelect, onDel
       >
         {columns.map((col) => {
           const colId = toColId(col.id)
-          const ungroupedPreRequisiteColumns = (
-            isStandardColId(colId) ? PREREQUISITE_FILTER_COLUMNS[colId] : []
-          ).filter((preReqCol) => !groups.includes(preReqCol))
+          const ungroupedPreRequisiteColumns = prerequisiteGroupingColumns(colId).filter(
+            (preReqCol) => !groups.includes(preReqCol),
+          )
 
           return (
             <MenuItem
@@ -97,7 +97,9 @@ function GroupColumnSelect({ columns, groups, currentlySelected, onSelect, onDel
                 <>
                   {" "}
                   (requires grouping by{" "}
-                  {ungroupedPreRequisiteColumns.map((preReqCol) => STANDARD_COLUMN_DISPLAY_NAMES[preReqCol]).join(", ")}
+                  {formatColumnList(
+                    ungroupedPreRequisiteColumns.map((preReqCol) => STANDARD_COLUMN_DISPLAY_NAMES[preReqCol]),
+                  )}
                   )
                 </>
               )}
@@ -154,10 +156,8 @@ export default function GroupBySelect({ groups, columns, onGroupsChanged }: Grou
                   onGroupsChanged(
                     groups
                       .filter((_, idx) => idx !== i)
-                      .filter(
-                        (colId) =>
-                          !isStandardColId(colId) ||
-                          PREREQUISITE_FILTER_COLUMNS[colId].every((preReqCol) => alreadyListed.includes(preReqCol)),
+                      .filter((colId) =>
+                        prerequisiteGroupingColumns(colId).every((preReqCol) => alreadyListed.includes(preReqCol)),
                       ),
                   )
                 }}

--- a/internal/lookoutui/src/pages/jobs/components/JobsTableActionBar.tsx
+++ b/internal/lookoutui/src/pages/jobs/components/JobsTableActionBar.tsx
@@ -3,7 +3,8 @@ import { memo, useCallback, useMemo, useState } from "react"
 import { Clear, FilterAltOff, ViewColumn } from "@mui/icons-material"
 import { Divider, Button, Checkbox, FormControlLabel, FormGroup, Tooltip } from "@mui/material"
 
-import { ColumnId, JobTableColumn, PINNED_COLUMNS, toColId } from "../../../common/jobsTableColumns"
+import { ColumnId, getColumnMetadata, JobTableColumn, PINNED_COLUMNS, toColId } from "../../../common/jobsTableColumns"
+import { formatColumnList } from "../../../common/jobsTableFormatters"
 import AutoRefreshToggle from "../../../components/AutoRefreshToggle"
 import RefreshButton from "../../../components/RefreshButton"
 import { JobFiltersWithExcludes } from "../../../models/lookoutModels"
@@ -95,6 +96,21 @@ export const JobsTableActionBar = memo(
       }).length
     }, [allColumns, visibleColumns])
 
+    // Filters on hidden columns have no visible input, so they are called out here to keep them
+    // discoverable
+    const activeFilterSummary = useMemo(() => {
+      if (filterColumns.length === 0) {
+        return ""
+      }
+      const visibleColumnsSet = new Set(visibleColumns)
+      const names = filterColumns.map((colId) => {
+        const column = allColumns.find((col) => toColId(col.id) === colId)
+        const displayName = (column ? getColumnMetadata(column).displayName : undefined) ?? colId
+        return visibleColumnsSet.has(colId) ? displayName : `${displayName} (hidden column)`
+      })
+      return `Filtering by ${formatColumnList(names)}`
+    }, [filterColumns, visibleColumns, allColumns])
+
     const numSelectedItems = selectedItemFilters.length
 
     const columnConfigurationDialogOpenOnClose = useCallback(() => setColumnConfigurationDialogOpen(false), [])
@@ -155,18 +171,20 @@ export const JobsTableActionBar = memo(
           </div>
           <Divider orientation="vertical" />
           <div>
-            <Button
-              variant="outlined"
-              onClick={() => {
-                onClearFilters()
-                onClearSorting()
-              }}
-              color="primary"
-              endIcon={<FilterAltOff />}
-              disabled={filterColumns.length === 0 && !customSortingApplied}
-            >
-              Clear Filters and Sorting
-            </Button>
+            <Tooltip title={activeFilterSummary}>
+              <Button
+                variant="outlined"
+                onClick={() => {
+                  onClearFilters()
+                  onClearSorting()
+                }}
+                color="primary"
+                endIcon={<FilterAltOff />}
+                disabled={filterColumns.length === 0 && !customSortingApplied}
+              >
+                Clear Filters{filterColumns.length > 0 && ` (${filterColumns.length})`} and Sorting
+              </Button>
+            </Tooltip>
           </div>
           <div>
             <Button

--- a/internal/lookoutui/src/pages/jobs/components/JobsTableCell.tsx
+++ b/internal/lookoutui/src/pages/jobs/components/JobsTableCell.tsx
@@ -12,10 +12,11 @@ import {
   StandardColumnId,
   toColId,
   isStandardColId,
-  PREREQUISITE_FILTER_COLUMNS,
+  prerequisiteFilterColumns,
   STANDARD_COLUMN_DISPLAY_NAMES,
 } from "../../../common/jobsTableColumns"
-import { matchForColumn } from "../../../common/jobsTableUtils"
+import { formatColumnList } from "../../../common/jobsTableFormatters"
+import { canFilterOnColumn, matchForColumn } from "../../../common/jobsTableUtils"
 import { ActionableValueOnHover } from "../../../components/ActionableValueOnHover"
 import { CopyIconButton } from "../../../components/CopyIconButton"
 import { JobsTableFilter } from "../../../components/JobsTableFilter"
@@ -128,13 +129,8 @@ export function HeaderCell({
     )
   }
 
-  const prerequisiteFilterColumns = isStandardColId(id) ? PREREQUISITE_FILTER_COLUMNS[id as StandardColumnId] : []
-  const prerequisiteFilterColumnsSatisfied = prerequisiteFilterColumns.every((pid) =>
-    header
-      .getContext()
-      .table.getState()
-      .columnFilters.some((f) => f.id === pid),
-  )
+  const prerequisiteColumns = prerequisiteFilterColumns(id)
+  const prerequisiteFilterColumnsSatisfied = canFilterOnColumn(id, header.getContext().table.getState().columnFilters)
 
   return (
     <HeaderTableCell
@@ -250,10 +246,7 @@ export function HeaderCell({
             ) : (
               <Typography component="div" variant="body2" color="textSecondary">
                 To filter by {metadata.displayName}, add a filter for{" "}
-                {prerequisiteFilterColumns
-                  .map((pid) => STANDARD_COLUMN_DISPLAY_NAMES[pid])
-                  .join(", ")
-                  .replace(/, ([^,]*)$/, " and $1")}
+                {formatColumnList(prerequisiteColumns.map((pid) => STANDARD_COLUMN_DISPLAY_NAMES[pid]))}
               </Typography>
             ))}
 
@@ -395,7 +388,10 @@ export const BodyCell = ({
         filterAction={
           rowIsGroup ||
           !value ||
-          (columnMetadata.filterType !== FilterType.Enum && columnMetadata.filterType !== FilterType.Text)
+          (columnMetadata.filterType !== FilterType.Enum && columnMetadata.filterType !== FilterType.Text) ||
+          // Filtering on this column requires a filter on another column which is not yet applied,
+          // so the filter would be discarded as soon as it was set
+          !canFilterOnColumn(cell.column.id, cell.getContext().table.getState().columnFilters)
             ? undefined
             : {
                 onFilter: () => {

--- a/internal/lookoutui/src/pages/jobs/components/JobsTableContainer.test.tsx
+++ b/internal/lookoutui/src/pages/jobs/components/JobsTableContainer.test.tsx
@@ -380,6 +380,84 @@ describe("JobsTableContainer", () => {
       await assertNumDataRowsShown(30)
     })
 
+    it("should clear a dependent filter when its prerequisite filter is cleared", async () => {
+      const jobs = [
+        ...makeTestJobs(5, "queue-1", "job-set-1", JobState.Queued),
+        ...makeTestJobs(10, "queue-2", "job-set-1", JobState.Pending),
+        ...makeTestJobs(15, "queue-1", "job-set-2", JobState.Running),
+      ]
+
+      mockServer.setGetQueuesResponse(["queue-1", "queue-2"])
+      mockServer.setPostJobsResponse(jobs)
+
+      const { baseElement, router } = renderComponent()
+      await waitForFinishedLoading()
+
+      await filterAutocompleteTextColumnTo("Queue", "queue-1", baseElement)
+      await assertNumDataRowsShown(20)
+
+      await filterTextColumnTo("Job Set", "job-set-2")
+      await assertNumDataRowsShown(15)
+
+      // Clearing the Queue filter removes the Job Set filter's input, so the Job Set filter must be
+      // dropped rather than remain applied with no way to remove it
+      await filterAutocompleteTextColumnTo("Queue", "", baseElement)
+
+      await assertNumDataRowsShown(30)
+      await waitFor(() => {
+        expect(router.state.location.search).not.toContain("jobSet")
+      })
+    })
+
+    it("should not offer the cell filter action when prerequisite filters are not applied", async () => {
+      const jobs = makeTestJobs(5, "queue-1", "job-set-1", JobState.Queued)
+
+      mockServer.setGetQueuesResponse(["queue-1"])
+      mockServer.setPostJobsResponse(jobs)
+
+      const { baseElement } = renderComponent()
+      await clearAllGroupings()
+      await waitForFinishedLoading()
+
+      // Filtering by Job Set requires a Queue filter, so the cell's filter action would be
+      // discarded as soon as it was applied. The button is queried by label rather than by role,
+      // since it carries the HTML hidden attribute until the cell is hovered.
+      const jobSetCell = await findCellByText("job-set-1")
+      expect(within(jobSetCell).queryByLabelText("Filter by this value")).toBeNull()
+
+      // Once a Queue filter is applied, the Job Set cell's filter action becomes available
+      await filterAutocompleteTextColumnTo("Queue", "queue-1", baseElement)
+      await waitForFinishedLoading()
+
+      const jobSetCellAfter = await findCellByText("job-set-1")
+      await within(jobSetCellAfter).findByLabelText("Filter by this value")
+    })
+
+    it("should restore a cascade-cleared filter when the change is undone", async () => {
+      const jobs = [
+        ...makeTestJobs(5, "queue-1", "job-set-1", JobState.Queued),
+        ...makeTestJobs(10, "queue-2", "job-set-1", JobState.Pending),
+        ...makeTestJobs(15, "queue-1", "job-set-2", JobState.Running),
+      ]
+
+      mockServer.setGetQueuesResponse(["queue-1", "queue-2"])
+      mockServer.setPostJobsResponse(jobs)
+
+      const { baseElement } = renderComponent()
+      await waitForFinishedLoading()
+
+      await filterAutocompleteTextColumnTo("Queue", "queue-1", baseElement)
+      await filterTextColumnTo("Job Set", "job-set-2")
+      await assertNumDataRowsShown(15)
+
+      await filterAutocompleteTextColumnTo("Queue", "", baseElement)
+      await assertNumDataRowsShown(30)
+
+      await userEvent.click(await screen.findByRole("button", { name: "Undo" }))
+
+      await assertNumDataRowsShown(15)
+    })
+
     it("should allow enum filtering", async () => {
       const jobs = [
         ...makeTestJobs(5, "queue-1", "job-set-1", JobState.Queued),
@@ -655,14 +733,38 @@ describe("JobsTableContainer", () => {
       mockServer.setPostJobsResponse(jobs)
 
       renderComponent(
+        // The Job Set filter requires a Queue filter, so both are included here
         // eslint-disable-next-line @cspell/spellchecker
-        `?page=0&g[0]=jobSet&sort[id]=jobId&sort[desc]=true&pS=50&f[0][id]=jobSet&f[0][value]=job-set-1&f[0][match]=startsWith&e[0]=jobSet%3Ajob-set-1`,
+        `?page=0&g[0]=jobSet&sort[id]=jobId&sort[desc]=true&pS=50&f[0][id]=queue&f[0][value]=queue-1&f[0][match]=anyOf&f[1][id]=jobSet&f[1][value]=job-set-1&f[1][match]=startsWith&e[0]=jobSet%3Ajob-set-1`,
       )
 
       await waitForFinishedLoading()
 
       // 1 job set + jobs for expanded job set
       await assertNumDataRowsShown(1 + 5)
+    })
+
+    it("should drop filters from query params whose prerequisite filters are absent", async () => {
+      const jobs = [
+        ...makeTestJobs(5, "queue-1", "job-set-1", JobState.Queued),
+        ...makeTestJobs(10, "queue-2", "job-set-2", JobState.Pending),
+      ]
+
+      mockServer.setPostJobsResponse(jobs)
+
+      // A Job Set filter with no Queue filter is unreachable through the UI, so it must not be
+      // applied, and must not appear in the query params
+      const { router } = renderComponent(
+        `?page=0&sort[id]=jobId&sort[desc]=true&pS=50&f[0][id]=jobSet&f[0][value]=job-set-1&f[0][match]=startsWith`,
+      )
+
+      await waitForFinishedLoading()
+
+      // All jobs are shown, rather than only those in job-set-1
+      await assertNumDataRowsShown(15)
+      await waitFor(() => {
+        expect(router.state.location.search).not.toContain("jobSet")
+      })
     })
 
     it("should populate page index from query params", async () => {
@@ -732,6 +834,15 @@ describe("JobsTableContainer", () => {
 
   async function getHeaderCell(columnDisplayName: string) {
     return await screen.findByRole("columnheader", { name: columnDisplayName })
+  }
+
+  async function findCellByText(text: string) {
+    const cells = await screen.findAllByRole("cell")
+    const matchingCell = cells.find((cell) => cell.textContent === text)
+    if (!matchingCell) {
+      throw new Error(`no cell found with text content "${text}"`)
+    }
+    return matchingCell
   }
 
   async function filterTextColumnTo(columnDisplayName: string, filterText: string) {

--- a/internal/lookoutui/src/pages/jobs/components/JobsTableContainer.test.tsx
+++ b/internal/lookoutui/src/pages/jobs/components/JobsTableContainer.test.tsx
@@ -458,6 +458,39 @@ describe("JobsTableContainer", () => {
       await assertNumDataRowsShown(15)
     })
 
+    it("should keep filter changes made after a cascade when the change is undone", async () => {
+      const jobs = [
+        ...makeTestJobs(5, "queue-1", "job-set-1", JobState.Queued),
+        ...makeTestJobs(10, "queue-2", "job-set-1", JobState.Pending),
+        ...makeTestJobs(15, "queue-1", "job-set-2", JobState.Running),
+        ...makeTestJobs(7, "queue-1", "job-set-2", JobState.Queued),
+      ]
+
+      mockServer.setGetQueuesResponse(["queue-1", "queue-2"])
+      mockServer.setPostJobsResponse(jobs)
+
+      const { baseElement } = renderComponent()
+      await waitForFinishedLoading()
+
+      await filterAutocompleteTextColumnTo("Queue", "queue-1", baseElement)
+      await filterTextColumnTo("Job Set", "job-set-2")
+      await assertNumDataRowsShown(22)
+
+      // Clearing the Queue filter cascades, clearing the Job Set filter and offering an undo
+      await filterAutocompleteTextColumnTo("Queue", "", baseElement)
+      await assertNumDataRowsShown(37)
+
+      // A filter added while the undo action is still available must survive the undo
+      await toggleEnumFilterOptions("State", ["Running"])
+      await assertNumDataRowsShown(15)
+
+      await userEvent.click(await screen.findByRole("button", { name: "Undo" }))
+
+      // The restored Queue and Job Set filters apply together with the newer State filter. Were the
+      // State filter discarded, all 22 jobs in queue-1 and job-set-2 would be shown instead.
+      await assertNumDataRowsShown(15)
+    })
+
     it("should allow enum filtering", async () => {
       const jobs = [
         ...makeTestJobs(5, "queue-1", "job-set-1", JobState.Queued),

--- a/internal/lookoutui/src/pages/jobs/components/JobsTableContainer.test.tsx
+++ b/internal/lookoutui/src/pages/jobs/components/JobsTableContainer.test.tsx
@@ -491,6 +491,37 @@ describe("JobsTableContainer", () => {
       await assertNumDataRowsShown(15)
     })
 
+    it("should withdraw the undo action once one of the filters it would restore is edited", async () => {
+      const jobs = [
+        ...makeTestJobs(5, "queue-1", "job-set-1", JobState.Queued),
+        ...makeTestJobs(10, "queue-2", "job-set-1", JobState.Pending),
+        ...makeTestJobs(15, "queue-1", "job-set-2", JobState.Running),
+      ]
+
+      mockServer.setGetQueuesResponse(["queue-1", "queue-2"])
+      mockServer.setPostJobsResponse(jobs)
+
+      const { baseElement } = renderComponent()
+      await waitForFinishedLoading()
+
+      await filterAutocompleteTextColumnTo("Queue", "queue-1", baseElement)
+      await filterTextColumnTo("Job Set", "job-set-2")
+      await assertNumDataRowsShown(15)
+
+      // Clearing the Queue filter cascades, clearing the Job Set filter and offering an undo
+      await filterAutocompleteTextColumnTo("Queue", "", baseElement)
+      await assertNumDataRowsShown(30)
+      await screen.findByRole("button", { name: "Undo" })
+
+      // Setting a Queue filter again would be overwritten by the undo, so the offer is withdrawn
+      await filterAutocompleteTextColumnTo("Queue", "queue-2", baseElement)
+      await assertNumDataRowsShown(10)
+
+      await waitFor(() => {
+        expect(screen.queryByRole("button", { name: "Undo" })).toBeNull()
+      })
+    })
+
     it("should allow enum filtering", async () => {
       const jobs = [
         ...makeTestJobs(5, "queue-1", "job-set-1", JobState.Queued),

--- a/internal/lookoutui/src/pages/jobs/components/JobsTableContainer.tsx
+++ b/internal/lookoutui/src/pages/jobs/components/JobsTableContainer.tsx
@@ -43,6 +43,7 @@ import {
   DEFAULT_COLUMN_ORDER,
   DEFAULT_COLUMN_VISIBILITY,
   getAnnotationKeyCols,
+  getColumnMetadata,
   INPUT_PARSERS,
   GET_JOB_COLUMNS,
   JobTableColumn,
@@ -53,12 +54,14 @@ import {
   JobColumnsOptions,
   LookoutColumnOrder,
 } from "../../../common/jobsTableColumns"
+import { formatColumnList } from "../../../common/jobsTableFormatters"
 import {
   LookoutColumnFilter,
   diffOfKeys,
   getFiltersForRowsSelection,
   PendingData,
   pendingDataForAllVisibleData,
+  pruneUnsatisfiedFilters,
   updaterToValue,
 } from "../../../common/jobsTableUtils"
 import { fromRowId, RowId } from "../../../common/reactTableUtils"
@@ -189,7 +192,11 @@ export const JobsTableContainer = ({ debug, autoRefreshMs, commandSpecs }: JobsT
   }
 
   // Filtering
-  const [columnFilterState, setColumnFilterState] = useState<ColumnFiltersState>(initialPrefs.filters)
+  const [columnFilterState, setColumnFilterState] = useState<ColumnFiltersState>(
+    // Filters may arrive from the query string with their prerequisites missing, e.g. from a stale
+    // or hand-edited link
+    pruneUnsatisfiedFilters(initialPrefs.filters).filters,
+  )
   const [lookoutFilters, setLookoutFilters] = useState<LookoutColumnFilter[]>([]) // Parsed later
   const [columnMatches, setColumnMatches] = useState<Record<string, Match>>(initialPrefs.columnMatches)
   const [parseErrors, setParseErrors] = useState<Record<string, string | undefined>>({})
@@ -301,8 +308,9 @@ export const JobsTableContainer = ({ debug, autoRefreshMs, commandSpecs }: JobsT
     setLookoutOrder(prefs.order)
     setSorting(fromLookoutOrder(prefs.order))
     setColumnSizing(prefs.columnSizing ?? {})
-    setColumnFilterState(prefs.filters)
-    setLookoutFilters(parseLookoutFilters(prefs.filters))
+    const { filters: prunedFilters } = pruneUnsatisfiedFilters(prefs.filters)
+    setColumnFilterState(prunedFilters)
+    setLookoutFilters(parseLookoutFilters(prunedFilters))
     setColumnMatches(prefs.columnMatches)
     const cols = GET_JOB_COLUMNS(jobColumnsOptions).concat(...prefs.annotationColumnKeys.map(createAnnotationColumn))
     setAllColumns(cols)
@@ -322,7 +330,7 @@ export const JobsTableContainer = ({ debug, autoRefreshMs, commandSpecs }: JobsT
     }
 
     // Have to manually set text fields to the filter values since they are uncontrolled
-    setTextFields(prefs.filters)
+    setTextFields(prunedFilters)
 
     // Load data
     setRowsToFetch(pendingDataForAllVisibleData(prefs.expandedState, data, prefs.pageSize))
@@ -431,11 +439,17 @@ export const JobsTableContainer = ({ debug, autoRefreshMs, commandSpecs }: JobsT
     if (columnIsAggregatable(colIdToToggle) && grouping.length > 0 && !visibleColumnIds.includes(colIdToToggle)) {
       shouldRefresh = true
     }
+    const isBeingHidden = Boolean(columnVisibility[colIdToToggle])
     setColumnVisibility({
       ...columnVisibility,
       [colIdToToggle]: !columnVisibility[colIdToToggle],
     })
-    if (shouldRefresh) {
+
+    // Hiding a column also removes its filter input, so clear any filter on it to avoid leaving a
+    // filter applied with no means of removing it. This refetches the data itself.
+    if (isBeingHidden && columnFilterState.some(({ id }) => id === colIdToToggle)) {
+      onFilterChange(columnFilterState.filter(({ id }) => id !== colIdToToggle))
+    } else if (shouldRefresh) {
       setRowsToFetch(pendingDataForAllVisibleData(expanded, data, pageSize, pageIndex * pageSize))
     }
   }
@@ -680,19 +694,48 @@ export const JobsTableContainer = ({ debug, autoRefreshMs, commandSpecs }: JobsT
     })
   }
 
+  const applyFilterState = (newFilterState: ColumnFiltersState, syncTextFields = false) => {
+    setToFirstPage()
+    setLookoutFilters(parseLookoutFilters(newFilterState))
+    setColumnFilterState(newFilterState)
+    if (syncTextFields) {
+      // The text field inputs are uncontrolled, so they only need updating when the filter state
+      // changes other than by the user typing into them
+      setTextFields(newFilterState)
+    }
+    setSelectedRows({})
+    setSidebarJobId(undefined)
+    setRowsToFetch(pendingDataForAllVisibleData(expanded, data, pageSize))
+  }
+
   const onFilterChange = (updater: Updater<ColumnFiltersState>) => {
-    const newFilterState = updaterToValue(updater, columnFilterState)
+    const requestedFilterState = updaterToValue(updater, columnFilterState)
+
+    // Removing a filter can leave filters on dependent columns applied but unreachable, since their
+    // inputs are replaced by a message prompting for the prerequisite filter. Such filters are
+    // dropped so that no filter can be in effect without a control to remove it.
+    const { filters: newFilterState, removedColumnIds } = pruneUnsatisfiedFilters(requestedFilterState)
 
     if (_.isEqual(newFilterState, columnFilterState)) {
       return
     }
 
-    setToFirstPage()
-    setLookoutFilters(parseLookoutFilters(newFilterState))
-    setColumnFilterState(newFilterState)
-    setSelectedRows({})
-    setSidebarJobId(undefined)
-    setRowsToFetch(pendingDataForAllVisibleData(expanded, data, pageSize))
+    const previousFilterState = columnFilterState
+    // Any pruned filter may have had a text input, which must be cleared along with it
+    applyFilterState(newFilterState, removedColumnIds.length > 0)
+
+    if (removedColumnIds.length > 0) {
+      const removedNames = removedColumnIds.map((colId) => {
+        const column = allColumns.find(({ id }) => id === colId)
+        return (column ? getColumnMetadata(column).displayName : undefined) ?? colId
+      })
+      openUndoableSnackbar(
+        `${formatColumnList(removedNames)} ${removedNames.length === 1 ? "filter" : "filters"} cleared, as ${
+          removedNames.length === 1 ? "it requires" : "they require"
+        } a filter on another column.`,
+        () => applyFilterState(previousFilterState, true),
+      )
+    }
   }
 
   const onColumnMatchChange = (columnId: string, newMatch: Match) => {

--- a/internal/lookoutui/src/pages/jobs/components/JobsTableContainer.tsx
+++ b/internal/lookoutui/src/pages/jobs/components/JobsTableContainer.tsx
@@ -57,6 +57,7 @@ import {
 import { formatColumnList } from "../../../common/jobsTableFormatters"
 import {
   LookoutColumnFilter,
+  changedFilterColumnIds,
   diffOfKeys,
   getFiltersForRowsSelection,
   PendingData,
@@ -197,6 +198,10 @@ export const JobsTableContainer = ({ debug, autoRefreshMs, commandSpecs }: JobsT
     // or hand-edited link
     pruneUnsatisfiedFilters(initialPrefs.filters).filters,
   )
+  // Tracks the current filter state for callbacks which may outlive the render they were created in,
+  // such as the undo action of a snackbar
+  const columnFilterStateRef = useRef(columnFilterState)
+  columnFilterStateRef.current = columnFilterState
   const [lookoutFilters, setLookoutFilters] = useState<LookoutColumnFilter[]>([]) // Parsed later
   const [columnMatches, setColumnMatches] = useState<Record<string, Match>>(initialPrefs.columnMatches)
   const [parseErrors, setParseErrors] = useState<Record<string, string | undefined>>({})
@@ -708,23 +713,34 @@ export const JobsTableContainer = ({ debug, autoRefreshMs, commandSpecs }: JobsT
     setRowsToFetch(pendingDataForAllVisibleData(expanded, data, pageSize))
   }
 
-  const onFilterChange = (updater: Updater<ColumnFiltersState>) => {
-    const requestedFilterState = updaterToValue(updater, columnFilterState)
+  const onFilterChange = (updater: Updater<ColumnFiltersState>, syncTextFields = false) => {
+    const requestedFilterState = updaterToValue(updater, columnFilterStateRef.current)
 
     // Removing a filter can leave filters on dependent columns applied but unreachable, since their
     // inputs are replaced by a message prompting for the prerequisite filter. Such filters are
     // dropped so that no filter can be in effect without a control to remove it.
     const { filters: newFilterState, removedColumnIds } = pruneUnsatisfiedFilters(requestedFilterState)
 
-    if (_.isEqual(newFilterState, columnFilterState)) {
+    if (_.isEqual(newFilterState, columnFilterStateRef.current)) {
       return
     }
 
-    const previousFilterState = columnFilterState
     // Any pruned filter may have had a text input, which must be cleared along with it
-    applyFilterState(newFilterState, removedColumnIds.length > 0)
+    applyFilterState(newFilterState, syncTextFields || removedColumnIds.length > 0)
 
     if (removedColumnIds.length > 0) {
+      const previousFilterState = columnFilterStateRef.current
+      // Undoing must restore the filters which were pruned, but a pruned filter cannot stand on its
+      // own: it was pruned precisely because the edit left its prerequisite unsatisfied. So the
+      // columns the edit itself changed are restored too, and only those. Filters on any other
+      // column are left as they are, so that changes made while the undo action was available are
+      // not discarded.
+      const restoredColumnIds = _.union(
+        changedFilterColumnIds(previousFilterState, requestedFilterState),
+        removedColumnIds,
+      )
+      const restoredFilters = previousFilterState.filter(({ id }) => restoredColumnIds.includes(id))
+
       const removedNames = removedColumnIds.map((colId) => {
         const column = allColumns.find(({ id }) => id === colId)
         return (column ? getColumnMetadata(column).displayName : undefined) ?? colId
@@ -733,7 +749,11 @@ export const JobsTableContainer = ({ debug, autoRefreshMs, commandSpecs }: JobsT
         `${formatColumnList(removedNames)} ${removedNames.length === 1 ? "filter" : "filters"} cleared, as ${
           removedNames.length === 1 ? "it requires" : "they require"
         } a filter on another column.`,
-        () => applyFilterState(previousFilterState, true),
+        () =>
+          onFilterChange(
+            (current) => [...current.filter(({ id }) => !restoredColumnIds.includes(id)), ...restoredFilters],
+            true,
+          ),
       )
     }
   }

--- a/internal/lookoutui/src/pages/jobs/components/JobsTableContainer.tsx
+++ b/internal/lookoutui/src/pages/jobs/components/JobsTableContainer.tsx
@@ -767,14 +767,19 @@ export const JobsTableContainer = ({ debug, autoRefreshMs, commandSpecs }: JobsT
         `${formatColumnList(removedNames)} ${removedNames.length === 1 ? "filter" : "filters"} cleared, as ${
           removedNames.length === 1 ? "it requires" : "they require"
         } a filter on another column.`,
-        () => {
-          outstandingUndoActionsRef.current = outstandingUndoActionsRef.current.filter(
-            (undo) => undo.snackbarKey !== snackbarKey,
-          )
+        () =>
           onFilterChange(
             (current) => [...current.filter(({ id }) => !restoredColumnIds.includes(id)), ...restoredFilters],
             true,
-          )
+          ),
+        {
+          // However the snackbar goes away, whether undone, dismissed or auto-hidden, its undo
+          // action is no longer available and so must no longer be tracked
+          onExited: (_node, key) => {
+            outstandingUndoActionsRef.current = outstandingUndoActionsRef.current.filter(
+              (undoAction) => undoAction.snackbarKey !== key,
+            )
+          },
         },
       )
       outstandingUndoActionsRef.current = [...outstandingUndoActionsRef.current, { snackbarKey, restoredColumnIds }]

--- a/internal/lookoutui/src/pages/jobs/components/JobsTableContainer.tsx
+++ b/internal/lookoutui/src/pages/jobs/components/JobsTableContainer.tsx
@@ -33,6 +33,7 @@ import {
   VisibilityState,
 } from "@tanstack/react-table"
 import _ from "lodash"
+import { SnackbarKey } from "notistack"
 import { ErrorBoundary } from "react-error-boundary"
 
 import { buildViewEventData } from "../../../analytics/viewMetadata"
@@ -74,7 +75,7 @@ import {
   useFormatIsoTimestampWithUserSettings,
   useDisplayedTimeZoneWithUserSettings,
 } from "../../../components/hooks/formatTimeWithUserSettings"
-import { useCustomSnackbar, useUndoableSnackbar } from "../../../components/hooks/useCustomSnackbar"
+import { useCloseSnackbar, useCustomSnackbar, useUndoableSnackbar } from "../../../components/hooks/useCustomSnackbar"
 import { columnIsAggregatable, useFetchJobsTableData } from "../../../components/hooks/useJobsTableData"
 import { CommandSpec } from "../../../config"
 import { isJobGroupRow, JobRow, JobTableRow } from "../../../models/jobsTableModels"
@@ -125,6 +126,7 @@ function fromLookoutOrder(lookoutOrder: LookoutColumnOrder): SortingState {
 export const JobsTableContainer = ({ debug, autoRefreshMs, commandSpecs }: JobsTableContainerProps) => {
   const openSnackbar = useCustomSnackbar()
   const openUndoableSnackbar = useUndoableSnackbar()
+  const closeSnackbar = useCloseSnackbar()
   const groupJobs = useGroupJobs()
 
   const router = useStableRouter()
@@ -202,6 +204,8 @@ export const JobsTableContainer = ({ debug, autoRefreshMs, commandSpecs }: JobsT
   // such as the undo action of a snackbar
   const columnFilterStateRef = useRef(columnFilterState)
   columnFilterStateRef.current = columnFilterState
+  // Undo actions which are still on screen, each with the columns its undo action would overwrite
+  const outstandingUndoActionsRef = useRef<{ snackbarKey: SnackbarKey; restoredColumnIds: string[] }[]>([])
   const [lookoutFilters, setLookoutFilters] = useState<LookoutColumnFilter[]>([]) // Parsed later
   const [columnMatches, setColumnMatches] = useState<Record<string, Match>>(initialPrefs.columnMatches)
   const [parseErrors, setParseErrors] = useState<Record<string, string | undefined>>({})
@@ -714,22 +718,36 @@ export const JobsTableContainer = ({ debug, autoRefreshMs, commandSpecs }: JobsT
   }
 
   const onFilterChange = (updater: Updater<ColumnFiltersState>, syncTextFields = false) => {
-    const requestedFilterState = updaterToValue(updater, columnFilterStateRef.current)
+    const previousFilterState = columnFilterStateRef.current
+    const requestedFilterState = updaterToValue(updater, previousFilterState)
 
     // Removing a filter can leave filters on dependent columns applied but unreachable, since their
     // inputs are replaced by a message prompting for the prerequisite filter. Such filters are
     // dropped so that no filter can be in effect without a control to remove it.
     const { filters: newFilterState, removedColumnIds } = pruneUnsatisfiedFilters(requestedFilterState)
 
-    if (_.isEqual(newFilterState, columnFilterStateRef.current)) {
+    if (_.isEqual(newFilterState, previousFilterState)) {
       return
     }
+
+    // An outstanding undo action would overwrite the filters on its own columns with the values they
+    // held before its cascade. Once the user has edited one of those columns themselves, undoing
+    // would discard that newer edit, so the offer is withdrawn.
+    const changedColumnIds = changedFilterColumnIds(previousFilterState, newFilterState)
+    outstandingUndoActionsRef.current = outstandingUndoActionsRef.current.filter(
+      ({ snackbarKey, restoredColumnIds }) => {
+        if (_.intersection(restoredColumnIds, changedColumnIds).length === 0) {
+          return true
+        }
+        closeSnackbar(snackbarKey)
+        return false
+      },
+    )
 
     // Any pruned filter may have had a text input, which must be cleared along with it
     applyFilterState(newFilterState, syncTextFields || removedColumnIds.length > 0)
 
     if (removedColumnIds.length > 0) {
-      const previousFilterState = columnFilterStateRef.current
       // Undoing must restore the filters which were pruned, but a pruned filter cannot stand on its
       // own: it was pruned precisely because the edit left its prerequisite unsatisfied. So the
       // columns the edit itself changed are restored too, and only those. Filters on any other
@@ -745,16 +763,21 @@ export const JobsTableContainer = ({ debug, autoRefreshMs, commandSpecs }: JobsT
         const column = allColumns.find(({ id }) => id === colId)
         return (column ? getColumnMetadata(column).displayName : undefined) ?? colId
       })
-      openUndoableSnackbar(
+      const snackbarKey = openUndoableSnackbar(
         `${formatColumnList(removedNames)} ${removedNames.length === 1 ? "filter" : "filters"} cleared, as ${
           removedNames.length === 1 ? "it requires" : "they require"
         } a filter on another column.`,
-        () =>
+        () => {
+          outstandingUndoActionsRef.current = outstandingUndoActionsRef.current.filter(
+            (undo) => undo.snackbarKey !== snackbarKey,
+          )
           onFilterChange(
             (current) => [...current.filter(({ id }) => !restoredColumnIds.includes(id)), ...restoredFilters],
             true,
-          ),
+          )
+        },
       )
+      outstandingUndoActionsRef.current = [...outstandingUndoActionsRef.current, { snackbarKey, restoredColumnIds }]
     }
   }
 


### PR DESCRIPTION
Filters on some columns in the job table require a filter on another column, for example job set and namespace each require queue. When the prerequisite filter was removed, the dependent filter stayed applied but its input was replaced by a message prompting for the prerequisite, leaving the filter constraining every query with no control to remove it.

This change fixes that by pruning filters whose prerequisites are absent in onFilterChange. Show an undoable snackbar naming the cleared filters, rather than dropping them silently. It applies this pruning to filters restored from the query string or a custom view so a stale or hand-edited link cannot reintroduce the invalid state.

Also shows the active filter count on the clear button.