### PR TITLE
Make job runs use ULID IDs

### DIFF
--- a/internal/scheduler/jobdb/job.go
+++ b/internal/scheduler/jobdb/job.go
@@ -808,7 +808,7 @@ func (job *Job) ValidateResourceRequests() error {
 func (job *Job) WithNewRun(executor, nodeId, nodeName, pool string, scheduledAtPriority int32) *Job {
 	now := job.jobDb.clock.Now()
 	return job.WithUpdatedRun(job.jobDb.CreateRun(
-		job.jobDb.uuidProvider.New(),
+		job.jobDb.jobRunIDProvider.New(),
 		job.Id(),
 		now.UnixNano(),
 		executor,

--- a/internal/scheduler/jobdb/jobdb.go
+++ b/internal/scheduler/jobdb/jobdb.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 
 	"github.com/benbjohnson/immutable"
-	"github.com/google/uuid"
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"golang.org/x/exp/maps"
@@ -18,6 +17,7 @@ import (
 	armadaresource "github.com/armadaproject/armada/internal/common/resource"
 	"github.com/armadaproject/armada/internal/common/stringinterner"
 	"github.com/armadaproject/armada/internal/common/types"
+	"github.com/armadaproject/armada/internal/common/util"
 	"github.com/armadaproject/armada/internal/scheduler/adapters"
 	"github.com/armadaproject/armada/internal/scheduler/internaltypes"
 	"github.com/armadaproject/armada/internal/scheduler/pricing"
@@ -87,7 +87,7 @@ type JobDb struct {
 	// Set here so that it can be mocked.
 	clock clock.PassiveClock
 	// Used for generating job run ids.
-	uuidProvider IDProvider
+	jobRunIDProvider IDProvider
 	// Used to make efficient ResourceList types.
 	resourceListFactory  *internaltypes.ResourceListFactory
 	respectNodePodLimits bool
@@ -101,11 +101,11 @@ type IDProvider interface {
 	New() string
 }
 
-// RealUUIDProvider generates an id using a UUID
-type RealUUIDProvider struct{}
+// RealULIDProvider generates an id using a ULID
+type RealULIDProvider struct{}
 
-func (_ RealUUIDProvider) New() string {
-	return uuid.New().String()
+func (_ RealULIDProvider) New() string {
+	return util.NewULID()
 }
 
 func NewJobDb(priorityClasses map[string]types.PriorityClass,
@@ -149,7 +149,7 @@ func NewJobDbWithSchedulingKeyGenerator(
 		schedulingKeyGenerator: skg,
 		stringInterner:         stringInterner,
 		clock:                  clock.RealClock{},
-		uuidProvider:           RealUUIDProvider{},
+		jobRunIDProvider:       RealULIDProvider{},
 		resourceListFactory:    resourceListFactory,
 	}
 }
@@ -162,8 +162,8 @@ func (jobDb *JobDb) SetRespectNodePodLimits(enabled bool) {
 	jobDb.respectNodePodLimits = enabled
 }
 
-func (jobDb *JobDb) SetUUIDProvider(uuidProvider IDProvider) {
-	jobDb.uuidProvider = uuidProvider
+func (jobDb *JobDb) SetJobRunIDProvider(jobRunIDProvider IDProvider) {
+	jobDb.jobRunIDProvider = jobRunIDProvider
 }
 
 // Clone returns a copy of the jobDb.

--- a/internal/scheduler/testfixtures/testfixtures.go
+++ b/internal/scheduler/testfixtures/testfixtures.go
@@ -156,9 +156,9 @@ func NewJobDb(resourceListFactory *internaltypes.ResourceListFactory) *jobdb.Job
 		stringinterner.New(1024),
 		resourceListFactory,
 	)
-	// Mock out the clock and uuid provider to ensure consistent ids and timestamps are generated.
+	// Mock out the clock and job run ID provider to ensure consistent IDs and timestamps are generated.
 	jobDb.SetClock(NewMockPassiveClock())
-	jobDb.SetUUIDProvider(NewMockIDProvider())
+	jobDb.SetJobRunIDProvider(NewMockIDProvider())
 	return jobDb
 }
 


### PR DESCRIPTION
Job runs' IDs are stored within Armada databases as strings, so this is a straightforward change which is transparent to the database. This change improves database performance by making insertions cheaper. The run ID column's index is a standard B-tree index, so monotonically increasing ULIDs (by insertion time) means new rows are inserted at the end of the index rather than somewhere random in the middle.