### PR TITLE
chore: add mage_output_file.go to gitignore

### DIFF
--- a/magefiles/.gitignore
+++ b/magefiles/.gitignore
@@ -1,0 +1,1 @@
+mage_output_file.go


### PR DESCRIPTION
It is a temporary generated main file that Mage creates when parsing build files.